### PR TITLE
fix: Ensure the kind-based prev/next is initialized

### DIFF
--- a/src/components/GridTable.test.tsx
+++ b/src/components/GridTable.test.tsx
@@ -618,11 +618,7 @@ describe("GridTable", () => {
     const rowLookup: MutableRefObject<GridRowLookup<Row> | undefined> = { current: undefined };
     await render(<GridTable<Row> columns={columns} rows={rows} rowLookup={rowLookup} />);
     // Then we get nothing back
-    expect(rowLookup.current!.lookup(r1)).toMatchObject({
-      prev: undefined,
-      next: undefined,
-      data: { prev: undefined, next: undefined },
-    });
+    expect(rowLookup.current!.lookup(r1)).toMatchObject({ data: {} });
   });
 });
 

--- a/src/components/GridTable.tsx
+++ b/src/components/GridTable.tsx
@@ -299,19 +299,8 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
       },
       lookup(row) {
         const rows = filteredRows.map((r) => r[0]);
-
-        // Use the 1st column to get the runtime list of kinds
-        const nonKindKeys = ["w", "sort", "sortValue", "align"];
-        const result: any = {
-          ...Object.fromEntries(
-            Object.keys(columns[0] || {})
-              .filter((key) => !nonKindKeys.includes(key))
-              .map((key) => [key, { prev: undefined, next: undefined }]),
-          ),
-          prev: undefined,
-          next: undefined,
-        };
-
+        // Ensure we have `result.kind = {}` for each kind
+        const result: any = Object.fromEntries(getKinds(columns).map((kind) => [kind, {}]));
         // This is an admittedly cute/fancy scan, instead of just `rows.findIndex`, but
         // we do it this way so that we can do kind-aware prev/next detection.
         let key: "prev" | "next" = "prev";
@@ -980,6 +969,12 @@ export function observableColumns<T extends Kinded>(cols: GridColumn<T>[]): Grid
 /** GridTable as Table utility to wrap table header or body with thead or tbody */
 function maybeWrapWith(children: ReactNode, as: TableAs, Node: "thead" | "tbody") {
   return as === "div" ? children : <Node>{children}</Node>;
+}
+
+function getKinds<R extends Kinded>(columns: GridColumn<R>[]): R[] {
+  // Use the 1st column to get the runtime list of kinds
+  const nonKindKeys = ["w", "sort", "sortValue", "align"];
+  return Object.keys(columns[0] || {}).filter((key) => !nonKindKeys.includes(key)) as any;
 }
 
 /** GridTable as Table utility to apply <tr> element override styles */


### PR DESCRIPTION
Previously if there was only one row, the `result["data"].prev` would blow up because we lazy created the `data` key as we found it on iteration. So for kinds we didn't happen to iterate over, that key wouldn't be there. Now we create them all up-front.