### PR TITLE
feat: Add SelectField.mapOption prop.

### DIFF
--- a/src/forms/BoundSelectField.test.tsx
+++ b/src/forms/BoundSelectField.test.tsx
@@ -2,6 +2,7 @@ import { createObjectState, ObjectConfig, required } from "@homebound/form-state
 import { render } from "@homebound/rtl-utils";
 import { BoundSelectField } from "src/forms/BoundSelectField";
 import { AuthorInput } from "src/forms/formStateDomain";
+import { idAndName, identity } from "src/inputs/SelectField";
 
 const sports = [
   { id: "s:1", name: "Football" },
@@ -50,11 +51,3 @@ const formConfig: ObjectConfig<AuthorInput> = {
   favoriteSport: { type: "value", rules: [required] },
   isAvailable: { type: "value" },
 };
-
-function identity<T>(o: T): T {
-  return o;
-}
-
-function idAndName({ id, name }: { id: string; name: string }) {
-  return { value: id, label: name };
-}

--- a/src/forms/BoundSelectField.test.tsx
+++ b/src/forms/BoundSelectField.test.tsx
@@ -11,20 +11,26 @@ const sports = [
 describe("BoundSelectField", () => {
   it("shows the current value", async () => {
     const author = createObjectState(formConfig, { favoriteSport: "s:1" });
-    const { favoriteSport } = await render(<BoundSelectField field={author.favoriteSport} options={sports} />);
+    const { favoriteSport } = await render(
+      <BoundSelectField field={author.favoriteSport} options={sports} mapOption={idAndName} />,
+    );
     expect(favoriteSport()).toHaveValue("Football");
   });
 
   it("shows the error message", async () => {
     const author = createObjectState(formConfig, {});
     author.favoriteSport.touched = true;
-    const { favoriteSport_errorMsg } = await render(<BoundSelectField field={author.favoriteSport} options={sports} />);
+    const { favoriteSport_errorMsg } = await render(
+      <BoundSelectField field={author.favoriteSport} options={sports} mapOption={idAndName} />,
+    );
     expect(favoriteSport_errorMsg()).toHaveTextContent("Required");
   });
 
   it("shows the label", async () => {
     const author = createObjectState(formConfig, { favoriteSport: "s:1" });
-    const { favoriteSport_label } = await render(<BoundSelectField field={author.favoriteSport} options={sports} />);
+    const { favoriteSport_label } = await render(
+      <BoundSelectField field={author.favoriteSport} options={sports} mapOption={idAndName} />,
+    );
     expect(favoriteSport_label()).toHaveTextContent("Favorite Sport");
   });
 
@@ -35,14 +41,7 @@ describe("BoundSelectField", () => {
       { label: "No", value: false },
       { label: "", value: undefined },
     ];
-    const r = await render(
-      <BoundSelectField
-        field={author.isAvailable}
-        options={options}
-        getOptionLabel={(o) => o.label}
-        getOptionValue={(o) => o.value}
-      />,
-    );
+    const r = await render(<BoundSelectField field={author.isAvailable} options={options} mapOption={identity} />);
     expect(r.isAvailable()).toHaveValue("");
   });
 });
@@ -51,3 +50,11 @@ const formConfig: ObjectConfig<AuthorInput> = {
   favoriteSport: { type: "value", rules: [required] },
   isAvailable: { type: "value" },
 };
+
+function identity<T>(o: T): T {
+  return o;
+}
+
+function idAndName({ id, name }: { id: string; name: string }) {
+  return { value: id, label: name };
+}

--- a/src/forms/BoundSelectField.tsx
+++ b/src/forms/BoundSelectField.tsx
@@ -1,7 +1,6 @@
 import { FieldState } from "@homebound/form-state/dist/formState";
 import { Observer } from "mobx-react";
 import { SelectField, SelectFieldProps, Value } from "src/inputs";
-import { HasIdAndName, Optional } from "src/types";
 import { defaultLabel } from "src/utils/defaultLabel";
 import { useTestIds } from "src/utils/useTestIds";
 
@@ -24,19 +23,11 @@ export type BoundSelectFieldProps<T, V extends Value> = Omit<
  * The caller has to tell us how to turn `T` into `V`, which is usually a
  * lambda like `t => t.id`.
  */
-export function BoundSelectField<T, V extends Value>(props: BoundSelectFieldProps<T, V>): JSX.Element;
-export function BoundSelectField<T extends HasIdAndName<V>, V extends Value>(
-  props: Optional<BoundSelectFieldProps<T, V>, "getOptionLabel" | "getOptionValue">,
-): JSX.Element;
-export function BoundSelectField<T extends object, V extends Value>(
-  props: Optional<BoundSelectFieldProps<T, V>, "getOptionValue" | "getOptionLabel">,
-): JSX.Element {
+export function BoundSelectField<T extends object, V extends Value>(props: BoundSelectFieldProps<T, V>): JSX.Element {
   const {
     field,
     options,
     readOnly,
-    getOptionValue = (opt: T) => (opt as any).id, // if unset, assume O implements HasId
-    getOptionLabel = (opt: T) => (opt as any).name, // if unset, assume O implements HasName
     onSelect = (value) => field.set(value),
     label = defaultLabel(field.key),
     ...others
@@ -53,8 +44,6 @@ export function BoundSelectField<T extends object, V extends Value>(
           readOnly={readOnly ?? field.readOnly}
           errorMsg={field.touched ? field.errors.join(" ") : undefined}
           required={field.required}
-          getOptionLabel={getOptionLabel}
-          getOptionValue={getOptionValue}
           onBlur={() => field.blur()}
           onFocus={() => field.focus()}
           {...others}

--- a/src/inputs/SelectField.stories.tsx
+++ b/src/inputs/SelectField.stories.tsx
@@ -3,8 +3,7 @@ import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { GridColumn, GridTable, Icon, Icons, simpleHeader, SimpleHeaderAndDataOf } from "src/components";
 import { Css } from "src/Css";
-import { SelectField, SelectFieldProps, Value } from "src/inputs";
-import { HasIdAndName, Optional } from "src/types";
+import { idAndName, identity, SelectField, SelectFieldProps, Value } from "src/inputs";
 import { noop } from "src/utils";
 import { zeroTo } from "src/utils/sb";
 
@@ -51,61 +50,73 @@ export function SelectFields() {
           label="Favorite Icon"
           value={options[2].id}
           options={options}
-          getOptionMenuLabel={(o) => (
-            <div css={Css.df.itemsCenter.$}>
-              {o.icon && (
-                <span css={Css.fs0.mr2.$}>
-                  <Icon icon={o.icon} />
-                </span>
-              )}
-              {o.name}
-            </div>
-          )}
+          mapOption={(o) => ({
+            ...idAndName(o),
+            menuLabel: (
+              <div css={Css.df.itemsCenter.$}>
+                {o.icon && (
+                  <span css={Css.fs0.mr2.$}>
+                    <Icon icon={o.icon} />
+                  </span>
+                )}
+                {o.name}
+              </div>
+            ),
+          })}
         />
         <TestSelectField
           label="Favorite Icon - with field decoration"
           options={options}
           fieldDecoration={(o) => o.icon && <Icon icon={o.icon} />}
           value={options[1].id}
-          getOptionMenuLabel={(o) => (
-            <div css={Css.df.itemsCenter.$}>
-              {o.icon && (
-                <span css={Css.fs0.mr2.$}>
-                  <Icon icon={o.icon} />
-                </span>
-              )}
-              {o.name}
-            </div>
-          )}
+          mapOption={(o) => ({
+            ...idAndName(o),
+            menuLabel: (
+              <div css={Css.df.itemsCenter.$}>
+                {o.icon && (
+                  <span css={Css.fs0.mr2.$}>
+                    <Icon icon={o.icon} />
+                  </span>
+                )}
+                {o.name}
+              </div>
+            ),
+          })}
         />
         <TestSelectField<TestOption, string>
           label="Favorite Icon - Disabled"
           value={undefined}
           options={options}
           disabled
+          mapOption={idAndName}
         />
-        <TestSelectField label="Favorite Icon - Read Only" options={options} value={options[2].id} readOnly />
-        <TestSelectField<TestOption, string> label="Favorite Icon - Invalid" value={undefined} options={options} />
+        <TestSelectField
+          label="Favorite Icon - Read Only"
+          options={options}
+          value={options[2].id}
+          readOnly
+          mapOption={idAndName}
+        />
+        <TestSelectField<TestOption, string>
+          label="Favorite Icon - Invalid"
+          value={undefined}
+          options={options}
+          mapOption={idAndName}
+        />
         <TestSelectField
           label="Favorite Icon - Helper Text"
           value={options[0].id}
           options={options}
           helperText="Some really long helper text that we expect to wrap."
+          mapOption={idAndName}
         />
         <TestSelectField
           label="Favorite Number - Numeric"
           value={1}
           options={optionsWithNumericIds}
-          getOptionValue={(o) => o.id}
-          getOptionLabel={(o) => o.name}
+          mapOption={idAndName}
         />
-        <TestSelectField
-          label="Is Available - Boolean"
-          value={false}
-          options={booleanOptions}
-          getOptionValue={(o) => o.value}
-          getOptionLabel={(o) => o.label}
-        />
+        <TestSelectField label="Is Available - Boolean" value={false} options={booleanOptions} mapOption={identity} />
       </div>
 
       <div css={Css.df.flexColumn.childGap2.$}>
@@ -115,16 +126,19 @@ export function SelectFields() {
           label="Favorite Icon"
           value={options[2].id}
           options={options}
-          getOptionMenuLabel={(o) => (
-            <div css={Css.df.itemsCenter.$}>
-              {o.icon && (
-                <span css={Css.fs0.mr2.$}>
-                  <Icon icon={o.icon} />
-                </span>
-              )}
-              {o.name}
-            </div>
-          )}
+          mapOption={(o) => ({
+            ...idAndName(o),
+            menuLabel: (
+              <div css={Css.df.itemsCenter.$}>
+                {o.icon && (
+                  <span css={Css.fs0.mr2.$}>
+                    <Icon icon={o.icon} />
+                  </span>
+                )}
+                {o.name}
+              </div>
+            ),
+          })}
         />
         <TestSelectField
           compact
@@ -132,57 +146,90 @@ export function SelectFields() {
           options={options}
           fieldDecoration={(o) => o.icon && <Icon icon={o.icon} />}
           value={options[1].id}
-          getOptionMenuLabel={(o) => (
-            <div css={Css.df.itemsCenter.$}>
-              {o.icon && (
-                <span css={Css.fs0.mr2.$}>
-                  <Icon icon={o.icon} />
-                </span>
-              )}
-              {o.name}
-            </div>
-          )}
+          mapOption={(o) => ({
+            ...idAndName(o),
+            menuLabel: (
+              <div css={Css.df.itemsCenter.$}>
+                {o.icon && (
+                  <span css={Css.fs0.mr2.$}>
+                    <Icon icon={o.icon} />
+                  </span>
+                )}
+                {o.name}
+              </div>
+            ),
+          })}
         />
         <TestSelectField<TestOption, string>
           compact
           label="Favorite Icon - Disabled"
           value={undefined}
           options={options}
+          mapOption={idAndName}
           disabled
         />
-        <TestSelectField compact label="Favorite Icon - Read Only" options={options} value={options[2].id} readOnly />
+        <TestSelectField
+          compact
+          label="Favorite Icon - Read Only"
+          options={options}
+          value={options[2].id}
+          readOnly
+          mapOption={idAndName}
+        />
         <TestSelectField<TestOption, string>
           compact
           label="Favorite Icon - Invalid"
           options={options}
           value={undefined}
+          mapOption={idAndName}
         />
       </div>
       <div css={Css.df.flexColumn.childGap2.$}>
         <h1 css={Css.lg.$}>Inline Label</h1>
-        <TestSelectField inlineLabel label="Favorite Icon" value={options[2].id} options={options} />
-        <TestSelectField inlineLabel compact label="Favorite Icon" value={options[2].id} options={options} />
+        <TestSelectField
+          inlineLabel
+          label="Favorite Icon"
+          value={options[2].id}
+          options={options}
+          mapOption={idAndName}
+        />
+        <TestSelectField
+          inlineLabel
+          compact
+          label="Favorite Icon"
+          value={options[2].id}
+          options={options}
+          mapOption={idAndName}
+        />
         <TestSelectField
           label="Favorite Icon"
           inlineLabel
           options={options}
           fieldDecoration={(o) => o.icon && <Icon icon={o.icon} />}
           value={options[4].id}
-          getOptionMenuLabel={(o) => (
-            <div css={Css.df.itemsCenter.$}>
-              {o.icon && (
-                <span css={Css.fs0.mr2.$}>
-                  <Icon icon={o.icon} />
-                </span>
-              )}
-              {o.name}
-            </div>
-          )}
+          mapOption={(o) => ({
+            ...idAndName(o),
+            menuLabel: (
+              <div css={Css.df.itemsCenter.$}>
+                {o.icon && (
+                  <span css={Css.fs0.mr2.$}>
+                    <Icon icon={o.icon} />
+                  </span>
+                )}
+                {o.name}
+              </div>
+            ),
+          })}
         />
       </div>
       <div css={Css.df.flexColumn.childGap2.$}>
         <h1 css={Css.lg.$}>Load test, 1000 Options</h1>
-        <TestSelectField label="Project" value={loadTestOptions[2].id} options={loadTestOptions} />
+        <TestSelectField
+          label="Project"
+          value={loadTestOptions[2].id}
+          options={loadTestOptions}
+          mapOption={idAndName}
+        />
       </div>
     </div>
   );
@@ -210,15 +257,7 @@ const columns: GridColumn<Row>[] = [
   { header: "Address", data: (data) => data.address },
   {
     header: "Contact",
-    data: (data) => (
-      <SelectField
-        getOptionValue={(iu) => iu.id}
-        getOptionLabel={(iu) => iu.name}
-        value={data.user.id}
-        onSelect={noop}
-        options={people}
-      />
-    ),
+    data: (data) => <SelectField value={data.user.id} onSelect={noop} options={people} mapOption={idAndName} />,
   },
   { header: "Market", data: (data) => data.market },
 ];
@@ -226,25 +265,15 @@ type Row = SimpleHeaderAndDataOf<Request>;
 type InternalUser = { name: string; id: string };
 type Request = { id: string; user: InternalUser; address: string; homeowner: string; market: string };
 
-// Kind of annoying but to get type inference for HasIdAndName working, we
-// have to re-copy/paste the overload here.
 function TestSelectField<T extends object, V extends Value>(
   props: Omit<SelectFieldProps<T, V>, "onSelect">,
-): JSX.Element;
-function TestSelectField<O extends HasIdAndName<V>, V extends Value>(
-  props: Optional<Omit<SelectFieldProps<O, V>, "onSelect">, "getOptionValue" | "getOptionLabel">,
-): JSX.Element;
-function TestSelectField<T extends object, V extends Value>(
-  props: Optional<Omit<SelectFieldProps<T, V>, "onSelect">, "getOptionValue" | "getOptionLabel">,
 ): JSX.Element {
   const [selectedOption, setSelectedOption] = useState<V | undefined>(props.value);
 
   return (
     <div css={Css.df.$}>
       <SelectField<T, V>
-        // The `as any` is due to something related to https://github.com/emotion-js/emotion/issues/2169
-        // We may have to redo the conditional getOptionValue/getOptionLabel
-        {...(props as any)}
+        {...props}
         value={selectedOption}
         onSelect={setSelectedOption}
         errorMsg={

--- a/src/inputs/SelectField.test.tsx
+++ b/src/inputs/SelectField.test.tsx
@@ -1,6 +1,6 @@
 import { click, input, render } from "@homebound/rtl-utils";
 import { useState } from "react";
-import { SelectField, SelectFieldProps, Value } from "src/inputs";
+import { idAndName, SelectField, SelectFieldProps, Value } from "src/inputs";
 
 const options = [
   { id: "1", name: "One" },
@@ -14,13 +14,7 @@ describe("SelectFieldTest", () => {
   it("can set a value", async () => {
     // Given a MultiSelectField
     const { getByRole } = await render(
-      <TestSelectField
-        label="Age"
-        value={"1"}
-        options={options}
-        getOptionLabel={(o) => o.name}
-        getOptionValue={(o) => o.id}
-      />,
+      <TestSelectField label="Age" value={"1"} options={options} mapOption={idAndName} />,
     );
     // That initially has "One" selected
     const text = getByRole("combobox");

--- a/src/inputs/SelectField.tsx
+++ b/src/inputs/SelectField.tsx
@@ -1,17 +1,14 @@
-import React, { ReactNode } from "react";
+import React from "react";
 import { Value } from "src/inputs";
 import { BeamSelectFieldBaseProps, SelectFieldBase } from "src/inputs/internal/SelectFieldBase";
-import { HasIdAndName, Optional } from "src/types";
 
 export interface SelectFieldProps<O, V extends Value> extends BeamSelectFieldBaseProps<O> {
   /** Renders `opt` in the dropdown menu, defaults to the `getOptionLabel` prop. */
-  getOptionMenuLabel?: (opt: O) => string | ReactNode;
-  getOptionValue: (opt: O) => V;
-  getOptionLabel: (opt: O) => string;
   /** The current value; it can be `undefined`, even if `V` cannot be. */
   value: V | undefined;
   onSelect: (value: V, opt: O) => void;
   options: O[];
+  mapOption: (opt: O) => { label: string; value: V; menuLabel?: string };
 }
 
 /**
@@ -20,33 +17,24 @@ export interface SelectFieldProps<O, V extends Value> extends BeamSelectFieldBas
  * The `O` type is a list of options to show, the `V` is the primitive value of a
  * given `O` (i.e. it's id) that you want to use as the current/selected value.
  */
-export function SelectField<O, V extends Value>(props: SelectFieldProps<O, V>): JSX.Element;
-export function SelectField<O extends HasIdAndName<V>, V extends Value>(
-  props: Optional<SelectFieldProps<O, V>, "getOptionValue" | "getOptionLabel">,
-): JSX.Element;
-export function SelectField<O, V extends Value>(
-  props: Optional<SelectFieldProps<O, V>, "getOptionLabel" | "getOptionValue">,
-): JSX.Element {
-  const {
-    getOptionValue = (opt: O) => (opt as any).id, // if unset, assume O implements HasId
-    getOptionLabel = (opt: O) => (opt as any).name, // if unset, assume O implements HasName
-    options,
-    onSelect,
-    value,
-    ...otherProps
-  } = props;
+export function SelectField<O, V extends Value>(props: SelectFieldProps<O, V>): JSX.Element {
+  const { options, onSelect, value, mapOption, ...otherProps } = props;
 
   return (
     <SelectFieldBase
       {...otherProps}
       options={options}
-      getOptionLabel={getOptionLabel}
-      getOptionValue={getOptionValue}
+      getOptionLabel={(o) => mapOption(o).label}
+      getOptionMenuLabel={(o) => {
+        const mapped = mapOption(o);
+        return mapped.menuLabel ?? mapped.label;
+      }}
+      getOptionValue={(o) => mapOption(o).value}
       values={value ? [value] : []}
       onSelect={(values) => {
         if (values.length > 0) {
-          const selectedOption = options.find((o) => getOptionValue(o) === values[0]);
-          onSelect && selectedOption && onSelect(getOptionValue(selectedOption), selectedOption);
+          const selectedOption = options.find((o) => mapOption(o).value === values[0]);
+          onSelect && selectedOption && onSelect(mapOption(selectedOption).value, selectedOption);
         }
       }}
     />

--- a/src/inputs/SelectField.tsx
+++ b/src/inputs/SelectField.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import { Value } from "src/inputs";
 import { BeamSelectFieldBaseProps, SelectFieldBase } from "src/inputs/internal/SelectFieldBase";
 
@@ -8,7 +8,7 @@ export interface SelectFieldProps<O, V extends Value> extends BeamSelectFieldBas
   value: V | undefined;
   onSelect: (value: V, opt: O) => void;
   options: O[];
-  mapOption: (opt: O) => { label: string; value: V; menuLabel?: string };
+  mapOption: (opt: O) => { label: string; value: V; menuLabel?: ReactNode };
 }
 
 /**
@@ -39,4 +39,12 @@ export function SelectField<O, V extends Value>(props: SelectFieldProps<O, V>): 
       }}
     />
   );
+}
+
+export function identity<T>(o: T): T {
+  return o;
+}
+
+export function idAndName<V extends Value>({ id, name }: { id: V; name: string }) {
+  return { value: id, label: name };
 }


### PR DESCRIPTION
Trying out an alternative API for `SelectField`.

Having to type out `getOptionLabel` and `getOptionValue` all the time has been boilerplately.

One attempt to reduce this was some type system magic to realize "oh the option already has an id+name, we'll just use that".

But it was pretty ugly to pull off, and also very limited, you had to implement id+name to get the succinct versions.

Playing around, it seems cute to combine `getOptionLabel` + `getOptionValue` + `getOptionMenuLabel` into a single prop of "hey we need you to map this option to 'stuff we need'".

The upshot of it being a single prop is that, even when defining by hand it's more succinct, but also you can apply defaults for all three behaviors from a single function, i.e. `idAndName`:

```
        <TestSelectField
          label="Favorite Icon - Disabled"
          value={undefined}
          options={options}
          disabled
          mapOption={idAndName}
        />
```
