### PR TITLE
feat: Hide tabs if only one is active.

### DIFF
--- a/src/components/Tabs.stories.tsx
+++ b/src/components/Tabs.stories.tsx
@@ -41,7 +41,6 @@ function getChildren(label: string) {
 export const TabsWithContent = () => {
   const [selectedTab1, setSelectedTab1] = useState<TabValue>("tab1");
   const [selectedTab2, setSelectedTab2] = useState<TabValue>("tab1");
-
   return (
     <div css={Css.df.flexColumn.childGap3.$}>
       <div css={Css.df.flexColumn.childGap1.$}>
@@ -65,6 +64,16 @@ export const TabsWithContent = () => {
       </div>
     </div>
   );
+};
+
+export const TabsHiddenIfOnlyOneActive = () => {
+  const testTabs: Tab<TabValue>[] = [
+    { name: "Tab 1", value: "tab1", render: () => <TabContent title="Tab 1 Content" /> },
+    { name: "Tab 2", value: "tab2", disabled: true, render: () => <TabContent title="Tab 2 Content" /> },
+    { name: "Tab 3", value: "tab3", disabled: true, render: () => <TabContent title="Tab 3 Content" /> },
+    { name: "Tab 4", value: "tab4", disabled: true, render: () => <TabContent title="Tab 4 Content" /> },
+  ];
+  return <TabsWithContentComponent tabs={testTabs} onChange={() => {}} selected={"tab1"} ariaLabel="Sample Tabs" />;
 };
 
 const tabsWithIconsAndContent: Tab<TabValue>[] = [

--- a/src/components/Tabs.test.tsx
+++ b/src/components/Tabs.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent } from "@testing-library/react";
 import { useState } from "react";
 import { Palette } from "src/Css";
 import { click, render } from "src/utils/rtl";
-import { getNextTabValue, TabsWithContent } from "./Tabs";
-import { testTabs } from "./testData";
+import { getNextTabValue, Tab, TabsWithContent } from "./Tabs";
+import { TabContent, TabValue, testTabs } from "./testData";
 
 describe("TabsWithContent", () => {
   it("should display content of selected tab", async () => {
@@ -73,6 +73,21 @@ describe("TabsWithContent", () => {
       const nextTabValue = getNextTabValue(currentTabValue, "ArrowLeft", testTabs);
       expect(nextTabValue).toBe("tab4");
     });
+  });
+
+  it("hides the tabs if only a single tab is enabled", async () => {
+    // Given only the 1st tab is enabled
+    const testTabs: Tab<TabValue>[] = [
+      { name: "Tab 1", value: "tab1", render: () => <TabContent title="Tab 1 Content" /> },
+      { name: "Tab 2", value: "tab2", disabled: true, render: () => <TabContent title="Tab 2 Content" /> },
+      { name: "Tab 3", value: "tab3", disabled: true, render: () => <TabContent title="Tab 3 Content" /> },
+      { name: "Tab 4", value: "tab4", disabled: true, render: () => <TabContent title="Tab 4 Content" /> },
+    ];
+    const r = await render(<TabsWithContent tabs={testTabs} onChange={() => {}} selected="tab1" />);
+    // Then the tabs are not even in the dom
+    expect(() => r.tabs_tab1()).toThrow("Unable to find an element");
+    // But the 1st tab's content is
+    expect(r.tab_panel()).toHaveTextContent("Tab 1 Content");
   });
 });
 

--- a/src/components/Tabs.test.tsx
+++ b/src/components/Tabs.test.tsx
@@ -86,8 +86,8 @@ describe("TabsWithContent", () => {
     const r = await render(<TabsWithContent tabs={testTabs} onChange={() => {}} selected="tab1" />);
     // Then the tabs are not even in the dom
     expect(() => r.tabs_tab1()).toThrow("Unable to find an element");
-    // But the 1st tab's content is
-    expect(r.tab_panel()).toHaveTextContent("Tab 1 Content");
+    // But the selected tab's content is shown
+    expect(r.tab_panel().textContent).toBe("Tab 1 Content");
   });
 });
 

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -35,9 +35,11 @@ export function TabsWithContent<V extends string, X extends Only<TabsContentXss,
   const selectedTab = tabs.find((tab) => tab.value === selected) || tabs[0];
   const tid = useTestIds(others, "tab");
 
+  const onlyOneTabEnabled = tabs.filter((t) => !t.disabled).length === 1;
+
   return (
     <div>
-      <Tabs {...props} />
+      {!onlyOneTabEnabled && <Tabs {...props} />}
       <div
         aria-labelledby={`${selectedTab.value}-tab`}
         id={`${selectedTab.value}-tabPanel`}


### PR DESCRIPTION
This matches a change @bdow made to the old BP tabs, requested by Lauren. It should also help some of our create flows that "open in drawer, only enable the details tab" hopefully for-free match the mocks, where the "in drawer" create flows leave out the tabs.

Granted, sometimes the different between create-flow vs. update-flow is more than just "don't show the other tabs", but hopefully this is a good default.