### PR TITLE
[beamMocks] - update select field and multi select field mocks

### DIFF
--- a/src/inputs/MultiSelectField.mock.tsx
+++ b/src/inputs/MultiSelectField.mock.tsx
@@ -11,12 +11,14 @@ export function MultiSelectField<T, V extends Value>(props: MultiSelectFieldProp
     onSelect,
     readOnly = false,
     errorMsg,
+    onFocus,
     onBlur,
   } = props;
   const tid = useTestIds(props, "multiSelect");
 
   return (
     <select
+      {...tid}
       // We're cheating and assume the values are strings...what we should really do is either:
       // a) use beam's valueToKey mapping to string-encode any Value, or
       // b) instead of using `values` directly, use the index of each value's `option` in `options`
@@ -40,13 +42,17 @@ export function MultiSelectField<T, V extends Value>(props: MultiSelectFieldProp
         );
       }}
       multiple
-      onBlur={onBlur}
+      onFocus={() => {
+        if (!readOnly && onFocus) onFocus();
+      }}
+      onBlur={() => {
+        if (!readOnly && onBlur) onBlur();
+      }}
       // Read Only does not apply to `select` fields, instead we'll add in disabled for tests to verify.
       disabled={readOnly}
       data-error={!!errorMsg}
       data-errormsg={errorMsg}
       data-readonly={readOnly}
-      {...tid}
     >
       <option disabled value=""></option>
       {options.map((option, i) => {

--- a/src/inputs/SelectField.mock.tsx
+++ b/src/inputs/SelectField.mock.tsx
@@ -13,23 +13,29 @@ export function SelectField<T extends object, V extends Key>(props: SelectFieldP
     readOnly = false,
     errorMsg,
     onBlur,
+    onFocus,
   } = props;
   const tid = useTestIds(props, "select");
+
+  const currentOption = options.find((o) => getOptionValue(o) === value) || options[0];
 
   return (
     <select
       {...tid}
       value={
         // @ts-ignore - allow `value` to be seen as a string
-        value !== undefined && value !== ""
-          ? getOptionValue(options.find((o) => getOptionValue(o) === value) || options[0])
-          : ""
+        value !== undefined && value !== "" && currentOption ? getOptionValue(currentOption) : ""
       }
       onChange={(e) => {
         const option = options.find((o) => `${getOptionValue(o)}` === e.target.value) || options[0];
         onSelect(getOptionValue(option), option);
       }}
-      onBlur={onBlur}
+      onFocus={() => {
+        if (!readOnly && onFocus) onFocus();
+      }}
+      onBlur={() => {
+        if (!readOnly && onBlur) onBlur();
+      }}
       // Read Only does not apply to `select` fields, instead we'll add in disabled for tests to verify.
       disabled={readOnly}
       data-error={!!errorMsg}


### PR DESCRIPTION
- Move updated `internal-frontend` logic for handling blur and focus with readonly in our mocks