### PR TITLE
fix: Resolve openInDrawer and addCanCloseDrawerCheck not emitting tick event

### DIFF
--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -7,6 +7,7 @@ import { EmptyRef } from "src/utils/index";
 
 /** The internal state of our Beam context; see useModal and useSuperDrawer for the public APIs. */
 export interface BeamContextState {
+  // SuperDrawer contentStack
   contentStack: MutableRefObject<ContentStack[]>;
   modalState: MutableRefObject<ModalProps | undefined>;
   canCloseModalChecks: MutableRefObject<Array<() => boolean>>;

--- a/src/components/SuperDrawer/useSuperDrawer.tsx
+++ b/src/components/SuperDrawer/useSuperDrawer.tsx
@@ -156,7 +156,7 @@ export function useSuperDrawer(): UseSuperDrawerHook {
         if (!contentStack.current.length) {
           throw new Error("openInDrawer was not called before openDrawerDetail");
         }
-        contentStack.current.push({ kind: "detail", opts });
+        contentStack.current = [...contentStack.current, { kind: "detail", opts }];
       },
       /** Add a new close check to SuperDrawer */
       addCanCloseDrawerCheck(canCloseCheck: () => boolean) {
@@ -167,7 +167,7 @@ export function useSuperDrawer(): UseSuperDrawerHook {
           return;
         }
 
-        canCloseDrawerChecks.current.push(canCloseCheck);
+        canCloseDrawerChecks.current = [...canCloseDrawerChecks.current, canCloseCheck];
       },
       /** Add a new close check to the current SuperDrawer detail */
       addCanCloseDrawerDetailCheck(canCloseCheck: () => boolean) {


### PR DESCRIPTION
When using `.push` with the new PretendRefThatTicks, the `set current` method is not called. Changing all `.push` to `= ...` resolved this issue.