### PR TITLE
feat: Add titleRightContent to use SuperDrawer.

### DIFF
--- a/src/components/SuperDrawer/SuperDrawer.stories.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.stories.tsx
@@ -86,6 +86,7 @@ export function OpenWithTitleRightContent() {
     openInDrawer({
       title: "Title",
       content: <TestDrawerContent book={Books[0]} />,
+      titleLeftContent: "ASSIGNED",
       titleRightContent: <Button label="Manage RFP" onClick={() => {}} />,
     });
   }

--- a/src/components/SuperDrawer/SuperDrawer.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.tsx
@@ -42,7 +42,7 @@ export function SuperDrawer(): ReactPortal | null {
 
   // Also get the first / non-detail element on the stack
   const firstContent = contentStack.current[0].opts as OpenInDrawerOpts;
-  const { onPrevClick, onNextClick, onClose, titleRightContent = null } = firstContent;
+  const { onPrevClick, onNextClick, onClose, titleRightContent, titleLeftContent } = firstContent;
 
   const isDetail = currentContent !== firstContent;
   const title = currentContent.title || firstContent.title;
@@ -90,14 +90,17 @@ export function SuperDrawer(): ReactPortal | null {
             >
               <header css={Css.df.p3.bb.bGray200.df.itemsCenter.justifyBetween.$}>
                 {/* Left */}
-                <div css={Css.xl2Em.gray900.$} {...testId.title}>
-                  {title}
+                <div css={Css.df.itemsCenter.$}>
+                  <div css={Css.xl2Em.gray900.mr2.$} {...testId.title}>
+                    {title}
+                  </div>
+                  {titleLeftContent || null}
                 </div>
                 {/* Right */}
                 {!modalState.current && (
                   // Forcing height to 32px to match title height
                   <div css={Css.df.childGap3.itemsCenter.hPx(32).$}>
-                    {titleRightContent}
+                    {titleRightContent || null}
                     {/* Disable buttons is handlers are not given or if childContent is shown */}
                     <ButtonGroup
                       buttons={[

--- a/src/components/SuperDrawer/useSuperDrawer.tsx
+++ b/src/components/SuperDrawer/useSuperDrawer.tsx
@@ -4,8 +4,10 @@ import { BeamContext } from "src/components/BeamContext";
 export interface OpenInDrawerOpts {
   /** Title of the SuperDrawer */
   title: string;
-  /** Optional content to place next to the prev/next buttons. */
+  /** Optional content to place left of the prev/next buttons, i.e. a "Manage" link. */
   titleRightContent?: ReactNode;
+  /** Optional content to place right of the title, i.e. a status badge. */
+  titleLeftContent?: ReactNode;
   /** Invokes left, disabled if undefined. */
   onPrevClick?: () => void;
   /** Invokes right, disabled if undefined. */


### PR DESCRIPTION
For showing the 'Manage RFP' button per mocks.

![image](https://user-images.githubusercontent.com/6401/124485065-cf116a00-dd71-11eb-8929-a57cadd64900.png)

https://www.figma.com/file/WeLtKm34C82oJplAU8tOPS/21-Q2--%F0%9F%9B%92-RFP?node-id=1279%3A556