### PR TITLE
fix: Add z-index to GridTable sticky headers

### DIFF
--- a/src/components/GridTable.tsx
+++ b/src/components/GridTable.tsx
@@ -712,7 +712,7 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
           ...(isHeader && style.headerCellCss),
           ...getJustification(column, maybeContent, as),
           ...(idx === 0 && getIndentationCss(rowStyle)),
-          ...(isHeader && stickyHeader && Css.sticky.top(stickyOffset).$),
+          ...(isHeader && stickyHeader && Css.sticky.top(stickyOffset).z1.$),
           ...rowStyleCellCss,
         };
 


### PR DESCRIPTION
# GROW-871

As part of using the GridTable inside BP with sticky headers and MUI inputs, we have found that the inputs stack above the table header. See the follow PR comment for details https://github.com/homebound-team/internal-frontend/pull/1103#pullrequestreview-685323925

Adding a z-index of 1 resolves this issue.

Validating this issue agains our SelectFields and it looks like there is no problem when those ones, just MUI.