### PR TITLE
feat: Allow IconButton to be smaller.

### DIFF
--- a/src/components/IconButton.stories.tsx
+++ b/src/components/IconButton.stories.tsx
@@ -44,6 +44,10 @@ export const IconButton = (args: IconButtonProps) => (
         <h2>Colored</h2>
         <IconButtonComponent {...args} color={Palette.Red700} />
       </div>
+      <div>
+        <h2>Smaller</h2>
+        <IconButtonComponent {...args} inc={2} />
+      </div>
     </div>
   </div>
 );

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -6,13 +6,15 @@ import { BeamButtonProps, BeamFocusableProps } from "src/interfaces";
 import { useTestIds } from "src/utils/useTestIds";
 
 export interface IconButtonProps extends BeamButtonProps, BeamFocusableProps {
-  // The icon to use within the button
+  /** The icon to use within the button. */
   icon: IconProps["icon"];
   color?: Palette;
+  /** The size of the icon, in increments, defaults to 3 which is 24px. */
+  inc?: number;
 }
 
 export function IconButton(props: IconButtonProps) {
-  const { onClick: onPress, disabled: isDisabled, color, icon, autoFocus } = props;
+  const { onClick: onPress, disabled: isDisabled, color, icon, autoFocus, inc } = props;
   const ariaProps = { onPress, isDisabled, autoFocus };
   const ref = useRef(null);
   const { buttonProps } = useButton(ariaProps, ref);
@@ -32,7 +34,7 @@ export function IconButton(props: IconButtonProps) {
 
   return (
     <button {...testIds} {...buttonProps} {...focusProps} {...hoverProps} ref={ref} css={styles}>
-      <Icon icon={icon} color={color || (isDisabled ? Palette.Gray400 : Palette.Gray900)} />
+      <Icon icon={icon} color={color || (isDisabled ? Palette.Gray400 : Palette.Gray900)} inc={inc} />
     </button>
   );
 }


### PR DESCRIPTION
Icon already had a `inc` for exceptional cases, so just exposing in `IconButton`.

Specifically, I want smaller expand/collapse buttons in the admin table of cost codes.