### PR TITLE
chore: Enable the semantic-release/git plugin.

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -5,5 +5,6 @@ module.exports = {
     ["@semantic-release/release-notes-generator", { preset: "conventionalcommits" }],
     "@semantic-release/npm",
     "@semantic-release/github",
+    "@semantic-release/git",
   ],
 };


### PR DESCRIPTION
This will push the `package.json` version bump into `main` + update a `CHANGELOG.md` file (which is what really sealed it for me).