### PR TITLE
feat: Sort nested rows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "storybook": "start-storybook -p 9000 -s ./testAssets",
     "chromatic": "chromatic --project-token=074248da7284 --exit-once-uploaded",
     "copy": "npx copyfiles -u 1 \"./src/**/*.css\" \"./dist/\"",
+    "copy-to-internal-frontend": "cp -r dist/* ~/homebound/internal-frontend/node_modules/@homebound/beam/dist/",
     "format": "prettier --loglevel warn --write \"**/*.{ts,tsx,css,md}\""
   },
   "dependencies": {

--- a/src/components/Table/CollapseToggle.tsx
+++ b/src/components/Table/CollapseToggle.tsx
@@ -1,13 +1,18 @@
 import { useContext } from "react";
-import { GridCollapseContext, IconButton } from "src/components";
+import { GridCollapseContext, GridDataRow, IconButton } from "src/components";
 
 export interface GridTableCollapseToggleProps {
-  isHeader?: boolean;
+  row: GridDataRow<any>;
 }
 
-export function CollapseToggle({ isHeader }: GridTableCollapseToggleProps) {
+export function CollapseToggle(props: GridTableCollapseToggleProps) {
+  const { row } = props;
   const { isCollapsed, toggleCollapse } = useContext(GridCollapseContext);
   const iconKey = isCollapsed ? "chevronRight" : "chevronDown";
   const headerIconKey = isCollapsed ? "chevronsRight" : "chevronsDown";
+  const isHeader = row.kind === "header";
+  if (!isHeader && (!props.row.children || props.row.children.length === 0)) {
+    return null;
+  }
   return <IconButton onClick={toggleCollapse} icon={isHeader ? headerIconKey : iconKey} />;
 }

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -49,9 +49,9 @@ const nestedColumns: GridColumn<NestedRow>[] = [
   },
   {
     header: () => "Name",
-    parent: (row) => <div>{row.name}</div>,
-    child: (row) => <div css={Css.ml2.$}>{row.name}</div>,
-    grandChild: (row) => <div css={Css.ml4.$}>{row.name}</div>,
+    parent: (row) => ({ content: <div>{row.name}</div>, value: row.name }),
+    child: (row) => ({ content: <div css={Css.ml2.$}>{row.name}</div>, value: row.name }),
+    grandChild: (row) => ({ content: <div css={Css.ml4.$}>{row.name}</div>, value: row.name }),
   },
 ];
 
@@ -649,6 +649,32 @@ describe("GridTable", () => {
     );
     expect(cell(r, 0, 0)).toHaveTextContent("Name");
     expect(cell(r, 1, 0)).toHaveTextContent("bar");
+    expect(row(r, 2)).toBeUndefined();
+  });
+
+  it("can filter child rows", async () => {
+    // Given a parent that won't match the filter
+    const rows: GridDataRow<NestedRow>[] = [
+      { kind: "header", id: "header" },
+      {
+        kind: "parent",
+        id: "1",
+        name: "p1",
+        children: [
+          // And one child does match the filter
+          { kind: "child", id: "p1c1", name: "child foo" },
+          // And the other does not
+          { kind: "child", id: "p1c2", name: "child bar" },
+        ],
+      },
+    ];
+    // When we filter by 'foo'
+    const r = await render(<GridTable filter="foo" columns={nestedColumns} rows={rows} />);
+    // Then we show the header
+    expect(cell(r, 0, 1)).toHaveTextContent("Name");
+    // And the child that matched
+    expect(cell(r, 1, 1)).toHaveTextContent("foo");
+    // And that's it
     expect(row(r, 2)).toBeUndefined();
   });
 

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -294,8 +294,7 @@ describe("GridTable", () => {
         />,
       );
       // Then when sorted by the 2nd column
-      const { sortHeader_1 } = r;
-      click(sortHeader_1);
+      click(r.sortHeader_1);
       // Then the `value: undefined` row is first
       expect(cell(r, 1, 0)).toHaveTextContent("a");
       expect(cell(r, 2, 0)).toHaveTextContent("d");
@@ -380,6 +379,51 @@ describe("GridTable", () => {
       // Then the data is sorted by name
       expect(cell(r, 1, 0)).toHaveTextContent("a");
       expect(cell(r, 2, 0)).toHaveTextContent("b");
+    });
+
+    it("can sort nested rows", async () => {
+      // Given a table with nested rows
+      const r = await render(
+        <GridTable
+          columns={[nameColumn, valueColumn]}
+          // And there is no initial sort given
+          sorting={{ on: "client" }}
+          rows={[
+            simpleHeader,
+            // And the data is initially unsorted
+            {
+              ...{ kind: "data", id: "2", name: "2", value: 2 },
+              children: [
+                { kind: "data", id: "20", name: "1", value: 1 },
+                { kind: "data", id: "21", name: "2", value: 2 },
+              ],
+            },
+            {
+              ...{ kind: "data", id: "1", name: "1", value: 1 },
+              children: [
+                { kind: "data", id: "10", name: "1", value: 1 },
+                { kind: "data", id: "11", name: "2", value: 2 },
+              ],
+            },
+          ]}
+        />,
+      );
+      // Then the data is sorted by 1 (1 2) then 2 (1 2)
+      expect(cell(r, 1, 0)).toHaveTextContent("1");
+      expect(cell(r, 2, 0)).toHaveTextContent("1");
+      expect(cell(r, 3, 0)).toHaveTextContent("2");
+      expect(cell(r, 4, 0)).toHaveTextContent("2");
+      expect(cell(r, 5, 0)).toHaveTextContent("1");
+      expect(cell(r, 6, 0)).toHaveTextContent("2");
+      // And when we reverse the sort
+      click(r.sortHeader_0);
+      // Then the data is sorted by 2 (2 1) then 1 (2 1)
+      expect(cell(r, 1, 0)).toHaveTextContent("2");
+      expect(cell(r, 2, 0)).toHaveTextContent("2");
+      expect(cell(r, 3, 0)).toHaveTextContent("1");
+      expect(cell(r, 4, 0)).toHaveTextContent("1");
+      expect(cell(r, 5, 0)).toHaveTextContent("2");
+      expect(cell(r, 6, 0)).toHaveTextContent("1");
     });
 
     it("throws an error if a column value is not sortable", async () => {
@@ -611,9 +655,15 @@ describe("GridTable", () => {
   it("can collapse parent rows", async () => {
     // Given a parent with a child and grandchild
     const rows: GridDataRow<NestedRow>[] = [
-      { kind: "parent", id: "p1", name: "parent 1" },
-      { kind: "child", id: "p1c1", parentIds: ["p1"], name: "child p1c1" },
-      { kind: "grandChild", id: "p1c1g1", parentIds: ["p1", "p1c1"], name: "grandchild p1c1g1" },
+      {
+        ...{ kind: "parent", id: "p1", name: "parent 1" },
+        children: [
+          {
+            ...{ kind: "child", id: "p1c1", name: "child p1c1" },
+            children: [{ kind: "grandChild", id: "p1c1g1", name: "grandchild p1c1g1" }],
+          },
+        ],
+      },
     ];
     const r = await render(<GridTable<NestedRow> columns={nestedColumns} rows={rows} />);
     // And all three rows are initially rendered
@@ -630,9 +680,15 @@ describe("GridTable", () => {
   it("can collapse child rows", async () => {
     // Given a parent with a child and grandchild
     const rows: GridDataRow<NestedRow>[] = [
-      { kind: "parent", id: "p1", name: "parent 1" },
-      { kind: "child", id: "p1c1", parentIds: ["p1"], name: "child p1c1" },
-      { kind: "grandChild", id: "p1c1g1", parentIds: ["p1", "p1c1"], name: "grandchild p1c1g1" },
+      {
+        ...{ kind: "parent", id: "p1", name: "parent 1" },
+        children: [
+          {
+            ...{ kind: "child", id: "p1c1", name: "child p1c1" },
+            children: [{ kind: "grandChild", id: "p1c1g1", name: "grandchild p1c1g1" }],
+          },
+        ],
+      },
     ];
     const r = await render(<GridTable<NestedRow> columns={nestedColumns} rows={rows} />);
     // And all three rows are initially rendered
@@ -652,9 +708,15 @@ describe("GridTable", () => {
     // Given a parent with a child and grandchild
     const rows: GridDataRow<NestedRow>[] = [
       { kind: "header", id: "header" },
-      { kind: "parent", id: "p1", name: "parent 1" },
-      { kind: "child", id: "p1c1", parentIds: ["p1"], name: "child p1c1" },
-      { kind: "grandChild", id: "p1c1g1", parentIds: ["p1", "p1c1"], name: "grandchild p1c1g1" },
+      {
+        ...{ kind: "parent", id: "p1", name: "parent 1" },
+        children: [
+          {
+            ...{ kind: "child", id: "p1c1", name: "child p1c1" },
+            children: [{ kind: "grandChild", id: "p1c1g1", name: "grandchild p1c1g1" }],
+          },
+        ],
+      },
     ];
     const r = await render(<GridTable<NestedRow> columns={nestedColumns} rows={rows} />);
     // And all three rows are initially rendered
@@ -684,10 +746,8 @@ describe("GridTable", () => {
     // And two parents with a child each
     const rows: GridDataRow<NestedRow>[] = [
       { kind: "header", id: "header" },
-      { kind: "parent", id: "p1", name: "parent 1" },
-      { kind: "child", id: "p1c1", parentIds: ["p1"], name: "child p1c1" },
-      { kind: "parent", id: "p2", name: "parent 2" },
-      { kind: "child", id: "p2c1", parentIds: ["p2"], name: "child p2c1" },
+      { kind: "parent", id: "p1", name: "parent 1", children: [{ kind: "child", id: "p1c1", name: "child p1c1" }] },
+      { kind: "parent", id: "p2", name: "parent 2", children: [{ kind: "child", id: "p2c1", name: "child p2c1" }] },
     ];
 
     // When we render the table with the persistCollapse prop set

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -1288,7 +1288,8 @@ function useToggleIds(rows: GridDataRow<Kinded>[], persistCollapse: string | und
         } else {
           // Otherwise push `header` on the list as a hint that we're in the collapsed-all state
           collapsedIds.push("header");
-          // Find all non-leaf rows
+          // Find all non-leaf rows so that toggling "all collapsed" -> "all not collapsed" opens
+          // the parent rows of any level.
           const parentIds = new Set<string>();
           const todo = [...rows];
           while (todo.length > 0) {


### PR DESCRIPTION
We hadn't gotten around to sorting nested rows.

To sort nested rows, we need to know the original non-flatted structure.

I originally thought we could/should decipher this by going through the flattened list and observing the `kind` values. I.e. if we saw `kind=parent, kind=child, kind=child, kind=grandchild, kind=parent` we could probably guess the tree.

That said, it's a lot simpler to just be passed the tree as-is, because currently all of the code that passes nested rows is `flatMap`-ing from a nested structure anyway.

So, we make a large breaking change by removing the `parentIds` key that used to hint at the structure of parent/children, and instead just add a `GridDataRow.children` to make `rows` now a recursive/non-flat structure.

We still flatten before handing off to the css grid/table/virtuoso renders.

Despite being a in-theory large breaking change, I think updating the code in internal-frontend to "stop flat mapping" will be pretty trivial.
