### PR TITLE
fix: Update TextAreaField padding to match TextField.

### DIFF
--- a/src/inputs/TextAreaField.stories.tsx
+++ b/src/inputs/TextAreaField.stories.tsx
@@ -2,7 +2,7 @@ import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
 import { useMemo, useState } from "react";
 import { Css } from "src/Css";
-import { TextAreaField, TextAreaFieldProps } from "src/inputs";
+import { TextAreaField, TextAreaFieldProps, TextField } from "src/inputs";
 
 export default {
   component: TextAreaField,
@@ -24,6 +24,7 @@ export function TextAreas() {
           helperText="Some really long helper text that we expect to wrap."
         />
         <ValidationTextArea value="Not enough characters" />
+        <TextField label="Regular Field For Reference" value="value" onChange={() => {}} />
       </div>
     </div>
   );

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -85,7 +85,7 @@ export function TextFieldBase(props: TextFieldBaseProps) {
         css={{
           ...Css.add("resize", "none").bgWhite.sm.px1.hPx(40).gray900.br4.outline0.ba.bGray300.if(compact).hPx(32).$,
           ...xss,
-          ...Css.if(multiline).mh(px(96)).py1.px2.$,
+          ...Css.if(multiline).mh(px(96)).$,
           "&:focus": Css.bLightBlue700.$,
           "&:disabled": Css.gray400.bgGray100.cursorNotAllowed.$,
           ...(errorMsg ? Css.bRed600.$ : {}),

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -85,7 +85,7 @@ export function TextFieldBase(props: TextFieldBaseProps) {
         css={{
           ...Css.add("resize", "none").bgWhite.sm.px1.hPx(40).gray900.br4.outline0.ba.bGray300.if(compact).hPx(32).$,
           ...xss,
-          ...Css.if(multiline).mh(px(96)).$,
+          ...Css.if(multiline).mh(px(96)).py1.$,
           "&:focus": Css.bLightBlue700.$,
           "&:disabled": Css.gray400.bgGray100.cursorNotAllowed.$,
           ...(errorMsg ? Css.bRed600.$ : {}),


### PR DESCRIPTION
When looking at a screen that has both regular `TextField`s as well as `TextAreaField`s it looked weird that the `TextAreaField`'s content was indented more than the regular text fields.