### PR TITLE
fix: Infer cents type, drop suffix.

### DIFF
--- a/src/components/NumberField.tsx
+++ b/src/components/NumberField.tsx
@@ -75,7 +75,7 @@ export function NumberField(props: NumberFieldProps) {
 
   return (
     <div css={Css.df.flexColumn.wPx(width).$} {...groupProps}>
-      {label && <Label labelProps={labelProps} label={label} />}
+      {label && <Label labelProps={labelProps} label={label} {...tid.label} />}
       <input
         {...mergeProps(inputProps, { onBlur })}
         {...(errorMsg ? { "aria-errormessage": errorMessageId } : {})}

--- a/src/forms/BoundNumberField.test.tsx
+++ b/src/forms/BoundNumberField.test.tsx
@@ -16,8 +16,17 @@ describe("BoundNumberField", () => {
     const { heightInInches_errorMsg } = await render(<BoundNumberField field={author.heightInInches} />);
     expect(heightInInches_errorMsg()).toHaveTextContent("Required");
   });
+
+  it("drops the 'in cents' suffix from labels", async () => {
+    const author = createObjectState(formConfig, { royaltiesInCents: 1_00 });
+    const r = await render(<BoundNumberField field={author.royaltiesInCents} />);
+    expect(r.royaltiesInCents_label()).toHaveTextContent("Royalties");
+    expect(r.royaltiesInCents_label()).not.toHaveTextContent("Cents");
+    expect(r.royaltiesInCents()).toHaveValue("$1.00");
+  });
 });
 
 const formConfig: ObjectConfig<AuthorInput> = {
   heightInInches: { type: "value", rules: [required] },
+  royaltiesInCents: { type: "value" },
 };

--- a/src/forms/BoundNumberField.tsx
+++ b/src/forms/BoundNumberField.tsx
@@ -12,7 +12,14 @@ export type BoundNumberFieldProps = Omit<NumberFieldProps, "value" | "onChange">
 
 /** Wraps `NumberField` and binds it to a form field. */
 export function BoundNumberField(props: BoundNumberFieldProps) {
-  const { field, readOnly, onChange = (value) => field.set(value), label = defaultLabel(field.key), ...others } = props;
+  const {
+    field,
+    readOnly,
+    onChange = (value) => field.set(value),
+    label = defaultLabel(field.key.replace(/InCents$/, "")),
+    type = field.key.endsWith("InCents") ? "cents" : undefined,
+    ...others
+  } = props;
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
@@ -21,6 +28,7 @@ export function BoundNumberField(props: BoundNumberFieldProps) {
           label={label}
           value={field.value || undefined}
           onChange={onChange}
+          type={type}
           readOnly={readOnly ?? field.readOnly}
           errorMsg={field.touched ? field.errors.join(" ") : undefined}
           onBlur={() => field.blur()}

--- a/src/forms/formStateDomain.ts
+++ b/src/forms/formStateDomain.ts
@@ -13,6 +13,7 @@ export interface AuthorInput {
   lastName?: string | null;
   birthday?: Date | null;
   heightInInches?: number | null;
+  royaltiesInCents?: number | null;
   books?: BookInput[] | null;
   address?: AuthorAddress | null;
   favoriteSport?: string | null;


### PR DESCRIPTION
If we have a form state field that is `fooInCents`, the label can be just `Foo`.

Small quality-of-life change for users.