### PR TITLE
fix: Remove dependency of rtl-util from build

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@emotion/react": "^11.1.5",
     "@homebound/form-state": "^2.0.0",
     "@homebound/rtl-react-router-utils": "^1.0.3",
-    "@homebound/rtl-utils": "2.45.0",
+    "@homebound/rtl-utils": "^2.48.0",
     "@homebound/tsconfig": "^1.0.3",
     "@semantic-release/git": "^9.0.0",
     "@storybook/addon-essentials": "^6.3.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,4 @@ export * from "./hooks";
 export * from "./inputs";
 export * from "./interfaces";
 export * from "./utils/defaultTestId";
-export { withBeamRTL } from "./utils/rtl";
-export { withBeamDecorator } from "./utils/sb";
 export * from "./utils/useTestIds";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1455,12 +1455,12 @@
     react-router "^5.1.2"
     use-query-params "^1.2.2"
 
-"@homebound/rtl-utils@2.45.0":
-  version "2.45.0"
-  resolved "https://registry.yarnpkg.com/@homebound/rtl-utils/-/rtl-utils-2.45.0.tgz#ba6f89b9635715fbadccbfa6f738118d4d7b1df3"
-  integrity sha512-wIQd4DV1aGBmZZ3RKAopmVi5zgXRSGoJ/8IJnAO2oii4aaQlWBntErmObW8kkCF9hWWc5plAY1BD9ARwCQczlA==
+"@homebound/rtl-utils@^2.48.0":
+  version "2.48.0"
+  resolved "https://registry.yarnpkg.com/@homebound/rtl-utils/-/rtl-utils-2.48.0.tgz#098473d653947c1a7030da9b8fc86f671d0fecd1"
+  integrity sha512-CKPZTuWUF5d0wpqGQOrkOoy5WTVSANgD6oOYQkouIZ7YKrNDH0mo71a0bHtlnI8N5eo4IrphFUVf/DMk49Go8Q==
   dependencies:
-    "@testing-library/react" "^11.1.0"
+    "@testing-library/react" "^12.0.0"
 
 "@homebound/tsconfig@^1.0.3":
   version "1.0.3"
@@ -1676,6 +1676,17 @@
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
     "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
+"@jest/types@^27.0.6":
+  version "27.0.6"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.0.6.tgz#9a992bc517e0c49f035938b8549719c2de40706b"
+  integrity sha512-aSquT1qa9Pik26JK5/3rvnYb4bGtm1VFNesHKmNTwmPIgOrixvhL2ghIvFRNEpzy3gU+rUgjIF/KodbkFAl++g==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
 "@juggle/resize-observer@^3.3.1":
@@ -3849,10 +3860,10 @@
     resolve-from "^5.0.0"
     store2 "^2.12.0"
 
-"@testing-library/dom@^7.28.1":
-  version "7.31.2"
-  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.2.tgz#df361db38f5212b88555068ab8119f5d841a8c4a"
-  integrity sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==
+"@testing-library/dom@^8.0.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.1.0.tgz#f8358b1883844ea569ba76b7e94582168df5370d"
+  integrity sha512-kmW9alndr19qd6DABzQ978zKQ+J65gU2Rzkl8hriIetPnwpesRaK4//jEQyYh8fEALmGhomD/LBQqt+o+DL95Q==
   dependencies:
     "@babel/code-frame" "^7.10.4"
     "@babel/runtime" "^7.12.5"
@@ -3861,7 +3872,7 @@
     chalk "^4.1.0"
     dom-accessibility-api "^0.5.6"
     lz-string "^1.4.4"
-    pretty-format "^26.6.2"
+    pretty-format "^27.0.2"
 
 "@testing-library/jest-dom@^5.11.9":
   version "5.11.10"
@@ -3888,13 +3899,13 @@
     "@types/react-test-renderer" ">=16.9.0"
     react-error-boundary "^3.1.0"
 
-"@testing-library/react@^11.1.0":
-  version "11.2.7"
-  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.7.tgz#b29e2e95c6765c815786c0bc1d5aed9cb2bf7818"
-  integrity sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==
+"@testing-library/react@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.0.0.tgz#9aeb2264521522ab9b68f519eaf15136148f164a"
+  integrity sha512-sh3jhFgEshFyJ/0IxGltRhwZv2kFKfJ3fN1vTZ6hhMXzz9ZbbcTgmDYM4e+zJv+oiVKKEWZPyqPAh4MQBI65gA==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@testing-library/dom" "^7.28.1"
+    "@testing-library/dom" "^8.0.0"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -4331,6 +4342,13 @@
   version "15.0.13"
   resolved "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.13.tgz"
   integrity sha512-kQ5JNTrbDv3Rp5X2n/iUu37IJBDU2gsZ5R/g1/KHOOEc5IKfUFjXT6DENPGduh08I/pamwtEq4oul7gUqKTQDQ==
+  dependencies:
+    "@types/yargs-parser" "*"
+
+"@types/yargs@^16.0.0":
+  version "16.0.4"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-16.0.4.tgz#26aad98dd2c2a38e421086ea9ad42b9e51642977"
+  integrity sha512-T8Yc9wt/5LbJyCaLiHPReJa0kApcIgJ7Bn735GjItUfh08Z1pJvu8QZqb9s+mMvKV6WUQRV7K2R46YbjMXTTJw==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -4784,6 +4802,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0, ansi-styles@^4.3.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansi-to-html@^0.6.11:
   version "0.6.14"
@@ -12355,6 +12378,16 @@ pretty-format@^26.0.0, pretty-format@^26.6.2:
     "@jest/types" "^26.6.2"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.0.2:
+  version "27.0.6"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.0.6.tgz#ab770c47b2c6f893a21aefc57b75da63ef49a11f"
+  integrity sha512-8tGD7gBIENgzqA+UBzObyWqQ5B778VIFZA/S66cclyd5YkFLYs2Js7gxDKf0MXtTc9zcS7t1xhdfcElJ3YIvkQ==
+  dependencies:
+    "@jest/types" "^27.0.6"
+    ansi-regex "^5.0.0"
+    ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
 pretty-hrtime@^1.0.3:


### PR DESCRIPTION
Bumping rtl-utils back to 2.46.0.
Remove exporting of Beam's RTL and Storybook helpers, which have a direct dependency on @homebound/rtl-utils. This was causing rtl-util to be bundled with our production builds in frontend applications.