### PR TITLE
feat: Add 'All' to single select filters.

### DIFF
--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -123,39 +123,6 @@ export function GroupBy() {
   );
 }
 
-export function GroupByViewAll() {
-  const groupBy = useGroupBy({ costCode: "Cost Code", tradeCategory: "Trade Category" });
-  type Filter = ProjectFilter & { view: string };
-  const filterDefs: FilterDefs<Filter> = useMemo(() => {
-    return {
-      view: singleFilter({
-        options: [
-          { id: "all", name: "All" },
-          { id: "selections", name: "Selections" },
-        ],
-        getOptionValue: (o) => o.id,
-        getOptionLabel: (o) => o.name,
-        defaultValue: "all",
-      }),
-      marketId: multiFilter({
-        options: markets,
-        getOptionValue: (o) => o.code,
-        getOptionLabel: (o) => o.name,
-      }),
-    };
-  }, []);
-  const { setFilter, filter } = usePersistedFilter<ProjectFilter>({
-    storageKey: "GroupByViewAll",
-    filterDefs,
-  });
-  return (
-    <div css={Css.df.fdc.childGap2.$}>
-      <Filters groupBy={groupBy} filter={filter} onChange={setFilter} filterDefs={filterDefs} />
-      <strong>Applied Filter:</strong> {JSON.stringify(filter)}
-    </div>
-  );
-}
-
 const internalUsers: InternalUser[] = zeroTo(10).map((i) => ({ id: `${i + 1}`, name: `Employee ${i + 1}` }));
 const markets: Market[] = zeroTo(5).map((i) => ({ code: `${i + 1}`, name: `Market ${i + 1}` }));
 const stages: Stage[] = [Stage.StageOne, Stage.StageTwo];

--- a/src/components/Filters/SingleSelectFilter.test.tsx
+++ b/src/components/Filters/SingleSelectFilter.test.tsx
@@ -1,0 +1,37 @@
+import { click } from "@homebound/rtl-utils";
+import { fireEvent } from "@testing-library/react";
+import { useState } from "react";
+import { FilterDefs, Filters } from "src/components/Filters";
+import { ProjectFilter, stageSingleFilter } from "src/components/Filters/testDomain";
+import { render } from "src/utils/rtl";
+
+describe("SingleSelectFilter", () => {
+  it("shows All by default", async () => {
+    const r = await render(<TestFilters defs={{ stageSingle: stageSingleFilter }} />);
+    expect(r.filter_stageSingle()).toHaveValue("All");
+  });
+
+  it("shows All as an option to unset the filter", async () => {
+    const r = await render(<TestFilters defs={{ stageSingle: stageSingleFilter }} />);
+    // Given we select a filter
+    fireEvent.focus(r.filter_stageSingle());
+    click(r.getByRole("option", { name: "One" }));
+    expect(r.filter_value()).toHaveTextContent(`{"stageSingle":"ONE"}`);
+    // When we select All
+    fireEvent.focus(r.filter_stageSingle());
+    click(r.getByRole("option", { name: "All" }));
+    // Then it is unset
+    expect(r.filter_value()).toHaveTextContent(`{}`);
+  });
+});
+
+function TestFilters(props: { defs: FilterDefs<ProjectFilter> }) {
+  const { defs } = props;
+  const [filter, setFilter] = useState<ProjectFilter>({});
+  return (
+    <div>
+      <Filters filterDefs={defs} filter={filter} onChange={setFilter} />
+      <div data-testid="filter_value">{JSON.stringify(filter)}</div>
+    </div>
+  );
+}

--- a/src/components/Filters/SingleSelectFilter.tsx
+++ b/src/components/Filters/SingleSelectFilter.tsx
@@ -15,7 +15,7 @@ export function singleFilter<O, V extends Key>(props: SingleFilterProps<O, V>): 
 }
 
 // Make an option that we'll sneak into every select field
