### PR TITLE
feat: Allow passing undefined to simple row factories.

### DIFF
--- a/src/components/GridTable.test.tsx
+++ b/src/components/GridTable.test.tsx
@@ -12,6 +12,7 @@ import {
   simpleHeader,
   SimpleHeaderAndDataOf,
   SimpleHeaderAndDataWith,
+  simpleRows,
 } from "src/components/GridTable";
 import { Css, Palette } from "src/Css";
 import { cell, click, render, row } from "src/utils/rtl";
@@ -796,6 +797,24 @@ describe("GridTable", () => {
     const r = await render(<GridTable columns={[valueColumn]} rows={rows} />);
     expect(cell(r, 1, 0)).toHaveTextContent("id=a:1 value=1");
     expect(cell(r, 2, 0)).toHaveTextContent("id=a:2 value=2");
+  });
+
+  it("simpleRows can accept undefined", async () => {
+    // Given a row that uses SimpleHeaderAndDataOf
+    type Row = SimpleHeaderAndDataOf<{ value: number }>;
+    // And we don't have any data defined yet
+    const rows: GridDataRow<Row>[] = simpleRows(undefined);
+    // Then we still get back the header row
+    expect(rows).toEqual([simpleHeader]);
+  });
+
+  it("simpleDataRows can accept undefined", async () => {
+    // Given a row that uses SimpleHeaderAndDataWith
+    type Row = SimpleHeaderAndDataWith<{ value: number }>;
+    // And we don't have any data defined yet
+    const rows: GridDataRow<Row>[] = simpleDataRows(undefined);
+    // Then we still get back the header row
+    expect(rows).toEqual([simpleHeader]);
   });
 });
 

--- a/src/components/GridTable.tsx
+++ b/src/components/GridTable.tsx
@@ -40,7 +40,7 @@ export type SimpleHeaderAndDataWith<T> =
 export const simpleHeader = { kind: "header" as const, id: "header" };
 
 export function simpleRows<T extends { id: string }, R extends { kind: "header" | "data" }>(
-  data: T[],
+  data: T[] | undefined = [],
 ): GridDataRow<R>[] {
   // @ts-ignore Not sure why this doesn't type-check, something esoteric with the DiscriminateUnion type
   return [simpleHeader, ...data.map((c) => ({ kind: "data" as const, ...c }))];
@@ -48,7 +48,7 @@ export function simpleRows<T extends { id: string }, R extends { kind: "header" 
 
 /** Like `simpleRows` but for `SimpleHeaderAndDataWith`. */
 export function simpleDataRows<T extends { id: string }, R extends { kind: "header" | "data" }>(
-  data: T[],
+  data: T[] | undefined = [],
 ): GridDataRow<R>[] {
   // @ts-ignore Not sure why this doesn't type-check, something esoteric with the DiscriminateUnion type
   return [simpleHeader, ...data.map((data) => ({ kind: "data" as const, data, id: data.id }))];


### PR DESCRIPTION
I.e. if a GraphQL query has not come back yet, we still want to show the header.