### PR TITLE
feat: Catch misconfigured client-side sorting.

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -381,6 +381,22 @@ describe("GridTable", () => {
       expect(cell(r, 1, 0)).toHaveTextContent("a");
       expect(cell(r, 2, 0)).toHaveTextContent("b");
     });
+
+    it("throws an error if a column value is not sortable", async () => {
+      // Given the table is using client-side sorting
+      // And we have a column that returns a react component w/o GridCellContent
+      const nameColumn: GridColumn<Row> = { header: () => "Name", data: ({ name }) => <div>{name}</div> };
+      // Then the render will fail
+      await expect(
+        render(
+          <GridTable
+            columns={[nameColumn, valueColumn]}
+            sorting={{ on: "client" }}
+            rows={[simpleHeader, { kind: "data", id: "1", name: "a", value: 3 }]}
+          />,
+        ),
+      ).rejects.toThrow("Column 0 passed an unsortable value, use GridCellContent or clientSideSort=false");
+    });
   });
 
   describe("server-side sorting", () => {


### PR DESCRIPTION
It's easy to turn on client-side sorting but then have a column accidentally return only a react component for a cell (which we cannot sort).

I've been thinking about this problem for awhile, and specifically really wanted to solve it in the type system, i.e. once you used `GridTable sorting={{ on: client }}` the typings would know all of your columns need to either return primitives or GridCellContents.

Maybe someday, but for now this runtime checking I think is better than nothing, and will also disable itself in production just in case (which could keep today's production behavior, which is that sorting columns that are react components just does nothing / sorts randomly).