### PR TITLE
feat: Add nothingSelectedText to customize All behavior.

### DIFF
--- a/src/components/Filters/utils.tsx
+++ b/src/components/Filters/utils.tsx
@@ -82,6 +82,7 @@ export function getFilterComponents<F>(props: GetFilterComponentsOpts<F>) {
           inlineLabel
           sizeToContent={!inModal}
           onSelect={(values) => updateFilter(filter, key, values)}
+          nothingSelectedText="All"
         />,
         inModal,
         filterDef.label,

--- a/src/inputs/MultiSelectField.test.tsx
+++ b/src/inputs/MultiSelectField.test.tsx
@@ -1,6 +1,7 @@
-import { click, input, render } from "@homebound/rtl-utils";
+import { click, input, render, RenderResult } from "@homebound/rtl-utils";
 import { useState } from "react";
-import { MultiSelectField, MultiSelectFieldProps, Value } from "src/inputs";
+import { MultiSelectField, MultiSelectFieldProps } from "src/inputs";
+import { HasIdAndName, Optional } from "src/types";
 
 const options = [
   { id: "1", name: "One" },
@@ -12,31 +13,48 @@ describe("MultiSelectFieldTest", () => {
   const onSelect = jest.fn();
 
   it("can set a value", async () => {
-    // Given a MultiSelectField
-    const { getByRole } = await render(
-      <TestMultiSelectField
-        label="Age"
-        values={["1"] as string[]}
-        options={options}
-        getOptionLabel={(o) => o.name}
-        getOptionValue={(o) => o.id}
-      />,
-    );
+    // Given a MultiSelectField with 1 selected value
+    const r = await render(<TestMultiSelectField values={["1"] as string[]} options={options} />);
     // That initially has "One" selected
-    const text = getByRole("combobox");
-    expect(text).toHaveValue("One");
+    expect(r.getByRole("combobox")).toHaveValue("One");
     // When we select the 3rd option
-    text.focus();
-    input(text, "");
-    click(getByRole("option", { name: "Three" }));
+    selectOption(r, "Three");
     // Then onSelect was called
     expect(onSelect).toHaveBeenCalledWith(["1", "3"]);
   });
 
-  function TestMultiSelectField<O, V extends Value>(props: Omit<MultiSelectFieldProps<O, V>, "onSelect">): JSX.Element {
-    const [selected, setSelected] = useState<V[]>(props.values);
+  it("has an empty text box not set", async () => {
+    // Given a MultiSelectField with no selected values
+    const { getByRole } = await render(<TestMultiSelectField values={[]} options={options} />);
+    // That initially has "One" selected
+    const text = getByRole("combobox");
+    expect(text).toHaveValue("");
+  });
+
+  it("can have custom an empty text", async () => {
+    // Given a MultiSelectField with no selected values
+    const r = await render(<TestMultiSelectField values={[]} options={options} nothingSelectedText="All" />);
+    // That initially has "One" selected
+    const text = r.getByRole("combobox");
+    expect(text).toHaveValue("All");
+    // And when we select the first option
+    selectOption(r, "One");
+    // Then it changes to that one
+    expect(text).toHaveValue("One");
+  });
+
+  function TestMultiSelectField(
+    props: Optional<
+      MultiSelectFieldProps<HasIdAndName<string>, string>,
+      "label" | "onSelect" | "getOptionLabel" | "getOptionValue"
+    >,
+  ): JSX.Element {
+    const [selected, setSelected] = useState(props.values);
     return (
-      <MultiSelectField<O, V>
+      <MultiSelectField
+        label="Age"
+        getOptionLabel={(o) => o.name}
+        getOptionValue={(o) => o.id}
         {...props}
         values={selected}
         onSelect={(values) => {
@@ -47,3 +65,10 @@ describe("MultiSelectFieldTest", () => {
     );
   }
 });
+
+function selectOption(r: RenderResult, name: string): void {
+  const text = r.getByRole("combobox");
+  text.focus();
+  input(text, "");
+  click(r.getByRole("option", { name }));
+}

--- a/src/inputs/SelectField.test.tsx
+++ b/src/inputs/SelectField.test.tsx
@@ -1,0 +1,49 @@
+import { click, input, render } from "@homebound/rtl-utils";
+import { useState } from "react";
+import { SelectField, SelectFieldProps, Value } from "src/inputs";
+
+const options = [
+  { id: "1", name: "One" },
+  { id: "2", name: "Two" },
+  { id: "3", name: "Three" },
+];
+
+describe("SelectFieldTest", () => {
+  const onSelect = jest.fn();
+
+  it("can set a value", async () => {
+    // Given a MultiSelectField
+    const { getByRole } = await render(
+      <TestSelectField
+        label="Age"
+        value={"1"}
+        options={options}
+        getOptionLabel={(o) => o.name}
+        getOptionValue={(o) => o.id}
+      />,
+    );
+    // That initially has "One" selected
+    const text = getByRole("combobox");
+    expect(text).toHaveValue("One");
+    // When we select the 3rd option
+    text.focus();
+    input(text, "");
+    click(getByRole("option", { name: "Three" }));
+    // Then onSelect was called
+    expect(onSelect).toHaveBeenCalledWith("3");
+  });
+
+  function TestSelectField<O, V extends Value>(props: Omit<SelectFieldProps<O, V>, "onSelect">): JSX.Element {
+    const [selected, setSelected] = useState<V | undefined>(props.value);
+    return (
+      <SelectField<O, V>
+        {...props}
+        value={selected}
+        onSelect={(value) => {
+          onSelect(value);
+          setSelected(value);
+        }}
+      />
+    );
+  }
+});

--- a/src/inputs/internal/SelectFieldBase.tsx
+++ b/src/inputs/internal/SelectFieldBase.tsx
@@ -58,6 +58,7 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
     getOptionMenuLabel = getOptionLabel,
     sizeToContent = false,
     values,
+    nothingSelectedText = "",
     ...otherProps
   } = props;
 
@@ -76,7 +77,7 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
       setFieldState({
         ...fieldState,
         isOpen: true,
-        inputValue: "All",
+        inputValue: nothingSelectedText,
         selectedKeys: [],
         selectedOptions: [],
       });
@@ -131,7 +132,7 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
         selectedOptions.length === 1
           ? getOptionLabel(selectedOptions[0])
           : multiselect && selectedOptions.length === 0
-          ? "All"
+          ? nothingSelectedText
           : "",
       filteredOptions: options,
       selectedOptions: selectedOptions,
@@ -285,4 +286,6 @@ export interface BeamSelectFieldBaseProps<T> extends BeamFocusableProps {
   onBlur?: () => void;
   onFocus?: () => void;
   sizeToContent?: boolean;
+  /** The text to show when nothing is selected, i.e. could be "All" for filters. */
+  nothingSelectedText?: string;
 }


### PR DESCRIPTION
The "All" behavior was hard-coded for filters and not something we want for like editing in a form.