### PR TITLE
fix: Fix date field width, match others.

### DIFF
--- a/src/inputs/DateField.stories.tsx
+++ b/src/inputs/DateField.stories.tsx
@@ -14,7 +14,7 @@ export default {
 export function DateFields() {
   return samples(
     ["TextField for comparison", <TextField label="First Name" value="Foo" onChange={() => {}} />],
-    ["With Label", <TestDateField label="Start Date" />],
+    ["With Label", <TestDateField label="Projected Client Presentation Date" />],
     ["Without Label", <TestDateField />],
     ["Disabled", <TestDateField disabled />],
     ["Error Message", <TestDateField errorMsg="Required" />],

--- a/src/inputs/DateField.tsx
+++ b/src/inputs/DateField.tsx
@@ -35,16 +35,14 @@ export function DateField(props: DateFieldProps) {
   const textFieldProps = { ...otherProps, label: label ?? "date", isDisabled: disabled, isReadOnly: false };
   const { labelProps, inputProps } = useTextField(textFieldProps, inputRef);
 
-  const width = 128;
-
   return (
     <div
       css={{
-        ...Css.df.flexColumn.wPx(width).$,
+        ...Css.df.flexColumn.w100.maxw("550px").$,
         "& .DayPickerInput": Css.relative.$,
         // Copy/pasted from TextFieldBase to soften the border, fix our border/padding/height
         "& .DayPickerInput input": {
-          ...Css.add("resize", "none").bgWhite.wPx(width).sm.px1.hPx(40).gray900.br4.outline0.ba.bGray300.$,
+          ...Css.add("resize", "none").bgWhite.w100.sm.px1.hPx(40).gray900.br4.outline0.ba.bGray300.$,
           // Turn gray when disabled
           ...(disabled ? Css.gray400.bgGray100.cursorNotAllowed.$ : {}),
           ...(errorMsg ? Css.bRed600.$ : {}),


### PR DESCRIPTION
Making them behave width-wise like our other form fields:

![image](https://user-images.githubusercontent.com/6401/126016544-f11fd6c4-bf6b-4af1-bdca-c5eddbd45e54.png)

(We didn't have this width convention figured out yet with date field was written.)