### PR TITLE
feat: CH-6240: Update Beam Button to have feature parity with BP buttons.

### DIFF
--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -1,6 +1,6 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
-import { Button, ButtonProps, Icon } from "src";
+import { Button, ButtonProps } from "src";
 import { Css } from "src/Css";
 import { withRouter } from "src/utils/sb";
 
@@ -28,7 +28,7 @@ export function ButtonVariations(args: ButtonProps) {
       <div>
         <h2>Primary</h2>
         <div css={buttonRowStyles}>
-          <Button onClick="https://google.com" label="Primary Button" autoFocus />
+          <Button {...args} label="Primary Button" autoFocus />
           <Button {...args} disabled label="Disabled" />
         </div>
         <div css={buttonRowStyles}>
@@ -165,48 +165,29 @@ export function ButtonLink() {
         <h2>Primary</h2>
         <div css={buttonRowStyles}>
           <Button onClick="/fakePath" label="Relative URL link" />
-          <Button
-            onClick="https://www.homebound.com"
-            label="Absolute URL link"
-            endAdornment={<Icon icon="linkExternal" />}
-          />
-          <Button icon="plus" onClick="https://www.homebound.com" label="Disabled link" disabled />
+          <Button onClick="https://www.homebound.com" label="Absolute URL link" />
+          <Button icon="plus" onClick="/fakePath" label="Disabled link" disabled />
         </div>
 
         <h2>Secondary</h2>
         <div css={buttonRowStyles}>
           <Button variant="secondary" onClick="/fakePath" label="Relative URL link" />
-          <Button
-            variant="secondary"
-            onClick="https://www.homebound.com"
-            label="Absolute URL link"
-            endAdornment={<Icon icon="linkExternal" />}
-          />
-          <Button variant="secondary" icon="plus" onClick="https://www.homebound.com" label="Disabled link" disabled />
+          <Button variant="secondary" onClick="https://www.homebound.com" label="Absolute URL link" />
+          <Button variant="secondary" icon="plus" onClick="/fakePath" label="Disabled link" disabled />
         </div>
 
         <h2>Tertiary</h2>
         <div css={buttonRowStyles}>
           <Button variant="tertiary" onClick="/fakePath" label="Relative URL link" />
-          <Button
-            variant="tertiary"
-            onClick="https://www.homebound.com"
-            label="Absolute URL link"
-            endAdornment={<Icon icon="linkExternal" />}
-          />
-          <Button variant="tertiary" icon="plus" onClick="https://www.homebound.com" label="Disabled link" disabled />
+          <Button variant="tertiary" onClick="https://www.homebound.com" label="Absolute URL link" />
+          <Button variant="tertiary" icon="plus" onClick="/fakePath" label="Disabled link" disabled />
         </div>
 
         <h2>Danger</h2>
         <div css={buttonRowStyles}>
           <Button variant="danger" onClick="/fakePath" label="Relative URL link" />
-          <Button
-            variant="danger"
-            onClick="https://www.homebound.com"
-            label="Absolute URL link"
-            endAdornment={<Icon icon="linkExternal" />}
-          />
-          <Button variant="danger" icon="plus" onClick="https://www.homebound.com" label="Disabled link" disabled />
+          <Button variant="danger" onClick="https://www.homebound.com" label="Absolute URL link" />
+          <Button variant="danger" icon="plus" onClick="/fakePath" label="Disabled link" disabled />
         </div>
       </div>
     </div>

--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -1,11 +1,13 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
-import { Button, ButtonProps } from "src";
+import { Button, ButtonProps, Icon } from "src";
 import { Css } from "src/Css";
+import { withRouter } from "src/utils/sb";
 
 export default {
   title: "Components/Button",
   component: Button,
+  decorators: [withRouter()],
   args: { onClick: action("onPress") },
   argTypes: {
     autoFocus: { control: false },
@@ -21,13 +23,12 @@ export default {
 } as Meta<ButtonProps>;
 
 export function ButtonVariations(args: ButtonProps) {
-  const buttonRowStyles = Css.df.childGap1.my1.$;
   return (
     <div css={Css.dg.flexColumn.childGap2.$}>
       <div>
         <h2>Primary</h2>
         <div css={buttonRowStyles}>
-          <Button {...args} label="Primary Button" autoFocus />
+          <Button onClick="https://google.com" label="Primary Button" autoFocus />
           <Button {...args} disabled label="Disabled" />
         </div>
         <div css={buttonRowStyles}>
@@ -133,17 +134,83 @@ export function ButtonVariations(args: ButtonProps) {
 
 export function ButtonWithTooltip() {
   return (
-    <Button
-      disabled={
-        <div>
-          You <b>cannot</b> currently perform this operation because of:
-          <ul>
-            <li>reason one</li>
-            <li>reason two</li>
-          </ul>
-        </div>
-      }
-      label="Upload"
-    />
+    <div css={Css.dg.flexColumn.childGap2.justifyStart.$}>
+      <div>
+        <h2>Tooltip provided via 'disabled' property</h2>
+        <Button
+          disabled={
+            <div>
+              You <b>cannot</b> currently perform this operation because of:
+              <ul>
+                <li>reason one</li>
+                <li>reason two</li>
+              </ul>
+            </div>
+          }
+          label="Upload"
+        />
+      </div>
+      <div>
+        <h2>Tooltip provided via 'tooltip' property</h2>
+        <Button tooltip="Create a new entity" label="Add new" />
+      </div>
+    </div>
   );
 }
+
+export function ButtonLink() {
+  return (
+    <div css={Css.dg.flexColumn.childGap2.$}>
+      <div>
+        <h2>Primary</h2>
+        <div css={buttonRowStyles}>
+          <Button onClick="/fakePath" label="Relative URL link" />
+          <Button
+            onClick="https://www.homebound.com"
+            label="Absolute URL link"
+            endAdornment={<Icon icon="linkExternal" />}
+          />
+          <Button icon="plus" onClick="https://www.homebound.com" label="Disabled link" disabled />
+        </div>
+
+        <h2>Secondary</h2>
+        <div css={buttonRowStyles}>
+          <Button variant="secondary" onClick="/fakePath" label="Relative URL link" />
+          <Button
+            variant="secondary"
+            onClick="https://www.homebound.com"
+            label="Absolute URL link"
+            endAdornment={<Icon icon="linkExternal" />}
+          />
+          <Button variant="secondary" icon="plus" onClick="https://www.homebound.com" label="Disabled link" disabled />
+        </div>
+
+        <h2>Tertiary</h2>
+        <div css={buttonRowStyles}>
+          <Button variant="tertiary" onClick="/fakePath" label="Relative URL link" />
+          <Button
+            variant="tertiary"
+            onClick="https://www.homebound.com"
+            label="Absolute URL link"
+            endAdornment={<Icon icon="linkExternal" />}
+          />
+          <Button variant="tertiary" icon="plus" onClick="https://www.homebound.com" label="Disabled link" disabled />
+        </div>
+
+        <h2>Danger</h2>
+        <div css={buttonRowStyles}>
+          <Button variant="danger" onClick="/fakePath" label="Relative URL link" />
+          <Button
+            variant="danger"
+            onClick="https://www.homebound.com"
+            label="Absolute URL link"
+            endAdornment={<Icon icon="linkExternal" />}
+          />
+          <Button variant="danger" icon="plus" onClick="https://www.homebound.com" label="Disabled link" disabled />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const buttonRowStyles = Css.df.childGap1.my1.$;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,5 +1,4 @@
 import { AriaButtonProps } from "@react-types/button";
-import { PressEvent } from "@react-types/shared";
 import { ReactNode, RefObject, useMemo, useRef } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
 import { Link } from "react-router-dom";
@@ -9,19 +8,16 @@ import { Css } from "src/Css";
 import { BeamButtonProps, BeamFocusableProps } from "src/interfaces";
 import { isAbsoluteUrl, noop } from "src/utils";
 
-export interface ButtonProps extends Omit<BeamButtonProps, "onClick">, BeamFocusableProps {
+export interface ButtonProps extends BeamButtonProps, BeamFocusableProps {
   label: string;
   variant?: ButtonVariant;
   size?: ButtonSize;
   icon?: IconProps["icon"];
+  /** Displays contents after the Button's label. Will be ignored for Buttons rendered as a link with an absolute URL */
   endAdornment?: ReactNode;
   /** HTML attributes to apply to the button element when it is being used to trigger a menu. */
   menuTriggerProps?: AriaButtonProps;
   buttonRef?: RefObject<HTMLElement>;
-  /** If function, then it is the handler that is called when the press is released over the target. Otherwise if string, it is the URL path for the link */
-  onClick?: ((e: PressEvent) => void) | string;
-  /** Text to be shown via a tooltip when the user hovers over the button */
-  tooltip?: ReactNode;
 }
 
 export function Button(props: ButtonProps) {
@@ -50,7 +46,10 @@ export function Button(props: ButtonProps) {
     <>
       {icon && <Icon xss={iconStyles[size]} icon={icon} />}
       {label}
-      {endAdornment && <span css={Css.ml1.$}>{endAdornment}</span>}
+      {/* Do not apply endAdornment for links to Absolute URLs. Component will apply the 'linkExternal' icon as an endAdornment by default */}
+      {!(typeof onPress === "string" && isAbsoluteUrl(onPress)) && endAdornment && (
+        <span css={Css.ml1.$}>{endAdornment}</span>
+      )}
     </>
   );
   const buttonAttrs = {
@@ -73,6 +72,9 @@ export function Button(props: ButtonProps) {
       isAbsoluteUrl(onPress) ? (
         <a {...buttonAttrs} href={onPress} className={navLink} target="_blank" rel="noreferrer noopener">
           {buttonContent}
+          <span css={Css.ml1.$}>
+            <Icon icon="linkExternal" />
+          </span>
         </a>
       ) : (
         <Link {...buttonAttrs} to={onPress} className={navLink}>

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,12 +1,15 @@
 import { AriaButtonProps } from "@react-types/button";
+import { PressEvent } from "@react-types/shared";
 import { ReactNode, RefObject, useMemo, useRef } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
-import { Icon, IconProps } from "src";
+import { Link } from "react-router-dom";
+import { Icon, IconProps, navLink } from "src";
 import { Tooltip } from "src/components/Tooltip";
 import { Css } from "src/Css";
 import { BeamButtonProps, BeamFocusableProps } from "src/interfaces";
+import { isAbsoluteUrl, noop } from "src/utils";
 
-export interface ButtonProps extends BeamButtonProps, BeamFocusableProps {
+export interface ButtonProps extends Omit<BeamButtonProps, "onClick">, BeamFocusableProps {
   label: string;
   variant?: ButtonVariant;
   size?: ButtonSize;
@@ -14,49 +17,76 @@ export interface ButtonProps extends BeamButtonProps, BeamFocusableProps {
   endAdornment?: ReactNode;
   /** HTML attributes to apply to the button element when it is being used to trigger a menu. */
   menuTriggerProps?: AriaButtonProps;
-  buttonRef?: RefObject<HTMLButtonElement>;
+  buttonRef?: RefObject<HTMLElement>;
+  /** If function, then it is the handler that is called when the press is released over the target. Otherwise if string, it is the URL path for the link */
+  onClick?: ((e: PressEvent) => void) | string;
+  /** Text to be shown via a tooltip when the user hovers over the button */
+  tooltip?: ReactNode;
 }
 
 export function Button(props: ButtonProps) {
-  const { onClick: onPress, disabled, endAdornment, menuTriggerProps, ...otherProps } = props;
+  const { onClick: onPress, disabled, endAdornment, menuTriggerProps, tooltip, ...otherProps } = props;
   const isDisabled = !!disabled;
   const ariaProps = { onPress, isDisabled, ...otherProps, ...menuTriggerProps };
   const { label, icon, variant = "primary", size = "sm", buttonRef } = ariaProps;
   const ref = buttonRef || useRef(null);
-  const { buttonProps, isPressed } = useButton(ariaProps, ref as RefObject<HTMLButtonElement>);
+  const { buttonProps, isPressed } = useButton(
+    {
+      ...ariaProps,
+      onPress: typeof onPress === "string" ? noop : onPress,
+      elementType: typeof onPress === "string" ? "a" : "button",
+    },
+    ref as RefObject<HTMLElement>,
+  );
   const { isFocusVisible, focusProps } = useFocusRing(ariaProps);
   const { hoverProps, isHovered } = useHover(ariaProps);
-  const { baseStyles, hoverStyles, disabledStyles, pressedStyles } = useMemo(() => getButtonStyles(variant, size), [
-    variant,
-    size,
-  ]);
+  const { baseStyles, hoverStyles, disabledStyles, pressedStyles } = useMemo(
+    () => getButtonStyles(variant, size),
+    [variant, size],
+  );
   const focusRingStyles = useMemo(() => (variant === "danger" ? Css.bshDanger.$ : Css.bshFocus.$), [variant]);
 
-  const button = (
-    <button
-      ref={ref}
-      {...buttonProps}
-      {...focusProps}
-      {...hoverProps}
-      css={{
-        ...Css.buttonBase.$,
-        ...baseStyles,
-        ...(isHovered && !isPressed ? hoverStyles : {}),
-        ...(isPressed ? pressedStyles : {}),
-        ...(isDisabled ? { ...disabledStyles, ...Css.cursorNotAllowed.$ } : {}),
-        ...(isFocusVisible ? focusRingStyles : {}),
-      }}
-    >
+  const buttonContent = (
+    <>
       {icon && <Icon xss={iconStyles[size]} icon={icon} />}
       {label}
       {endAdornment && <span css={Css.ml1.$}>{endAdornment}</span>}
-    </button>
+    </>
   );
+  const buttonAttrs = {
+    ref: ref as any,
+    ...buttonProps,
+    ...focusProps,
+    ...hoverProps,
+    css: {
+      ...Css.buttonBase.$,
+      ...baseStyles,
+      ...(isHovered && !isPressed ? hoverStyles : {}),
+      ...(isPressed ? pressedStyles : {}),
+      ...(isDisabled ? { ...disabledStyles, ...Css.cursorNotAllowed.$ } : {}),
+      ...(isFocusVisible ? focusRingStyles : {}),
+    },
+  };
 
-  // If we're disabled b/c of a non-boolean ReactNode, show it in a tooltip
-  if (isDisabled && typeof disabled !== "boolean") {
+  const button =
+    typeof onPress === "string" ? (
+      isAbsoluteUrl(onPress) ? (
+        <a {...buttonAttrs} href={onPress} className={navLink} target="_blank" rel="noreferrer noopener">
+          {buttonContent}
+        </a>
+      ) : (
+        <Link {...buttonAttrs} to={onPress} className={navLink}>
+          {buttonContent}
+        </Link>
+      )
+    ) : (
+      <button {...buttonAttrs}>{buttonContent}</button>
+    );
+
+  // If we're disabled b/c of a non-boolean ReactNode, or the caller specified tooltip text, then show it in a tooltip
+  if ((isDisabled && typeof disabled !== "boolean") || tooltip) {
     return (
-      <Tooltip title={disabled} delay={100}>
+      <Tooltip title={isDisabled && typeof disabled !== "boolean" ? disabled : tooltip} placement="top">
         {button}
       </Tooltip>
     );
@@ -72,38 +102,36 @@ function getButtonStyles(variant: ButtonVariant, size: ButtonSize) {
   };
 }
 
-const variantStyles: Record<
-  ButtonVariant,
-  { baseStyles: {}; hoverStyles: {}; disabledStyles: {}; pressedStyles: {} }
-> = {
-  primary: {
-    baseStyles: Css.bgLightBlue700.white.$,
-    hoverStyles: Css.bgLightBlue900.$,
-    pressedStyles: Css.bgLightBlue500.$,
-    disabledStyles: Css.bgLightBlue200.$,
-  },
+const variantStyles: Record<ButtonVariant, { baseStyles: {}; hoverStyles: {}; disabledStyles: {}; pressedStyles: {} }> =
+  {
+    primary: {
+      baseStyles: Css.bgLightBlue700.white.$,
+      hoverStyles: Css.bgLightBlue900.$,
+      pressedStyles: Css.bgLightBlue500.$,
+      disabledStyles: Css.bgLightBlue200.$,
+    },
 
-  secondary: {
-    baseStyles: Css.bgWhite.bGray300.bw1.ba.gray800.$,
-    hoverStyles: Css.bgGray100.$,
-    pressedStyles: Css.bgGray200.$,
-    disabledStyles: Css.bgWhite.gray400.$,
-  },
+    secondary: {
+      baseStyles: Css.bgWhite.bGray300.bw1.ba.gray800.$,
+      hoverStyles: Css.bgGray100.$,
+      pressedStyles: Css.bgGray200.$,
+      disabledStyles: Css.bgWhite.gray400.$,
+    },
 
-  tertiary: {
-    baseStyles: Css.bgTransparent.lightBlue700.$,
-    hoverStyles: Css.bgGray100.$,
-    pressedStyles: Css.lightBlue900.$,
-    disabledStyles: Css.gray400.$,
-  },
+    tertiary: {
+      baseStyles: Css.bgTransparent.lightBlue700.$,
+      hoverStyles: Css.bgGray100.$,
+      pressedStyles: Css.lightBlue900.$,
+      disabledStyles: Css.gray400.$,
+    },
 
-  danger: {
-    baseStyles: Css.bgRed900.white.$,
-    hoverStyles: Css.bgRed500.$,
-    pressedStyles: Css.bgRed900.$,
-    disabledStyles: Css.bgRed200.$,
-  },
-};
+    danger: {
+      baseStyles: Css.bgRed900.white.$,
+      hoverStyles: Css.bgRed500.$,
+      pressedStyles: Css.bgRed900.$,
+      disabledStyles: Css.bgRed200.$,
+    },
+  };
 
 const sizeStyles: Record<ButtonSize, {}> = {
   sm: Css.hPx(32).pxPx(12).$,

--- a/src/components/IconButton.stories.tsx
+++ b/src/components/IconButton.stories.tsx
@@ -1,11 +1,12 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
-import { IconButton as IconButton, IconButtonProps, iconButtonStylesHover, Icons } from "src";
-import { Css, Palette } from "src/Css";
+import { Css, IconButton as IconButton, IconButtonProps, iconButtonStylesHover, Icons, Palette } from "src";
+import { withRouter } from "src/utils/sb";
 
 export default {
   title: "Components/Icon Button",
   component: IconButton,
+  decorators: [withRouter()],
   args: {
     icon: "arrowBack",
     onClick: action("onPress"),
@@ -52,20 +53,44 @@ export const IconButtonStyles = (args: IconButtonProps) => (
   </div>
 );
 
-export function IconButtonDisabled() {
+export function WithTooltip() {
   return (
-    <IconButton
-      disabled={
-        <div>
-          You <b>cannot</b> currently perform this operation because of:
-          <ul>
-            <li>reason one</li>
-            <li>reason two</li>
-          </ul>
-        </div>
-      }
-      icon="arrowBack"
-    />
+    <div css={Css.dg.flexColumn.childGap2.justifyStart.$}>
+      <div>
+        <h2>Tooltip provided via 'disabled' property</h2>
+        <IconButton
+          disabled={
+            <div>
+              You <b>cannot</b> currently perform this operation because of:
+              <ul>
+                <li>reason one</li>
+                <li>reason two</li>
+              </ul>
+            </div>
+          }
+          icon="arrowBack"
+        />
+      </div>
+      <div>
+        <h2>Tooltip provided via 'tooltip' property</h2>
+        <IconButton icon="arrowBack" tooltip="Back to previous page" />
+      </div>
+    </div>
+  );
+}
+
+export function IconButtonLink() {
+  return (
+    <div>
+      <div>
+        <h2>Relative Path Link</h2>
+        <IconButton icon="plus" onClick="/fakePath" />
+      </div>
+      <div>
+        <h2>Absolute Link</h2>
+        <IconButton icon="linkExternal" onClick="https://www.homebound.com" />
+      </div>
+    </div>
   );
 }
 

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,9 +1,11 @@
 import { AriaButtonProps } from "@react-types/button";
 import { RefObject, useMemo, useRef } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
-import { Icon, IconProps, Tooltip } from "src/components";
+import { Link } from "react-router-dom";
+import { Icon, IconProps, navLink, Tooltip } from "src/components";
 import { Css, Palette } from "src/Css";
 import { BeamButtonProps, BeamFocusableProps } from "src/interfaces";
+import { isAbsoluteUrl, noop } from "src/utils";
 import { useTestIds } from "src/utils/useTestIds";
 
 export interface IconButtonProps extends BeamButtonProps, BeamFocusableProps {
@@ -18,12 +20,19 @@ export interface IconButtonProps extends BeamButtonProps, BeamFocusableProps {
 }
 
 export function IconButton(props: IconButtonProps) {
-  const { onClick: onPress, disabled, color, icon, autoFocus, inc, buttonRef, menuTriggerProps } = props;
+  const { onClick: onPress, disabled, color, icon, autoFocus, inc, buttonRef, tooltip, menuTriggerProps } = props;
   const isDisabled = !!disabled;
   const ariaProps = { onPress, isDisabled, autoFocus, ...menuTriggerProps };
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const ref = buttonRef || useRef(null);
-  const { buttonProps } = useButton(ariaProps, ref);
+  const { buttonProps } = useButton(
+    {
+      ...ariaProps,
+      onPress: typeof onPress === "string" ? noop : onPress,
+      elementType: typeof onPress === "string" ? "a" : "button",
+    },
+    ref,
+  );
   const { focusProps, isFocusVisible } = useFocusRing(ariaProps);
   const { hoverProps, isHovered } = useHover(ariaProps);
   const testIds = useTestIds(props, icon);
@@ -38,16 +47,30 @@ export function IconButton(props: IconButtonProps) {
     [isHovered, isFocusVisible, isDisabled],
   );
 
-  const button = (
-    <button {...testIds} {...buttonProps} {...focusProps} {...hoverProps} ref={ref} css={styles}>
-      <Icon icon={icon} color={color || (isDisabled ? Palette.Gray400 : Palette.Gray900)} inc={inc} />
-    </button>
+  const buttonAttrs = { ...testIds, ...buttonProps, ...focusProps, ...hoverProps, ref: ref as any, css: styles };
+  const buttonContent = (
+    <Icon icon={icon} color={color || (isDisabled ? Palette.Gray400 : Palette.Gray900)} inc={inc} />
   );
 
-  // If we're disabled b/c of a non-boolean ReactNode, show it in a tooltip
-  if (isDisabled && typeof disabled !== "boolean") {
+  const button =
+    typeof onPress === "string" ? (
+      isAbsoluteUrl(onPress) ? (
+        <a {...buttonAttrs} href={onPress} className={navLink} target="_blank" rel="noreferrer noopener">
+          {buttonContent}
+        </a>
+      ) : (
+        <Link {...buttonAttrs} to={onPress} className={navLink}>
+          {buttonContent}
+        </Link>
+      )
+    ) : (
+      <button {...buttonAttrs}>{buttonContent}</button>
+    );
+
+  // If we're disabled b/c of a non-boolean ReactNode, or the caller specified tooltip text, then show it in a tooltip
+  if ((isDisabled && typeof disabled !== "boolean") || tooltip) {
     return (
-      <Tooltip title={disabled} delay={100}>
+      <Tooltip title={isDisabled && typeof disabled !== "boolean" ? disabled : tooltip} placement="top">
         {button}
       </Tooltip>
     );
@@ -56,8 +79,9 @@ export function IconButton(props: IconButtonProps) {
   return button;
 }
 
-const iconButtonStylesReset = Css.hPx(28).wPx(28).br8.bTransparent.bsSolid.bw2.bgTransparent.cursorPointer.outline0.p0
-  .dif.itemsCenter.justifyCenter.transition.$;
+const iconButtonStylesReset =
+  Css.hPx(28).wPx(28).br8.bTransparent.bsSolid.bw2.bgTransparent.cursorPointer.outline0.p0.dif.itemsCenter.justifyCenter
+    .transition.$;
 export const iconButtonStylesHover = Css.bgGray100.$;
 const iconButtonStylesFocus = Css.bLightBlue700.$;
 const iconButtonStylesDisabled = Css.cursorNotAllowed.$;

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -18,15 +18,11 @@ interface TooltipProps {
 }
 
 export function Tooltip(props: TooltipProps) {
-  const { placement, children, title, disabled, delay } = props;
+  const { placement, children, title, disabled, delay = 0 } = props;
 
   const state = useTooltipTriggerState({ delay, isDisabled: disabled });
   const triggerRef = React.useRef(null);
-  const { triggerProps, tooltipProps: _tooltipProps } = useTooltipTrigger(
-    { delay, isDisabled: disabled },
-    state,
-    triggerRef,
-  );
+  const { triggerProps, tooltipProps: _tooltipProps } = useTooltipTrigger({ isDisabled: disabled }, state, triggerRef);
   const { tooltipProps } = useTooltip(_tooltipProps, state);
 
   return (
@@ -67,7 +63,12 @@ function Popper({ triggerRef, content, placement = "auto" }: PopperProps) {
   });
 
   return (
-    <div ref={popperRef} style={styles.popper} {...attributes.popper} css={Css.bgGray900.white.px1.py("4px").br4.xs.$}>
+    <div
+      ref={popperRef}
+      style={{ ...styles.popper, maxWidth: "320px" }}
+      {...attributes.popper}
+      css={Css.bgGray900.white.px1.py("4px").br4.xs.$}
+    >
       <div ref={setArrowRef} style={{ ...styles.arrow }} id="arrow" />
       {content}
     </div>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -14,8 +14,10 @@ export interface BeamButtonProps {
    * If a ReactNode, it's treated as a "disabled reason" that's shown in a tooltip.
    */
   disabled?: boolean | ReactNode;
-  /** Handler that is called when the press is released over the target. */
-  onClick?: (e: PressEvent) => void;
+  /** If function, then it is the handler that is called when the press is released over the target. Otherwise if string, it is the URL path for the link */
+  onClick?: ((e: PressEvent) => void) | string;
+  /** Text to be shown via a tooltip when the user hovers over the button */
+  tooltip?: ReactNode;
 }
 
 export interface BeamTextFieldProps extends BeamFocusableProps {


### PR DESCRIPTION
Allow Beam buttons to render as links, both absolute and relative (using react-router).
Allow Beam buttons to render tooltips for non-disabled buttons