### PR TITLE
fix: SelectFields should only resize to fit content when explicitly requested

### DIFF
--- a/src/components/Filters/utils.tsx
+++ b/src/components/Filters/utils.tsx
@@ -29,6 +29,7 @@ export function getFilterComponents<F>(props: GetFilterComponentsOpts<F>) {
           compact
           value={String(filter[key])}
           inlineLabel
+          sizeToContent={!inModal}
           onSelect={(value) => {
             const parsedValue = value === "undefined" ? undefined : value === "true" ? true : false;
             updateFilter(filter, key, parsedValue);
@@ -46,6 +47,7 @@ export function getFilterComponents<F>(props: GetFilterComponentsOpts<F>) {
           compact
           value={filter[key]}
           inlineLabel
+          sizeToContent={!inModal}
           onSelect={(value) => updateFilter(filter, key, value)}
         />,
         inModal,
@@ -78,6 +80,7 @@ export function getFilterComponents<F>(props: GetFilterComponentsOpts<F>) {
           compact
           values={filter[key] || []}
           inlineLabel
+          sizeToContent={!inModal}
           onSelect={(values) => updateFilter(filter, key, values)}
         />,
         inModal,

--- a/src/components/RichTextField.tsx
+++ b/src/components/RichTextField.tsx
@@ -127,7 +127,7 @@ export function RichTextField(props: RichTextFieldProps) {
     <div css={Css.w100.maxw("550px").$}>
       {/* TODO: Not sure what to pass to labelProps. */}
       {label && <Label labelProps={{}} label={label} />}
-      <div css={{...Css.br4.bgWhite.$, ...trixCssOverrides}}>
+      <div css={{ ...Css.br4.bgWhite.$, ...trixCssOverrides }}>
         {createElement("trix-editor", {
           id: `editor-${id}`,
           input: `input-${id}`,

--- a/src/inputs/SelectField.stories.tsx
+++ b/src/inputs/SelectField.stories.tsx
@@ -1,10 +1,11 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
 import { Key, useState } from "react";
-import { Icon, Icons } from "src/components";
+import { GridColumn, GridTable, Icon, Icons, simpleHeader, SimpleHeaderAndDataOf } from "src/components";
 import { Css } from "src/Css";
 import { SelectField, SelectFieldProps } from "src/inputs";
 import { HasIdAndName, Optional } from "src/types";
+import { noop } from "src/utils";
 import { zeroTo } from "src/utils/sb";
 
 export default {
@@ -157,6 +158,44 @@ export function SelectFields() {
     </div>
   );
 }
+
+export function InTable() {
+  return (
+    <GridTable columns={columns} rows={[simpleHeader, ...rowData.map((r) => ({ kind: "data" as const, ...r }))]} />
+  );
+}
+const people: InternalUser[] = zeroTo(10).map((i) => ({
+  id: `iu:${i + 1}`,
+  name: `Test user ${i + 1}`.repeat((i % 2) + 1),
+}));
+const rowData: Request[] = zeroTo(10).map((i) => ({
+  id: `r:${i + 1}`,
+  user: people[i],
+  address: "1234 Address Lane",
+  market: "SO Cal",
+  homeowner: "John Doe",
+}));
+const columns: GridColumn<Row>[] = [
+  { header: "ID", data: (data) => data.id },
+  { header: "Homeowner", data: (data) => data.homeowner },
+  { header: "Address", data: (data) => data.address },
+  {
+    header: "Contact",
+    data: (data) => (
+      <SelectField
+        getOptionValue={(iu) => iu.id}
+        getOptionLabel={(iu) => iu.name}
+        value={data.user.id}
+        onSelect={noop}
+        options={people}
+      />
+    ),
+  },
+  { header: "Market", data: (data) => data.market },
+];
+type Row = SimpleHeaderAndDataOf<Request>;
+type InternalUser = { name: string; id: string };
+type Request = { id: string; user: InternalUser; address: string; homeowner: string; market: string };
 
 // Kind of annoying but to get type inference for HasIdAndName working, we
 // have to re-copy/paste the overload here.

--- a/src/inputs/internal/SelectFieldBase.tsx
+++ b/src/inputs/internal/SelectFieldBase.tsx
@@ -189,6 +189,7 @@ function ComboBox<O, V extends Key>(props: ComboBoxProps<O, V>) {
     multiselect,
     getOptionLabel,
     getOptionValue,
+    sizeToContent = false,
     ...otherProps
   } = props;
 
@@ -289,6 +290,7 @@ function ComboBox<O, V extends Key>(props: ComboBoxProps<O, V>) {
         labelProps={labelProps}
         selectedOptions={selectedOptions}
         getOptionValue={getOptionValue}
+        sizeToContent={sizeToContent}
       />
       {state.isOpen && (
         <Popover
@@ -325,4 +327,5 @@ export interface BeamSelectFieldBaseProps<T> extends BeamFocusableProps {
   readOnly?: boolean;
   onBlur?: () => void;
   onFocus?: () => void;
+  sizeToContent?: boolean;
 }

--- a/src/inputs/internal/SelectFieldInput.tsx
+++ b/src/inputs/internal/SelectFieldInput.tsx
@@ -38,6 +38,7 @@ interface SelectFieldInputProps<O, V extends Key> {
   label?: string;
   selectedOptions: O[];
   getOptionValue: (opt: O) => V;
+  sizeToContent: boolean;
 }
 
 export function SelectFieldInput<O, V extends Key>(props: SelectFieldInputProps<O, V>) {
@@ -62,6 +63,7 @@ export function SelectFieldInput<O, V extends Key>(props: SelectFieldInputProps<
     labelProps,
     selectedOptions,
     getOptionValue,
+    sizeToContent,
   } = props;
   const errorMessageId = `${inputProps.id}-error`;
   const { hoverProps, isHovered } = useHover({});
@@ -72,7 +74,7 @@ export function SelectFieldInput<O, V extends Key>(props: SelectFieldInputProps<
   const readOnlyStyles = isReadOnly ? Css.bn.pl0.pt0.add("backgroundColor", "unset").$ : {};
   const tid = useTestIds(inputProps); // data-testid comes in through here
   const isMultiSelect = state.selectionManager.selectionMode === "multiple";
-  const [isSizeBasedOnContent, setIsSizeBasedOnContent] = useState(true);
+  const [isSizeCurrentlyBasedOnContent, setIsSizeBasedOnContent] = useState(true);
 
   return (
     <Fragment>
@@ -166,7 +168,13 @@ export function SelectFieldInput<O, V extends Key>(props: SelectFieldInputProps<
             e.target.select();
             state.open();
           }}
-          size={isSizeBasedOnContent ? inputRef?.current?.value.length || 1 : 20}
+          size={
+            sizeToContent
+              ? isSizeCurrentlyBasedOnContent
+                ? String(inputProps.value || "").length || 1
+                : Math.max(String(inputProps.value || "").length, 20)
+              : undefined
+          }
         />
         {!isReadOnly && (
           <button


### PR DESCRIPTION
Adds 'sizeToContent' prop for Select and MultiSelect fields. By default this is false. When enabled the input.value will dictate the field's width.