### PR TITLE
feat: Form lines, widths, required labels

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,6 @@
 module.exports = {
   stories: ["../src/**/*.stories.tsx"],
-  addons: ["@storybook/addon-links", "@storybook/addon-essentials", "storybook-addon-performance/register"],
+  addons: ["@storybook/addon-links", "@storybook/addon-essentials"],
   // https://storybook.js.org/docs/react/configure/typescript#mainjs-configuration
   typescript: { check: false },
   webpackFinal: async (config) => {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,6 @@
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "semantic-release": "^17.4.0",
-    "storybook-addon-performance": "^0.16.0",
     "tinycolor2": "^1.4.1",
     "ts-jest": "^26.5.3",
     "ts-node": "^9.1.1",

--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -6,15 +6,18 @@ interface LabelProps {
   // We don't usually have `fooProps`-style props, but this is for/from react-aria
   labelProps?: LabelHTMLAttributes<HTMLLabelElement>;
   label: string;
+  suffix?: string;
   // If set, it is recommended to wrap in an element with `position: relative;` set, as the label will have an absolute position.
   hidden?: boolean;
 }
 
 /** An internal helper component for rendering form labels. */
-export function Label({ labelProps, label, hidden, ...others }: LabelProps) {
+export function Label(props: LabelProps) {
+  const { labelProps, label, hidden, suffix, ...others } = props;
   const labelEl = (
     <label {...labelProps} {...others} css={Css.dib.sm.gray700.mbPx(4).$}>
       {label}
+      {suffix && ` ${suffix}`}
     </label>
   );
   return hidden ? <VisuallyHidden>{labelEl}</VisuallyHidden> : labelEl;

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -4,12 +4,11 @@ import { Button, ModalProps, useModal } from "src/components/index";
 import { Modal } from "src/components/Modal/Modal";
 import { TestModalContent } from "src/components/Modal/TestModalContent";
 import { withBeamDecorator, withDimensions } from "src/utils/sb";
-import { withPerformance } from "storybook-addon-performance";
 
 export default {
   component: Modal,
   title: "Components/Modal",
-  decorators: [withPerformance, withBeamDecorator, withDimensions()],
+  decorators: [withBeamDecorator, withDimensions()],
 } as Meta;
 
 export const Small = () => <ModalExample size="sm" />;

--- a/src/forms/BoundDateField.tsx
+++ b/src/forms/BoundDateField.tsx
@@ -1,8 +1,5 @@
 import { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
-import { useContext } from "react";
-import { FormContext } from "src/forms/FormContext";
-import { getLabelSuffix } from "src/forms/labelUtils";
 import { DateField, DateFieldProps } from "src/inputs";
 import { useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
@@ -16,17 +13,16 @@ export type BoundDateFieldProps = Omit<DateFieldProps, "value" | "onChange" | "o
 /** Wraps `TextField` and binds it to a form field. */
 export function BoundDateField(props: BoundDateFieldProps) {
   const { field, onChange = (value) => field.set(value), label = defaultLabel(field.key), ...others } = props;
-  const settings = useContext(FormContext);
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
       {() => (
         <DateField
           label={label}
-          labelSuffix={getLabelSuffix(settings, field)}
           value={field.value || undefined}
           onChange={onChange}
           errorMsg={field.touched ? field.errors.join(" ") : undefined}
+          required={field.required}
           onBlur={() => field.blur()}
           onFocus={() => field.focus()}
           {...testId}

--- a/src/forms/BoundDateField.tsx
+++ b/src/forms/BoundDateField.tsx
@@ -1,5 +1,8 @@
 import { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
+import { useContext } from "react";
+import { FormContext } from "src/forms/FormContext";
+import { getLabelSuffix } from "src/forms/labelUtils";
 import { DateField, DateFieldProps } from "src/inputs";
 import { useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
@@ -13,12 +16,14 @@ export type BoundDateFieldProps = Omit<DateFieldProps, "value" | "onChange" | "o
 /** Wraps `TextField` and binds it to a form field. */
 export function BoundDateField(props: BoundDateFieldProps) {
   const { field, onChange = (value) => field.set(value), label = defaultLabel(field.key), ...others } = props;
+  const settings = useContext(FormContext);
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
       {() => (
         <DateField
           label={label}
+          labelSuffix={getLabelSuffix(settings, field)}
           value={field.value || undefined}
           onChange={onChange}
           errorMsg={field.touched ? field.errors.join(" ") : undefined}

--- a/src/forms/BoundMultiSelectField.tsx
+++ b/src/forms/BoundMultiSelectField.tsx
@@ -1,5 +1,8 @@
 import { FieldState } from "@homebound/form-state/dist/formState";
 import { Observer } from "mobx-react";
+import { useContext } from "react";
+import { FormContext } from "src/forms/FormContext";
+import { getLabelSuffix } from "src/forms/labelUtils";
 import { MultiSelectField, MultiSelectFieldProps, Value } from "src/inputs";
 import { HasIdAndName, Optional } from "src/types";
 import { defaultLabel } from "src/utils/defaultLabel";
@@ -41,12 +44,14 @@ export function BoundMultiSelectField<O, V extends Value>(
     label = defaultLabel(field.key),
     ...others
   } = props;
+  const settings = useContext(FormContext);
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
       {() => (
         <MultiSelectField<O, V>
           label={label}
+          labelSuffix={getLabelSuffix(settings, field)}
           values={(field.value as V[]) ?? []}
           onSelect={onSelect}
           options={options}

--- a/src/forms/BoundMultiSelectField.tsx
+++ b/src/forms/BoundMultiSelectField.tsx
@@ -1,8 +1,5 @@
 import { FieldState } from "@homebound/form-state/dist/formState";
 import { Observer } from "mobx-react";
-import { useContext } from "react";
-import { FormContext } from "src/forms/FormContext";
-import { getLabelSuffix } from "src/forms/labelUtils";
 import { MultiSelectField, MultiSelectFieldProps, Value } from "src/inputs";
 import { HasIdAndName, Optional } from "src/types";
 import { defaultLabel } from "src/utils/defaultLabel";
@@ -44,19 +41,18 @@ export function BoundMultiSelectField<O, V extends Value>(
     label = defaultLabel(field.key),
     ...others
   } = props;
-  const settings = useContext(FormContext);
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
       {() => (
         <MultiSelectField<O, V>
           label={label}
-          labelSuffix={getLabelSuffix(settings, field)}
           values={(field.value as V[]) ?? []}
           onSelect={onSelect}
           options={options}
           readOnly={readOnly ?? field.readOnly}
           errorMsg={field.touched ? field.errors.join(" ") : undefined}
+          required={field.required}
           getOptionLabel={getOptionLabel}
           getOptionValue={getOptionValue}
           onBlur={() => field.blur()}

--- a/src/forms/BoundNumberField.tsx
+++ b/src/forms/BoundNumberField.tsx
@@ -1,8 +1,5 @@
 import { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
-import { useContext } from "react";
-import { FormContext } from "src/forms/FormContext";
-import { getLabelSuffix } from "src/forms/labelUtils";
 import { NumberField, NumberFieldProps } from "src/inputs";
 import { useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
@@ -25,19 +22,18 @@ export function BoundNumberField(props: BoundNumberFieldProps) {
     type = field.key.endsWith("InCents") ? "cents" : undefined,
     ...others
   } = props;
-  const settings = useContext(FormContext);
   const testId = useTestIds(props, label || field.key);
   return (
     <Observer>
       {() => (
         <NumberField
           label={label}
-          labelSuffix={getLabelSuffix(settings, field)}
           value={typeof field.value === "number" ? field.value : undefined}
           onChange={onChange}
           type={type}
           readOnly={readOnly ?? field.readOnly}
           errorMsg={field.touched ? field.errors.join(" ") : undefined}
+          required={field.required}
           onFocus={() => field.focus()}
           onBlur={() => field.blur()}
           {...testId}

--- a/src/forms/BoundNumberField.tsx
+++ b/src/forms/BoundNumberField.tsx
@@ -1,5 +1,8 @@
 import { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
+import { useContext } from "react";
+import { FormContext } from "src/forms/FormContext";
+import { getLabelSuffix } from "src/forms/labelUtils";
 import { NumberField, NumberFieldProps } from "src/inputs";
 import { useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
@@ -22,12 +25,14 @@ export function BoundNumberField(props: BoundNumberFieldProps) {
     type = field.key.endsWith("InCents") ? "cents" : undefined,
     ...others
   } = props;
+  const settings = useContext(FormContext);
   const testId = useTestIds(props, label || field.key);
   return (
     <Observer>
       {() => (
         <NumberField
           label={label}
+          labelSuffix={getLabelSuffix(settings, field)}
           value={typeof field.value === "number" ? field.value : undefined}
           onChange={onChange}
           type={type}

--- a/src/forms/BoundSelectField.tsx
+++ b/src/forms/BoundSelectField.tsx
@@ -1,5 +1,8 @@
 import { FieldState } from "@homebound/form-state/dist/formState";
 import { Observer } from "mobx-react";
+import { useContext } from "react";
+import { FormContext } from "src/forms/FormContext";
+import { getLabelSuffix } from "src/forms/labelUtils";
 import { SelectField, SelectFieldProps, Value } from "src/inputs";
 import { HasIdAndName, Optional } from "src/types";
 import { defaultLabel } from "src/utils/defaultLabel";
@@ -41,12 +44,14 @@ export function BoundSelectField<T extends object, V extends Value>(
     label = defaultLabel(field.key),
     ...others
   } = props;
+  const settings = useContext(FormContext);
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
       {() => (
         <SelectField<T, V>
           label={label}
+          labelSuffix={getLabelSuffix(settings, field)}
           value={field.value ?? undefined}
           onSelect={onSelect}
           options={options}

--- a/src/forms/BoundSelectField.tsx
+++ b/src/forms/BoundSelectField.tsx
@@ -1,8 +1,5 @@
 import { FieldState } from "@homebound/form-state/dist/formState";
 import { Observer } from "mobx-react";
-import { useContext } from "react";
-import { FormContext } from "src/forms/FormContext";
-import { getLabelSuffix } from "src/forms/labelUtils";
 import { SelectField, SelectFieldProps, Value } from "src/inputs";
 import { HasIdAndName, Optional } from "src/types";
 import { defaultLabel } from "src/utils/defaultLabel";
@@ -44,19 +41,18 @@ export function BoundSelectField<T extends object, V extends Value>(
     label = defaultLabel(field.key),
     ...others
   } = props;
-  const settings = useContext(FormContext);
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
       {() => (
         <SelectField<T, V>
           label={label}
-          labelSuffix={getLabelSuffix(settings, field)}
           value={field.value ?? undefined}
           onSelect={onSelect}
           options={options}
           readOnly={readOnly ?? field.readOnly}
           errorMsg={field.touched ? field.errors.join(" ") : undefined}
+          required={field.required}
           getOptionLabel={getOptionLabel}
           getOptionValue={getOptionValue}
           onBlur={() => field.blur()}

--- a/src/forms/BoundTextField.tsx
+++ b/src/forms/BoundTextField.tsx
@@ -1,8 +1,5 @@
 import { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
-import { useContext } from "react";
-import { FormContext } from "src/forms/FormContext";
-import { getLabelSuffix } from "src/forms/labelUtils";
 import { TextField, TextFieldProps } from "src/inputs";
 import { useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
@@ -18,18 +15,17 @@ export type BoundTextFieldProps = Omit<TextFieldProps, "value" | "onChange" | "o
 /** Wraps `TextField` and binds it to a form field. */
 export function BoundTextField(props: BoundTextFieldProps) {
   const { field, readOnly, onChange = (value) => field.set(value), label = defaultLabel(field.key), ...others } = props;
-  const settings = useContext(FormContext);
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
       {() => (
         <TextField
           label={label}
-          labelSuffix={getLabelSuffix(settings, field)}
           value={field.value || undefined}
           onChange={onChange}
           readOnly={readOnly ?? field.readOnly}
           errorMsg={field.touched ? field.errors.join(" ") : undefined}
+          required={field.required}
           onBlur={() => field.blur()}
           onFocus={() => field.focus()}
           {...testId}

--- a/src/forms/BoundTextField.tsx
+++ b/src/forms/BoundTextField.tsx
@@ -1,5 +1,8 @@
 import { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
+import { useContext } from "react";
+import { FormContext } from "src/forms/FormContext";
+import { getLabelSuffix } from "src/forms/labelUtils";
 import { TextField, TextFieldProps } from "src/inputs";
 import { useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
@@ -15,12 +18,14 @@ export type BoundTextFieldProps = Omit<TextFieldProps, "value" | "onChange" | "o
 /** Wraps `TextField` and binds it to a form field. */
 export function BoundTextField(props: BoundTextFieldProps) {
   const { field, readOnly, onChange = (value) => field.set(value), label = defaultLabel(field.key), ...others } = props;
+  const settings = useContext(FormContext);
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
       {() => (
         <TextField
           label={label}
+          labelSuffix={getLabelSuffix(settings, field)}
           value={field.value || undefined}
           onChange={onChange}
           readOnly={readOnly ?? field.readOnly}

--- a/src/forms/FormContext.ts
+++ b/src/forms/FormContext.ts
@@ -4,9 +4,28 @@ export interface FormSettings {
   labelSuffix: LabelSuffixStyle;
 }
 
-export type LabelSuffixStyle = { required?: string; optional?: string };
+/**
+ * Label settings for required/optional fields.
+ *
+ * We may want to just hard-code this behavior, so that it's very consistent,
+ * but for now making it configurable.
+ */
+export type LabelSuffixStyle = {
+  /** The suffix to use for required fields. */
+  required?: string;
+  /** The suffix to use for explicitly optional (i.e. `required=false`) fields. */
+  optional?: string;
+};
 
-/** An internal context for holding form-wide state/preferences. */
+/**
+ * An internal context for holding form-wide state/preferences.
+ *
+ * Currently this can only be set via the `FormLines.labelSuffix` prop,
+ * otherwise we just use a hard-coded default.
+ *
+ * Eventually we should probably expose a way to set this via the `BeamContext`
+ * as well, and also override on individual fields as needed.
+ */
 export const FormContext = createContext<FormSettings>({
   labelSuffix: { required: "*", optional: "(Optional)" },
 });

--- a/src/forms/FormContext.ts
+++ b/src/forms/FormContext.ts
@@ -1,0 +1,12 @@
+import { createContext } from "react";
+
+export interface FormSettings {
+  labelSuffix: LabelSuffixStyle;
+}
+
+export type LabelSuffixStyle = "required" | "optional" | "both" | "none";
+
+/** An internal context for holding form-wide state/preferences. */
+export const FormContext = createContext<FormSettings>({
+  labelSuffix: "none",
+});

--- a/src/forms/FormContext.ts
+++ b/src/forms/FormContext.ts
@@ -27,5 +27,5 @@ export type LabelSuffixStyle = {
  * as well, and also override on individual fields as needed.
  */
 export const FormContext = createContext<FormSettings>({
-  labelSuffix: { required: "*", optional: "(Optional)" },
+  labelSuffix: { required: undefined, optional: undefined },
 });

--- a/src/forms/FormContext.ts
+++ b/src/forms/FormContext.ts
@@ -4,9 +4,9 @@ export interface FormSettings {
   labelSuffix: LabelSuffixStyle;
 }
 
-export type LabelSuffixStyle = "required" | "optional" | "both" | "none";
+export type LabelSuffixStyle = { required?: string; optional?: string };
 
 /** An internal context for holding form-wide state/preferences. */
 export const FormContext = createContext<FormSettings>({
-  labelSuffix: "none",
+  labelSuffix: { required: "*", optional: "(Optional)" },
 });

--- a/src/forms/FormLines.stories.tsx
+++ b/src/forms/FormLines.stories.tsx
@@ -26,9 +26,67 @@ export function SmallFlatList() {
   );
 }
 
-export function SideBySide() {
+export function SideBySideMedium() {
   return (
     <FormLines>
+      <FieldGroup>
+        <TextField label="First" value="first" onChange={() => {}} />
+        <TextField label="Middle" value="middle" onChange={() => {}} />
+      </FieldGroup>
+      <TextField label="Address" value="123 Main" onChange={() => {}} />
+      <FieldGroup>
+        <Switch label="Primary" labelStyle="form" selected={false} onChange={() => {}} />
+        <Switch label="Signatory" labelStyle="form" selected={true} onChange={() => {}} />
+      </FieldGroup>
+      <FieldGroup>
+        <TextField label="Title" value="Engineer" onChange={() => {}} />
+        <span />
+      </FieldGroup>
+      <FieldGroup>
+        <TextField label="First" value="first" onChange={() => {}} />
+        <TextField label="Middle" value="middle" onChange={() => {}} />
+        <TextField label="Last" value="last" onChange={() => {}} />
+      </FieldGroup>
+      <FieldGroup basis={["100%", "30%", "100%"]}>
+        <TextField label="First" value="first" onChange={() => {}} />
+        <TextField label="Middle" value="M" onChange={() => {}} />
+        <TextField label="Last" value="last" onChange={() => {}} />
+      </FieldGroup>
+    </FormLines>
+  );
+}
+export function SideBySideLarge() {
+  return (
+    <FormLines width="lg">
+      <FieldGroup>
+        <TextField label="First" value="first" onChange={() => {}} />
+        <TextField label="Middle" value="middle" onChange={() => {}} />
+      </FieldGroup>
+      <TextField label="Address" value="123 Main" onChange={() => {}} />
+      <FieldGroup>
+        <Switch label="Primary" labelStyle="form" selected={false} onChange={() => {}} />
+        <Switch label="Signatory" labelStyle="form" selected={true} onChange={() => {}} />
+      </FieldGroup>
+      <FieldGroup>
+        <TextField label="Title" value="Engineer" onChange={() => {}} />
+        <span />
+      </FieldGroup>
+      <FieldGroup>
+        <TextField label="First" value="first" onChange={() => {}} />
+        <TextField label="Middle" value="middle" onChange={() => {}} />
+        <TextField label="Last" value="last" onChange={() => {}} />
+      </FieldGroup>
+      <FieldGroup basis={["100%", "30%", "100%"]}>
+        <TextField label="First" value="first" onChange={() => {}} />
+        <TextField label="Middle" value="M" onChange={() => {}} />
+        <TextField label="Last" value="last" onChange={() => {}} />
+      </FieldGroup>
+    </FormLines>
+  );
+}
+export function SideBySideSmall() {
+  return (
+    <FormLines width="sm">
       <FieldGroup>
         <TextField label="First" value="first" onChange={() => {}} />
         <TextField label="Middle" value="middle" onChange={() => {}} />

--- a/src/forms/FormLines.stories.tsx
+++ b/src/forms/FormLines.stories.tsx
@@ -1,7 +1,8 @@
 import { Meta } from "@storybook/react";
-import { FieldGroup, FormLines } from "src/forms/FormLines";
+import { FieldGroup, FormDivider, FormLines } from "src/forms/FormLines";
 import { Switch } from "src/inputs/Switch";
 import { TextField } from "src/inputs/TextField";
+import { noop } from "src/utils/index";
 
 export default {
   component: FormLines,
@@ -80,6 +81,16 @@ export function SideBySideLarge() {
         <TextField label="First" value="first" onChange={() => {}} />
         <TextField label="Middle" value="M" onChange={() => {}} />
         <TextField label="Last" value="last" onChange={() => {}} />
+      </FieldGroup>
+      <FormDivider />
+      <FieldGroup widths={[3, 1]}>
+        <TextField label="Street" value="" onChange={noop} />
+        <div />
+      </FieldGroup>
+      <FieldGroup widths={[2, 1, 1]}>
+        <TextField label="City" value="" onChange={noop} />
+        <TextField label="State" value="" onChange={noop} />
+        <TextField label="Postal Code" value="" onChange={noop} />
       </FieldGroup>
     </FormLines>
   );

--- a/src/forms/FormLines.stories.tsx
+++ b/src/forms/FormLines.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta } from "@storybook/react";
 import { FieldGroup, FormLines } from "src/forms/FormLines";
+import { Switch } from "src/inputs/Switch";
 import { TextField } from "src/inputs/TextField";
 
 export default {
@@ -10,8 +11,8 @@ export default {
 export function FlatList() {
   return (
     <FormLines>
-      <TextField label={"First"} value={"first"} onChange={() => {}} />
-      <TextField label={"Last"} value={"last"} onChange={() => {}} />
+      <TextField label="First" value="first" onChange={() => {}} />
+      <TextField label="Last" value="last" onChange={() => {}} />
     </FormLines>
   );
 }
@@ -19,8 +20,8 @@ export function FlatList() {
 export function SmallFlatList() {
   return (
     <FormLines width="sm">
-      <TextField label={"First"} value={"first"} onChange={() => {}} />
-      <TextField label={"Last"} value={"last"} onChange={() => {}} />
+      <TextField label="First" value="first" onChange={() => {}} />
+      <TextField label="Last" value="last" onChange={() => {}} />
     </FormLines>
   );
 }
@@ -29,15 +30,27 @@ export function SideBySide() {
   return (
     <FormLines>
       <FieldGroup>
-        <TextField label={"First"} value={"first"} onChange={() => {}} />
-        <TextField label={"Middle"} value={"middle"} onChange={() => {}} />
+        <TextField label="First" value="first" onChange={() => {}} />
+        <TextField label="Middle" value="middle" onChange={() => {}} />
       </FieldGroup>
       <TextField label="Address" value="123 Main" onChange={() => {}} />
-      {/* Having three is too wide, so not supported.*/}
       <FieldGroup>
-        <TextField label={"First"} value={"first"} onChange={() => {}} />
-        <TextField label={"Middle"} value={"middle"} onChange={() => {}} />
-        <TextField label={"Last"} value={"last"} onChange={() => {}} />
+        <Switch label="Primary" labelStyle="form" selected={false} onChange={() => {}} />
+        <Switch label="Signatory" labelStyle="form" selected={true} onChange={() => {}} />
+      </FieldGroup>
+      <FieldGroup>
+        <TextField label="Title" value="Engineer" onChange={() => {}} />
+        <span />
+      </FieldGroup>
+      <FieldGroup>
+        <TextField label="First" value="first" onChange={() => {}} />
+        <TextField label="Middle" value="middle" onChange={() => {}} />
+        <TextField label="Last" value="last" onChange={() => {}} />
+      </FieldGroup>
+      <FieldGroup basis={["100%", "30%", "100%"]}>
+        <TextField label="First" value="first" onChange={() => {}} />
+        <TextField label="Middle" value="M" onChange={() => {}} />
+        <TextField label="Last" value="last" onChange={() => {}} />
       </FieldGroup>
     </FormLines>
   );

--- a/src/forms/FormLines.stories.tsx
+++ b/src/forms/FormLines.stories.tsx
@@ -47,7 +47,7 @@ export function SideBySideMedium() {
         <TextField label="Middle" value="middle" onChange={() => {}} />
         <TextField label="Last" value="last" onChange={() => {}} />
       </FieldGroup>
-      <FieldGroup basis={["100%", "30%", "100%"]}>
+      <FieldGroup widths={[2, 1, 2]}>
         <TextField label="First" value="first" onChange={() => {}} />
         <TextField label="Middle" value="M" onChange={() => {}} />
         <TextField label="Last" value="last" onChange={() => {}} />
@@ -76,7 +76,7 @@ export function SideBySideLarge() {
         <TextField label="Middle" value="middle" onChange={() => {}} />
         <TextField label="Last" value="last" onChange={() => {}} />
       </FieldGroup>
-      <FieldGroup basis={["100%", "30%", "100%"]}>
+      <FieldGroup widths={[2, 1, 2]}>
         <TextField label="First" value="first" onChange={() => {}} />
         <TextField label="Middle" value="M" onChange={() => {}} />
         <TextField label="Last" value="last" onChange={() => {}} />
@@ -105,7 +105,7 @@ export function SideBySideSmall() {
         <TextField label="Middle" value="middle" onChange={() => {}} />
         <TextField label="Last" value="last" onChange={() => {}} />
       </FieldGroup>
-      <FieldGroup basis={["100%", "30%", "100%"]}>
+      <FieldGroup widths={[2, 1, 2]}>
         <TextField label="First" value="first" onChange={() => {}} />
         <TextField label="Middle" value="M" onChange={() => {}} />
         <TextField label="Last" value="last" onChange={() => {}} />

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -1,4 +1,4 @@
-import { Css } from "src/Css";
+import { Css, Properties } from "src/Css";
 
 export interface FormLinesProps {
   /** Let the user interleave group-less lines and grouped lines. */
@@ -32,10 +32,19 @@ export function FieldGroup(props: {
   /** The legend/title for this group. */
   title?: string;
   children: JSX.Element[];
+  basis?: Properties["flexBasis"][];
 }) {
   // TODO Actually use title
-  const { title, children } = props;
-  return <div css={Css.df.childGap2.$}>{children}</div>;
+  const { title, children, basis = [] } = props;
+  return (
+    <div css={Css.df.childGap2.$}>
+      {children.map((child, i) => (
+        <div key={i} css={Css.fg1.fb(String(basis[i] || "100%")).$}>
+          {child}
+        </div>
+      ))}
+    </div>
+  );
 }
 
 const sizes: Record<"md" | "sm", number> = {

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -29,6 +29,11 @@ export function FormLines(props: FormLinesProps) {
   );
 }
 
+/** Draws a line between form lines. */
+export function FormDivider() {
+  return <div css={Css.hPx(1).my2.bgGray200.$} />;
+}
+
 /** Groups multiple fields side-by-side. */
 export function FieldGroup(props: {
   /** The legend/title for this group. */

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -23,7 +23,7 @@ export interface FormLinesProps {
  * (see the `FieldGroup` component), where they will be laid out side-by-side.
  */
 export function FormLines(props: FormLinesProps) {
-  const { children, width = "md", labelSuffix = "none" } = props;
+  const { children, width = "md", labelSuffix = {} } = props;
   return (
     <FormContext.Provider value={{ labelSuffix }}>
       <div

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -1,3 +1,4 @@
+import { useContext } from "react";
 import { Css } from "src/Css";
 import { FormContext, LabelSuffixStyle } from "src/forms/FormContext";
 
@@ -23,7 +24,8 @@ export interface FormLinesProps {
  * (see the `FieldGroup` component), where they will be laid out side-by-side.
  */
 export function FormLines(props: FormLinesProps) {
-  const { children, width = "md", labelSuffix = {} } = props;
+  const settings = useContext(FormContext);
+  const { children, width = "md", labelSuffix = settings.labelSuffix } = props;
   return (
     <FormContext.Provider value={{ labelSuffix }}>
       <div

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -1,7 +1,13 @@
 import { Css } from "src/Css";
 import { FormContext, LabelSuffixStyle } from "src/forms/FormContext";
 
-export type FormWidth = "sm" | "md" | "lg";
+export type FormWidth =
+  /** 320px, works well in a modal. */
+  | "sm"
+  /** 480px, works well in a small, single-stack form. */
+  | "md"
+  /** 550px, works well for showing side-by-side/double-stack fields. */
+  | "lg";
 
 export interface FormLinesProps {
   /** Let the user interleave group-less lines and grouped lines. */
@@ -64,7 +70,7 @@ export function FieldGroup(props: {
 }
 
 const sizes: Record<FormWidth, number> = {
-  lg: 550, // works well for side-by-side
-  md: 480, // normal full-page size
-  sm: 320, // works well in a modal
+  lg: 550,
+  md: 480,
+  sm: 320,
 };

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -1,10 +1,12 @@
 import { Css } from "src/Css";
+import { FormContext, LabelSuffixStyle } from "src/forms/FormContext";
 
 export type FormWidth = "sm" | "md" | "lg";
 
 export interface FormLinesProps {
   /** Let the user interleave group-less lines and grouped lines. */
   children: JSX.Element[];
+  labelSuffix?: LabelSuffixStyle;
   width?: FormWidth;
 }
 
@@ -15,17 +17,19 @@ export interface FormLinesProps {
  * (see the `FieldGroup` component), where they will be laid out side-by-side.
  */
 export function FormLines(props: FormLinesProps) {
-  const { children, width = "md" } = props;
+  const { children, width = "md", labelSuffix = "none" } = props;
   return (
-    <div
-      css={{
-        ...Css.df.flexColumn.wPx(sizes[width]).$,
-        // Purposefully use this instead of childGap3 to put margin-bottom on the last line
-        "& > *": Css.mb3.$,
-      }}
-    >
-      {children}
-    </div>
+    <FormContext.Provider value={{ labelSuffix }}>
+      <div
+        css={{
+          ...Css.df.flexColumn.wPx(sizes[width]).$,
+          // Purposefully use this instead of childGap3 to put margin-bottom on the last line
+          "& > *": Css.mb3.$,
+        }}
+      >
+        {children}
+      </div>
+    </FormContext.Provider>
   );
 }
 

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -1,4 +1,4 @@
-import { Css, Properties } from "src/Css";
+import { Css } from "src/Css";
 
 export type FormWidth = "sm" | "md" | "lg";
 
@@ -34,17 +34,22 @@ export function FieldGroup(props: {
   /** The legend/title for this group. */
   title?: string;
   children: JSX.Element[];
-  basis?: Properties["flexBasis"][];
+  /** An array of widths for each child, if a number we use `fr` units. */
+  widths?: Array<number | string>;
 }) {
   // TODO Actually use title
-  const { title, children, basis = [] } = props;
+  const { title, children, widths = [] } = props;
+  const gtc = children
+    .map((_, i) => {
+      const width = widths[i] || 1;
+      return typeof width === `number` ? `${width}fr` : width;
+    })
+    .join(" ");
   return (
-    <div css={Css.df.childGap2.$}>
-      {children.map((child, i) => (
-        <div key={i} css={Css.fg1.fb(String(basis[i] || "100%")).$}>
-          {child}
-        </div>
-      ))}
+    <div css={Css.dg.gap2.gtc(gtc).$}>
+      {children.map((child) => {
+        return child;
+      })}
     </div>
   );
 }

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -1,9 +1,11 @@
 import { Css, Properties } from "src/Css";
 
+export type FormWidth = "sm" | "md" | "lg";
+
 export interface FormLinesProps {
   /** Let the user interleave group-less lines and grouped lines. */
   children: JSX.Element[];
-  width?: "md" | "sm";
+  width?: FormWidth;
 }
 
 /**
@@ -47,7 +49,8 @@ export function FieldGroup(props: {
   );
 }
 
-const sizes: Record<"md" | "sm", number> = {
+const sizes: Record<FormWidth, number> = {
+  lg: 550, // works well for side-by-side
   md: 480, // normal full-page size
   sm: 320, // works well in a modal
 };

--- a/src/forms/FormStateApp.tsx
+++ b/src/forms/FormStateApp.tsx
@@ -84,7 +84,7 @@ export function FormStateApp() {
       {() => (
         <div>
           <header>
-            <FormLines>
+            <FormLines labelSuffix={{ required: "*", optional: "(Opt)" }}>
               <b>Author</b>
               <BoundTextField field={formState.firstName} />
               <BoundTextField field={formState.middleInitial} />

--- a/src/forms/FormStateApp.tsx
+++ b/src/forms/FormStateApp.tsx
@@ -84,9 +84,10 @@ export function FormStateApp() {
       {() => (
         <div>
           <header>
-            <FormLines labelSuffix={{ required: "Req", optional: "Opt" }}>
+            <FormLines>
               <b>Author</b>
               <BoundTextField field={formState.firstName} />
+              <BoundTextField field={formState.middleInitial} />
               <BoundTextField field={formState.lastName} />
               <BoundDateField field={formState.birthday} />
               <BoundNumberField field={formState.heightInInches} />
@@ -149,6 +150,7 @@ type FormValue = ObjectState<AuthorInput>;
 // Configure the fields/behavior for AuthorInput's fields
 export const formConfig: ObjectConfig<AuthorInput> = {
   firstName: { type: "value", rules: [required] },
+  middleInitial: { type: "value" },
   lastName: { type: "value", rules: [required] },
   birthday: { type: "value", rules: [required] },
   heightInInches: { type: "value", rules: [required] },

--- a/src/forms/FormStateApp.tsx
+++ b/src/forms/FormStateApp.tsx
@@ -84,7 +84,7 @@ export function FormStateApp() {
       {() => (
         <div>
           <header>
-            <FormLines labelSuffix="both">
+            <FormLines labelSuffix={{ required: "Req", optional: "Opt" }}>
               <b>Author</b>
               <BoundTextField field={formState.firstName} />
               <BoundTextField field={formState.lastName} />

--- a/src/forms/FormStateApp.tsx
+++ b/src/forms/FormStateApp.tsx
@@ -19,6 +19,7 @@ import {
   BoundSwitchField,
   BoundTextField,
   BoundToggleChipGroupField,
+  FormDivider,
 } from "src/forms";
 import { BoundCheckboxGroupField } from "src/forms/BoundCheckboxGroupField";
 import { FormLines } from "src/forms/FormLines";
@@ -83,17 +84,18 @@ export function FormStateApp() {
       {() => (
         <div>
           <header>
-            <FormLines>
+            <FormLines labelSuffix="both">
               <b>Author</b>
               <BoundTextField field={formState.firstName} />
               <BoundTextField field={formState.lastName} />
               <BoundDateField field={formState.birthday} />
               <BoundNumberField field={formState.heightInInches} />
+              <FormDivider />
               <BoundSelectField field={formState.favoriteSport} options={sports} />
-              <br />
               <BoundMultiSelectField field={formState.favoriteShapes} options={shapes} />
               <BoundCheckboxGroupField field={formState.favoriteColors} options={colors} />
               <BoundToggleChipGroupField field={formState.animals} options={animals} />
+              <FormDivider />
               <BoundSwitchField field={formState.isAvailable} />
             </FormLines>
 

--- a/src/forms/formStateDomain.ts
+++ b/src/forms/formStateDomain.ts
@@ -10,6 +10,7 @@ export const dd200: DeweyDecimalClassification = { number: "200", category: "Rel
 export interface AuthorInput {
   id?: string | null;
   firstName?: string | null;
+  middleInitial?: string | null;
   lastName?: string | null;
   birthday?: Date | null;
   heightInInches?: number | null;

--- a/src/forms/labelUtils.ts
+++ b/src/forms/labelUtils.ts
@@ -1,0 +1,16 @@
+import { FieldState } from "@homebound/form-state";
+import { FormSettings } from "src/forms/FormContext";
+
+export function getLabelSuffix(settings: FormSettings, field: FieldState<any, any>): string {
+  switch (settings.labelSuffix) {
+    case "required":
+      return field.required ? "(Required)" : "";
+    case "optional":
+      return field.required ? "" : "(Optional)";
+    case "none":
+      return "";
+    case "both":
+      return field.required ? "(Req)" : "(Opt)";
+  }
+  return "";
+}

--- a/src/forms/labelUtils.ts
+++ b/src/forms/labelUtils.ts
@@ -1,16 +1,15 @@
-import { FieldState } from "@homebound/form-state";
-import { FormSettings } from "src/forms/FormContext";
+import { useContext } from "react";
+import { FormContext } from "src/forms/FormContext";
 
-export function getLabelSuffix(settings: FormSettings, field: FieldState<any, any>): string {
-  switch (settings.labelSuffix) {
-    case "required":
-      return field.required ? "(Required)" : "";
-    case "optional":
-      return field.required ? "" : "(Optional)";
-    case "none":
-      return "";
-    case "both":
-      return field.required ? "(Req)" : "(Opt)";
+export function getLabelSuffix(required: boolean | undefined): string | undefined {
+  // We promise to always call `getLabelSuffix` deterministically
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const settings = useContext(FormContext);
+  if (required === true) {
+    return settings.labelSuffix.required;
+  } else if (required === false) {
+    return settings.labelSuffix.optional;
+  } else {
+    return undefined;
   }
-  return "";
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-export * from "./components";
+// organize-imports-ignore
 export * from "./Css";
+export * from "./components";
 export * from "./forms";
 export * from "./hooks";
 export * from "./inputs";

--- a/src/inputs/DateField.tsx
+++ b/src/inputs/DateField.tsx
@@ -7,6 +7,7 @@ import { Icon, IconButton } from "src/components";
 import { HelperText } from "src/components/HelperText";
 import { Label } from "src/components/Label";
 import { Css, Palette } from "src/Css";
+import { getLabelSuffix } from "src/forms/labelUtils";
 import { ErrorMessage } from "src/inputs/ErrorMessage";
 import "./DateField.css";
 
@@ -15,8 +16,6 @@ const format = "MM/dd/yy";
 export interface DateFieldProps {
   value: Date | undefined;
   label?: string;
-  /** An optional suffix for the label, i.e. `(Required)` or `(Optional). */
-  labelSuffix?: string;
   onChange: (value: Date) => void;
   /** Called when the component loses focus */
   onBlur?: () => void;
@@ -24,11 +23,13 @@ export interface DateFieldProps {
   onFocus?: () => void;
   disabled?: boolean;
   errorMsg?: string;
+  required?: boolean;
   helperText?: string | ReactNode;
 }
 
 export function DateField(props: DateFieldProps) {
-  const { label, labelSuffix, disabled, value, onChange, onFocus, onBlur, errorMsg, helperText } = props;
+  const { label, disabled, required, value, onChange, onFocus, onBlur, errorMsg, helperText } = props;
+  const labelSuffix = getLabelSuffix(required);
 
   const { ...otherProps } = {};
   // We don't really use the inputRef, but `useTextField` needs it. We probably shouldn't

--- a/src/inputs/DateField.tsx
+++ b/src/inputs/DateField.tsx
@@ -15,6 +15,8 @@ const format = "MM/dd/yy";
 export interface DateFieldProps {
   value: Date | undefined;
   label?: string;
+  /** An optional suffix for the label, i.e. `(Required)` or `(Optional). */
+  labelSuffix?: string;
   onChange: (value: Date) => void;
   /** Called when the component loses focus */
   onBlur?: () => void;
@@ -26,7 +28,7 @@ export interface DateFieldProps {
 }
 
 export function DateField(props: DateFieldProps) {
-  const { label, disabled, value, onChange, onFocus, onBlur, errorMsg, helperText } = props;
+  const { label, labelSuffix, disabled, value, onChange, onFocus, onBlur, errorMsg, helperText } = props;
 
   const { ...otherProps } = {};
   // We don't really use the inputRef, but `useTextField` needs it. We probably shouldn't
@@ -67,7 +69,7 @@ export function DateField(props: DateFieldProps) {
         "& .DayPicker-Caption > div": Css.base.pyPx(2).$,
       }}
     >
-      {label && <Label labelProps={labelProps} label={label} />}
+      {label && <Label labelProps={labelProps} label={label} suffix={labelSuffix} />}
       <DayPickerInput
         onDayChange={onChange as any}
         dayPickerProps={{

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -10,6 +10,8 @@ export interface NumberFieldProps {
   label: string;
   /** If set, the label will be defined as 'aria-label` on the input element */
   hideLabel?: boolean;
+  /** An optional suffix for the label, i.e. `(Required)` or `(Optional). */
+  labelSuffix?: string;
   type?: "cents" | "percent" | "basisPoints";
   value: number | undefined;
   onChange: (value: number | undefined) => void;
@@ -30,6 +32,7 @@ export function NumberField(props: NumberFieldProps) {
     readOnly: isReadOnly = false,
     type,
     label,
+    labelSuffix,
     onBlur,
     onFocus,
     errorMsg,
@@ -105,6 +108,7 @@ export function NumberField(props: NumberFieldProps) {
       groupProps={groupProps}
       labelProps={labelProps}
       label={label}
+      labelSuffix={labelSuffix}
       inputProps={inputProps}
       // This is called on each DOM change, to push the latest value into the field
       onChange={(rawInputValue) => {

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -3,6 +3,7 @@ import { ReactNode, useMemo, useRef } from "react";
 import { useLocale, useNumberField } from "react-aria";
 import { useNumberFieldState } from "react-stately";
 import { Css, Xss } from "src/Css";
+import { getLabelSuffix } from "src/forms/labelUtils";
 import { TextFieldBase } from "./TextFieldBase";
 
 // exported for testing purposes
@@ -10,13 +11,12 @@ export interface NumberFieldProps {
   label: string;
   /** If set, the label will be defined as 'aria-label` on the input element */
   hideLabel?: boolean;
-  /** An optional suffix for the label, i.e. `(Required)` or `(Optional). */
-  labelSuffix?: string;
   type?: "cents" | "percent" | "basisPoints";
   value: number | undefined;
   onChange: (value: number | undefined) => void;
   compact?: boolean;
   disabled?: boolean;
+  required?: boolean;
   errorMsg?: string;
   helperText?: string | ReactNode;
   onBlur?: () => void;
@@ -29,10 +29,10 @@ export interface NumberFieldProps {
 export function NumberField(props: NumberFieldProps) {
   const {
     disabled: isDisabled = false,
+    required,
     readOnly: isReadOnly = false,
     type,
     label,
-    labelSuffix,
     onBlur,
     onFocus,
     errorMsg,
@@ -45,6 +45,7 @@ export function NumberField(props: NumberFieldProps) {
   } = props;
 
   const factor = type === "percent" || type === "cents" ? 100 : type === "basisPoints" ? 10_000 : 1;
+  const labelSuffix = getLabelSuffix(required);
 
   // If formatOptions isn't memo'd, a useEffect in useNumberStateField will cause jank,
   // see: https://github.com/adobe/react-spectrum/issues/1893.
@@ -108,7 +109,7 @@ export function NumberField(props: NumberFieldProps) {
       groupProps={groupProps}
       labelProps={labelProps}
       label={label}
-      labelSuffix={labelSuffix}
+      required={required}
       inputProps={inputProps}
       // This is called on each DOM change, to push the latest value into the field
       onChange={(rawInputValue) => {

--- a/src/inputs/TextField.stories.tsx
+++ b/src/inputs/TextField.stories.tsx
@@ -16,7 +16,7 @@ export function TextFields() {
         <h1 css={Css.lg.$}>Regular</h1>
         <TestTextField value="" label="Name" hideLabel />
         <TestTextField label="Name" value="" />
-        <TestTextField label="Name" labelSuffix="(Required)" value="" />
+        <TestTextField label="Name" required value="" />
         <TestTextField label="Name Focused" value="Brandon" autoFocus />
         <TestTextField label="Name Disabled" value="Brandon" disabled />
         <TestTextField

--- a/src/inputs/TextField.stories.tsx
+++ b/src/inputs/TextField.stories.tsx
@@ -16,6 +16,7 @@ export function TextFields() {
         <h1 css={Css.lg.$}>Regular</h1>
         <TestTextField value="" label="Name" hideLabel />
         <TestTextField label="Name" value="" />
+        <TestTextField label="Name" labelSuffix="(Required)" value="" />
         <TestTextField label="Name Focused" value="Brandon" autoFocus />
         <TestTextField label="Name Disabled" value="Brandon" disabled />
         <TestTextField

--- a/src/inputs/TextField.test.tsx
+++ b/src/inputs/TextField.test.tsx
@@ -20,6 +20,21 @@ describe("TextFieldTest", () => {
     expect(r.name()).toHaveValue("");
     expect(lastSet).toBeUndefined();
   });
+
+  it("sets aria-required if required", async () => {
+    const r = await render(<TestTextField value="foo" required={true} />);
+    expect(r.name()).toHaveAttribute("aria-required", "true");
+  });
+
+  it("doesn't set aria-required if not required", async () => {
+    const r = await render(<TestTextField value="foo" required={false} />);
+    expect(r.name()).not.toHaveAttribute("aria-required");
+  });
+
+  it("sets aria-validation if invalid", async () => {
+    const r = await render(<TestTextField value="foo" errorMsg="Required" />);
+    expect(r.name()).toHaveAttribute("aria-invalid", "true");
+  });
 });
 
 function TestTextField(props: Omit<TextFieldProps, "onChange" | "label">) {

--- a/src/inputs/TextField.tsx
+++ b/src/inputs/TextField.tsx
@@ -12,17 +12,27 @@ export function TextField(props: TextFieldProps) {
   const {
     disabled: isDisabled = false,
     readOnly: isReadOnly = false,
+    required: isRequired,
+    errorMsg,
     value = "",
     onBlur,
     onFocus,
     ...otherProps
   } = props;
-  const textFieldProps = { ...otherProps, isDisabled, isReadOnly, value };
+  const textFieldProps = {
+    ...otherProps,
+    isDisabled,
+    isReadOnly,
+    isRequired,
+    validationState: errorMsg ? ("invalid" as const) : ("valid" as const),
+    value,
+  };
   const inputRef = useRef<HTMLInputElement | null>(null);
   const { labelProps, inputProps } = useTextField(textFieldProps, inputRef);
   return (
     <TextFieldBase
       {...mergeProps(textFieldProps, { onBlur, onFocus })}
+      errorMsg={errorMsg}
       labelProps={labelProps}
       inputProps={inputProps}
       inputRef={inputRef}

--- a/src/inputs/TextField.tsx
+++ b/src/inputs/TextField.tsx
@@ -12,7 +12,7 @@ export function TextField(props: TextFieldProps) {
   const {
     disabled: isDisabled = false,
     readOnly: isReadOnly = false,
-    required: isRequired,
+    required,
     errorMsg,
     value = "",
     onBlur,
@@ -23,7 +23,7 @@ export function TextField(props: TextFieldProps) {
     ...otherProps,
     isDisabled,
     isReadOnly,
-    isRequired,
+    isRequired: required,
     validationState: errorMsg ? ("invalid" as const) : ("valid" as const),
     value,
   };
@@ -33,6 +33,7 @@ export function TextField(props: TextFieldProps) {
     <TextFieldBase
       {...mergeProps(textFieldProps, { onBlur, onFocus })}
       errorMsg={errorMsg}
+      required={required}
       labelProps={labelProps}
       inputProps={inputProps}
       inputRef={inputRef}

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -11,6 +11,7 @@ import { chain, mergeProps } from "react-aria";
 import { HelperText } from "src/components/HelperText";
 import { Label } from "src/components/Label";
 import { Css, px, Xss } from "src/Css";
+import { getLabelSuffix } from "src/forms/labelUtils";
 import { ErrorMessage } from "src/inputs/ErrorMessage";
 import { BeamTextFieldProps } from "src/interfaces";
 import { defaultTestId } from "src/utils/defaultTestId";
@@ -19,7 +20,7 @@ import { useTestIds } from "src/utils/useTestIds";
 interface TextFieldBaseProps
   extends Pick<
       BeamTextFieldProps,
-      "label" | "labelSuffix" | "errorMsg" | "onBlur" | "onFocus" | "helperText" | "hideLabel"
+      "label" | "required" | "errorMsg" | "onBlur" | "onFocus" | "helperText" | "hideLabel"
     >,
     Partial<Pick<BeamTextFieldProps, "onChange">> {
   labelProps?: LabelHTMLAttributes<HTMLLabelElement>;
@@ -37,7 +38,7 @@ interface TextFieldBaseProps
 export function TextFieldBase(props: TextFieldBaseProps) {
   const {
     label,
-    labelSuffix,
+    required,
     labelProps,
     hideLabel,
     inputProps,
@@ -53,6 +54,7 @@ export function TextFieldBase(props: TextFieldBaseProps) {
     xss,
   } = props;
   const errorMessageId = `${inputProps.id}-error`;
+  const labelSuffix = getLabelSuffix(required);
 
   const ElementType: React.ElementType = multiline ? "textarea" : "input";
   const tid = useTestIds(props, defaultTestId(label || "textField"));

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -17,7 +17,10 @@ import { defaultTestId } from "src/utils/defaultTestId";
 import { useTestIds } from "src/utils/useTestIds";
 
 interface TextFieldBaseProps
-  extends Pick<BeamTextFieldProps, "label" | "errorMsg" | "onBlur" | "onFocus" | "helperText" | "hideLabel">,
+  extends Pick<
+      BeamTextFieldProps,
+      "label" | "labelSuffix" | "errorMsg" | "onBlur" | "onFocus" | "helperText" | "hideLabel"
+    >,
     Partial<Pick<BeamTextFieldProps, "onChange">> {
   labelProps?: LabelHTMLAttributes<HTMLLabelElement>;
   inputProps: InputHTMLAttributes<HTMLInputElement> | TextareaHTMLAttributes<HTMLTextAreaElement>;
@@ -34,6 +37,7 @@ interface TextFieldBaseProps
 export function TextFieldBase(props: TextFieldBaseProps) {
   const {
     label,
+    labelSuffix,
     labelProps,
     hideLabel,
     inputProps,
@@ -72,7 +76,7 @@ export function TextFieldBase(props: TextFieldBaseProps) {
 
   return (
     <div css={Css.df.flexColumn.w100.maxw(px(550)).$} {...groupProps}>
-      {label && !hideLabel && <Label labelProps={labelProps} label={label} {...tid.label} />}
+      {label && !hideLabel && <Label labelProps={labelProps} label={label} suffix={labelSuffix} {...tid.label} />}
       <ElementType
         {...mergeProps(
           inputProps,

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -83,7 +83,8 @@ export function TextFieldBase(props: TextFieldBaseProps) {
         ref={inputRef as any}
         rows={multiline ? 1 : undefined}
         css={{
-          ...Css.add("resize", "none").bgWhite.sm.px1.hPx(40).gray900.br4.outline0.ba.bGray300.if(compact).hPx(32).$,
+          ...Css.add("resize", "none").bgWhite.sm.px1.w100.hPx(40).gray900.br4.outline0.ba.bGray300.if(compact).hPx(32)
+            .$,
           ...xss,
           ...Css.if(multiline).mh(px(96)).py1.$,
           "&:focus": Css.bLightBlue700.$,

--- a/src/inputs/internal/SelectFieldBase.tsx
+++ b/src/inputs/internal/SelectFieldBase.tsx
@@ -45,13 +45,14 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
     errorMsg,
     helperText,
     label,
+    labelSuffix,
+    inlineLabel,
     readOnly: isReadOnly = false,
     onSelect,
     fieldDecoration,
     options,
     onBlur,
     onFocus,
-    inlineLabel,
     multiselect = false,
     getOptionLabel,
     getOptionValue,
@@ -245,6 +246,7 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
         onFocus={onFocus}
         inlineLabel={inlineLabel}
         label={label}
+        labelSuffix={labelSuffix}
         labelProps={labelProps}
         selectedOptions={fieldState.selectedOptions}
         getOptionValue={getOptionValue}
@@ -281,6 +283,9 @@ export interface BeamSelectFieldBaseProps<T> extends BeamFocusableProps {
   fieldDecoration?: (opt: T) => ReactNode;
   /** Sets the form field label. */
   label?: string;
+  /** An optional suffix for the label, i.e. `(Required)` or `(Optional). */
+  labelSuffix?: string;
+  /** Renders the label inside the input field, i.e. for filters. */
   inlineLabel?: boolean;
   readOnly?: boolean;
   onBlur?: () => void;

--- a/src/inputs/internal/SelectFieldBase.tsx
+++ b/src/inputs/internal/SelectFieldBase.tsx
@@ -45,7 +45,7 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
     errorMsg,
     helperText,
     label,
-    labelSuffix,
+    required,
     inlineLabel,
     readOnly: isReadOnly = false,
     onSelect,
@@ -239,6 +239,7 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
         inputRef={inputRef}
         inputWrapRef={inputWrapRef}
         isDisabled={isDisabled}
+        required={required}
         isFocused={isFocused}
         isReadOnly={isReadOnly}
         state={state}
@@ -246,7 +247,6 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
         onFocus={onFocus}
         inlineLabel={inlineLabel}
         label={label}
-        labelSuffix={labelSuffix}
         labelProps={labelProps}
         selectedOptions={fieldState.selectedOptions}
         getOptionValue={getOptionValue}
@@ -277,14 +277,13 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
 export interface BeamSelectFieldBaseProps<T> extends BeamFocusableProps {
   compact?: boolean;
   disabled?: boolean;
+  required?: boolean;
   errorMsg?: string;
   helperText?: string | ReactNode;
   /** Allow placing an icon/decoration within the input field. */
   fieldDecoration?: (opt: T) => ReactNode;
   /** Sets the form field label. */
   label?: string;
-  /** An optional suffix for the label, i.e. `(Required)` or `(Optional). */
-  labelSuffix?: string;
   /** Renders the label inside the input field, i.e. for filters. */
   inlineLabel?: boolean;
   readOnly?: boolean;

--- a/src/inputs/internal/SelectFieldInput.tsx
+++ b/src/inputs/internal/SelectFieldInput.tsx
@@ -5,6 +5,7 @@ import { Icon } from "src/components";
 import { HelperText } from "src/components/HelperText";
 import { InlineLabel, Label } from "src/components/Label";
 import { Css, Palette } from "src/Css";
+import { getLabelSuffix } from "src/forms/labelUtils";
 import { ErrorMessage } from "src/inputs/ErrorMessage";
 import { Value, valueToKey } from "src/inputs/Value";
 import { maybeCall, useTestIds } from "src/utils";
@@ -22,13 +23,13 @@ interface SelectFieldInputProps<O, V extends Value> {
   isReadOnly: boolean;
   fieldDecoration?: (opt: O) => ReactNode;
   errorMsg?: string;
+  required?: boolean;
   helperText?: string | ReactNode;
   onBlur?: () => void;
   onFocus?: () => void;
   inlineLabel?: boolean;
   labelProps: LabelHTMLAttributes<HTMLLabelElement>;
   label?: string;
-  labelSuffix?: string;
   selectedOptions: O[];
   getOptionValue: (opt: O) => V;
   sizeToContent: boolean;
@@ -43,6 +44,7 @@ export function SelectFieldInput<O, V extends Value>(props: SelectFieldInputProp
     buttonRef,
     compact = false,
     errorMsg,
+    required,
     helperText,
     state,
     isFocused,
@@ -53,7 +55,6 @@ export function SelectFieldInput<O, V extends Value>(props: SelectFieldInputProp
     onFocus,
     inlineLabel,
     label,
-    labelSuffix,
     labelProps,
     selectedOptions,
     getOptionValue,
@@ -68,6 +69,7 @@ export function SelectFieldInput<O, V extends Value>(props: SelectFieldInputProp
   const readOnlyStyles = isReadOnly ? Css.bn.pl0.pt0.add("backgroundColor", "unset").$ : {};
   const tid = useTestIds(inputProps); // data-testid comes in through here
   const isMultiSelect = state.selectionManager.selectionMode === "multiple";
+  const labelSuffix = getLabelSuffix(required);
 
   return (
     <Fragment>

--- a/src/inputs/internal/SelectFieldInput.tsx
+++ b/src/inputs/internal/SelectFieldInput.tsx
@@ -28,6 +28,7 @@ interface SelectFieldInputProps<O, V extends Value> {
   inlineLabel?: boolean;
   labelProps: LabelHTMLAttributes<HTMLLabelElement>;
   label?: string;
+  labelSuffix?: string;
   selectedOptions: O[];
   getOptionValue: (opt: O) => V;
   sizeToContent: boolean;
@@ -52,6 +53,7 @@ export function SelectFieldInput<O, V extends Value>(props: SelectFieldInputProp
     onFocus,
     inlineLabel,
     label,
+    labelSuffix,
     labelProps,
     selectedOptions,
     getOptionValue,
@@ -69,7 +71,7 @@ export function SelectFieldInput<O, V extends Value>(props: SelectFieldInputProp
 
   return (
     <Fragment>
-      {!inlineLabel && label && <Label labelProps={labelProps} label={label} {...tid.label} />}
+      {!inlineLabel && label && <Label labelProps={labelProps} label={label} suffix={labelSuffix} {...tid.label} />}
       <div
         css={{
           ...Css.df.ba.bGray300.br4.px1.itemsCenter.bgWhite.hPx(40).if(compact).hPx(32).$,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,8 +21,8 @@ export interface BeamTextFieldProps extends BeamFocusableProps {
   helperText?: string | ReactNode;
   /** Input label */
   label: string;
-  /** An optional suffix for the label, i.e. `(Required)` or `(Optional). */
-  labelSuffix?: string;
+  /** Marks the field as required or optional, the default is assumed ambiguous/unknown. */
+  required?: boolean;
   /** If set, label will be placed as `aria-label` on input element */
   hideLabel?: boolean;
   value: string | undefined;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -21,6 +21,8 @@ export interface BeamTextFieldProps extends BeamFocusableProps {
   helperText?: string | ReactNode;
   /** Input label */
   label: string;
+  /** An optional suffix for the label, i.e. `(Required)` or `(Optional). */
+  labelSuffix?: string;
   /** If set, label will be placed as `aria-label` on input element */
   hideLabel?: boolean;
   value: string | undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -118,13 +118,6 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/helper-annotate-as-pure@^7.0.0":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz#7bf478ec3b71726d56a8ca5775b046fc29879e61"
-  integrity sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==
-  dependencies:
-    "@babel/types" "^7.14.5"
-
 "@babel/helper-annotate-as-pure@^7.10.4", "@babel/helper-annotate-as-pure@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.13.tgz#0f58e86dfc4bb3b1fcd7db806570e177d439b6ab"
@@ -1181,21 +1174,6 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.4.5":
-  version "7.14.5"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.5.tgz#c111b0f58afab4fea3d3385a406f692748c59870"
-  integrity sha512-G3BiS15vevepdmFqmUc9X+64y0viZYygubAMO8SvBmKARuF6CPSZtH4Ng9vi/lrWlZFGe3FWdXNy835akH8Glg==
-  dependencies:
-    "@babel/code-frame" "^7.14.5"
-    "@babel/generator" "^7.14.5"
-    "@babel/helper-function-name" "^7.14.5"
-    "@babel/helper-hoist-variables" "^7.14.5"
-    "@babel/helper-split-export-declaration" "^7.14.5"
-    "@babel/parser" "^7.14.5"
-    "@babel/types" "^7.14.5"
-    debug "^4.1.0"
-    globals "^11.1.0"
-
 "@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.12.7", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.14", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.13.14"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.13.14.tgz#c35a4abb15c7cd45a2746d78ab328e362cbace0d"
@@ -1331,7 +1309,7 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
-"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.2", "@emotion/is-prop-valid@^0.8.6", "@emotion/is-prop-valid@^0.8.8":
+"@emotion/is-prop-valid@0.8.8", "@emotion/is-prop-valid@^0.8.2", "@emotion/is-prop-valid@^0.8.6":
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
   integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
@@ -1422,12 +1400,12 @@
     "@emotion/styled-base" "^10.0.27"
     babel-plugin-emotion "^10.0.27"
 
-"@emotion/stylis@0.8.5", "@emotion/stylis@^0.8.4":
+"@emotion/stylis@0.8.5":
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
   integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
 
-"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.4", "@emotion/unitless@^0.7.5":
+"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.5":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
@@ -3316,7 +3294,7 @@
     prop-types "^15.7.2"
     regenerator-runtime "^0.13.7"
 
-"@storybook/addons@6.3.4", "@storybook/addons@^6.2.9", "@storybook/addons@^6.3.0", "@storybook/addons@^6.3.4":
+"@storybook/addons@6.3.4", "@storybook/addons@^6.3.0", "@storybook/addons@^6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/addons/-/addons-6.3.4.tgz#016c5c3e36c78a320eb8b022cf7fe556d81577c2"
   integrity sha512-rf8K8X3JrB43gq5nw5SYgfucQkFg2QgUMWdByf7dQ4MyIl5zet+2MYiSXJ9lfbhGKJZ8orc81rmMtiocW4oBjg==
@@ -3331,7 +3309,7 @@
     global "^4.4.0"
     regenerator-runtime "^0.13.7"
 
-"@storybook/api@6.3.4", "@storybook/api@^6.2.9", "@storybook/api@^6.3.0":
+"@storybook/api@6.3.4", "@storybook/api@^6.3.0":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/api/-/api-6.3.4.tgz#25b8b842104693000b018b3f64986e95fa032b45"
   integrity sha512-12q6dvSR4AtyuZbKAy3Xt+ZHzZ4ePPRV1q20xtgYBoiFEgB9vbh4XKEeeZD0yIeTamQ2x1Hn87R79Rs1GIdKRQ==
@@ -3446,7 +3424,7 @@
     qs "^6.10.0"
     telejson "^5.3.2"
 
-"@storybook/channels@6.3.4", "@storybook/channels@^6.2.9":
+"@storybook/channels@6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/channels/-/channels-6.3.4.tgz#425b31a67e42ac66ccb03465e4ba2e2ef9c8344b"
   integrity sha512-zdZzBbIu9JHEe+uw8FqKsNUiFY+iqI9QdHH/pM3DTTQpBN/JM1Xwfo3CkqA8c5PkhSGqpW0YjXoPash4lawr1Q==
@@ -3487,7 +3465,7 @@
     core-js "^3.8.2"
     global "^4.4.0"
 
-"@storybook/components@6.3.4", "@storybook/components@^6.2.9", "@storybook/components@^6.3.0":
+"@storybook/components@6.3.4", "@storybook/components@^6.3.0":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/components/-/components-6.3.4.tgz#c872ec267edf315eaada505be8595c70eb6db09b"
   integrity sha512-0hBKTkkQbW+daaA6nRedkviPr2bEzy1kwq0H5eaLKI1zYeXN3U5Z8fVhO137PPqH5LmLietrmTPkqiljUBk9ug==
@@ -3594,7 +3572,7 @@
     util-deprecate "^1.0.2"
     webpack "4"
 
-"@storybook/core-events@6.3.4", "@storybook/core-events@^6.2.9", "@storybook/core-events@^6.3.0":
+"@storybook/core-events@6.3.4", "@storybook/core-events@^6.3.0":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/core-events/-/core-events-6.3.4.tgz#f841b8659a8729d334acd9a6dcfc470c88a2be8f"
   integrity sha512-6qI5bU5VcAoRfxkvpdRqO16eYrX5M0P2E3TakqUUDcgDo5Rfcwd1wTTcwiXslMIh7oiVGiisA+msKTlfzyKf9Q==
@@ -3818,7 +3796,7 @@
     prettier "~2.2.1"
     regenerator-runtime "^0.13.7"
 
-"@storybook/theming@6.3.4", "@storybook/theming@^6.2.9":
+"@storybook/theming@6.3.4":
   version "6.3.4"
   resolved "https://registry.yarnpkg.com/@storybook/theming/-/theming-6.3.4.tgz#69d3f912c74a7b6ba78c1c95fac3315356468bdd"
   integrity sha512-L0lJcwUi7mse+U7EBAv5NVt81mH1MtUzk9paik8hMAc68vDtR/X0Cq4+zPsgykCROOTtEGrQ/JUUrpcEqeprTQ==
@@ -3871,20 +3849,6 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
-"@testing-library/dom@^7.22.0":
-  version "7.31.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.2.tgz#df361db38f5212b88555068ab8119f5d841a8c4a"
-  integrity sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/runtime" "^7.12.5"
-    "@types/aria-query" "^4.2.0"
-    aria-query "^4.2.2"
-    chalk "^4.1.0"
-    dom-accessibility-api "^0.5.6"
-    lz-string "^1.4.4"
-    pretty-format "^26.6.2"
-
 "@testing-library/dom@^7.28.1":
   version "7.30.3"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.30.3.tgz#779ea9bbb92d63302461800a388a5a890ac22519"
@@ -3898,21 +3862,6 @@
     dom-accessibility-api "^0.5.4"
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
-
-"@testing-library/jest-dom@^5.11.2":
-  version "5.14.1"
-  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-5.14.1.tgz#8501e16f1e55a55d675fe73eecee32cdaddb9766"
-  integrity sha512-dfB7HVIgTNCxH22M1+KU6viG5of2ldoA5ly8Ar8xkezKHKXjRvznCdbMbqjYGgO2xjRbwnR+rR8MLUIqF3kKbQ==
-  dependencies:
-    "@babel/runtime" "^7.9.2"
-    "@types/testing-library__jest-dom" "^5.9.1"
-    aria-query "^4.2.2"
-    chalk "^3.0.0"
-    css "^3.0.0"
-    css.escape "^1.5.1"
-    dom-accessibility-api "^0.5.6"
-    lodash "^4.17.15"
-    redent "^3.0.0"
 
 "@testing-library/jest-dom@^5.11.9":
   version "5.11.10"
@@ -4599,14 +4548,6 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
-
-"@xstate/react@^1.3.0":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@xstate/react/-/react-1.5.1.tgz#60817e60e54e338b8e7c3e51bfa4cd3babebdc7d"
-  integrity sha512-DJHDqDlZHus08X98uMJw4KR17FRWBXLHMQ02YRxx0DMm5VLn75VwGyt4tXdlNZHQWjyk++C5c9Ichq3PdmM3og==
-  dependencies:
-    use-isomorphic-layout-effect "^1.0.0"
-    use-subscription "^1.3.0"
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -5309,16 +5250,6 @@ babel-plugin-react-docgen@^4.2.1:
     lodash "^4.17.15"
     react-docgen "^5.0.0"
 
-"babel-plugin-styled-components@>= 1.12.0":
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.12.0.tgz#1dec1676512177de6b827211e9eda5a30db4f9b9"
-  integrity sha512-FEiD7l5ZABdJPpLssKXjBUJMYqzbcNzBowfXDCdJhOpbhWiewapUaY+LZGT8R4Jg2TwOjGjG4RKeyrO5p9sBkA==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.0.0"
-    "@babel/helper-module-imports" "^7.0.0"
-    babel-plugin-syntax-jsx "^6.18.0"
-    lodash "^4.17.11"
-
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
@@ -5780,11 +5711,6 @@ camelcase@^6.0.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
-
-camelize@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
-  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001181:
   version "1.0.30001208"
@@ -6518,11 +6444,6 @@ cpy@^8.1.1:
     p-filter "^2.1.0"
     p-map "^3.0.0"
 
-"crc32@>= 0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/crc32/-/crc32-0.2.2.tgz#7ad220d6ffdcd119f9fc127a7772cacea390a4ba"
-  integrity sha1-etIg1v/c0Rn5/BJ6d3LKzqOQpLo=
-
 create-ecdh@^4.0.0:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/create-ecdh/-/create-ecdh-4.0.4.tgz#d6e7f4bffa66736085a0762fd3a632684dabcc4e"
@@ -6609,11 +6530,6 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
-css-color-keywords@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
-  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
-
 css-loader@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-3.6.0.tgz#2e4b2c7e6e2d27f8c8f28f61bffcd2e6c91ef645"
@@ -6642,15 +6558,6 @@ css-select@^2.0.2:
     css-what "^3.2.1"
     domutils "^1.7.0"
     nth-check "^1.0.2"
-
-css-to-react-native@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
-  integrity sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==
-  dependencies:
-    camelize "^1.0.0"
-    css-color-keywords "^1.0.0"
-    postcss-value-parser "^4.0.2"
 
 css-what@^3.2.1:
   version "3.4.2"
@@ -6859,11 +6766,6 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
-"deflate-js@>= 0.2.2":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/deflate-js/-/deflate-js-0.2.3.tgz#f85abb58ebc5151a306147473d57c3e4f7e4426b"
-  integrity sha1-+Fq7WOvFFRowYUdHPVfD5PfkQms=
-
 del@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/del/-/del-6.0.0.tgz#0b40d0332cea743f1614f818be4feb717714c952"
@@ -7016,11 +6918,6 @@ dom-accessibility-api@^0.5.4:
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
   integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
-
-dom-accessibility-api@^0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.6.tgz#3f5d43b52c7a3bd68b5fb63fa47b4e4c1fdf65a9"
-  integrity sha512-DplGLZd8L1lN64jlT27N9TVSESFR5STaEJvX+thCby7fuCHonfPpAlodYc3vuUYbDuDec5w8AMP7oCM5TWFsqw==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -8552,14 +8449,6 @@ gud@^1.0.0:
   resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
   integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
 
-gzip-js@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/gzip-js/-/gzip-js-0.3.2.tgz#23117efeeb28cf385248deff0dffad894836d96b"
-  integrity sha1-IxF+/usozzhSSN7/Df+tiUg22Ws=
-  dependencies:
-    crc32 ">= 0.2.2"
-    deflate-js ">= 0.2.2"
-
 gzip-size@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
@@ -8809,7 +8698,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -10640,7 +10529,7 @@ lodash.uniqby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=
 
-lodash@4.x, lodash@^4.17.11, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
+lodash@4.x, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -12390,7 +12279,7 @@ postcss-selector-parser@^6.0.0, postcss-selector-parser@^6.0.2:
     uniq "^1.0.1"
     util-deprecate "^1.0.2"
 
-postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0:
+postcss-value-parser@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
@@ -14216,25 +14105,6 @@ storybook-addon-outline@^1.4.1:
     "@storybook/core-events" "^6.3.0"
     ts-dedent "^2.1.1"
 
-storybook-addon-performance@^0.16.0:
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/storybook-addon-performance/-/storybook-addon-performance-0.16.0.tgz#75a7c451202484aefff13162ebcd2d45f2c5b370"
-  integrity sha512-agAs4kxHHvIlaHLCSY05aXL5ZTVwskbMPxmSz9o2C4GGVeoolZEnTvv2Q1mSzu7BS9JqUj6DouM5tw4TM4u0Uw==
-  dependencies:
-    "@storybook/addons" "^6.2.9"
-    "@storybook/api" "^6.2.9"
-    "@storybook/channels" "^6.2.9"
-    "@storybook/components" "^6.2.9"
-    "@storybook/core-events" "^6.2.9"
-    "@storybook/theming" "^6.2.9"
-    "@testing-library/dom" "^7.22.0"
-    "@testing-library/jest-dom" "^5.11.2"
-    "@xstate/react" "^1.3.0"
-    gzip-js "^0.3.2"
-    styled-components "^5.1.1"
-    tiny-invariant "^1.1.0"
-    xstate "^4.11.0"
-
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"
@@ -14482,22 +14352,6 @@ style-value-types@4.1.4:
     hey-listen "^1.0.8"
     tslib "^2.1.0"
 
-styled-components@^5.1.1:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.3.0.tgz#e47c3d3e9ddfff539f118a3dd0fd4f8f4fb25727"
-  integrity sha512-bPJKwZCHjJPf/hwTJl6TbkSZg/3evha+XPEizrZUGb535jLImwDUdjTNxXqjjaASt2M4qO4AVfoHJNe3XB/tpQ==
-  dependencies:
-    "@babel/helper-module-imports" "^7.0.0"
-    "@babel/traverse" "^7.4.5"
-    "@emotion/is-prop-valid" "^0.8.8"
-    "@emotion/stylis" "^0.8.4"
-    "@emotion/unitless" "^0.7.4"
-    babel-plugin-styled-components ">= 1.12.0"
-    css-to-react-native "^3.0.0"
-    hoist-non-react-statics "^3.0.0"
-    shallowequal "^1.1.0"
-    supports-color "^5.5.0"
-
 stylis@^4.0.3:
   version "4.0.10"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.10.tgz#446512d1097197ab3f02fb3c258358c3f7a14240"
@@ -14508,7 +14362,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.3.0, supports-color@^5.5.0:
+supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -14741,7 +14595,7 @@ tiny-emitter@^2.0.0:
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
 
-tiny-invariant@^1.0.2, tiny-invariant@^1.1.0:
+tiny-invariant@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
   integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
@@ -15360,13 +15214,6 @@ use-query-params@^1.2.2:
   dependencies:
     serialize-query-params "^1.3.3"
 
-use-subscription@^1.3.0:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/use-subscription/-/use-subscription-1.5.1.tgz#73501107f02fad84c6dd57965beb0b75c68c42d1"
-  integrity sha512-Xv2a1P/yReAjAbhylMfFplFKj9GssgTwN7RlcTxBujFQcloStWNDQdc4g4NRWH9xS4i/FDk04vQBptAXoF3VcA==
-  dependencies:
-    object-assign "^4.1.1"
-
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -15813,11 +15660,6 @@ xmlchars@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-
-xstate@^4.11.0:
-  version "4.20.0"
-  resolved "https://registry.yarnpkg.com/xstate/-/xstate-4.20.0.tgz#6f241f2b49c840cb6e05b32544a6048362f558e2"
-  integrity sha512-u5Ou1CMo/oWApasmv1TYTHgj38k69DJdTqQdBBwt+/ooNhPJQiSIKTB3Y3HvX0h5tulwfSo6xAwZgBgjRsK3LA==
 
 xstate@^4.23.0:
   version "4.23.0"


### PR DESCRIPTION
Building out a form for Trade Partner Contacts and infra-izing various things about forms.

The biggest change is that most `...Field`s learned a new `required` prop, that if set to `true` or `false`, they'll add `Required` / `Optional` to their label (the text "Required" or "Optional" is currently controlled by a new `FormContext`).

Also the `Bound...Field`s learned to pass `field.required` in as the new `required` prop, so for the most part everything should wire together automatically/for free, based on `rules: [required]` in the form config.