### PR TITLE
fix: Make SuperDrawer Content Stable when ConfirmationModal Appears

### DIFF
--- a/src/components/SuperDrawer/SuperDrawer.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.tsx
@@ -40,7 +40,7 @@ export function SuperDrawer(): ReactPortal | null {
       modalBodyRef.current.appendChild(modalBodyDiv);
       modalFooterRef.current.appendChild(modalFooterDiv);
     }
-  }, [modalBodyRef.current, modalFooterRef.current, modalState.current]);
+  }, [modalBodyDiv, modalFooterDiv, modalState]);
 
   if (contentStack.current.length === 0) {
     return null;
@@ -88,7 +88,7 @@ export function SuperDrawer(): ReactPortal | null {
             {/* Content container */}
             <motion.aside
               key="superDrawerContainer"
-              css={Css.bgWhite.h100.maxw(px(1040)).w100.df.flexColumn.$}
+              css={Css.bgWhite.h100.maxw(px(1040)).w100.df.flexColumn.relative.$}
               // Keeping initial x to 1040 as this will still work if the container is smaller
               initial={{ x: 1040 }}
               animate={{ x: 0 }}
@@ -102,9 +102,9 @@ export function SuperDrawer(): ReactPortal | null {
                 {/* Left */}
                 <div css={Css.df.itemsCenter.$}>
                   <div css={Css.xl2Em.gray900.mr2.$} {...testId.title}>
-                    {title}
+                    {modalState.current?.title || title}
                   </div>
-                  {titleLeftContent || null}
+                  {!modalState.current && (titleLeftContent || null)}
                 </div>
                 {/* Right */}
                 {!modalState.current && (
@@ -132,17 +132,21 @@ export function SuperDrawer(): ReactPortal | null {
                   </div>
                 )}
               </header>
-              {modalState.current ? (
+              {content}
+              {modalState.current && (
                 // Forcing some design constraints on the modal component
-                <div css={Css.bgWhite.df.itemsCenter.justifyCenter.fg1.flexColumn.$}>
+                <div
+                  css={
+                    Css.fg1.topPx(81).left0.right0.bottom0.absolute.bgWhite.df.itemsCenter.justifyCenter.fg1.flexColumn
+                      .z5.$
+                  }
+                >
                   {/* We'll include content here, but we expect ModalBody and ModalFooter to use their respective portals. */}
                   {modalState.current.content}
                   {/* TODO Work in some notion of the modal size + width/height + scrolling?*/}
                   <div ref={modalBodyRef} />
                   <div ref={modalFooterRef} />
                 </div>
-              ) : (
-                content
               )}
             </motion.aside>
           </motion.div>

--- a/src/components/SuperDrawer/SuperDrawer.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.tsx
@@ -138,13 +138,14 @@ export function SuperDrawer(): ReactPortal | null {
                 // Forcing some design constraints on the modal component
                 <div
                   css={
+                    // topPX(81) is the offset from the header
                     Css.fg1.topPx(81).left0.right0.bottom0.absolute.bgWhite.df.itemsCenter.justifyCenter.fg1.flexColumn
                       .z5.$
                   }
                 >
                   {/* We'll include content here, but we expect ModalBody and ModalFooter to use their respective portals. */}
                   {modalState.current.content}
-                  {/* TODO Work in some notion of the modal size + width/height + scrolling?*/}
+                  {/* TODO: Work in some notion of the modal size + width/height + scrolling?*/}
                   <div ref={modalBodyRef} />
                   <div ref={modalFooterRef} />
                 </div>

--- a/src/components/SuperDrawer/SuperDrawer.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.tsx
@@ -40,7 +40,8 @@ export function SuperDrawer(): ReactPortal | null {
       modalBodyRef.current.appendChild(modalBodyDiv);
       modalFooterRef.current.appendChild(modalFooterDiv);
     }
-  }, [modalBodyDiv, modalFooterDiv, modalState]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [modalBodyRef.current, modalFooterRef.current, modalState.current]);
 
   if (contentStack.current.length === 0) {
     return null;

--- a/src/forms/FormStateApp.tsx
+++ b/src/forms/FormStateApp.tsx
@@ -126,7 +126,7 @@ function createColumns(formState: FormValue): GridColumn<Row>[] {
 type FormValue = ObjectState<AuthorInput>;
 
 // Configure the fields/behavior for AuthorInput's fields
-const formConfig: ObjectConfig<AuthorInput> = {
+export const formConfig: ObjectConfig<AuthorInput> = {
   firstName: { type: "value", rules: [required] },
   lastName: { type: "value", rules: [required] },
   birthday: { type: "value", rules: [required] },

--- a/src/forms/SuperDrawerApp.stories.tsx
+++ b/src/forms/SuperDrawerApp.stories.tsx
@@ -25,8 +25,7 @@ export default { title: "Forms/Super Drawer App", decorators: [withBeamDecorator
 export function SuperDrawerApp() {
   const { openInDrawer } = useSuperDrawer();
 
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(openSuperDrawer, []);
+  useEffect(openSuperDrawer, [openInDrawer]);
 
   function openSuperDrawer() {
     openInDrawer({

--- a/src/forms/SuperDrawerApp.stories.tsx
+++ b/src/forms/SuperDrawerApp.stories.tsx
@@ -1,0 +1,76 @@
+import { useFormState } from "@homebound/form-state";
+import { Meta } from "@storybook/react";
+import { useEffect } from "react";
+import { Button, SuperDrawerContent, useSuperDrawer } from "src/components";
+import { Css } from "src/Css";
+import { withBeamDecorator, withDimensions } from "src/utils/sb";
+import { BoundDateField } from "./BoundDateField";
+import { BoundNumberField } from "./BoundNumberField";
+import { BoundTextField } from "./BoundTextField";
+import { formConfig } from "./FormStateApp";
+import { AuthorInput } from "./formStateDomain";
+
+/**
+ * Example app using Superdrawer and FormState.
+ *
+ * Key features:
+ * - When attempting to close the drawer when the form is "dirty" a
+ * confirmation message appears.
+ * - When cancelling the close, the form values are untouched.
+ * - When filling the form and successfully clicking "save", closing the form
+ * does not show a confirmation message.
+ */
+export default { title: "Forms/Super Drawer App", decorators: [withBeamDecorator, withDimensions()] } as Meta;
+
+export function SuperDrawerApp() {
+  const { openInDrawer } = useSuperDrawer();
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(openSuperDrawer, []);
+
+  function openSuperDrawer() {
+    openInDrawer({
+      title: "Create Author",
+      content: <SuperDrawerForm />,
+    });
+  }
+
+  return (
+    <>
+      <h1 css={Css.xl2.mb1.$}>SuperDrawer App</h1>
+      <Button label="Open SuperDrawer" onClick={openSuperDrawer} />
+    </>
+  );
+}
+
+const initFormValue: AuthorInput = {};
+function SuperDrawerForm() {
+  const { closeDrawer, addCanCloseDrawerCheck } = useSuperDrawer();
+  const formState = useFormState({ config: formConfig, init: initFormValue });
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => addCanCloseDrawerCheck(() => !formState.dirty), []);
+
+  return (
+    <SuperDrawerContent
+      actions={[
+        { label: "Cancel", onClick: closeDrawer },
+        {
+          label: "Save",
+          onClick: () => {
+            formState.canSave();
+            formState.save();
+          },
+        },
+      ]}
+    >
+      <fieldset>
+        <legend css={Css.xl.mb2.$}>Author</legend>
+        <BoundTextField field={formState.firstName} />
+        <BoundTextField field={formState.lastName} />
+        <BoundDateField field={formState.birthday} />
+        <BoundNumberField field={formState.heightInInches} />
+      </fieldset>
+    </SuperDrawerContent>
+  );
+}


### PR DESCRIPTION
When using the canClose checks with the SuperDrawer, the drawer content would unmount when any checks failed. This causes implementation problems when using forms inside drawer content which would cause the form to lose it's state.