### PR TITLE
feat: Add OpenModal helper for testing modals.

### DIFF
--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -8,7 +8,7 @@ import { EmptyRef } from "src/utils/index";
 /** The internal state of our Beam context; see useModal and useSuperDrawer for the public APIs. */
 export interface BeamContextState {
   // SuperDrawer contentStack
-  contentStack: MutableRefObject<ContentStack[]>;
+  contentStack: MutableRefObject<readonly ContentStack[]>;
   modalState: MutableRefObject<ModalProps | undefined>;
   canCloseModalChecks: MutableRefObject<Array<() => boolean>>;
   /** The div for ModalBody to portal into; note this can't be a ref b/c Modal hasn't set the ref at the time ModalBody renders. */
@@ -52,7 +52,7 @@ export function BeamProvider({ children }: { children: ReactNode }) {
     return {
       modalState: new PretendRefThatTicks(modalRef, tick),
       contentStack: new PretendRefThatTicks(contentStackRef, tick),
-      // We don't need to rerender when this is mutated, so just expose as-is
+      // We don't need to rerender when these are mutated, so just expose as-is
       modalBodyDiv,
       modalFooterDiv,
       canCloseModalChecks: canCloseModalChecksRef,

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -1,13 +1,13 @@
 import { fireEvent } from "@testing-library/react";
 import { useEffect } from "react";
 import { ModalBody, ModalFooter, ModalProps, useModal } from "src/components/Modal";
+import { OpenModal } from "src/components/Modal/OpenModal";
 import { click, render } from "src/utils/rtl";
 
 describe("Modal", () => {
   it("renders", async () => {
     // When rendered
     const r = await render(<TestModalApp title="Title" content={<TestModalComponent />} />);
-
     // Then expect the content to match
     expect(r.modal_title().textContent).toBe("Title");
     expect(r.modal_titleClose()).toBeTruthy();
@@ -18,7 +18,6 @@ describe("Modal", () => {
     // Given mocked actions
     const canClose = jest.fn().mockReturnValue(false);
     const r = await render(<TestModalApp canClose={canClose} title="Title" content={<TestModalComponent />} />);
-
     // When invoking the `onClose` in various interactions
     click(r.modal_titleClose);
     expect(canClose).toBeCalledTimes(1);
@@ -42,6 +41,18 @@ describe("Modal", () => {
       // Then expect the footer content to be displayed
       expect(r.modal_footer().textContent).toBe("Modal Footer");
     });
+  });
+
+  it("supports testing modal components on their own", async () => {
+    // Given a test wants to directly render a modal component
+    const r = await render(
+      // And it wraps it in the OpenModal helper component
+      <OpenModal>
+        <TestModalComponent />
+      </OpenModal>,
+    );
+    // Then we can assert against it
+    expect(r.modal_footer().textContent).toBe("Modal Footer");
   });
 });
 

--- a/src/components/Modal/OpenModal.tsx
+++ b/src/components/Modal/OpenModal.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { useModal } from "src/components/Modal/useModal";
+
+/**
+ * A component for testing open modals in unit tests.
+ *
+ * Current, calling `render(<ModalComponent />)` in a test currently doesn't work, because
+ * nothing has called `useModal` to get the header & footer mounted into the DOM.
+ *
+ * So instead tests can call:
+ *
+ * ```tsx
+ * render(
+ *   <OpenModal>
+ *     <ModalComponent />
+ *   </OpenModal>
+ * );
+ * ```
+ *
+ * And `OpenModal` will do a boilerplate `openModal` call, so that the content
+ * shows up in the DOM as expected.
+ */
+export function OpenModal(props: { children: JSX.Element }): JSX.Element {
+  const { openModal } = useModal();
+  useEffect(() => openModal({ title: "Title", content: props.children }), [openModal]);
+  return <div>dummy content</div>;
+}

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -1,3 +1,4 @@
 export { ModalBody, ModalFooter } from "./Modal";
 export type { ModalProps } from "./Modal";
+export { OpenModal } from "./OpenModal";
 export * from "./useModal";


### PR DESCRIPTION
An unintended artifact of moving the `ModalBody` / `ModalFooter` to using portals it that if tests render a `SomeModalComponent` directly, the content goes in the portals ... but the divs aren't mounted in the DOM yet, b/c that only happens when `openModal` is called.

So, this is just a wrapper to easily call `openModal` for tests ... would eventually be nice to not use this, and somehow have the divs already mounted.

Fwiw another approach would be to make another wrapper, like:

```
const r = await render(
  <ModalComponent id=foo />,
  withOpenModal,
  withApollo(...)
);
```

Where `withOpenModal`'s `wrap` function would basically have a `useEffect` that calls `openModal`.

This seems a little more straight forward, but not sure, the `withOpenModal` is a little less code...