### PR TITLE
fix: MultiSelectField to empty input value upon selecting an option

### DIFF
--- a/src/inputs/MultiSelectField.test.tsx
+++ b/src/inputs/MultiSelectField.test.tsx
@@ -35,12 +35,24 @@ describe("MultiSelectFieldTest", () => {
   it("can have custom an empty text", async () => {
     // Given a MultiSelectField with no selected values
     const r = await render(<TestMultiSelectField values={[]} options={options} nothingSelectedText="All" />);
+    const text = r.getByRole("combobox");
+    // Then expect the text input value to show the `nothingSelectedText` value
+    expect(text).toHaveValue("All");
+  });
+
+  it("only populates input field with selected single option on blur", async () => {
+    // Given a MultiSelectField with no selected values
+    const r = await render(<TestMultiSelectField values={[]} options={options} nothingSelectedText="All" />);
     // That initially has "One" selected
     const text = r.getByRole("combobox");
-    expect(text).toHaveValue("All");
     // And when we select the first option
     selectOption(r, "One");
-    // Then it changes to that one
+    // Then the input field is still empty
+    expect(text).toHaveValue("");
+
+    // When blurring the field
+    fireEvent.blur(text);
+    // Then the field should populate with the selected options's value.
     expect(text).toHaveValue("One");
   });
 
@@ -77,6 +89,22 @@ describe("MultiSelectFieldTest", () => {
     fireEvent.blur(age());
     // Then expect the value to be reset to empty
     expect(age()).toHaveValue("");
+  });
+
+  it("does not populate input field with multiple items selected", async () => {
+    // Given a MultiSelectField with no selected values
+    const r = await render(<TestMultiSelectField values={[]} options={options} nothingSelectedText="All" />);
+    const text = r.getByRole("combobox");
+
+    // When we select two options
+    selectOption(r, "One");
+    selectOption(r, "Two");
+
+    // And when blurring the field
+    fireEvent.blur(text);
+
+    // Then the input field is stay empty
+    expect(text).toHaveValue("");
   });
 
   function TestMultiSelectField(

--- a/src/inputs/internal/SelectFieldInput.tsx
+++ b/src/inputs/internal/SelectFieldInput.tsx
@@ -98,7 +98,8 @@ export function SelectFieldInput<O, V extends Value>(props: SelectFieldInputProp
             {state.selectionManager.selectedKeys.size}
           </span>
         )}
-        {fieldDecoration && selectedOptions.length === 1 && (
+        {/* For MultiSelect -> Only show the `fieldDecoration` when input is not in focus. */}
+        {(!isMultiSelect || (isMultiSelect && !isFocused)) && fieldDecoration && selectedOptions.length === 1 && (
           <span
             css={{
               ...Css.itemsCenter.br4.fs0.pr1.$,


### PR DESCRIPTION
Usability issue discovered in user testing - When a user is actively using the MultiSelectField and chooses a single option, that option's text is used to populate the input. However, user expectations were for that input value to be removed and allow them to start typing to filter again without having to delete the current input.

Fix is to empty out the input value upon selection change for MultiSelectFields. If only one option is selected, then upon blurring the field the selected option should show in the input.