### PR TITLE
fix: Add 'data-readonly' attribute to help with testing.

### DIFF
--- a/src/inputs/TextField.test.tsx
+++ b/src/inputs/TextField.test.tsx
@@ -40,6 +40,7 @@ describe("TextFieldTest", () => {
     const onFocus = jest.fn();
     const onBlur = jest.fn();
     const r = await render(<TestTextField value="foo" readOnly={true} onBlur={onBlur} onFocus={onFocus} />);
+    expect(r.name()).toHaveAttribute("data-readonly");
     fireEvent.focus(r.name());
     fireEvent.blur(r.name());
     expect(onFocus).not.toHaveBeenCalled();

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -91,6 +91,7 @@ export function TextFieldBase(props: TextFieldBaseProps) {
               : Css.add({ overflow: "hidden", whiteSpace: "nowrap" }).$),
           }}
           {...tid}
+          data-readonly="true"
         >
           {multiline
             ? (inputProps.value as string | undefined)?.split("\n\n").map((p) => <p>{p}</p>)


### PR DESCRIPTION
Previously we were able to check for the 'readonly' attribute added to the `<input />` element. Now that the read only version is not an input element, we are adding an explicit data-readonly attribute to help identify that the TextField is in the expected state