### PR TITLE
fix: Require 'label' in all Text/Number fields.

### DIFF
--- a/src/forms/BoundNumberField.tsx
+++ b/src/forms/BoundNumberField.tsx
@@ -4,7 +4,9 @@ import { NumberField, NumberFieldProps } from "src/inputs";
 import { useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
 
-export type BoundNumberFieldProps = Omit<NumberFieldProps, "value" | "onChange" | "onBlur" | "onFocus"> & {
+export type BoundNumberFieldProps = Omit<NumberFieldProps, "value" | "onChange" | "onBlur" | "onFocus" | "label"> & {
+  // Make optional as it'll create a label from the field's key if not present
+  label?: string;
   field: FieldState<any, number | null | undefined>;
   // Optional in case the page wants extra behavior
   onChange?: (value: number | undefined) => void;

--- a/src/forms/BoundTextAreaField.tsx
+++ b/src/forms/BoundTextAreaField.tsx
@@ -4,7 +4,12 @@ import { TextAreaField, TextAreaFieldProps } from "src/inputs";
 import { useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
 
-export type BoundTextAreaFieldProps = Omit<TextAreaFieldProps, "value" | "onChange" | "onBlur" | "onFocus"> & {
+export type BoundTextAreaFieldProps = Omit<
+  TextAreaFieldProps,
+  "value" | "onChange" | "onBlur" | "onFocus" | "label"
+> & {
+  // Make optional as it'll create a label from the field's key if not present
+  label?: string;
   field: FieldState<any, string | null | undefined>;
   // Optional in case the page wants extra behavior
   onChange?: (value: string | undefined) => void;

--- a/src/forms/BoundTextField.tsx
+++ b/src/forms/BoundTextField.tsx
@@ -4,7 +4,9 @@ import { TextField, TextFieldProps } from "src/inputs";
 import { useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
 
-export type BoundTextFieldProps = Omit<TextFieldProps, "value" | "onChange" | "onBlur" | "onFocus"> & {
+export type BoundTextFieldProps = Omit<TextFieldProps, "value" | "onChange" | "onBlur" | "onFocus" | "label"> & {
+  // Make optional as it'll create a label from the field's key if not present
+  label?: string;
   field: FieldState<any, string | null | undefined>;
   // Optional in case the page wants extra behavior
   onChange?: (value: string | undefined) => void;

--- a/src/inputs/NumberField.stories.tsx
+++ b/src/inputs/NumberField.stories.tsx
@@ -14,7 +14,7 @@ export function NumberFields() {
     <div css={Css.df.flexColumn.childGap5.$}>
       <div css={Css.df.flexColumn.childGap2.$}>
         <h1 css={Css.lg.$}>Regular</h1>
-        <TestNumberField value={0} />
+        <TestNumberField value={0} label="Age" hideLabel />
         <TestNumberField label="Age" value={1000} />
         <TestNumberField label="Age Disabled" value={1000} disabled />
         <TestNumberField label="Age Read Only" value={1000} readOnly />
@@ -28,7 +28,7 @@ export function NumberFields() {
 
       <div css={Css.df.flexColumn.childGap2.$}>
         <h1 css={Css.lg.$}>Compact</h1>
-        <TestNumberField compact value={0} />
+        <TestNumberField compact value={0} label="Age" hideLabel />
         <TestNumberField compact label="Age" value={1000} />
         <TestNumberField compact label="Age Disabled" value={1000} disabled />
         <ValidationNumberField label="Age Validated" compact value={-1} />

--- a/src/inputs/NumberField.test.tsx
+++ b/src/inputs/NumberField.test.tsx
@@ -7,7 +7,7 @@ let lastSet: any = undefined;
 
 describe("NumberFieldTest", () => {
   it("can set a value", async () => {
-    const r = await render(<TestNumberField value={1} />);
+    const r = await render(<TestNumberField label="Age" value={1} />);
     expect(r.age()).toHaveValue("1");
     type(r.age, "2");
     expect(r.age()).toHaveValue("2");
@@ -86,7 +86,7 @@ describe("NumberFieldTest", () => {
 });
 
 function TestNumberField(props: Omit<NumberFieldProps, "onChange">) {
-  const { value, label = "Age", ...otherProps } = props;
+  const { value, label, ...otherProps } = props;
   const [internalValue, setValue] = useState(value);
   return (
     <NumberField

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -7,7 +7,9 @@ import { TextFieldBase } from "./TextFieldBase";
 
 // exported for testing purposes
 export interface NumberFieldProps {
-  label?: string;
+  label: string;
+  /** If set, the label will be defined as 'aria-label` on the input element */
+  hideLabel?: boolean;
   type?: "cents" | "percent" | "basisPoints";
   value: number | undefined;
   onChange: (value: number | undefined) => void;
@@ -87,7 +89,7 @@ export function NumberField(props: NumberFieldProps) {
       valueRef.current = { wip: false };
     },
     validationState: errorMsg !== undefined ? "invalid" : "valid",
-    label: label ?? "number",
+    label: label,
     isDisabled,
     isReadOnly,
     formatOptions,

--- a/src/inputs/TextAreaField.stories.tsx
+++ b/src/inputs/TextAreaField.stories.tsx
@@ -14,7 +14,7 @@ export function TextAreas() {
     <div css={Css.df.flexColumn.childGap5.$}>
       <div css={Css.df.flexColumn.childGap2.$}>
         <h1 css={Css.lg.$}>Regular</h1>
-        <TestTextArea value="" />
+        <TestTextArea value="" label="Description" hideLabel />
         <TestTextArea label="Description" value="" />
         <TestTextArea label="Description" value="An example description text." autoFocus />
         <TestTextArea label="Description" value="This is a description that can no longer be edited." disabled />

--- a/src/inputs/TextAreaField.test.tsx
+++ b/src/inputs/TextAreaField.test.tsx
@@ -22,12 +22,12 @@ describe("TextAreaFieldTest", () => {
   });
 });
 
-function TestTextAreaField(props: Omit<TextAreaFieldProps, "onChange">) {
-  const { value, label = "Note", ...otherProps } = props;
+function TestTextAreaField(props: Omit<TextAreaFieldProps, "onChange" | "label">) {
+  const { value, ...otherProps } = props;
   const [internalValue, setValue] = useState(value);
   return (
     <TextAreaField
-      label={label}
+      label="Note"
       value={internalValue}
       onChange={(v) => {
         lastSet = v;

--- a/src/inputs/TextField.stories.tsx
+++ b/src/inputs/TextField.stories.tsx
@@ -14,7 +14,7 @@ export function TextFields() {
     <div css={Css.df.flexColumn.childGap5.$}>
       <div css={Css.df.flexColumn.childGap2.$}>
         <h1 css={Css.lg.$}>Regular</h1>
-        <TestTextField value="" />
+        <TestTextField value="" label="Name" hideLabel />
         <TestTextField label="Name" value="" />
         <TestTextField label="Name Focused" value="Brandon" autoFocus />
         <TestTextField label="Name Disabled" value="Brandon" disabled />
@@ -32,7 +32,7 @@ export function TextFields() {
             </div>
           }
         />
-        <ValidationTextField value="not a valid email" />
+        <ValidationTextField value="not a valid email" label="Email" />
         <ValidationTextField
           label="Name"
           value="Brandon"
@@ -42,7 +42,7 @@ export function TextFields() {
 
       <div css={Css.df.flexColumn.childGap2.$}>
         <h1 css={Css.lg.$}>Compact</h1>
-        <TestTextField compact value="" />
+        <TestTextField compact value="" label="Name" hideLabel />
         <TestTextField compact label="Name" value="" />
         <TestTextField compact label="Name" value="Brandon" />
         <TestTextField compact label="Name" value="Brandon" disabled />
@@ -52,7 +52,7 @@ export function TextFields() {
           value="Brandon"
           helperText="Some really long helper text that we expect to wrap."
         />
-        <ValidationTextField compact value="not a valid email" />
+        <ValidationTextField compact value="not a valid email" label="Email" />
       </div>
     </div>
   );
@@ -81,7 +81,6 @@ function ValidationTextField(props: Omit<TextFieldProps, "onChange">) {
   ]);
   return (
     <TextField
-      label="Email"
       {...otherProps}
       value={internalValue}
       onChange={setValue}

--- a/src/inputs/TextField.test.tsx
+++ b/src/inputs/TextField.test.tsx
@@ -22,12 +22,12 @@ describe("TextFieldTest", () => {
   });
 });
 
-function TestTextField(props: Omit<TextFieldProps, "onChange">) {
-  const { value, label = "Name", ...otherProps } = props;
+function TestTextField(props: Omit<TextFieldProps, "onChange" | "label">) {
+  const { value, ...otherProps } = props;
   const [internalValue, setValue] = useState(value);
   return (
     <TextField
-      label={label}
+      label="Name"
       value={internalValue}
       onChange={(v) => {
         lastSet = v;

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -18,7 +18,7 @@ import { defaultTestId } from "src/utils/defaultTestId";
 import { useTestIds } from "src/utils/useTestIds";
 
 interface TextFieldBaseProps
-  extends Pick<BeamTextFieldProps, "label" | "errorMsg" | "onBlur" | "onFocus" | "helperText">,
+  extends Pick<BeamTextFieldProps, "label" | "errorMsg" | "onBlur" | "onFocus" | "helperText" | "hideLabel">,
     Partial<Pick<BeamTextFieldProps, "onChange">> {
   labelProps?: LabelHTMLAttributes<HTMLLabelElement>;
   inputProps: InputHTMLAttributes<HTMLInputElement> | TextareaHTMLAttributes<HTMLTextAreaElement>;
@@ -36,6 +36,7 @@ export function TextFieldBase(props: TextFieldBaseProps) {
   const {
     label,
     labelProps,
+    hideLabel,
     inputProps,
     inputRef,
     groupProps,
@@ -72,12 +73,12 @@ export function TextFieldBase(props: TextFieldBaseProps) {
 
   return (
     <div css={Css.df.flexColumn.w100.maxw(px(550)).$} {...groupProps}>
-      {label && <Label labelProps={labelProps} label={label} {...tid.label} />}
+      {label && !hideLabel && <Label labelProps={labelProps} label={label} {...tid.label} />}
       <ElementType
         {...mergeProps(
           inputProps,
           { onBlur, onFocus: onFocusChained, onChange: onDomChange },
-          { "aria-invalid": Boolean(errorMsg) },
+          { "aria-invalid": Boolean(errorMsg), ...(hideLabel ? { "aria-label": label } : {}) },
         )}
         {...(errorMsg ? { "aria-errormessage": errorMessageId } : {})}
         ref={inputRef as any}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,7 +20,9 @@ export interface BeamTextFieldProps extends BeamFocusableProps {
   errorMsg?: string;
   helperText?: string | ReactNode;
   /** Input label */
-  label?: string;
+  label: string;
+  /** If set, label will be placed as `aria-label` on input element */
+  hideLabel?: boolean;
   value: string | undefined;
   /** Handler called when the interactive element state changes. */
   onChange: (value: string | undefined) => void;


### PR DESCRIPTION
A label is required for accessibility purposes. We are not using the <VisuallyHidden /> for this input, as the label can be placed on the input element directly via aria-label. This allows us to omit possible styling issues that <VisuallyHidden /> has caused in the past due to it being absolutely positioned.