### PR TITLE
fix: Add 'position: relative;' to elements that wrap <VisuallyHidden />

### DIFF
--- a/src/inputs/CheckboxBase.tsx
+++ b/src/inputs/CheckboxBase.tsx
@@ -48,7 +48,7 @@ export function CheckboxBase(props: CheckboxBaseProps) {
   return (
     <label
       css={
-        Css.df.cursorPointer
+        Css.df.cursorPointer.relative
           // Prevents accidental checkbox clicks due to label width being longer
           // than the content.
           .w("max-content")

--- a/src/inputs/Switch.tsx
+++ b/src/inputs/Switch.tsx
@@ -89,7 +89,7 @@ const toggleWidth = (isCompact: boolean) => (isCompact ? 44 : 40);
 const circleDiameter = (isCompact: boolean) => (isCompact ? 14 : 20);
 
 // Label styles
-const switchLabelDefaultStyles = Css.cursorPointer.df.itemsCenter.childGap2.w("max-content").smEm.selectNone.$;
+const switchLabelDefaultStyles = Css.relative.cursorPointer.df.itemsCenter.childGap2.w("max-content").smEm.selectNone.$;
 const switchLabelDisabledStyles = Css.cursorNotAllowed.gray400.$;
 
 // Switcher/Toggle element styles


### PR DESCRIPTION
The VisuallyHidden component creates an absolutely position element of height and width of 1px. This absolutely positioned element can act up when a parent element uses `display: grid`, and can cause the <VisuallyHidden /> element to take up space in the DOM when it shouldn't.
Updating to add 'position: relative;` keeps the VisuallyHidden element within the field's container and prevents it from being placed elsewhere in the app.