### PR TITLE
fix: Render TextFields as just text when readOnly.

### DIFF
--- a/src/inputs/SelectField.test.tsx
+++ b/src/inputs/SelectField.test.tsx
@@ -1,4 +1,5 @@
 import { click, input, render } from "@homebound/rtl-utils";
+import { fireEvent } from "@testing-library/react";
 import { useState } from "react";
 import { SelectField, SelectFieldProps, Value } from "src/inputs";
 
@@ -31,6 +32,28 @@ describe("SelectFieldTest", () => {
     click(getByRole("option", { name: "Three" }));
     // Then onSelect was called
     expect(onSelect).toHaveBeenCalledWith("3");
+  });
+
+  it("does not fire focus/blur when readOnly", async () => {
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    const r = await render(
+      <TestSelectField
+        label="Age"
+        value={"1"}
+        readOnly={true}
+        options={options}
+        getOptionLabel={(o) => o.name}
+        getOptionValue={(o) => o.id}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        data-testid="age"
+      />,
+    );
+    fireEvent.focus(r.age());
+    fireEvent.blur(r.age());
+    expect(onBlur).not.toHaveBeenCalled();
+    expect(onFocus).not.toHaveBeenCalled();
   });
 
   function TestSelectField<O, V extends Value>(props: Omit<SelectFieldProps<O, V>, "onSelect">): JSX.Element {

--- a/src/inputs/TextAreaField.stories.tsx
+++ b/src/inputs/TextAreaField.stories.tsx
@@ -6,10 +6,10 @@ import { TextAreaField, TextAreaFieldProps, TextField } from "src/inputs";
 
 export default {
   component: TextAreaField,
-  title: "Inputs/Text Areas",
+  title: "Inputs/Text Area",
 } as Meta;
 
-export function TextAreas() {
+export function TextAreaStyles() {
   return (
     <div css={Css.df.flexColumn.childGap5.$}>
       <div css={Css.df.flexColumn.childGap2.$}>
@@ -25,6 +25,26 @@ export function TextAreas() {
         />
         <ValidationTextArea value="Not enough characters" />
         <TextField label="Regular Field For Reference" value="value" onChange={() => {}} />
+      </div>
+    </div>
+  );
+}
+
+export function TextAreaReadOnly() {
+  return (
+    <div css={Css.df.childGap2.$}>
+      <div css={Css.df.flexColumn.childGap3.$}>
+        <b>Read Only</b>
+        <TestTextArea label="Name" value="first" readOnly={true} />
+        <TestTextArea label="Name" value="first" hideLabel readOnly={true} />
+        <TestTextArea label="Name" value={("first ".repeat(40) + "last.\n\n").repeat(4)} readOnly={true} />
+      </div>
+      {/*Matching column but w/o readOnly for comparison*/}
+      <div css={Css.df.flexColumn.childGap3.wPx(400).$}>
+        <b>Editable</b>
+        <TestTextArea label="Name" value="first" />
+        <TestTextArea label="Name" value="first" hideLabel />
+        <TestTextArea label="Name" value={("first ".repeat(40) + "last.\n\n").repeat(4)} />
       </div>
     </div>
   );

--- a/src/inputs/TextAreaField.test.tsx
+++ b/src/inputs/TextAreaField.test.tsx
@@ -21,10 +21,13 @@ describe("TextAreaFieldTest", () => {
     expect(lastSet).toBeUndefined();
   });
 
-  it("does not fire blur when readOnly", async () => {
+  it("does not fire focus/blur when readOnly", async () => {
+    const onFocus = jest.fn();
     const onBlur = jest.fn();
-    const r = await render(<TestTextAreaField value="foo" readOnly={true} onBlur={onBlur} />);
+    const r = await render(<TestTextAreaField value="foo" readOnly={true} onFocus={onFocus} onBlur={onBlur} />);
+    fireEvent.focus(r.note());
     fireEvent.blur(r.note());
+    expect(onFocus).not.toHaveBeenCalled();
     expect(onBlur).not.toHaveBeenCalled();
   });
 });

--- a/src/inputs/TextAreaField.test.tsx
+++ b/src/inputs/TextAreaField.test.tsx
@@ -20,6 +20,13 @@ describe("TextAreaFieldTest", () => {
     expect(r.note()).toHaveValue("");
     expect(lastSet).toBeUndefined();
   });
+
+  it("does not fire blur when readOnly", async () => {
+    const onBlur = jest.fn();
+    const r = await render(<TestTextAreaField value="foo" readOnly={true} onBlur={onBlur} />);
+    fireEvent.blur(r.note());
+    expect(onBlur).not.toHaveBeenCalled();
+  });
 });
 
 function TestTextAreaField(props: Omit<TextAreaFieldProps, "onChange" | "label">) {

--- a/src/inputs/TextAreaField.tsx
+++ b/src/inputs/TextAreaField.tsx
@@ -9,15 +9,8 @@ export interface TextAreaFieldProps extends BeamTextFieldProps {}
 
 /** Returns a <textarea /> element that auto-adjusts height based on the field's value */
 export function TextAreaField(props: TextAreaFieldProps) {
-  const {
-    value = "",
-    disabled: isDisabled = false,
-    readOnly: isReadOnly = false,
-    onBlur,
-    onFocus,
-    ...otherProps
-  } = props;
-  const textFieldProps = { ...otherProps, value, isDisabled, isReadOnly };
+  const { value = "", disabled = false, readOnly = false, onBlur, onFocus, ...otherProps } = props;
+  const textFieldProps = { ...otherProps, value, isDisabled: disabled, isReadOnly: readOnly };
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   // not in stately because this is so we know when to re-measure, which is a spectrum design
 
@@ -48,6 +41,7 @@ export function TextAreaField(props: TextAreaFieldProps) {
       labelProps={labelProps}
       inputProps={inputProps}
       inputRef={inputRef}
+      readOnly={readOnly}
     />
   );
 }

--- a/src/inputs/TextField.stories.tsx
+++ b/src/inputs/TextField.stories.tsx
@@ -6,10 +6,10 @@ import { TextField, TextFieldProps } from "src/inputs";
 
 export default {
   component: TextField,
-  title: "Inputs/Text Fields",
+  title: "Inputs/Text Field",
 } as Meta;
 
-export function TextFields() {
+export function TextFieldStyles() {
   return (
     <div css={Css.df.flexColumn.childGap5.$}>
       <div css={Css.df.flexColumn.childGap2.$}>
@@ -59,6 +59,26 @@ export function TextFields() {
   );
 }
 
+export function TextFieldReadOnly() {
+  return (
+    <div css={Css.df.childGap2.$}>
+      <div css={Css.df.flexColumn.childGap3.$}>
+        <b>Read Only</b>
+        <TestTextField label="Name" value="first" readOnly={true} />
+        <TestTextField label="Name" value="first" hideLabel readOnly={true} />
+        <TestTextField label="Name" value={"first ".repeat(20) + "last"} readOnly={true} />
+      </div>
+      {/*Matching column but w/o readOnly for comparison*/}
+      <div css={Css.df.flexColumn.childGap3.$}>
+        <b>Editable</b>
+        <TestTextField label="Name" value="first" />
+        <TestTextField label="Name" value="first" hideLabel />
+        <TestTextField label="Name" value={"first ".repeat(20) + "last"} />
+      </div>
+    </div>
+  );
+}
+
 function TestTextField(props: Omit<TextFieldProps, "onChange">) {
   const { value, ...otherProps } = props;
   const [internalValue, setValue] = useState(value);
@@ -77,9 +97,10 @@ function ValidationTextField(props: Omit<TextFieldProps, "onChange">) {
   const { value, ...otherProps } = props;
   const [internalValue, setValue] = useState<string | undefined>(value);
   // Validates that the input's value is a properly formatted email address.
-  const isValid = useMemo(() => internalValue && /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(internalValue), [
-    internalValue,
-  ]);
+  const isValid = useMemo(
+    () => internalValue && /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(internalValue),
+    [internalValue],
+  );
   return (
     <TextField
       {...otherProps}

--- a/src/inputs/TextField.test.tsx
+++ b/src/inputs/TextField.test.tsx
@@ -35,6 +35,13 @@ describe("TextFieldTest", () => {
     const r = await render(<TestTextField value="foo" errorMsg="Required" />);
     expect(r.name()).toHaveAttribute("aria-invalid", "true");
   });
+
+  it("does not fire blur when readOnly", async () => {
+    const onBlur = jest.fn();
+    const r = await render(<TestTextField value="foo" readOnly={true} onBlur={onBlur} />);
+    fireEvent.blur(r.name());
+    expect(onBlur).not.toHaveBeenCalled();
+  });
 });
 
 function TestTextField(props: Omit<TextFieldProps, "onChange" | "label">) {

--- a/src/inputs/TextField.test.tsx
+++ b/src/inputs/TextField.test.tsx
@@ -36,10 +36,13 @@ describe("TextFieldTest", () => {
     expect(r.name()).toHaveAttribute("aria-invalid", "true");
   });
 
-  it("does not fire blur when readOnly", async () => {
+  it("does not fire focus/blur when readOnly", async () => {
+    const onFocus = jest.fn();
     const onBlur = jest.fn();
-    const r = await render(<TestTextField value="foo" readOnly={true} onBlur={onBlur} />);
+    const r = await render(<TestTextField value="foo" readOnly={true} onBlur={onBlur} onFocus={onFocus} />);
+    fireEvent.focus(r.name());
     fireEvent.blur(r.name());
+    expect(onFocus).not.toHaveBeenCalled();
     expect(onBlur).not.toHaveBeenCalled();
   });
 });

--- a/src/inputs/TextField.tsx
+++ b/src/inputs/TextField.tsx
@@ -11,7 +11,7 @@ export interface TextFieldProps extends BeamTextFieldProps {
 export function TextField(props: TextFieldProps) {
   const {
     disabled: isDisabled = false,
-    readOnly: isReadOnly = false,
+    readOnly = false,
     required,
     errorMsg,
     value = "",
@@ -22,7 +22,7 @@ export function TextField(props: TextFieldProps) {
   const textFieldProps = {
     ...otherProps,
     isDisabled,
-    isReadOnly,
+    isReadOnly: readOnly,
     isRequired: required,
     validationState: errorMsg ? ("invalid" as const) : ("valid" as const),
     value,
@@ -32,6 +32,7 @@ export function TextField(props: TextFieldProps) {
   return (
     <TextFieldBase
       {...mergeProps(textFieldProps, { onBlur, onFocus })}
+      readOnly={readOnly}
       errorMsg={errorMsg}
       required={required}
       labelProps={labelProps}

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -20,7 +20,7 @@ import { useTestIds } from "src/utils/useTestIds";
 interface TextFieldBaseProps
   extends Pick<
       BeamTextFieldProps,
-      "label" | "required" | "errorMsg" | "onBlur" | "onFocus" | "helperText" | "hideLabel"
+      "label" | "required" | "readOnly" | "errorMsg" | "onBlur" | "onFocus" | "helperText" | "hideLabel"
     >,
     Partial<Pick<BeamTextFieldProps, "onChange">> {
   labelProps?: LabelHTMLAttributes<HTMLLabelElement>;
@@ -48,6 +48,7 @@ export function TextFieldBase(props: TextFieldBaseProps) {
     errorMsg,
     helperText,
     multiline = false,
+    readOnly,
     onChange,
     onBlur,
     onFocus,
@@ -79,26 +80,47 @@ export function TextFieldBase(props: TextFieldBaseProps) {
   return (
     <div css={Css.df.flexColumn.w100.maxw(px(550)).$} {...groupProps}>
       {label && !hideLabel && <Label labelProps={labelProps} label={label} suffix={labelSuffix} {...tid.label} />}
-      <ElementType
-        {...mergeProps(
-          inputProps,
-          { onBlur, onFocus: onFocusChained, onChange: onDomChange },
-          { "aria-invalid": Boolean(errorMsg), ...(hideLabel ? { "aria-label": label } : {}) },
-        )}
-        {...(errorMsg ? { "aria-errormessage": errorMessageId } : {})}
-        ref={inputRef as any}
-        rows={multiline ? 1 : undefined}
-        css={{
-          ...Css.add("resize", "none").bgWhite.sm.px1.w100.hPx(40).gray900.br4.outline0.ba.bGray300.if(compact).hPx(32)
-            .$,
-          ...xss,
-          ...Css.if(multiline).mh(px(96)).py1.$,
-          "&:focus": Css.bLightBlue700.$,
-          "&:disabled": Css.gray400.bgGray100.cursorNotAllowed.$,
-          ...(errorMsg ? Css.bRed600.$ : {}),
-        }}
-        {...tid}
-      />
+      {readOnly && (
+        <div
+          css={{
+            // Copy/pasted from StaticField, maybe we should combine?
+            ...Css.smEm.gray900.hPx(40).df.itemsCenter.$,
+            ...Css.maxw(px(500)).$,
+            ...(multiline
+              ? Css.flexColumn.itemsStart.childGap2.$
+              : Css.add({ overflow: "hidden", whiteSpace: "nowrap" }).$),
+          }}
+          {...tid}
+        >
+          {multiline
+            ? (inputProps.value as string | undefined)?.split("\n\n").map((p) => <p>{p}</p>)
+            : inputProps.value}
+        </div>
+      )}
+      {!readOnly && (
+        <ElementType
+          {...mergeProps(
+            inputProps,
+            { onBlur, onFocus: onFocusChained, onChange: onDomChange },
+            { "aria-invalid": Boolean(errorMsg), ...(hideLabel ? { "aria-label": label } : {}) },
+          )}
+          {...(errorMsg ? { "aria-errormessage": errorMessageId } : {})}
+          ref={inputRef as any}
+          rows={multiline ? 1 : undefined}
+          css={{
+            ...Css.add("resize", "none")
+              .bgWhite.sm.px1.w100.hPx(40)
+              .gray900.br4.outline0.ba.bGray300.if(compact)
+              .hPx(32).$,
+            ...xss,
+            ...Css.if(multiline).mh(px(96)).py1.$,
+            "&:focus": Css.bLightBlue700.$,
+            "&:disabled": Css.gray400.bgGray100.cursorNotAllowed.$,
+            ...(errorMsg ? Css.bRed600.$ : {}),
+          }}
+          {...tid}
+        />
+      )}
       {errorMsg && <ErrorMessage id={errorMessageId} errorMsg={errorMsg} {...tid.errorMsg} />}
       {helperText && <HelperText helperText={helperText} {...tid.helperText} />}
     </div>

--- a/src/inputs/internal/SelectFieldInput.tsx
+++ b/src/inputs/internal/SelectFieldInput.tsx
@@ -158,12 +158,15 @@ export function SelectFieldInput<O, V extends Value>(props: SelectFieldInputProp
             // `inputValue`, so it thinks it needs to call `resetInputValue()`.
             //
             // I assume we don't pass `selectedKey` b/c we support multiple keys.
+            if (isReadOnly) {
+              return;
+            }
             maybeCall(onBlur);
             state.close();
           }}
           onFocus={(e) => {
-            maybeCall(onFocus);
             if (isReadOnly) return;
+            maybeCall(onFocus);
             e.target.select();
             state.open();
           }}


### PR DESCRIPTION
To support flipping between read/edit on forms that use `BoundTextField` / `BoundTextAreaField`.

