### PR TITLE
feat: Add BoundSwitchField, FormLines.

### DIFF
--- a/src/forms/BoundSwitchField.tsx
+++ b/src/forms/BoundSwitchField.tsx
@@ -1,0 +1,37 @@
+import { FieldState } from "@homebound/form-state";
+import { Observer } from "mobx-react";
+import { Switch, SwitchProps } from "src/inputs";
+import { useTestIds } from "src/utils";
+import { defaultLabel } from "src/utils/defaultLabel";
+
+export type BoundSwitchFieldProps = Omit<SwitchProps, "selected" | "onChange" | "label" | "labelStyle"> & {
+  field: FieldState<any, boolean | null | undefined>;
+  /** Make optional so that callers can override if they want to. */
+  onChange?: (value: boolean) => void;
+  label?: string;
+};
+
+/** Wraps `Switch` and binds it to a form field. */
+export function BoundSwitchField(props: BoundSwitchFieldProps) {
+  const { field, onChange = (value) => field.set(value), label = defaultLabel(field.key), ...others } = props;
+  const testId = useTestIds(props, field.key);
+  return (
+    <Observer>
+      {() => (
+        <Switch
+          label={label}
+          labelStyle="form"
+          selected={field.value ?? false}
+          onChange={(selected) => {
+            // We are triggering blur manually for checkbox fields due to its transactional nature
+            onChange(selected);
+            field.blur();
+          }}
+          // errorMsg={field.touched ? field.errors.join(" ") : undefined}
+          {...testId}
+          {...others}
+        />
+      )}
+    </Observer>
+  );
+}

--- a/src/forms/BoundSwitchFieldTest.tsx
+++ b/src/forms/BoundSwitchFieldTest.tsx
@@ -1,0 +1,32 @@
+import { createObjectState, ObjectConfig, required } from "@homebound/form-state";
+import { click, render } from "@homebound/rtl-utils";
+import { BoundSwitchField } from "src/forms";
+import { AuthorInput } from "src/forms/formStateDomain";
+
+describe("BoundSwitchField", () => {
+  it("should be checked", async () => {
+    // Given a formState with true boolean field
+    const formState = createObjectState(formConfig, { isAvailable: true });
+    // When rendered
+    const r = await render(<BoundSwitchField field={formState.isAvailable} />);
+    // Expect the BoundSwitchField to be checked
+    expect(r.isAvailable()).toBeChecked();
+  });
+
+  it("should uncheck when clicked", async () => {
+    // Given a rendered checked BoundSwitchField
+    const formState = createObjectState(formConfig, { isAvailable: true });
+    const { isAvailable } = await render(<BoundSwitchField field={formState.isAvailable} />);
+
+    // When interacting with a BoundSwitchField
+    click(isAvailable());
+
+    // Then expect the checkbox to be unchecked and the formState to reflect that state
+    expect(isAvailable()).not.toBeChecked();
+    expect(formState.isAvailable.value).toBeFalsy();
+  });
+});
+
+const formConfig: ObjectConfig<AuthorInput> = {
+  isAvailable: { type: "value", rules: [required] },
+};

