### PR TITLE
fix: Always left align columns by default.

### DIFF
--- a/src/components/GridTable.tsx
+++ b/src/components/GridTable.tsx
@@ -546,7 +546,7 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>) {
           // Apply any static/all-cell styling
           ...style.cellCss,
           ...(isHeader && style.headerCellCss),
-          ...getJustification(column, maybeContent, isHeader, idx, as),
+          ...getJustification(column, maybeContent, as),
           ...(idx === 0 && getIndentationCss(rowStyle)),
           ...(isHeader && stickyHeader && Css.sticky.top(stickyOffset).$),
           ...rowStyleCellCss,
@@ -723,19 +723,8 @@ const alignmentToTextAlign: Record<GridCellAlignment, Properties["textAlign"]> =
   right: "right",
 };
 
-// For alignment, use: 1) user-specified, else 2) center if non-1st header, else 3) left.
-function getJustification(
-  column: GridColumn<any>,
-  maybeContent: ReactNode | GridCellContent,
-  isHeader: boolean,
-  idx: number,
-  as: TableAs,
-) {
-  const alignment =
-    (isContentAndSettings(maybeContent) && maybeContent.alignment) ||
-    column.align ||
-    // When beam-ified, we'll probably remove this `isHeader` logic and make headers/content always line up.
-    (isHeader && idx > 0 ? "center" : "left");
+function getJustification(column: GridColumn<any>, maybeContent: ReactNode | GridCellContent, as: TableAs) {
+  const alignment = (isContentAndSettings(maybeContent) && maybeContent.alignment) || column.align || "left";
   if (as === "div") {
     return Css.justify(alignmentToJustify[alignment]).$;
   }

--- a/src/components/__snapshots__/GridTable.test.tsx.snap
+++ b/src/components/__snapshots__/GridTable.test.tsx.snap
@@ -66,10 +66,10 @@ exports[`GridTable renders 1`] = `
   background-color: rgba(236,235,235,1);
   height: 100%;
   white-space: nowrap;
-  -webkit-box-pack: center;
-  -ms-flex-pack: center;
-  -webkit-justify-content: center;
-  justify-content: center;
+  -webkit-box-pack: start;
+  -ms-flex-pack: start;
+  -webkit-justify-content: flex-start;
+  justify-content: flex-start;
 }
 
 .emotion-5 {


### PR DESCRIPTION
BP was originally fancier about "only left align the 1st column ... and if it's a header"or something like that, but now we just want it left always (by default, can still be overridden)