-const unboundOption = {} as any;
+const allOption = {} as any;
 
 class SingleFilter<O, V extends Key> implements Filter<V> {
   constructor(private key: string, private props: SingleFilterProps<O, V>) {}
@@ -27,11 +27,11 @@ class SingleFilter<O, V extends Key> implements Filter<V> {
         {...props}
         options={[
           // We always add "All" as the 1st option, to allow unselecting with a click
-          unboundOption as O,
+          allOption as O,
           ...options,
         ]}
-        getOptionValue={(o) => (o === unboundOption ? (undefined as any as V) : getOptionValue(o))}
-        getOptionLabel={(o) => (o === unboundOption ? "All" : getOptionLabel(o))}
+        getOptionValue={(o) => (o === allOption ? (undefined as any as V) : getOptionValue(o))}
+        getOptionLabel={(o) => (o === allOption ? "All" : getOptionLabel(o))}
         compact
         value={value}
         label={this.label}

--- a/src/components/Filters/SingleSelectFilter.tsx
+++ b/src/components/Filters/SingleSelectFilter.tsx
@@ -14,19 +14,30 @@ export function singleFilter<O, V extends Key>(props: SingleFilterProps<O, V>): 
   return (key) => new SingleFilter(key, props);
 }
 
+// Make an option that we'll sneak into every select field
+const unboundOption = {} as any;
+
 class SingleFilter<O, V extends Key> implements Filter<V> {
   constructor(private key: string, private props: SingleFilterProps<O, V>) {}
 
   render(value: V | undefined, setValue: (value: V | undefined) => void, tid: TestIds, inModal: boolean) {
-    const { label, defaultValue, ...props } = this.props;
+    const { label, defaultValue, options, getOptionLabel, getOptionValue, ...props } = this.props;
     return (
       <SelectField<O, V>
         {...props}
+        options={[
+          // We always add "All" as the 1st option, to allow unselecting with a click
+          unboundOption as O,
+          ...options,
+        ]}
+        getOptionValue={(o) => (o === unboundOption ? (undefined as any as V) : getOptionValue(o))}
+        getOptionLabel={(o) => (o === unboundOption ? "All" : getOptionLabel(o))}
         compact
         value={value}
         label={this.label}
         inlineLabel
         sizeToContent={!inModal}
+        nothingSelectedText="All"
         onSelect={(value) => setValue(value || undefined)}
         {...tid[defaultTestId(this.label)]}
       />

--- a/src/components/Filters/testDomain.ts
+++ b/src/components/Filters/testDomain.ts
@@ -1,3 +1,7 @@
+import { multiFilter } from "src/components/Filters/MultiSelectFilter";
+import { singleFilter } from "src/components/Filters/SingleSelectFilter";
+import { FilterDefs } from "src/components/Filters/types";
+
 export enum Stage {
   StageOne = "ONE",
   StageTwo = "TWO",
@@ -40,3 +44,23 @@ export type ProjectFilter = {
   isTest?: boolean | null;
   doNotUse?: boolean | null;
 };
+
+export type StageFilter = FilterDefs<ProjectFilter>["stage"];
+export type StageSingleFilter = FilterDefs<ProjectFilter>["stageSingle"];
+
+const stageOptions = [
+  { code: Stage.StageOne, name: "One" },
+  { code: Stage.StageTwo, name: "Two" },
+];
+
+export const stageFilter: StageFilter = multiFilter({
+  options: stageOptions,
+  getOptionValue: (s) => s.code,
+  getOptionLabel: (s) => s.name,
+});
+
+export const stageSingleFilter: StageSingleFilter = singleFilter({
+  options: stageOptions,
+  getOptionValue: (s) => s.code,
+  getOptionLabel: (s) => s.name,
+});

--- a/src/hooks/usePersistedFilter.test.tsx
+++ b/src/hooks/usePersistedFilter.test.tsx
@@ -18,7 +18,7 @@ describe("usePersistedFilter", () => {
     });
     const r = await render(<TestPage filterDefs={{ stageSingle: stage }} />, withRouter());
     // Then the filter is initially empty
-    expect(r.filter_stageSingle()).toHaveValue("");
+    expect(r.filter_stageSingle()).toHaveValue("All");
     expect(r.applied().textContent).toEqual("{}");
   });
 


### PR DESCRIPTION
This matches multi select / boolean filter / etc. behavior, and means users don't have to add their own "All" options that can act slightly weird due to the "empty vs. All vs. actual value" tri-state.