--- a/src/forms/FormLines.stories.tsx
+++ b/src/forms/FormLines.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { FormLines } from "src/forms/FormLines";
+import { FieldGroup, FormLines } from "src/forms/FormLines";
 import { TextField } from "src/inputs/TextField";
 
 export default {
@@ -28,17 +28,17 @@ export function SmallFlatList() {
 export function SideBySide() {
   return (
     <FormLines>
-      {[
-        <TextField key="a" label={"First"} value={"first"} onChange={() => {}} />,
-        <TextField key="b" label={"Middle"} value={"middle"} onChange={() => {}} />,
-      ]}
+      <FieldGroup>
+        <TextField label={"First"} value={"first"} onChange={() => {}} />
+        <TextField label={"Middle"} value={"middle"} onChange={() => {}} />
+      </FieldGroup>
       <TextField label="Address" value="123 Main" onChange={() => {}} />
       {/* Having three is too wide, so not supported.*/}
-      {[
-        <TextField key="a" label={"First"} value={"first"} onChange={() => {}} />,
-        <TextField key="b" label={"Middle"} value={"middle"} onChange={() => {}} />,
-        <TextField key="c" label={"Last"} value={"last"} onChange={() => {}} />,
-      ]}
+      <FieldGroup>
+        <TextField label={"First"} value={"first"} onChange={() => {}} />
+        <TextField label={"Middle"} value={"middle"} onChange={() => {}} />
+        <TextField label={"Last"} value={"last"} onChange={() => {}} />
+      </FieldGroup>
     </FormLines>
   );
 }

--- a/src/forms/FormLines.stories.tsx
+++ b/src/forms/FormLines.stories.tsx
@@ -1,0 +1,44 @@
+import { Meta } from "@storybook/react";
+import { FormLines } from "src/forms/FormLines";
+import { TextField } from "src/inputs/TextField";
+
+export default {
+  component: FormLines,
+  title: "Forms/Form Lines",
+} as Meta;
+
+export function FlatList() {
+  return (
+    <FormLines>
+      <TextField label={"First"} value={"first"} onChange={() => {}} />
+      <TextField label={"Last"} value={"last"} onChange={() => {}} />
+    </FormLines>
+  );
+}
+
+export function SmallFlatList() {
+  return (
+    <FormLines width="sm">
+      <TextField label={"First"} value={"first"} onChange={() => {}} />
+      <TextField label={"Last"} value={"last"} onChange={() => {}} />
+    </FormLines>
+  );
+}
+
+export function SideBySide() {
+  return (
+    <FormLines>
+      {[
+        <TextField key="a" label={"First"} value={"first"} onChange={() => {}} />,
+        <TextField key="b" label={"Middle"} value={"middle"} onChange={() => {}} />,
+      ]}
+      <TextField label="Address" value="123 Main" onChange={() => {}} />
+      {/* Having three is too wide, so not supported.*/}
+      {[
+        <TextField key="a" label={"First"} value={"first"} onChange={() => {}} />,
+        <TextField key="b" label={"Middle"} value={"middle"} onChange={() => {}} />,
+        <TextField key="c" label={"Last"} value={"last"} onChange={() => {}} />,
+      ]}
+    </FormLines>
+  );
+}

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -1,7 +1,7 @@
 import { Css } from "src/Css";
 
 export interface FormLinesProps {
-  /** Let the user inter-leave group-less lines and grouped lines. */
+  /** Let the user interleave group-less lines and grouped lines. */
   children: JSX.Element[];
   width?: "md" | "sm";
 }
@@ -9,10 +9,8 @@ export interface FormLinesProps {
 /**
  * Applies standard Form layout/size/spacing between lines.
  *
- * Lines can either be individual form fields, or a group of form
- * fields, where they will be laid out side-by-side.
- *
- * TODO: Promote this to Beam?
+ * Lines can either be individual form fields, or a group of form fields
+ * (see the `FieldGroup` component), where they will be laid out side-by-side.
  */
 export function FormLines(props: FormLinesProps) {
   const { children, width = "md" } = props;
@@ -35,6 +33,7 @@ export function FieldGroup(props: {
   title?: string;
   children: JSX.Element[];
 }) {
+  // TODO Actually use title
   const { title, children } = props;
   return <div css={Css.df.childGap2.$}>{children}</div>;
 }

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -1,27 +1,10 @@
-import { Fragment } from "react";
 import { Css } from "src/Css";
-
-type Field = JSX.Element;
-
-/** Either a field all by itself or multiple fields on a line. */
-type FormLine = Field | Field[];
-
-export interface FieldGroup {
-  /** The legend/title for this group. */
-  title: string;
-  lines: FormLine[];
-}
 
 export interface FormLinesProps {
   /** Let the user inter-leave group-less lines and grouped lines. */
-  children: Array<FormLine | FieldGroup>;
+  children: JSX.Element[];
   width?: "md" | "sm";
 }
-
-const sizes: Record<"md" | "sm", number> = {
-  md: 480, // normal full-page size
-  sm: 320, // works well in a modal
-};
 
 /**
  * Applies standard Form layout/size/spacing between lines.
@@ -41,23 +24,22 @@ export function FormLines(props: FormLinesProps) {
         "& > *": Css.mb3.$,
       }}
     >
-      {children.map((field, i) => {
-        if (field instanceof Array) {
-          // This is an array of form lines, split evenly, i.e. as 50/50, 33/33/34, etc.
-          return (
-            <div key={i} css={Css.df.childGap2.$}>
-              {field.map((f, i) => (
-                <div key={i} css={Css.fb1.$}>
-                  {f}
-                </div>
-              ))}
-            </div>
-          );
-        } else {
-          // This is a form line by itself
-          return <Fragment key={i}>{field}</Fragment>;
-        }
-      })}
+      {children}
     </div>
   );
 }
+
+/** Groups multiple fields side-by-side. */
+export function FieldGroup(props: {
+  /** The legend/title for this group. */
+  title?: string;
+  children: JSX.Element[];
+}) {
+  const { title, children } = props;
+  return <div css={Css.df.childGap2.$}>{children}</div>;
+}
+
+const sizes: Record<"md" | "sm", number> = {
+  md: 480, // normal full-page size
+  sm: 320, // works well in a modal
+};

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -1,0 +1,63 @@
+import { Fragment } from "react";
+import { Css } from "src/Css";
+
+type Field = JSX.Element;
+
+/** Either a field all by itself or multiple fields on a line. */
+type FormLine = Field | Field[];
+
+export interface FieldGroup {
+  /** The legend/title for this group. */
+  title: string;
+  lines: FormLine[];
+}
+
+export interface FormLinesProps {
+  /** Let the user inter-leave group-less lines and grouped lines. */
+  children: Array<FormLine | FieldGroup>;
+  width?: "md" | "sm";
+}
+
+const sizes: Record<"md" | "sm", number> = {
+  md: 480, // normal full-page size
+  sm: 320, // works well in a modal
+};
+
+/**
+ * Applies standard Form layout/size/spacing between lines.
+ *
+ * Lines can either be individual form fields, or a group of form
+ * fields, where they will be laid out side-by-side.
+ *
+ * TODO: Promote this to Beam?
+ */
+export function FormLines(props: FormLinesProps) {
+  const { children, width = "md" } = props;
+  return (
+    <div
+      css={{
+        ...Css.df.flexColumn.wPx(sizes[width]).$,
+        // Purposefully use this instead of childGap3 to put margin-bottom on the last line
+        "& > *": Css.mb3.$,
+      }}
+    >
+      {children.map((field, i) => {
+        if (field instanceof Array) {
+          // This is an array of form lines, split evenly, i.e. as 50/50, 33/33/34, etc.
+          return (
+            <div key={i} css={Css.df.childGap2.$}>
+              {field.map((f, i) => (
+                <div key={i} css={Css.fb1.$}>
+                  {f}
+                </div>
+              ))}
+            </div>
+          );
+        } else {
+          // This is a form line by itself
+          return <Fragment key={i}>{field}</Fragment>;
+        }
+      })}
+    </div>
+  );
+}

--- a/src/forms/FormStateApp.tsx
+++ b/src/forms/FormStateApp.tsx
@@ -11,8 +11,17 @@ import {
   SimpleHeaderAndDataWith,
 } from "src/components";
 import { Css } from "src/Css";
-import { BoundDateField, BoundMultiSelectField, BoundNumberField, BoundSelectField, BoundTextField, BoundToggleChipGroupField } from "src/forms";
+import {
+  BoundDateField,
+  BoundMultiSelectField,
+  BoundNumberField,
+  BoundSelectField,
+  BoundSwitchField,
+  BoundTextField,
+  BoundToggleChipGroupField,
+} from "src/forms";
 import { BoundCheckboxGroupField } from "src/forms/BoundCheckboxGroupField";
+import { FormLines } from "src/forms/FormLines";
 import { AuthorInput } from "src/forms/formStateDomain";
 import { useComputed } from "src/hooks";
 import { CheckboxGroupItemOption } from "src/inputs";
@@ -62,19 +71,19 @@ export function FormStateApp() {
   ];
 
   const animals = [
-    { value:"a:1", label: "Cat" },
-    { value:"a:2", label: "Dog" },
-    { value:"a:3", label: "Fish" },
-    { value:"a:4", label: "Iguana" },
-    { value:"a:5", label: "Turtle" },
-  ]
+    { value: "a:1", label: "Cat" },
+    { value: "a:2", label: "Dog" },
+    { value: "a:3", label: "Fish" },
+    { value: "a:4", label: "Iguana" },
+    { value: "a:5", label: "Turtle" },
+  ];
 
   return (
     <Observer>
       {() => (
         <div>
           <header>
-            <div>
+            <FormLines>
               <b>Author</b>
               <BoundTextField field={formState.firstName} />
               <BoundTextField field={formState.lastName} />
@@ -85,7 +94,8 @@ export function FormStateApp() {
               <BoundMultiSelectField field={formState.favoriteShapes} options={shapes} />
               <BoundCheckboxGroupField field={formState.favoriteColors} options={colors} />
               <BoundToggleChipGroupField field={formState.animals} options={animals} />
-            </div>
+              <BoundSwitchField field={formState.isAvailable} />
+            </FormLines>
 
             <div>
               <strong>
@@ -152,4 +162,5 @@ export const formConfig: ObjectConfig<AuthorInput> = {
     },
   },
   animals: { type: "value", rules: [required] },
+  isAvailable: { type: "value" },
 };

--- a/src/forms/index.ts
+++ b/src/forms/index.ts
@@ -6,6 +6,7 @@ export * from "./BoundNumberField";
 export * from "./BoundRadioGroupField";
 export * from "./BoundRichTextField";
 export * from "./BoundSelectField";
+export * from "./BoundSwitchField";
 export * from "./BoundTextAreaField";
 export * from "./BoundTextField";
 export * from "./BoundToggleChipGroupField";

--- a/src/inputs/Switch.tsx
+++ b/src/inputs/Switch.tsx
@@ -1,7 +1,8 @@
 import { useRef } from "react";
 import { useFocusRing, useHover, useSwitch, VisuallyHidden } from "react-aria";
-import { Palette } from "../Css";
-import { Css, Icon } from "../index";
+import { Label } from "src/components/Label";
+import { Css, Palette } from "src/Css";
+import { Icon } from "../components/Icon";
 import { toToggleState } from "../utils";
 
 export interface SwitchProps {
@@ -13,6 +14,8 @@ export interface SwitchProps {
   disabled?: boolean;
   /** Input label */
   label: string;
+  /** Where to put the label. */
+  labelStyle?: "form" | "inline";
   /** Handler when the interactive element state changes. */
   onChange: (value: boolean) => void;
   /** Whether the switch is selected */
@@ -28,7 +31,8 @@ export function Switch(props: SwitchProps) {
     onChange,
     withIcon,
     compact = false,
-    label,
+    label = "inline",
+    labelStyle,
     ...otherProps
   } = props;
   const ariaProps = { isSelected, isDisabled, ...otherProps };
@@ -42,19 +46,22 @@ export function Switch(props: SwitchProps) {
     <label
       {...hoverProps}
       css={{
-        ...switchLabelDefaultStyles,
-        ...(isDisabled && switchLabelDisabledStyles),
+        ...Css.relative.cursorPointer.df.w("max-content").smEm.selectNone.$,
+        ...(labelStyle === "form" && Css.flexColumn.$),
+        ...(labelStyle === "inline" && Css.childGap2.itemsCenter.$),
+        ...(isDisabled && Css.cursorNotAllowed.gray400.$),
       }}
     >
+      {labelStyle === "form" && <Label label={label} />}
       {/* Background */}
       <div
         aria-hidden="true"
         css={{
-          ...switchDefaultStyles(compact),
+          ...Css.wPx(toggleWidth(compact)).hPx(toggleHeight(compact)).bgGray200.br12.relative.transition.$,
           ...(isHovered && switchHoverStyles),
           ...(isKeyboardFocus && switchFocusStyles),
-          ...(isDisabled && switchDisabledStyles),
-          ...(isSelected && switchSelectedStyles),
+          ...(isDisabled && Css.bgGray300.$),
+          ...(isSelected && Css.bgLightBlue700.$),
           ...(isSelected && isHovered && switchSelectedHoverStyles),
         }}
       >
@@ -62,7 +69,7 @@ export function Switch(props: SwitchProps) {
         <div
           css={{
             ...switchCircleDefaultStyles(compact),
-            ...(isDisabled && switchCircleDisabledStyles),
+            ...(isDisabled && Css.bgGray100.$),
             ...(isSelected && switchCircleSelectedStyles(compact)),
           }}
         >
@@ -74,7 +81,16 @@ export function Switch(props: SwitchProps) {
       </div>
       {/* Since we are using childGap, we must wrap the label in an element and
       match the height of the icon for horizontal alignment */}
-      <span css={switchTextStyles(compact)}>{label}</span>
+      {label === "inline" && (
+        <span
+          css={{
+            // LineHeight is conditionally applied to handle compact version text alignment
+            ...Css.hPx(toggleHeight(compact)).if(compact).add("lineHeight", "1").$,
+          }}
+        >
+          {label}
+        </span>
+      )}
       <VisuallyHidden>
         <input ref={ref} {...inputProps} {...focusProps} />
       </VisuallyHidden>
@@ -88,17 +104,9 @@ const toggleHeight = (isCompact: boolean) => (isCompact ? 16 : 24);
 const toggleWidth = (isCompact: boolean) => (isCompact ? 44 : 40);
 const circleDiameter = (isCompact: boolean) => (isCompact ? 14 : 20);
 
-// Label styles
-const switchLabelDefaultStyles = Css.relative.cursorPointer.df.itemsCenter.childGap2.w("max-content").smEm.selectNone.$;
-const switchLabelDisabledStyles = Css.cursorNotAllowed.gray400.$;
-
 // Switcher/Toggle element styles
-const switchDefaultStyles = (isCompact: boolean) =>
-  Css.wPx(toggleWidth(isCompact)).hPx(toggleHeight(isCompact)).bgGray200.br12.relative.transition.$;
 export const switchHoverStyles = Css.bgGray400.$;
 export const switchFocusStyles = Css.bshFocus.$;
-const switchDisabledStyles = Css.bgGray300.$;
-const switchSelectedStyles = Css.bgLightBlue700.$;
 export const switchSelectedHoverStyles = Css.bgLightBlue900.$;
 
 // Circle inside Switcher/Toggle element styles
@@ -106,10 +114,9 @@ const switchCircleDefaultStyles = (isCompact: boolean) => ({
   ...Css.wPx(circleDiameter(isCompact))
     .hPx(circleDiameter(isCompact))
     .br100.bgWhite.bshBasic.absolute.leftPx(2)
-    .topPx(isCompact ? 1 : 2).transition.df.itemsCenter.justifyCenter.$,
+    .topPx(isCompact ? 1 : 2).transition.$,
   svg: Css.hPx(toggleHeight(isCompact) / 2).wPx(toggleHeight(isCompact) / 2).$,
 });
-const switchCircleDisabledStyles = Css.bgGray100.$;
 
 /**
  * Affecting the `left` property due to transitions only working when there is
@@ -122,7 +129,3 @@ const switchCircleDisabledStyles = Css.bgGray100.$;
  */
 const switchCircleSelectedStyles = (isCompact: boolean) =>
   Css.left(`calc(100% - ${circleDiameter(isCompact)}px - 2px);`).$;
-
-const switchTextStyles = (isCompact: boolean) =>
-  // LineHeight is conditionally applied to handle compact version text alignment
-  Css.hPx(toggleHeight(isCompact)).if(isCompact).add("lineHeight", "1").$;

--- a/src/inputs/Switch.tsx
+++ b/src/inputs/Switch.tsx
@@ -31,8 +31,8 @@ export function Switch(props: SwitchProps) {
     onChange,
     withIcon,
     compact = false,
-    label = "inline",
-    labelStyle,
+    label,
+    labelStyle = "inline",
     ...otherProps
   } = props;
   const ariaProps = { isSelected, isDisabled, ...otherProps };
@@ -81,7 +81,7 @@ export function Switch(props: SwitchProps) {
       </div>
       {/* Since we are using childGap, we must wrap the label in an element and
       match the height of the icon for horizontal alignment */}
-      {label === "inline" && (
+      {labelStyle === "inline" && (
         <span
           css={{
             // LineHeight is conditionally applied to handle compact version text alignment

--- a/src/inputs/Switch.tsx
+++ b/src/inputs/Switch.tsx
@@ -114,7 +114,7 @@ const switchCircleDefaultStyles = (isCompact: boolean) => ({
   ...Css.wPx(circleDiameter(isCompact))
     .hPx(circleDiameter(isCompact))
     .br100.bgWhite.bshBasic.absolute.leftPx(2)
-    .topPx(isCompact ? 1 : 2).transition.$,
+    .topPx(isCompact ? 1 : 2).transition.df.itemsCenter.justifyCenter.$,
   svg: Css.hPx(toggleHeight(isCompact) / 2).wPx(toggleHeight(isCompact) / 2).$,
 });
 

--- a/src/inputs/index.ts
+++ b/src/inputs/index.ts
@@ -5,6 +5,7 @@ export * from "./MultiSelectField";
 export * from "./NumberField";
 export { RadioFieldOption, RadioGroupField, RadioGroupFieldProps } from "./RadioGroupField";
 export * from "./SelectField";
+export * from "./Switch";
 export * from "./TextAreaField";
 export * from "./TextField";
 export * from "./ToggleChipGroup";


### PR DESCRIPTION
For Trade Partner Contact screens in internal-internal.

FormLines is kinda WIP, but figure it might as well be WIP here instead of copy/pasting it across internal-frontend and procurement-frontend.