### PR TITLE
feat: Add onClose to modalProps

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -7,6 +7,7 @@ import { IconButton } from "src/components/IconButton";
 import { useModal as ourUseModal } from "src/components/Modal/useModal";
 import { Css, Only, Xss } from "src/Css";
 import { useTestIds } from "src/utils";
+import {Callback} from "src/types";
 
 export type ModalSize = "sm" | "md" | "lg" | "xl";
 
@@ -23,6 +24,8 @@ export interface ModalProps {
   content: ReactNode;
   /** Force scrolling i.e. to avoid content jumping left/right as scroll bar goes away/comes back. */
   forceScrolling?: boolean;
+  /** Adds a callback that is called _after_ close has definitely happened. */
+  onClose?: Callback;
 }
 
 /**

--- a/src/components/Modal/useModal.tsx
+++ b/src/components/Modal/useModal.tsx
@@ -2,6 +2,7 @@ import { useContext, useMemo, useRef } from "react";
 import { BeamContext } from "src/components/BeamContext";
 import { Callback, CheckFn } from "src/types";
 import { ModalProps } from "./Modal";
+import {maybeCall} from "src/utils";
 
 export interface UseModalHook {
   openModal: (props: ModalProps) => void;
@@ -26,6 +27,7 @@ export function useModal(): UseModalHook {
             return;
           }
         }
+        maybeCall(modalState.current?.onClose);
         modalState.current = undefined;
       },
       // TODO: Rename as a breaking change


### PR DESCRIPTION
This PR adds an optional `onClose` callback to the `modalProps` interface. It is blocking ch4803.

Note: the `onClose` is only called once all `canClose` checks pass. 