### PR TITLE
feat: Add tab xss, content default margin top

### DIFF
--- a/src/components/Tabs.stories.tsx
+++ b/src/components/Tabs.stories.tsx
@@ -60,6 +60,7 @@ export const TabsWithContent = () => {
           onChange={setSelectedTab2}
           selected={selectedTab2}
           ariaLabel="Sample Tabs With Content"
+          contentXss={Css.m3.$}
         />
       </div>
     </div>

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,6 +1,6 @@
 import { HTMLAttributes, KeyboardEvent, ReactNode, useMemo, useState } from "react";
 import { mergeProps, useFocusRing, useHover } from "react-aria";
-import { Css } from "src/Css";
+import { Css, Margin, Only, Properties, Xss } from "src/Css";
 import { BeamFocusableProps } from "src/interfaces";
 import { useTestIds } from "src/utils";
 import { Icon, Icons } from "./Icon";
@@ -13,12 +13,15 @@ export interface Tab {
   render: () => ReactNode;
 }
 
-export interface TabsProps {
+type TabsContentXss = Xss<Margin>;
+
+export interface TabsProps<X extends Properties> {
   ariaLabel?: string;
   // the selected tab is connected to the contents displayed
   selected: string;
   tabs: Tab[];
   onChange: (value: string) => void;
+  contentXss?: X;
 }
 
 /**
@@ -27,13 +30,13 @@ export interface TabsProps {
  * The caller is responsible for using `selected` / `onChange` to control
  * the current tab.
  */
-export function TabsWithContent(props: TabsProps) {
-  const { selected, tabs, ...others } = props;
+export function TabsWithContent<X extends Only<TabsContentXss, X>>(props: TabsProps<X>) {
+  const { selected, tabs, contentXss = {}, ...others } = props;
   const selectedTab = tabs.find((tab) => tab.value === selected) || tabs[0];
   const tid = useTestIds(others, "tab");
 
   return (
-    <>
+    <div>
       <Tabs {...props} />
       <div
         aria-labelledby={`${selectedTab.value}-tab`}
@@ -41,15 +44,19 @@ export function TabsWithContent(props: TabsProps) {
         role="tabpanel"
         tabIndex={0}
         {...tid.panel}
+        css={{
+          ...Css.mt2.$,
+          ...contentXss,
+        }}
       >
         {selectedTab.render()}
       </div>
-    </>
+    </div>
   );
 }
 
 /** The top list of tabs. */
-function Tabs(props: TabsProps) {
+function Tabs(props: TabsProps<{}>) {
   const { ariaLabel, onChange, selected, tabs, ...others } = props;
   const { isFocusVisible, focusProps } = useFocusRing();
   const tid = useTestIds(others, "tabs");


### PR DESCRIPTION
Adds both:

a) A default top margin of 16px between the tabs and the content
b) A `contextXss` prop for callers to customize the margin
c) Wraps the tabs + content in a single `div`

I think in retrospect maybe I was supposed to know that the tabs + content were returned in a fragment, such that if I wrapped them in my own wrapper `div` that did a `childGap`, I could spread them out within the application's page. (This is what the stories are doing, which I didn't realize until ~mostly done.)

That seemed fine, but I think this top-level-div + default margin + override is good too, at least coming from the bias that I had assumed that's how it already worked. :-) 

(I.e. I think as a caller if I put the `TabsWithContent` + several other components in a div and `childGap`'d the div, I think I would be surprised that the `childGap` would also apply between the tab + content instead of the tab + content being both a logical & physical single unit.)