### PR TITLE
feat: Add Modal.forceScrolling to always scroll.

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -15,21 +15,23 @@ export default {
 export const Small = () => <ModalExample size="sm" />;
 export const Medium = () => <ModalExample />;
 export const Large = () => <ModalExample size="lg" />;
-export const LargeFixedHeight = () => <ModalExample size={{ width: "lg", height: 300 }} />;
+export const LargeFixedHeight = () => <ModalExample size={{ width: "lg", height: 300 }} forceScrolling={true} />;
 export const WithScroll = () => <ModalExample initNumSentences={50} />;
 export const LeftAction = () => <ModalExample showLeftAction />;
 
 interface ModalExampleProps extends Pick<ModalProps, "size"> {
   initNumSentences?: number;
   showLeftAction?: boolean;
+  forceScrolling?: boolean;
 }
 
 function ModalExample(props: ModalExampleProps) {
-  const { size, showLeftAction, initNumSentences = 1 } = props;
+  const { size, showLeftAction, initNumSentences = 1, forceScrolling } = props;
   const { openModal } = useModal();
 
   const modalProps = {
     size,
+    forceScrolling,
     title: "The title of the modal that might wrap",
     content: <TestModalContent initNumSentences={initNumSentences} showLeftAction={showLeftAction} />,
   };

--- a/src/components/Modal/TestModalContent.tsx
+++ b/src/components/Modal/TestModalContent.tsx
@@ -16,11 +16,14 @@ export function TestModalContent(props: { initNumSentences?: number; showLeftAct
     <>
       <ModalBody>
         <div css={Css.df.gap1.flexColumn.itemsStart.$}>
-          <Button label="Add more text" onClick={() => setNumSentences(numSentences + 2)} />
-          <Button label="Toggle Primary Disabled" onClick={() => setPrimaryDisabled(!primaryDisabled)} />
-          {showLeftAction && (
-            <Button label="Toggle Left Action Disabled" onClick={() => setLeftActionDisabled(!leftActionDisabled)} />
-          )}
+          <div css={Css.df.childGap1.$}>
+            <Button label="More" onClick={() => setNumSentences(numSentences + 2)} />
+            <Button label="Clear" onClick={() => setNumSentences(0)} />
+            <Button label="Primary" onClick={() => setPrimaryDisabled(!primaryDisabled)} />
+            {showLeftAction && (
+              <Button label="Left Action" onClick={() => setLeftActionDisabled(!leftActionDisabled)} />
+            )}
+          </div>
           <p>{"The body content of the modal. This content can be anything!".repeat(numSentences)}</p>
         </div>
       </ModalBody>


### PR DESCRIPTION
In procurement-frontend we have a modal that we know will always scroll,
so I want to keep the scroll bar always visible to avoid content jumping
left/right as the body gets wider/narrower.