### PR TITLE
feat: Add dedicated cell sortValue.

### DIFF
--- a/src/components/GridTable.test.tsx
+++ b/src/components/GridTable.test.tsx
@@ -247,6 +247,37 @@ describe("GridTable", () => {
       expect(cell(r, 1, 0)).toHaveTextContent("c");
     });
 
+    it("can sort by dedicated sort values", async () => {
+      // Given the table is using client-side sorting
+      const r = await render(
+        <GridTable<Row>
+          columns={[
+            nameColumn,
+            {
+              header: () => "Value",
+              data: (row) => ({
+                // And the value is the name, for filtering
+                value: row.name,
+                // But the sort value is set to the numeric value
+                sortValue: row.value,
+                content: <div>{row.name}</div>,
+              }),
+            },
+          ]}
+          sorting={{ on: "client", initial: [1, "ASC"] }}
+          rows={[
+            simpleHeader,
+            // And the data is initially unsorted
+            { kind: "data", id: "2", name: "b", value: 2 },
+            { kind: "data", id: "1", name: "a", value: 3 },
+            { kind: "data", id: "3", name: "c", value: 1 },
+          ]}
+        />,
+      );
+      // Then the `value: 1` row is first
+      expect(cell(r, 1, 0)).toHaveTextContent("c");
+    });
+
     it("can sort undefined values", async () => {
       // Given the table is using client-side sorting
       const r = await render(

--- a/src/components/GridTable.tsx
+++ b/src/components/GridTable.tsx
@@ -732,6 +732,8 @@ export type GridCellContent = {
   alignment?: GridCellAlignment;
   /** Allow value to be a function in case it's a dynamic value i.e. reading from an inline-edited proxy. */
   value?: MaybeFn<number | string | Date>;
+  /** The value to use specifically for sorting (i.e. if `value` is used for filtering); defaults to `value`. */
+  sortValue?: MaybeFn<number | string | Date>;
   /** Whether to indent the cell. */
   indent?: 1 | 2;
 };
@@ -1064,8 +1066,8 @@ function sortBatch<R extends Kinded>(
   const column = columns[value];
   const invert = direction === "DESC";
   batch.sort((a, b) => {
-    const v1 = maybeValue(applyRowFn(column, a));
-    const v2 = maybeValue(applyRowFn(column, b));
+    const v1 = sortValue(applyRowFn(column, a));
+    const v2 = sortValue(applyRowFn(column, b));
     const v1e = v1 === null || v1 === undefined;
     const v2e = v2 === null || v2 === undefined;
     if ((v1e && v2e) || v1 === v2) {
@@ -1079,7 +1081,19 @@ function sortBatch<R extends Kinded>(
   });
 }
 
-function maybeValue(value: ReactNode | GridCellContent): any {
+/** Look at a row and get its sort value. */
+function sortValue(value: ReactNode | GridCellContent): any {
+  // Check sortValue and then fallback on value
+  const maybeFn = value && typeof value === "object" && "value" in value ? value.sortValue || value.value : value;
+  // Watch for functions that need to read from a potentially-changing proxy
+  if (maybeFn instanceof Function) {
+    return maybeFn();
+  }
+  return maybeFn;
+}
+
+/** Look at a row and get its filter value. */
+function filterValue(value: ReactNode | GridCellContent): any {
   const maybeFn = value && typeof value === "object" && "value" in value ? value.value : value;
   // Watch for functions that need to read from a potentially-changing proxy
   if (maybeFn instanceof Function) {
@@ -1164,7 +1178,7 @@ function maybeApplyFunction<T>(
 }
 
 export function matchesFilter(maybeContent: ReactNode | GridCellContent, filter: string): boolean {
-  let value = maybeValue(maybeContent);
+  let value = filterValue(maybeContent);
   if (typeof value === "string") {
     return value.toLowerCase().includes(filter.toLowerCase());
   } else if (typeof value === "number") {


### PR DESCRIPTION
Previously we had just `value` which was used for both filtering + sorting.

But you may want filtering to use text like "Accepted" and "Rejected" but, for whatever reason, have "Rejected" sort before "Accepted" so have sort values of like 2 and 1 respectively.