### PR TITLE
fix: Bump module down to commonjs to play nicely with Jest.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@emotion/babel-preset-css-prop": "^11.2.0",
     "@emotion/jest": "^11.2.1",
     "@homebound/rtl-utils": "^1.39.0",
+    "@homebound/tsconfig": "^1.0.2",
     "@storybook/addon-essentials": "^6.1.20",
     "@storybook/addon-info": "^5.3.21",
     "@storybook/addon-links": "^6.1.20",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,27 +1,15 @@
 {
-  "extends": "@tsconfig/recommended/tsconfig.json",
+  "extends": "@homebound/tsconfig/tsconfig.json",
   "compilerOptions": {
-    // Not esnext b/c storybook doesn't like `??`
-    "target": "ES2018",
-    "module": "esnext",
-    "moduleResolution": "Node",
     "lib": ["esnext", "dom"],
     // Supports the `css` prop
     "types": ["@emotion/core", "jest"],
     // Use React 17 _jsx / automatic runtime support for nice emotion integration
     "jsx": "react-jsx",
     "jsxImportSource": "@emotion/react",
-    "declaration": true,
-    "outDir": "./dist",
-    "baseUrl": ".",
-    "paths": {
-      "src/*": ["src/*"]
-    },
     "plugins": [
       { "transform": "typescript-transform-paths" },
       { "transform": "typescript-transform-paths", "afterDeclarations": true }
     ]
-  },
-  "include": ["src"],
-  "exclude": ["node_modules"]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1372,6 +1372,13 @@
     react-router "^5.1.2"
     use-query-params "^1.1.3"
 
+"@homebound/tsconfig@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@homebound/tsconfig/-/tsconfig-1.0.2.tgz#c056da31762d1d4f9c045ff674b130eaed0eb710"
+  integrity sha512-HSszWPsPhR6kwsKNcvQli4ecnxA0ZAKUGWxwiz6KGBEHnvhEIVqsmcpAxO3TK2zTL7zV6TM/7hi4NoqMsUGeUg==
+  dependencies:
+    "@tsconfig/recommended" "^1.0.1"
+
 "@hypnosphi/create-react-context@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@hypnosphi/create-react-context/-/create-react-context-0.3.1.tgz#f8bfebdc7665f5d426cba3753e0e9c7d3154d7c6"


### PR DESCRIPTION
I'd kinda naively set `module: esnext` thinking "let's see if it works!" and it actually does in create-react-app's build, but it doesn't work in Jest (specifically in Blueprint tests that are pulling in Beam components).

I.e. Jest is running in node and doesn't grok native imports yet (w/o experimental disclaimers I didn't want to look in to: https://jestjs.io/docs/ecmascript-modules).

I also used the opportunity to sneak in my `@homebound/tsconfig` thing from hack day, which is just some more defaults on top of the recommended defaults:

https://github.com/homebound-team/tsconfig/blob/main/tsconfig.json