### PR TITLE
fix: Always initial sort, fix sortValue w/o value.

### DIFF
--- a/src/components/GridTable.stories.tsx
+++ b/src/components/GridTable.stories.tsx
@@ -43,7 +43,10 @@ type Row = SimpleHeaderAndDataOf<Data>;
 // f1 (total-total)
 
 export function ClientSideSorting() {
-  const nameColumn: GridColumn<Row> = { header: "Name", data: ({ name }) => name };
+  const nameColumn: GridColumn<Row> = {
+    header: "Name",
+    data: ({ name }) => ({ content: <div>{name}</div>, sortValue: name }),
+  };
   const valueColumn: GridColumn<Row> = { header: "Value", data: ({ value }) => value };
   const actionColumn: GridColumn<Row> = { header: "Action", data: () => <div>Actions</div>, clientSideSort: false };
   return (

--- a/src/components/GridTable.test.tsx
+++ b/src/components/GridTable.test.tsx
@@ -169,14 +169,14 @@ describe("GridTable", () => {
           ]}
         />,
       );
-      // Then the data is initially render un-sorted
-      expect(cell(r, 1, 0)).toHaveTextContent("b");
+      // Then the data is initially render sorted by 1st column
+      expect(cell(r, 1, 0)).toHaveTextContent("a");
 
       // And when sorted by column 1
       const { sortHeader_0, sortHeader_1 } = r;
       click(sortHeader_0);
-      // Then 'name: a' row is first
-      expect(cell(r, 1, 0)).toHaveTextContent("a");
+      // Then 'name: c' row is first
+      expect(cell(r, 1, 0)).toHaveTextContent("c");
 
       // And when sorted by column 2
       click(sortHeader_1);
@@ -357,6 +357,27 @@ describe("GridTable", () => {
       );
       // Then the data is sorted by value
       expect(cell(r, 1, 0)).toHaveTextContent("c");
+      expect(cell(r, 2, 0)).toHaveTextContent("b");
+    });
+
+    it("initially sorts by the 1st column is not specified", async () => {
+      // Given a table
+      const r = await render(
+        <GridTable
+          columns={[nameColumn, valueColumn]}
+          // And there is no initial sort given
+          sorting={{ on: "client" }}
+          rows={[
+            simpleHeader,
+            // And the data is initially unsorted
+            { kind: "data", id: "2", name: "b", value: 2 },
+            { kind: "data", id: "1", name: "a", value: 3 },
+            { kind: "data", id: "3", name: "c", value: 1 },
+          ]}
+        />,
+      );
+      // Then the data is sorted by name
+      expect(cell(r, 1, 0)).toHaveTextContent("a");
       expect(cell(r, 2, 0)).toHaveTextContent("b");
     });
   });

--- a/src/components/GridTable.tsx
+++ b/src/components/GridTable.tsx
@@ -1127,7 +1127,8 @@ function useSortState<R extends Kinded, S>(
         return [(key as any) as S, initial[1]];
       } else {
         // If no explicit sorting, assume 1st column ascending
-        return [(0 as any) as S, "ASC"];
+        const firstSortableColumn = columns.findIndex((c) => c.clientSideSort !== false);
+        return [(firstSortableColumn as any) as S, "ASC"];
       }
       return undefined;
     } else {

--- a/src/components/GridTable.tsx
+++ b/src/components/GridTable.tsx
@@ -68,7 +68,7 @@ export function simpleDataRows<T extends { id: string }, R extends { kind: "head
  * a) `serverSideSortKey` if we're server-side sorting, or
  * b) it's index in the `columns` array, if client-side sorting
  */
-type SortState<S> = [S, Direction];
+type SortState<S> = readonly [S, Direction];
 
 export type Kinded = { kind: string };
 
@@ -1085,7 +1085,15 @@ function sortBatch<R extends Kinded>(
 /** Look at a row and get its sort value. */
 function sortValue(value: ReactNode | GridCellContent): any {
   // Check sortValue and then fallback on value
-  const maybeFn = value && typeof value === "object" && "value" in value ? value.sortValue || value.value : value;
+  let maybeFn = value;
+  if (value && typeof value === "object") {
+    // Look for GridCellContent.sortValue, then GridCellContent.value
+    if ("sortValue" in value) {
+      maybeFn = value.sortValue;
+    } else if ("value" in value) {
+      maybeFn = value.value;
+    }
+  }
   // Watch for functions that need to read from a potentially-changing proxy
   if (maybeFn instanceof Function) {
     return maybeFn();
@@ -1116,7 +1124,10 @@ function useSortState<R extends Kinded, S>(
       const { initial } = sorting;
       if (initial) {
         const key = typeof initial[0] === "number" ? initial[0] : columns.indexOf(initial[0] as any);
-        return ([key, initial[1]] as any) as SortState<S>;
+        return [(key as any) as S, initial[1]];
+      } else {
+        // If no explicit sorting, assume 1st column ascending
+        return [(0 as any) as S, "ASC"];
       }
       return undefined;
     } else {


### PR DESCRIPTION
Two changes:

* I went to use the new `sortValue` and realized it didn't work if there was not always a `value` key (bad `keyof` check)
* If client-side sorting, seems like a good default is to just sort by 1st column asc, it's come up before that our tables "don't look like they support sorting", when really it's just b/c they aren't initially sorted and the user has to click to see "oh I can sort"