### PR TITLE
fix: Do not allow button text to wrap

### DIFF
--- a/src/Css.ts
+++ b/src/Css.ts
@@ -821,7 +821,7 @@ class CssBuilder<T extends Properties1> {
   childGapPx(px: number) { return this.childGap(`${px}px`); }
 
   // buttonBase
-  get buttonBase() { return this.add("fontWeight", 500).add("fontSize", "14px").add("lineHeight", "20px").add("outline", 0).add("borderRadius", "4px").add("display", "inline-flex").add("alignItems", "center").add("transition", "background-color 200ms, border-color 200ms, box-shadow 200ms, left 200ms, right 200ms"); }
+  get buttonBase() { return this.add("fontWeight", 500).add("fontSize", "14px").add("lineHeight", "20px").add("outline", 0).add("borderRadius", "4px").add("display", "inline-flex").add("alignItems", "center").add("whiteSpace", "nowrap").add("transition", "background-color 200ms, border-color 200ms, box-shadow 200ms, left 200ms, right 200ms"); }
 
   // listReset
   get listReset() { return this.add("padding", 0).add("margin", 0).add("listStyle", "none"); }

--- a/src/components/Stepper.tsx
+++ b/src/components/Stepper.tsx
@@ -77,7 +77,7 @@ function StepButton({ label, disabled, state, isCurrent, onClick }: StepButtonPr
       {...hoverProps}
       css={{
         ...Css.buttonBase.$,
-        ...Css.tl.w100.h100.sm.gray700.if(state === "error").red600.$,
+        ...Css.tl.w100.h100.sm.gray700.add("whiteSpace", "initial").if(state === "error").red600.$,
         ...(isCurrent ? Css.lightBlue700.if(state === "error").red800.$ : {}),
         ...(isHovered && !isPressed ? Css.lightBlue800.if(state === "error").red500.$ : {}),
         ...(isPressed ? Css.lightBlue500.if(state === "error").red900.$ : {}),

--- a/truss/index.ts
+++ b/truss/index.ts
@@ -81,6 +81,7 @@ const sections: Sections = {
       borderRadius: "4px",
       display: "inline-flex",
       alignItems: "center",
+      whiteSpace: "nowrap",
       transition,
     }),
   ],


### PR DESCRIPTION
Reset Stepper's button styles to allow for wrapping.