### PR TITLE
fix: Add Create Portal to Tooltip component

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ _To see the latest designs, check out the [Figma](https://www.figma.com/file/aWU
 
 Beam is specifically "Homebound's design system". Given this extremely narrow purpose, we can lean into the simplicity of:
 
-* We don't need to support everything for everyone
-* We can prefer API/UX consistency & simplicity over configuration & complexity
+- We don't need to support everything for everyone
+- We can prefer API/UX consistency & simplicity over configuration & complexity
 
-The most concrete manifestation of this is that we want to *provide as few props as possible*.
+The most concrete manifestation of this is that we want to _provide as few props as possible_.
 
 Fewer props generally means:
 
@@ -41,7 +41,7 @@ All of these points are generally in stark contrast to traditional, "big" UI too
 
 For them, a MUI application in Company A shouldn't have to look & behave exactly like a MUI application in Company B. Which makes sense.
 
-But for Beam at Homebound, we specifically *want* a component that behaves in our App A to look & behave the same as it does in our App B.
+But for Beam at Homebound, we specifically _want_ a component that behaves in our App A to look & behave the same as it does in our App B.
 
 ## Beam and Open Source
 

--- a/src/components/Modal/useModal.tsx
+++ b/src/components/Modal/useModal.tsx
@@ -1,8 +1,8 @@
 import { useContext, useMemo, useRef } from "react";
 import { BeamContext } from "src/components/BeamContext";
 import { Callback, CheckFn } from "src/types";
+import { maybeCall } from "src/utils";
 import { ModalProps } from "./Modal";
-import {maybeCall} from "src/utils";
 
 export interface UseModalHook {
   openModal: (props: ModalProps) => void;

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -56,7 +56,6 @@ function Popper({ triggerRef, content, placement = "auto" }: PopperProps) {
   const [arrowRef, setArrowRef] = useState<HTMLDivElement | null>(null);
 
   const { styles, attributes } = usePopper(triggerRef.current, popperRef.current, {
-    strategy: "fixed",
     modifiers: [
       { name: "arrow", options: { element: arrowRef } },
       { name: "offset", options: { offset: [0, 5] } },

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,5 +1,6 @@
 import React, { cloneElement, ReactElement, ReactNode, useRef, useState } from "react";
 import { mergeProps, useTooltip, useTooltipTrigger } from "react-aria";
+import { createPortal } from "react-dom";
 import { usePopper } from "react-popper";
 import { useTooltipTriggerState } from "react-stately";
 import { Css } from "src/Css";
@@ -63,15 +64,11 @@ function Popper({ triggerRef, content, placement = "auto" }: PopperProps) {
     placement,
   });
 
-  return (
-    <div
-      ref={popperRef}
-      style={{ ...styles.popper, maxWidth: "320px" }}
-      {...attributes.popper}
-      css={Css.bgGray900.white.px1.py("4px").br4.xs.$}
-    >
+  return createPortal(
+    <div ref={popperRef} style={{ ...styles.popper, maxWidth: "320px" }} {...attributes.popper} css={Css.bgGray900.white.px1.py("4px").br4.xs.$}>
       <div ref={setArrowRef} style={{ ...styles.arrow }} id="arrow" />
       {content}
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -55,6 +55,7 @@ function Popper({ triggerRef, content, placement = "auto" }: PopperProps) {
   const [arrowRef, setArrowRef] = useState<HTMLDivElement | null>(null);
 
   const { styles, attributes } = usePopper(triggerRef.current, popperRef.current, {
+    strategy: "fixed",
     modifiers: [
       { name: "arrow", options: { element: arrowRef } },
       { name: "offset", options: { offset: [0, 5] } },

--- a/src/forms/BoundToggleChipGroupField.tsx
+++ b/src/forms/BoundToggleChipGroupField.tsx
@@ -4,10 +4,7 @@ import { ToggleChipGroup, ToggleChipGroupProps } from "src/inputs";
 import { useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
 
-export type BoundToggleChipGroupFieldProps = Omit<
-  ToggleChipGroupProps,
-  "values" | "onChange" | "label"
-> & {
+export type BoundToggleChipGroupFieldProps = Omit<ToggleChipGroupProps, "values" | "onChange" | "label"> & {
   field: FieldState<any, string[] | null | undefined>;
   /** Make optional so that callers can override if they want to. */
   onChange?: (values: string[]) => void;
@@ -20,15 +17,7 @@ export function BoundToggleChipGroupField(props: BoundToggleChipGroupFieldProps)
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
-      {() => (
-        <ToggleChipGroup
-          label={label}
-          values={field.value || []}
-          onChange={onChange}
-          {...testId}
-          {...others}
-        />
-      )}
+      {() => <ToggleChipGroup label={label} values={field.value || []} onChange={onChange} {...testId} {...others} />}
     </Observer>
   );
 }


### PR DESCRIPTION
Added a fixed strategy so the tooltip component will always sit on top of anything. 

![Screen Shot 2021-08-23 at 3 03 37 PM](https://user-images.githubusercontent.com/86630863/130625421-c39e4862-0a97-4231-8cae-ea9ab5c60849.png)
