### PR TITLE
fix: Remove onFocus BoundCheckboxField trigger

### DIFF
--- a/src/forms/BoundCheckboxField.tsx
+++ b/src/forms/BoundCheckboxField.tsx
@@ -22,8 +22,7 @@ export function BoundCheckboxField(props: BoundCheckboxFieldProps) {
           label={label}
           selected={field.value ?? false}
           onChange={(selected) => {
-            // We are ignoring focus and blur for checkbox fields due to its transactional nature
-            field.focus();
+            // We are triggering blur manually for checkbox fields due to its transactional nature
             onChange(selected);
             field.blur();
           }}


### PR DESCRIPTION
# GROW-870

Removing the `onFocus` trigger in the BoundCheckboxField since this is not performing any function in formState and should not since it's a boolean type compared to a text field.

Ref PR feedback in https://github.com/homebound-team/beam/pull/108