### PR TITLE
feat: Call OpenInDrawerOpts.onClose after close has happened.

### DIFF
--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -3,33 +3,34 @@ import { OverlayProvider } from "react-aria";
 import { Modal, ModalProps } from "src/components/Modal/Modal";
 import { SuperDrawer } from "src/components/SuperDrawer/SuperDrawer";
 import { ContentStack } from "src/components/SuperDrawer/useSuperDrawer";
+import { CheckFn } from "src/types";
 import { EmptyRef } from "src/utils/index";
 
 /** The internal state of our Beam context; see useModal and useSuperDrawer for the public APIs. */
 export interface BeamContextState {
-  // SuperDrawer contentStack
-  contentStack: MutableRefObject<readonly ContentStack[]>;
   modalState: MutableRefObject<ModalProps | undefined>;
-  canCloseModalChecks: MutableRefObject<Array<() => boolean>>;
+  modalCanCloseChecks: MutableRefObject<CheckFn[]>;
   /** The div for ModalBody to portal into; note this can't be a ref b/c Modal hasn't set the ref at the time ModalBody renders. */
   modalBodyDiv: HTMLDivElement;
   /** The div for ModalFooter to portal into. */
   modalFooterDiv: HTMLDivElement;
-  /** Checks when closing SuperDrawer */
-  canCloseDrawerChecks: MutableRefObject<Array<() => boolean>>;
-  /** Checks when closing SuperDrawer Details */
-  canCloseDrawerDetailsChecks: MutableRefObject<Array<Array<() => boolean>>>;
+  /** SuperDrawer contentStack, i.e. the main/non-detail content + 0-N detail contents. */
+  drawerContentStack: MutableRefObject<readonly ContentStack[]>;
+  /** Checks when closing SuperDrawer, for the main/non-detail drawer content. */
+  drawerCanCloseChecks: MutableRefObject<CheckFn[]>;
+  /** Checks when closing SuperDrawer Details, a double array to keep per-detail lists. */
+  drawerCanCloseDetailsChecks: MutableRefObject<CheckFn[][]>;
 }
 
 /** This is only exported internally, for useModal and useSuperDrawer, it's not a public API. */
 export const BeamContext = createContext<BeamContextState>({
-  contentStack: new EmptyRef(),
   modalState: new EmptyRef(),
-  canCloseModalChecks: new EmptyRef(),
+  modalCanCloseChecks: new EmptyRef(),
   modalBodyDiv: undefined!,
   modalFooterDiv: undefined!,
-  canCloseDrawerChecks: new EmptyRef(),
-  canCloseDrawerDetailsChecks: new EmptyRef(),
+  drawerContentStack: new EmptyRef(),
+  drawerCanCloseChecks: new EmptyRef(),
+  drawerCanCloseDetailsChecks: new EmptyRef(),
 });
 
 export function BeamProvider({ children }: { children: ReactNode }) {
@@ -40,24 +41,25 @@ export function BeamProvider({ children }: { children: ReactNode }) {
   const [, tick] = useReducer((prev) => prev + 1, 0);
   const modalRef = useRef<ModalProps | undefined>();
   const modalBodyDiv = useMemo(() => document.createElement("div"), []);
+  const modalCanCloseChecksRef = useRef<CheckFn[]>([]);
   const modalFooterDiv = useMemo(() => document.createElement("div"), []);
-  const contentStackRef = useRef<ContentStack[]>([]);
-  const canCloseModalChecksRef = useRef<Array<() => boolean>>([]);
-  const canCloseDrawerChecksRef = useRef<Array<() => boolean>>([]);
-  const canCloseDrawerDetailsChecksRef = useRef<Array<Array<() => boolean>>>([]);
+  const drawerContentStackRef = useRef<ContentStack[]>([]);
+  const drawerCanCloseChecks = useRef<CheckFn[]>([]);
+  const drawerCanCloseDetailsChecks = useRef<CheckFn[][]>([]);
 
   // We essentially expose the refs, but with our own getters/setters so that we can
   // have the setters call `tick` to re-render this Provider
   const context = useMemo<BeamContextState>(() => {
     return {
+      // These two keys need to trigger re-renders on change
       modalState: new PretendRefThatTicks(modalRef, tick),
-      contentStack: new PretendRefThatTicks(contentStackRef, tick),
-      // We don't need to rerender when these are mutated, so just expose as-is
+      drawerContentStack: new PretendRefThatTicks(drawerContentStackRef, tick),
+      // The rest we don't need to re-render when these are mutated, so just expose as-is
+      modalCanCloseChecks: modalCanCloseChecksRef,
       modalBodyDiv,
       modalFooterDiv,
-      canCloseModalChecks: canCloseModalChecksRef,
-      canCloseDrawerChecks: canCloseDrawerChecksRef,
-      canCloseDrawerDetailsChecks: canCloseDrawerDetailsChecksRef,
+      drawerCanCloseChecks,
+      drawerCanCloseDetailsChecks,
     };
   }, [modalBodyDiv, modalFooterDiv]);
 
@@ -67,7 +69,7 @@ export function BeamProvider({ children }: { children: ReactNode }) {
       <OverlayProvider>
         {children}
         {/*If the drawer is open, assume it will show modal content internally. */}
-        {modalRef.current && contentStackRef.current.length === 0 && <Modal {...modalRef.current} />}
+        {modalRef.current && drawerContentStackRef.current.length === 0 && <Modal {...modalRef.current} />}
       </OverlayProvider>
       <SuperDrawer />
     </BeamContext.Provider>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -33,7 +33,7 @@ export interface ModalProps {
 export function Modal(props: ModalProps) {
   const { title, size = "md", content, forceScrolling } = props;
   const ref = useRef(null);
-  const { modalBodyDiv, modalFooterDiv, contentStack } = useContext(BeamContext);
+  const { modalBodyDiv, modalFooterDiv, drawerContentStack } = useContext(BeamContext);
   const { closeModal } = ourUseModal();
   const { overlayProps, underlayProps } = useOverlay(
     { ...props, isOpen: true, onClose: closeModal, isDismissable: true },
@@ -61,7 +61,7 @@ export function Modal(props: ModalProps) {
   // use refs + useEffect to stitch those raw divs back into the React component tree.
   useEffect(() => {
     // If the superdrawer is open, let it own the modal content
-    if (contentStack.current.length > 0) {
+    if (drawerContentStack.current.length > 0) {
       return;
     }
     modalBodyRef.current!.appendChild(modalBodyDiv);

--- a/src/components/SuperDrawer/SuperDrawer.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.tsx
@@ -28,7 +28,7 @@ import { useTestIds } from "src/utils";
  * above the SuperDrawer.
  */
 export function SuperDrawer(): ReactPortal | null {
-  const { contentStack, modalState, modalBodyDiv, modalFooterDiv } = useContext(BeamContext);
+  const { drawerContentStack: contentStack, modalState, modalBodyDiv, modalFooterDiv } = useContext(BeamContext);
   const { closeDrawer } = useSuperDrawer();
   const modalBodyRef = useRef<HTMLDivElement | null>(null);
   const modalFooterRef = useRef<HTMLDivElement | null>(null);

--- a/src/components/SuperDrawer/SuperDrawerContent.tsx
+++ b/src/components/SuperDrawer/SuperDrawerContent.tsx
@@ -25,7 +25,7 @@ interface SuperDrawerContentProps {
  */
 export const SuperDrawerContent = ({ children, actions }: SuperDrawerContentProps) => {
   const { closeDrawerDetail } = useSuperDrawer();
-  const { contentStack } = useContext(BeamContext);
+  const { drawerContentStack: contentStack } = useContext(BeamContext);
 
   // Determine if the current element is a new content element or an detail element
   const { kind } = contentStack.current[contentStack.current.length - 1];

--- a/src/components/SuperDrawer/useSuperDrawer.test.tsx
+++ b/src/components/SuperDrawer/useSuperDrawer.test.tsx
@@ -65,7 +65,7 @@ describe("useSuperDrawer", () => {
     act(() => superDrawerHook.addCanCloseDrawerCheck(() => true));
 
     // Then expect no canCloseDrawerCheck to be added
-    expect(beamHook.canCloseDrawerChecks.current).toHaveLength(0);
+    expect(beamHook.drawerCanCloseChecks.current).toHaveLength(0);
   });
 
   it("should add canCloseDrawerCheckDetail when SuperDrawer details is opened", () => {
@@ -102,7 +102,7 @@ describe("useSuperDrawer", () => {
     act(() => superDrawerHook.addCanCloseDrawerDetailCheck(() => true));
 
     // Then expect the canCloseDrawerDetailChecks to be empty
-    expect(beamHook.canCloseDrawerDetailsChecks.current).toHaveLength(0);
+    expect(beamHook.drawerCanCloseDetailsChecks.current).toHaveLength(0);
   });
 
   it("should show ConfirmCloseModal when a canCloseDrawerCheck fails", async () => {
@@ -132,6 +132,22 @@ describe("useSuperDrawer", () => {
 
     // Then expect the drawer to not close.
     expect(hook.closeDrawer()).toBeFalsy();
+  });
+
+  it("calls onClose when closed", () => {
+    const onClose = jest.fn();
+
+    // Given the useSuperDrawer hook
+    const hook = renderHook(useSuperDrawer, { wrapper }).result.current;
+
+    // When the drawer is opened and closed
+    act(() => hook.openInDrawer({ title: "title", content: "content", onClose }));
+    act(() => {
+      hook.closeDrawer();
+    });
+
+    // Then we called the callback
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
 export type HasIdAndName<V> = { id: V; name: string };
 export type Optional<T, K extends keyof T> = Omit<T, K> & Partial<T>;
 export type Callback = () => void;
+export type CheckFn = () => boolean;


### PR DESCRIPTION
I'm playing with open/closing the drawer based on routes, i.e. `/requests/preq:1` would auto-open the drawer to `preq:1`.

It's basically working, but I need a way to know "the drawer is closed" to change the history from `/requests/preq:1` back to just `/requests`.

Ironically, this is re-using `onClose` that was originally added for the "can I close" confirmation that we re-purposed into `addOnCloseCheck` or what not, but as a "close has actually happened".