### PR TITLE
fix: Bump down typescript-transform-paths to avoid require bug.

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "tslib": "^2.1.0",
     "ttypescript": "^1.5.12",
     "typescript": "^4.3.5",
-    "typescript-transform-paths": "^3.2.1",
+    "typescript-transform-paths": "^2.2.4",
     "watch": "^1.0.2",
     "xstate": "^4.23.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14938,10 +14938,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript-transform-paths@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/typescript-transform-paths/-/typescript-transform-paths-3.2.1.tgz#aa3f60ebf8c9eb4c4c07c96b91f6ee0a0db1b3f8"
-  integrity sha512-A2WRrELxKz4ivai9NO2lq7+H2peNZ9/ouSULSgrE0IpEa/sdam2k70aWn9BNb1rFUZnWn/MFXcSijvpa2GgwzQ==
+typescript-transform-paths@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/typescript-transform-paths/-/typescript-transform-paths-2.2.4.tgz#9d4b74a063918ce528b696766634f854b8ce9134"
+  integrity sha512-i+/sgp3rw1ZronMCm2TKGBy1dlvN88Kd8CCb+HWnOE8+Hv0uIVnbC8xM5AD2t1JBCWabEhuH9p3n8DOVi0+R6g==
   dependencies:
     minimatch "^3.0.4"
 


### PR DESCRIPTION
When upgrading typescript, I'd upgraded typescript-transform-paths for good measure, but turns out it causes this bug:

https://github.com/LeDDGroup/typescript-transform-paths/issues/132

