### PR TITLE
feat: Nested cards

### DIFF
--- a/.storybook/.babelrc
+++ b/.storybook/.babelrc
@@ -4,5 +4,6 @@
     ["@emotion/babel-preset-css-prop"],
     ["@babel/preset-react", { "runtime": "automatic", "importSource": "@emotion/react" }],
     ["@babel/preset-typescript"]
-  ]
+  ],
+  "plugins": ["@babel/proposal-class-properties", "@babel/proposal-object-rest-spread"]
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,8 @@
   },
   "devDependencies": {
     "@babel/core": "^7.15.5",
+    "@babel/plugin-proposal-class-properties": "^7.14.5",
+    "@babel/preset-typescript": "^7.15.0",
     "@emotion/babel-preset-css-prop": "^11.2.0",
     "@emotion/jest": "^11.3.0",
     "@emotion/react": "^11.1.5",
@@ -95,7 +97,7 @@
     "@typescript-eslint/parser": "^4.17.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.2",
-    "chromatic": "^5.6.3",
+    "chromatic": "^5.9.2",
     "conventional-changelog-conventionalcommits": "^4.5.0",
     "eslint": "^7.21.0",
     "eslint-config-prettier": "^8.1.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     }
   },
   "devDependencies": {
-    "@babel/core": "^7.13.1",
+    "@babel/core": "^7.15.5",
     "@emotion/babel-preset-css-prop": "^11.2.0",
     "@emotion/jest": "^11.3.0",
     "@emotion/react": "^11.1.5",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@emotion/react": "^11.1.5",
     "@homebound/form-state": "^2.0.0",
     "@homebound/rtl-react-router-utils": "^1.0.3",
-    "@homebound/rtl-utils": "^2.50.0",
+    "@homebound/rtl-utils": "^2.51.0",
     "@homebound/tsconfig": "^1.0.3",
     "@semantic-release/git": "^9.0.0",
     "@storybook/addon-essentials": "^6.3.4",

--- a/src/Css.ts
+++ b/src/Css.ts
@@ -265,6 +265,8 @@ class CssBuilder<T extends Properties1> {
   // grid
   gtc(value: Properties["gridTemplateColumns"]) { return this.add("gridTemplateColumns", value); }
   gtr(value: Properties["gridTemplateRows"]) { return this.add("gridTemplateRows", value); }
+  gr(value: Properties["gridRow"]) { return this.add("gridRow", value); }
+  gc(value: Properties["gridColumn"]) { return this.add("gridColumn", value); }
   get gap0() { return this.gap(0); }
   get gap1() { return this.gap(1); }
   get gap2() { return this.gap(2); }

--- a/src/Css.ts
+++ b/src/Css.ts
@@ -107,6 +107,8 @@ class CssBuilder<T extends Properties1> {
   get br24() { return this.add("borderRadius", "24px"); }
   get br100() { return this.add("borderRadius", "100%"); }
   borderRadius(value: Properties["borderRadius"]) { return this.add("borderRadius", value); }
+  get brt4() { return this.add("borderTopRightRadius", "4px").add("borderTopLeftRadius", "4px"); }
+  get brb4() { return this.add("borderBottomRightRadius", "4px").add("borderBottomLeftRadius", "4px"); }
 
   // borderStyle
   get bsDashed() { return this.add("borderStyle", "dashed"); }

--- a/src/components/SuperDrawer/SuperDrawer.stories.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from "src";
 import { TestModalContent } from "src/components/Modal/TestModalContent";
 import { useModal } from "src/components/Modal/useModal";
-import { GridDataRow, GridRowLookup, simpleRows } from "src/components/Table/GridTable";
+import { GridDataRow, GridRowLookup, simpleRows } from "src/components/Table";
 import { withBeamDecorator, withDimensions } from "src/utils/sb";
 import { SuperDrawerContent, useSuperDrawer } from "./index";
 import { SuperDrawer as SuperDrawerComponent } from "./SuperDrawer";

--- a/src/components/Table/GridRowLookup.ts
+++ b/src/components/Table/GridRowLookup.ts
@@ -1,0 +1,84 @@
+import { MutableRefObject } from "react";
+import { VirtuosoHandle } from "react-virtuoso";
+import { DiscriminateUnion, GridColumn, GridDataRow, Kinded, RowTuple } from "src/components/Table/GridTable";
+
+/**
+ * Allows a caller to ask for the currently shown rows, given the current sorting/filtering.
+ *
+ * We will probably end up generalizing this into a GridTableApi that exposes more
+ * actions i.e. scrolling to a row and selection state.
+ */
+export interface GridRowLookup<R extends Kinded> {
+  /** Returns both the immediate next/prev rows, as well as `[kind].next/prev` values, ignoring headers. */
+  lookup(
+    row: GridDataRow<R>,
+    additionalFilter?: (row: GridDataRow<R>) => boolean,
+  ): NextPrev<R> &
+    {
+      [P in R["kind"]]: NextPrev<DiscriminateUnion<R, "kind", P>>;
+    };
+
+  /** Returns the list of currently filtered/sorted rows, without headers. */
+  currentList(): readonly GridDataRow<R>[];
+
+  /** Scroll's to the row with the given kind + id. Requires using `as=virtual`. */
+  scrollTo(kind: R["kind"], id: string): void;
+}
+
+interface NextPrev<R extends Kinded> {
+  next: GridDataRow<R> | undefined;
+  prev: GridDataRow<R> | undefined;
+}
+
+export function createRowLookup<R extends Kinded>(
+  columns: GridColumn<R>[],
+  filteredRows: RowTuple<R>[],
+  virtuosoRef: MutableRefObject<VirtuosoHandle | null>,
+): GridRowLookup<R> {
+  return {
+    scrollTo(kind, id) {
+      if (virtuosoRef.current === null) {
+        // In theory we could support as=div and as=table by finding the DOM
+        // element and calling .scrollIntoView, just not doing that yet.
+        throw new Error("scrollTo is only supported for as=virtual");
+      }
+      const index = filteredRows.findIndex(([r]) => r.kind === kind && r.id === id);
+      virtuosoRef.current.scrollToIndex({ index, behavior: "smooth" });
+    },
+    currentList() {
+      return filteredRows.map((r) => r[0]);
+    },
+    lookup(row, additionalFilter = () => true) {
+      const rows = filteredRows.map((r) => r[0]).filter(additionalFilter);
+      // Ensure we have `result.kind = {}` for each kind
+      const result: any = Object.fromEntries(getKinds(columns).map((kind) => [kind, {}]));
+      // This is an admittedly cute/fancy scan, instead of just `rows.findIndex`, but
+      // we do it this way so that we can do kind-aware prev/next detection.
+      let key: "prev" | "next" = "prev";
+      for (let i = 0; i < rows.length; i++) {
+        const each = rows[i];
+        // Flip from prev to next when we find it
+        if (each.kind === row.kind && each.id === row.id) {
+          key = "next";
+        } else {
+          if (key === "prev") {
+            // prev always overwrites what was there before
+            result[key] = each;
+            result[each.kind][key] = each;
+          } else {
+            // next only writes first seen
+            result[key] ??= each;
+            result[each.kind][key] ??= each;
+          }
+        }
+      }
+      return result;
+    },
+  };
+}
+
+function getKinds<R extends Kinded>(columns: GridColumn<R>[]): R[] {
+  // Use the 1st column to get the runtime list of kinds
+  const nonKindKeys = ["w", "sort", "sortValue", "align"];
+  return Object.keys(columns[0] || {}).filter((key) => !nonKindKeys.includes(key)) as any;
+}

--- a/src/components/Table/GridRowLookup.ts
+++ b/src/components/Table/GridRowLookup.ts
@@ -1,6 +1,7 @@
 import { MutableRefObject } from "react";
 import { VirtuosoHandle } from "react-virtuoso";
 import { DiscriminateUnion, GridColumn, GridDataRow, Kinded, RowTuple } from "src/components/Table/GridTable";
+import { dropChromeRows } from "src/components/Table/nestedCards";
 
 /**
  * Allows a caller to ask for the currently shown rows, given the current sorting/filtering.
@@ -42,14 +43,16 @@ export function createRowLookup<R extends Kinded>(
         // element and calling .scrollIntoView, just not doing that yet.
         throw new Error("scrollTo is only supported for as=virtual");
       }
-      const index = filteredRows.findIndex(([r]) => r.kind === kind && r.id === id);
+      const index = filteredRows.findIndex(([r]) => r && r.kind === kind && r.id === id);
       virtuosoRef.current.scrollToIndex({ index, behavior: "smooth" });
     },
     currentList() {
-      return filteredRows.map((r) => r[0]);
+      return dropChromeRows(filteredRows).map((r) => r[0]);
     },
     lookup(row, additionalFilter = () => true) {
-      const rows = filteredRows.map((r) => r[0]).filter(additionalFilter);
+      const rows = dropChromeRows(filteredRows)
+        .map((r) => r[0])
+        .filter(additionalFilter);
       // Ensure we have `result.kind = {}` for each kind
       const result: any = Object.fromEntries(getKinds(columns).map((kind) => [kind, {}]));
       // This is an admittedly cute/fancy scan, instead of just `rows.findIndex`, but

--- a/src/components/Table/GridTable.nestedCards.test.tsx
+++ b/src/components/Table/GridTable.nestedCards.test.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { GridColumn, GridTable, makeOpenOrCloseCard, NestedCardStyle } from "src/components/Table/GridTable";
+import {
+  addCardPadding,
+  GridColumn,
+  GridTable,
+  makeOpenOrCloseCard,
+  NestedCardStyle,
+} from "src/components/Table/GridTable";
 import { simpleHeader, SimpleHeaderAndDataOf } from "src/components/Table/simpleHelpers";
 import { Css, Palette } from "src/Css";
 import { cell, click, render } from "src/utils/rtl";
@@ -101,11 +107,11 @@ describe("GridTable nestedCards", () => {
     expect(r.firstElement).toMatchInlineSnapshot(`
       .emotion-0 {
         background-color: rgba(247,245,245,1);
+        padding-left: 8px;
+        padding-right: 8px;
         border-top-left-radius: 8px;
         border-top-right-radius: 8px;
         height: 8px;
-        padding-left: 8px;
-        padding-right: 8px;
       }
 
       <div
@@ -129,16 +135,18 @@ describe("GridTable nestedCards", () => {
 
       .emotion-1 {
         background-color: rgba(221,220,220,1);
+        padding-left: 6px;
+        padding-right: 6px;
+        border-top-left-radius: 6px;
+        border-top-right-radius: 6px;
+        height: 6px;
         border-color: rgba(236,235,235,1);
         border-left-style: solid;
         border-left-width: 1px;
         border-right-style: solid;
         border-right-width: 1px;
-        border-top-left-radius: 6px;
-        border-top-right-radius: 6px;
-        height: 6px;
-        padding-left: 6px;
-        padding-right: 6px;
+        border-top-style: solid;
+        border-top-width: 1px;
       }
 
       <div
@@ -150,6 +158,29 @@ describe("GridTable nestedCards", () => {
           <div
             class="emotion-1"
           />
+        </div>
+      </div>
+    `);
+  });
+
+  it("can add padding w/two levels", async () => {
+    const r = await render(addCardPadding([parentCardStyle, childCardStyle], <div>content</div>, "left"));
+    expect(r.firstElement).toMatchInlineSnapshot(`
+      .emotion-0 {
+        background-color: rgba(247,245,245,1);
+        padding-left: 8px;
+        padding-right: 8px;
+      }
+
+      <div
+        data-overlay-container="true"
+      >
+        <div
+          class="emotion-0"
+        >
+          <div>
+            content
+          </div>
         </div>
       </div>
     `);

--- a/src/components/Table/GridTable.nestedCards.test.tsx
+++ b/src/components/Table/GridTable.nestedCards.test.tsx
@@ -172,14 +172,29 @@ describe("GridTable nestedCards", () => {
         padding-right: 8px;
       }
 
+      .emotion-1 {
+        background-color: rgba(221,220,220,1);
+        border-color: rgba(236,235,235,1);
+        border-left-style: solid;
+        border-left-width: 1px;
+        border-right-style: solid;
+        border-right-width: 1px;
+        padding-left: 6px;
+        padding-right: 6px;
+      }
+
       <div
         data-overlay-container="true"
       >
         <div
           class="emotion-0"
         >
-          <div>
-            content
+          <div
+            class="emotion-1"
+          >
+            <div>
+              content
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/Table/GridTable.nestedCards.test.tsx
+++ b/src/components/Table/GridTable.nestedCards.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { GridColumn, GridTable } from "src/components/Table/GridTable";
+import { simpleHeader, SimpleHeaderAndDataOf } from "src/components/Table/simpleHelpers";
+import { Css } from "src/Css";
+import { cell, click, render } from "src/utils/rtl";
+
+// Most of our tests use this simple Row and 2 columns
+type Data = { name: string; value: number | undefined };
+type Row = SimpleHeaderAndDataOf<Data>;
+
+const nameColumn: GridColumn<Row> = { header: () => "Name", data: ({ name }) => name };
+const valueColumn: GridColumn<Row> = { header: () => "Value", data: ({ value }) => value };
+
+// Make a `NestedRow` ADT for a table with a header + 3 levels of nesting
+type HeaderRow = { kind: "header" };
+type ParentRow = { kind: "parent"; id: string; name: string };
+type ChildRow = { kind: "child"; id: string; name: string };
+type GrandChildRow = { kind: "grandChild"; id: string; name: string };
+type NestedRow = HeaderRow | ParentRow | ChildRow | GrandChildRow;
+
+// And two columns for NestedRow
+const nestedColumns: GridColumn<NestedRow>[] = [
+  {
+    header: () => "",
+    parent: () => "",
+    child: () => "",
+    grandChild: () => "",
+    w: 0,
+  },
+  {
+    header: () => "Name",
+    parent: (row) => ({ content: <div>{row.name}</div>, value: row.name }),
+    child: (row) => ({ content: <div css={Css.ml2.$}>{row.name}</div>, value: row.name }),
+    grandChild: (row) => ({ content: <div css={Css.ml4.$}>{row.name}</div>, value: row.name }),
+  },
+];
+
+describe("GridTable nestedCards", () => {
+  it("can sort nested rows", async () => {
+    // Given a table with nested rows
+    const r = await render(
+      <GridTable
+        columns={[nameColumn, valueColumn]}
+        // And there is no initial sort given
+        sorting={{ on: "client" }}
+        rows={[
+          simpleHeader,
+          // And the data is initially unsorted
+          {
+            ...{ kind: "data", id: "2", name: "2", value: 2 },
+            children: [
+              { kind: "data", id: "20", name: "1", value: 1 },
+              { kind: "data", id: "21", name: "2", value: 2 },
+            ],
+          },
+          {
+            ...{ kind: "data", id: "1", name: "1", value: 1 },
+            children: [
+              { kind: "data", id: "10", name: "1", value: 1 },
+              { kind: "data", id: "11", name: "2", value: 2 },
+            ],
+          },
+        ]}
+      />,
+    );
+    // Then the data is sorted by 1 (1 2) then 2 (1 2)
+    expect(cell(r, 1, 0)).toHaveTextContent("1");
+    expect(cell(r, 2, 0)).toHaveTextContent("1");
+    expect(cell(r, 3, 0)).toHaveTextContent("2");
+    expect(cell(r, 4, 0)).toHaveTextContent("2");
+    expect(cell(r, 5, 0)).toHaveTextContent("1");
+    expect(cell(r, 6, 0)).toHaveTextContent("2");
+    // And when we reverse the sort
+    click(r.sortHeader_0);
+    // Then the data is sorted by 2 (2 1) then 1 (2 1)
+    expect(cell(r, 1, 0)).toHaveTextContent("2");
+    expect(cell(r, 2, 0)).toHaveTextContent("2");
+    expect(cell(r, 3, 0)).toHaveTextContent("1");
+    expect(cell(r, 4, 0)).toHaveTextContent("1");
+    expect(cell(r, 5, 0)).toHaveTextContent("2");
+    expect(cell(r, 6, 0)).toHaveTextContent("1");
+  });
+});

--- a/src/components/Table/GridTable.nestedCards.test.tsx
+++ b/src/components/Table/GridTable.nestedCards.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { GridColumn, GridTable } from "src/components/Table/GridTable";
+import { GridColumn, GridTable, makeOpenOrCloseCard, NestedCardStyle } from "src/components/Table/GridTable";
 import { simpleHeader, SimpleHeaderAndDataOf } from "src/components/Table/simpleHelpers";
-import { Css } from "src/Css";
+import { Css, Palette } from "src/Css";
 import { cell, click, render } from "src/utils/rtl";
 
 // Most of our tests use this simple Row and 2 columns
@@ -34,6 +34,21 @@ const nestedColumns: GridColumn<NestedRow>[] = [
     grandChild: (row) => ({ content: <div css={Css.ml4.$}>{row.name}</div>, value: row.name }),
   },
 ];
+
+const parentCardStyle: NestedCardStyle = {
+  bgColor: Palette.Gray100,
+  brPx: 8,
+  pxPx: 8,
+  spacerPx: 8,
+};
+
+const childCardStyle: NestedCardStyle = {
+  bgColor: Palette.Gray300,
+  bColor: Palette.Gray200,
+  brPx: 6,
+  pxPx: 6,
+  spacerPx: 6,
+};
 
 describe("GridTable nestedCards", () => {
   it("can sort nested rows", async () => {
@@ -79,5 +94,64 @@ describe("GridTable nestedCards", () => {
     expect(cell(r, 4, 0)).toHaveTextContent("1");
     expect(cell(r, 5, 0)).toHaveTextContent("2");
     expect(cell(r, 6, 0)).toHaveTextContent("1");
+  });
+
+  it("can make open card w/one level", async () => {
+    const r = await render(makeOpenOrCloseCard([parentCardStyle], "open"));
+    expect(r.firstElement).toMatchInlineSnapshot(`
+      .emotion-0 {
+        background-color: rgba(247,245,245,1);
+        border-top-left-radius: 8px;
+        border-top-right-radius: 8px;
+        height: 8px;
+        padding-left: 8px;
+        padding-right: 8px;
+      }
+
+      <div
+        data-overlay-container="true"
+      >
+        <div
+          class="emotion-0"
+        />
+      </div>
+    `);
+  });
+
+  it("can make open card w/two levels", async () => {
+    const r = await render(makeOpenOrCloseCard([parentCardStyle, childCardStyle], "open"));
+    expect(r.firstElement).toMatchInlineSnapshot(`
+      .emotion-0 {
+        background-color: rgba(247,245,245,1);
+        padding-left: 8px;
+        padding-right: 8px;
+      }
+
+      .emotion-1 {
+        background-color: rgba(221,220,220,1);
+        border-color: rgba(236,235,235,1);
+        border-left-style: solid;
+        border-left-width: 1px;
+        border-right-style: solid;
+        border-right-width: 1px;
+        border-top-left-radius: 6px;
+        border-top-right-radius: 6px;
+        height: 6px;
+        padding-left: 6px;
+        padding-right: 6px;
+      }
+
+      <div
+        data-overlay-container="true"
+      >
+        <div
+          class="emotion-0"
+        >
+          <div
+            class="emotion-1"
+          />
+        </div>
+      </div>
+    `);
   });
 });

--- a/src/components/Table/GridTable.nestedCards.test.tsx
+++ b/src/components/Table/GridTable.nestedCards.test.tsx
@@ -1,45 +1,7 @@
 import React from "react";
-import {
-  addCardPadding,
-  GridColumn,
-  GridTable,
-  makeOpenOrCloseCard,
-  NestedCardStyle,
-} from "src/components/Table/GridTable";
-import { simpleHeader, SimpleHeaderAndDataOf } from "src/components/Table/simpleHelpers";
-import { Css, Palette } from "src/Css";
-import { cell, click, render } from "src/utils/rtl";
-
-// Most of our tests use this simple Row and 2 columns
-type Data = { name: string; value: number | undefined };
-type Row = SimpleHeaderAndDataOf<Data>;
-
-const nameColumn: GridColumn<Row> = { header: () => "Name", data: ({ name }) => name };
-const valueColumn: GridColumn<Row> = { header: () => "Value", data: ({ value }) => value };
-
-// Make a `NestedRow` ADT for a table with a header + 3 levels of nesting
-type HeaderRow = { kind: "header" };
-type ParentRow = { kind: "parent"; id: string; name: string };
-type ChildRow = { kind: "child"; id: string; name: string };
-type GrandChildRow = { kind: "grandChild"; id: string; name: string };
-type NestedRow = HeaderRow | ParentRow | ChildRow | GrandChildRow;
-
-// And two columns for NestedRow
-const nestedColumns: GridColumn<NestedRow>[] = [
-  {
-    header: () => "",
-    parent: () => "",
-    child: () => "",
-    grandChild: () => "",
-    w: 0,
-  },
-  {
-    header: () => "Name",
-    parent: (row) => ({ content: <div>{row.name}</div>, value: row.name }),
-    child: (row) => ({ content: <div css={Css.ml2.$}>{row.name}</div>, value: row.name }),
-    grandChild: (row) => ({ content: <div css={Css.ml4.$}>{row.name}</div>, value: row.name }),
-  },
-];
+import { addCardPadding, makeOpenOrCloseCard, NestedCardStyle } from "src/components/Table/GridTable";
+import { Palette } from "src/Css";
+import { render } from "src/utils/rtl";
 
 const parentCardStyle: NestedCardStyle = {
   bgColor: Palette.Gray100,
@@ -57,51 +19,6 @@ const childCardStyle: NestedCardStyle = {
 };
 
 describe("GridTable nestedCards", () => {
-  it("can sort nested rows", async () => {
-    // Given a table with nested rows
-    const r = await render(
-      <GridTable
-        columns={[nameColumn, valueColumn]}
-        // And there is no initial sort given
-        sorting={{ on: "client" }}
-        rows={[
-          simpleHeader,
-          // And the data is initially unsorted
-          {
-            ...{ kind: "data", id: "2", name: "2", value: 2 },
-            children: [
-              { kind: "data", id: "20", name: "1", value: 1 },
-              { kind: "data", id: "21", name: "2", value: 2 },
-            ],
-          },
-          {
-            ...{ kind: "data", id: "1", name: "1", value: 1 },
-            children: [
-              { kind: "data", id: "10", name: "1", value: 1 },
-              { kind: "data", id: "11", name: "2", value: 2 },
-            ],
-          },
-        ]}
-      />,
-    );
-    // Then the data is sorted by 1 (1 2) then 2 (1 2)
-    expect(cell(r, 1, 0)).toHaveTextContent("1");
-    expect(cell(r, 2, 0)).toHaveTextContent("1");
-    expect(cell(r, 3, 0)).toHaveTextContent("2");
-    expect(cell(r, 4, 0)).toHaveTextContent("2");
-    expect(cell(r, 5, 0)).toHaveTextContent("1");
-    expect(cell(r, 6, 0)).toHaveTextContent("2");
-    // And when we reverse the sort
-    click(r.sortHeader_0);
-    // Then the data is sorted by 2 (2 1) then 1 (2 1)
-    expect(cell(r, 1, 0)).toHaveTextContent("2");
-    expect(cell(r, 2, 0)).toHaveTextContent("2");
-    expect(cell(r, 3, 0)).toHaveTextContent("1");
-    expect(cell(r, 4, 0)).toHaveTextContent("1");
-    expect(cell(r, 5, 0)).toHaveTextContent("2");
-    expect(cell(r, 6, 0)).toHaveTextContent("1");
-  });
-
   it("can make open card w/one level", async () => {
     const r = await render(makeOpenOrCloseCard([parentCardStyle], "open"));
     expect(r.firstElement).toMatchInlineSnapshot(`

--- a/src/components/Table/GridTable.nestedCards.test.tsx
+++ b/src/components/Table/GridTable.nestedCards.test.tsx
@@ -163,8 +163,80 @@ describe("GridTable nestedCards", () => {
     `);
   });
 
-  it("can add padding w/two levels", async () => {
-    const r = await render(addCardPadding([parentCardStyle, childCardStyle], <div>content</div>, "left"));
+  it("can add left padding w/two levels", async () => {
+    const r = await render(
+      addCardPadding([{} as any, {} as any], [parentCardStyle, childCardStyle], 0, <div>content</div>),
+    );
+    expect(r.firstElement).toMatchInlineSnapshot(`
+      .emotion-0 {
+        background-color: rgba(247,245,245,1);
+        padding-left: 8px;
+      }
+
+      .emotion-1 {
+        background-color: rgba(221,220,220,1);
+        border-color: rgba(236,235,235,1);
+        border-left-style: solid;
+        border-left-width: 1px;
+        padding-left: 6px;
+      }
+
+      <div
+        data-overlay-container="true"
+      >
+        <div
+          class="emotion-0"
+        >
+          <div
+            class="emotion-1"
+          >
+            <div>
+              content
+            </div>
+          </div>
+        </div>
+      </div>
+    `);
+  });
+
+  it("can add right padding w/two levels", async () => {
+    const r = await render(
+      addCardPadding([{} as any, {} as any], [parentCardStyle, childCardStyle], 1, <div>content</div>),
+    );
+    expect(r.firstElement).toMatchInlineSnapshot(`
+      .emotion-0 {
+        background-color: rgba(247,245,245,1);
+        padding-right: 8px;
+      }
+
+      .emotion-1 {
+        background-color: rgba(221,220,220,1);
+        border-color: rgba(236,235,235,1);
+        border-right-style: solid;
+        border-right-width: 1px;
+        padding-right: 6px;
+      }
+
+      <div
+        data-overlay-container="true"
+      >
+        <div
+          class="emotion-0"
+        >
+          <div
+            class="emotion-1"
+          >
+            <div>
+              content
+            </div>
+          </div>
+        </div>
+      </div>
+    `);
+  });
+
+  it("can add left and right padding w/two levels if only one column", async () => {
+    const r = await render(addCardPadding([{} as any], [parentCardStyle, childCardStyle], 0, <div>content</div>));
     expect(r.firstElement).toMatchInlineSnapshot(`
       .emotion-0 {
         background-color: rgba(247,245,245,1);
@@ -177,9 +249,9 @@ describe("GridTable nestedCards", () => {
         border-color: rgba(236,235,235,1);
         border-left-style: solid;
         border-left-width: 1px;
+        padding-left: 6px;
         border-right-style: solid;
         border-right-width: 1px;
-        padding-left: 6px;
         padding-right: 6px;
       }
 

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -311,9 +311,13 @@ export function NestedCardsFirstCell() {
           <div />
         </div>
         <div css={Css.display("contents").$}>
+          <div data-level="level1" css={Css.pl1.$}>
+            Milestone 1
+          </div>
           <div data-level="level1">Milestone 1</div>
-          <div data-level="level1">Milestone 1</div>
-          <div data-level="level1">Milestone 1</div>
+          <div data-level="level1" css={Css.pr1.$}>
+            Milestone 1
+          </div>
         </div>
 
         {/*Row is not closing, so spacer level1.*/}
@@ -329,11 +333,15 @@ export function NestedCardsFirstCell() {
         </div>
         <div css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
-            <div data-level="level2">Group 1</div>
+            <div data-level="level2" css={Css.pl1.$}>
+              Group 1
+            </div>
           </div>
           <div data-level="level2">Group 1</div>
           <div data-level="level1" css={Css.pr1.$}>
-            <div data-level="level2">Group 1</div>
+            <div data-level="level2" css={Css.pr1.$}>
+              Group 1
+            </div>
           </div>
         </div>
         <div data-card-close="level2">
@@ -355,11 +363,15 @@ export function NestedCardsFirstCell() {
         </div>
         <div css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
-            <div data-level="level2">Group 2</div>
+            <div data-level="level2" css={Css.pl1.$}>
+              Group 2
+            </div>
           </div>
           <div data-level="level2">Group 2</div>
           <div data-level="level1" css={Css.pr1.$}>
-            <div data-level="level2">Group 2</div>
+            <div data-level="level2" css={Css.pr1.$}>
+              Group 2
+            </div>
           </div>
         </div>
 
@@ -381,13 +393,17 @@ export function NestedCardsFirstCell() {
         <div css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
             <div data-level="level2" css={Css.pl1.$}>
-              <div data-level="level3">Task 1</div>
+              <div data-level="level3" css={Css.pl1.$}>
+                Task 1
+              </div>
             </div>
           </div>
           <div data-level="level3">Task 1</div>
           <div data-level="level1" css={Css.pr1.$}>
             <div data-level="level2" css={Css.pr1.$}>
-              <div data-level="level3">Task 1</div>
+              <div data-level="level3" css={Css.pr1.$}>
+                Task 1
+              </div>
             </div>
           </div>
         </div>
@@ -417,13 +433,17 @@ export function NestedCardsFirstCell() {
         <div css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
             <div data-level="level2" css={Css.pl1.$}>
-              <div data-level="level3">Task 2</div>
+              <div data-level="level3" css={Css.pl1.$}>
+                Task 2
+              </div>
             </div>
           </div>
           <div data-level="level3">Task 2</div>
           <div data-level="level1" css={Css.pr1.$}>
             <div data-level="level2" css={Css.pr1.$}>
-              <div data-level="level3">Task 2</div>
+              <div data-level="level3" css={Css.pr1.$}>
+                Task 2
+              </div>
             </div>
           </div>
         </div>
@@ -453,11 +473,15 @@ export function NestedCardsFirstCell() {
         </div>
         <div css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
-            <div data-level="level2">Group 3</div>
+            <div data-level="level2" css={Css.pl1.$}>
+              Group 3
+            </div>
           </div>
           <div data-level="level2">Group 3</div>
           <div data-level="level1" css={Css.pr1.$}>
-            <div data-level="level2">Group 3</div>
+            <div data-level="level2" css={Css.pr1.$}>
+              Group 3
+            </div>
           </div>
         </div>
         <div data-card-close="level2">
@@ -476,9 +500,13 @@ export function NestedCardsFirstCell() {
           <div />
         </div>
         <div css={Css.display("contents").$}>
+          <div data-level="level1" css={Css.pl1.$}>
+            Milestone 1
+          </div>
           <div data-level="level1">Milestone 1</div>
-          <div data-level="level1">Milestone 1</div>
-          <div data-level="level1">Milestone 1</div>
+          <div data-level="level1" css={Css.pr1.$}>
+            Milestone 1
+          </div>
         </div>
         <div data-card-close="level1">
           <div />

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -199,77 +199,10 @@ export function NestedRows() {
   );
 }
 
-export function NestedCardsBeforeAfter() {
-  return (
-    <div>
-      foo
-      <div
-        css={{
-          ...Css.dg.gtc("100px 100px 100px").$,
-          "& > div[data-level*='open1'] > div": Css.bgGray500.$,
-          "& > div[data-level*='open2'] > div": Css.bgGray200.$,
-          // cards for top-level
-          "& > div[data-level*='open1']::before": Css.hPx(4)
-            .bgGray500.add({ content: "''", gridColumn: "span 3" })
-            .add({ borderTopLeftRadius: "4px", borderTopRightRadius: "4px" }).$,
-          "& > div[data-level*='close1']::after": Css.hPx(4)
-            .bgGray500.add({ content: "''", gridColumn: "span 3" })
-            .add({ borderBottomLeftRadius: "4px", borderBottomRightRadius: "4px" }).$,
-          // Draw gray between children to get a background effect
-          "& > div[data-level*='middle1']::before": Css.hPx(4).bgGray500.add({ content: "''", gridColumn: "span 3" }).$,
-          // cards for 2nd-level
-          "& > div[data-level*='open2']::before": Css.hPx(4)
-            .bgGray200.add({ content: "''", gridColumn: "span 3" })
-            .add({ borderTopLeftRadius: "4px", borderTopRightRadius: "4px" }).$,
-          "& > div[data-level*='close2']::after": Css.hPx(4)
-            .bgGray200.add({ content: "''", gridColumn: "span 3" })
-            .add({ borderBottomLeftRadius: "4px", borderBottomRightRadius: "4px" }).$,
-          // spacers
-          "& > div[data-spacer='level1']": Css.hPx(4).bgGray500.add({ gridColumn: "span 3" }).$,
-        }}
-      >
-        {/* Grand-parent row */}
-        <div data-level="open1" css={Css.display("contents").$}>
-          <div>Milestone 1</div>
-          <div>Milestone 1</div>
-          <div>Milestone 1</div>
-        </div>
-        <div data-spacer="level1" />
-        {/* Child row */}
-        <div data-level="open2 close2 middle1" css={Css.display("contents").$}>
-          <div>Group 1</div>
-          <div>Group 1</div>
-          <div>Group 1</div>
-        </div>
-        <div data-spacer="level1" />
-        {/* Child row */}
-        <div data-level="open2 close2 middle1" css={Css.display("contents").$}>
-          <div>Group 2</div>
-          <div>Group 2</div>
-          <div>Group 2</div>
-        </div>
-        <div data-spacer="level1" />
-        {/* Child row, could be "last grand-child" as well as "last child" */}
-        <div data-level="open2 close2 middle1 close1 " css={Css.display("contents").$}>
-          <div>Group 3</div>
-          <div>Group 3</div>
-          <div>Group 3</div>
-        </div>
-        <div data-spacer="level0" />
-        <div data-level="open1 close1" css={Css.display("contents").$}>
-          <div>Milestone 1</div>
-          <div>Milestone 1</div>
-          <div>Milestone 1</div>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 // Every row by-definition opens or closes a card.
 // Every row has a space between.
 
-export function NestedCardsFirstCell() {
+export function NestedCardsProofOfConcept() {
   return (
     <div>
       foo

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -220,7 +220,7 @@ export function NestedCards() {
     }),
   };
   const spacing = { brPx: 4, pxPx: 8, spacerPx: 8 };
-  const nestedStyle: GridStyle<NestedRow> = {
+  const nestedStyle: GridStyle = {
     nestedCards: {
       parent: { bgColor: Palette.Gray500, ...spacing },
       child: { bgColor: Palette.Gray200, bColor: Palette.Gray600, ...spacing },

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -202,25 +202,18 @@ export function NestedRows() {
 }
 
 export function NestedCards() {
-  const arrowColumn = actionColumn<NestedRow>({
-    header: (row) => <CollapseToggle row={row} />,
-    parent: (row) => <CollapseToggle row={row} />,
-    child: (row) => <CollapseToggle row={row} />,
-    grandChild: () => "",
-    w: 0,
-  });
   const nameColumn: GridColumn<NestedRow> = {
     header: () => "Name",
     parent: (row) => ({
-      content: <div>{row.name}</div>,
+      content: <div css={Css.base.$}>{row.name}</div>,
       value: row.name,
     }),
     child: (row) => ({
-      content: <div css={Css.ml2.$}>{row.name}</div>,
+      content: <div css={Css.sm.$}>{row.name}</div>,
       value: row.name,
     }),
     grandChild: (row) => ({
-      content: <div css={Css.ml4.$}>{row.name}</div>,
+      content: <div css={Css.xs.$}>{row.name}</div>,
       value: row.name,
     }),
   };
@@ -235,10 +228,10 @@ export function NestedCards() {
 
   return (
     <GridTable
-      columns={[arrowColumn, nameColumn]}
+      columns={[nameColumn]}
       {...{ rows }}
       style={nestedStyle}
-      sorting={{ on: "client", initial: [1, "ASC"] }}
+      sorting={{ on: "client", initial: [0, "ASC"] }}
     />
   );
 }

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -230,7 +230,7 @@ export function NestedCards() {
 
   return (
     <GridTable
-      columns={[nameColumn]}
+      columns={[nameColumn, nameColumn, nameColumn]}
       {...{ rows }}
       style={nestedStyle}
       sorting={{ on: "client", initial: [0, "ASC"] }}

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -223,8 +223,8 @@ export function NestedCards() {
   const nestedStyle: GridStyle = {
     nestedCards: {
       parent: { bgColor: Palette.Gray500, ...spacing },
-      child: { bgColor: Palette.Gray200, bColor: Palette.Gray100, ...spacing },
-      grandChild: { bgColor: Palette.Green200, ...spacing },
+      child: { bgColor: Palette.Gray200, bColor: Palette.Gray600, ...spacing },
+      grandChild: { bgColor: Palette.Green200, bColor: Palette.Green400, ...spacing },
     },
   };
 

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -20,7 +20,7 @@ import {
   numericColumn,
   SimpleHeaderAndDataOf,
 } from "src/components/index";
-import { Css } from "src/Css";
+import { Css, Palette } from "src/Css";
 import { NumberField } from "src/inputs";
 import { noop } from "src/utils";
 import { newStory, withRouter, zeroTo } from "src/utils/sb";
@@ -28,6 +28,7 @@ import { newStory, withRouter, zeroTo } from "src/utils/sb";
 export default {
   component: GridTable,
   title: "Components/GridTable",
+  parameters: { backgrounds: { default: "white" } },
 } as Meta;
 
 type Data = { name: string; value: number };
@@ -203,9 +204,22 @@ export function NestedRows() {
 // Every row has a space between.
 
 export function NestedCardsProofOfConcept() {
+  const gridStyle = {
+    nestedCards: {
+      0: { bg: Palette.Gray500 },
+      1: { bg: Palette.Gray200, border: Palette.Gray100 },
+      2: { bg: Palette.Green200 },
+      br: 4, // 4px border radius
+      px: 8, // 1 increment x padding within each
+      py: 8, // 1 increment y spacing between rows
+    },
+  };
+
+  // Combine rows into a single "kind: chrome" div that goes between
+  // each real row.
+
   return (
-    <div>
-      foo
+    <div css={Css.bgGray900.p2.$}>
       <div
         css={{
           ...Css.dg.gtc("100px 100px 100px").$,
@@ -216,17 +230,25 @@ export function NestedCardsProofOfConcept() {
           "& > [data-card-close] div": Css.hPx(4).px1.$,
           // open/close corners
           "& > div[data-card-open='level1'] > div": Css.brt4.$,
-          "& > div[data-card-open='level2'] > div > div": Css.brt4.$,
+          "& > div[data-card-open='level2'] > div > div": Css.brt4.bt.br.bl.bGray200.$,
           "& > div[data-card-open='level3'] > div > div > div": Css.brt4.$,
           "& > div[data-card-close='level3'] > div > div > div": Css.brb4.$,
-          "& > div[data-card-close='level2'] > div > div": Css.brb4.$,
+          "& > div[data-card-close='level2'] > div > div": Css.brb4.bb.br.bl.bGray200.$,
           "& > div[data-card-close='level1'] > div": Css.brb4.$,
+          // the 2nd level is special/has a border
+          "& > div[data-card-open='level3'] > div > div": Css.bGray200.bl.br.$,
+          "& > div[data-card-close='level3'] > div > div": Css.bGray200.bl.br.$,
+          // borders (TODO should not apply to 1st level)
+          "& > div[data-card] > div:first-of-type > div": Css.bl.bGray200.$,
+          "& > div[data-card] > div:last-of-type > div": Css.br.bGray200.$,
           // spacers
-          "& > div[data-spacer]": Css.add({ gridColumn: "span 3" }).hPx(4).$,
-          "& > div[data-spacer] div": Css.hPx(4).px1.$,
+          "& > div[data-spacer]": Css.add({ gridColumn: "span 3" }).hPx(8).$,
+          "& > div[data-spacer] div": Css.hPx(8).px1.$,
+          // the 2nd level is special/has a border
+          "& > div[data-spacer] > div > div": Css.bl.br.bGray200.$,
           // backgrounds
-          "& div[data-level='level1']": Css.bgGray500.$,
-          "& div[data-level='level2']": Css.bgGray200.$,
+          "& div[data-level='level1']": Css.bgGray100.$,
+          "& div[data-level='level2']": Css.bgWhite.$,
           "& div[data-level='level3']": Css.bgGreen200.$,
         }}
       >
@@ -234,7 +256,7 @@ export function NestedCardsProofOfConcept() {
         <div data-card-open="level1">
           <div data-level="level1" />
         </div>
-        <div css={Css.display("contents").$}>
+        <div data-card="level1" css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
             Milestone 1
           </div>
@@ -255,7 +277,7 @@ export function NestedCardsProofOfConcept() {
             <div data-level="level2" />
           </div>
         </div>
-        <div css={Css.display("contents").$}>
+        <div data-card="level2" css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
             <div data-level="level2" css={Css.pl1.$}>
               Group 1
@@ -285,7 +307,7 @@ export function NestedCardsProofOfConcept() {
             <div data-level="level2" />
           </div>
         </div>
-        <div css={Css.display("contents").$}>
+        <div data-card="level2" css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
             <div data-level="level2" css={Css.pl1.$}>
               Group 2
@@ -314,7 +336,7 @@ export function NestedCardsProofOfConcept() {
             </div>
           </div>
         </div>
-        <div css={Css.display("contents").$}>
+        <div data-card="level3" css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
             <div data-level="level2" css={Css.pl1.$}>
               <div data-level="level3" css={Css.pl1.$}>
@@ -354,7 +376,7 @@ export function NestedCardsProofOfConcept() {
             </div>
           </div>
         </div>
-        <div css={Css.display("contents").$}>
+        <div data-card="level3" css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
             <div data-level="level2" css={Css.pl1.$}>
               <div data-level="level3" css={Css.pl1.$}>
@@ -395,7 +417,7 @@ export function NestedCardsProofOfConcept() {
             <div data-level="level2" />
           </div>
         </div>
-        <div css={Css.display("contents").$}>
+        <div data-card="level2" css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
             <div data-level="level2" css={Css.pl1.$}>
               Group 3
@@ -423,13 +445,13 @@ export function NestedCardsProofOfConcept() {
         <div data-card-open="level1">
           <div data-level="level1" />
         </div>
-        <div css={Css.display("contents").$}>
+        <div data-card="level1" css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
-            Milestone 1
+            Milestone 2
           </div>
-          <div data-level="level1">Milestone 1</div>
+          <div data-level="level1">Milestone 2</div>
           <div data-level="level1" css={Css.pr1.$}>
-            Milestone 1
+            Milestone 2
           </div>
         </div>
         <div data-card-close="level1">

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { observable } from "mobx";
-import { useMemo, useRef, useState } from "react";
+import { Fragment, useMemo, useRef, useState } from "react";
 import {
   actionColumn,
   Button,
@@ -196,6 +196,293 @@ export function NestedRows() {
   };
   return (
     <GridTable columns={[arrowColumn, nameColumn]} {...{ rows }} sorting={{ on: "client", initial: [1, "ASC"] }} />
+  );
+}
+
+export function NestedCardsBeforeAfter() {
+  return (
+    <div>
+      foo
+      <div
+        css={{
+          ...Css.dg.gtc("100px 100px 100px").$,
+          "& > div[data-level*='open1'] > div": Css.bgGray500.$,
+          "& > div[data-level*='open2'] > div": Css.bgGray200.$,
+          // cards for top-level
+          "& > div[data-level*='open1']::before": Css.hPx(4)
+            .bgGray500.add({ content: "''", gridColumn: "span 3" })
+            .add({ borderTopLeftRadius: "4px", borderTopRightRadius: "4px" }).$,
+          "& > div[data-level*='close1']::after": Css.hPx(4)
+            .bgGray500.add({ content: "''", gridColumn: "span 3" })
+            .add({ borderBottomLeftRadius: "4px", borderBottomRightRadius: "4px" }).$,
+          // Draw gray between children to get a background effect
+          "& > div[data-level*='middle1']::before": Css.hPx(4).bgGray500.add({ content: "''", gridColumn: "span 3" }).$,
+          // cards for 2nd-level
+          "& > div[data-level*='open2']::before": Css.hPx(4)
+            .bgGray200.add({ content: "''", gridColumn: "span 3" })
+            .add({ borderTopLeftRadius: "4px", borderTopRightRadius: "4px" }).$,
+          "& > div[data-level*='close2']::after": Css.hPx(4)
+            .bgGray200.add({ content: "''", gridColumn: "span 3" })
+            .add({ borderBottomLeftRadius: "4px", borderBottomRightRadius: "4px" }).$,
+          // spacers
+          "& > div[data-spacer='level1']": Css.hPx(4).bgGray500.add({ gridColumn: "span 3" }).$,
+        }}
+      >
+        {/* Grand-parent row */}
+        <div data-level="open1" css={Css.display("contents").$}>
+          <div>Milestone 1</div>
+          <div>Milestone 1</div>
+          <div>Milestone 1</div>
+        </div>
+        <div data-spacer="level1" />
+        {/* Child row */}
+        <div data-level="open2 close2 middle1" css={Css.display("contents").$}>
+          <div>Group 1</div>
+          <div>Group 1</div>
+          <div>Group 1</div>
+        </div>
+        <div data-spacer="level1" />
+        {/* Child row */}
+        <div data-level="open2 close2 middle1" css={Css.display("contents").$}>
+          <div>Group 2</div>
+          <div>Group 2</div>
+          <div>Group 2</div>
+        </div>
+        <div data-spacer="level1" />
+        {/* Child row, could be "last grand-child" as well as "last child" */}
+        <div data-level="open2 close2 middle1 close1 " css={Css.display("contents").$}>
+          <div>Group 3</div>
+          <div>Group 3</div>
+          <div>Group 3</div>
+        </div>
+        <div data-spacer="level0" />
+        <div data-level="open1 close1" css={Css.display("contents").$}>
+          <div>Milestone 1</div>
+          <div>Milestone 1</div>
+          <div>Milestone 1</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Every row by-definition opens or closes a card.
+// Every row has a space between.
+
+export function NestedCardsFirstCell() {
+  return (
+    <div>
+      foo
+      <div
+        css={{
+          ...Css.dg.gtc("100px 100px 100px").$,
+          // All open/close rows are 4px
+          "& > [data-card-open]": Css.hPx(4).add({ gridColumn: "span 3" }).$,
+          "& > [data-card-close]": Css.hPx(4).add({ gridColumn: "span 3" }).$,
+          // three levels of open
+          "& > div[data-card-open]": Css.hPx(4).bgGray500.px1.$,
+          "& > div[data-card-open] > div": Css.hPx(4).bgGray200.px1.$,
+          "& > div[data-card-open] > div > div": Css.hPx(4).bgGreen200.px1.$,
+          "& > div[data-card-close] > div > div": Css.hPx(4).bgGreen200.px1.$,
+          "& > div[data-card-close] > div": Css.hPx(4).bgGray200.px1.$,
+          "& > div[data-card-close]": Css.hPx(4).bgGray500.px1.$,
+          // open corners
+          "& > div[data-card-open='level1']": Css.brt4.$,
+          "& > div[data-card-open='level2'] > div": Css.brt4.$,
+          "& > div[data-card-open='level3'] > div > div": Css.brt4.$,
+          "& > div[data-card-close='level3'] > div > div": Css.brb4.$,
+          "& > div[data-card-close='level2'] > div": Css.brb4.$,
+          "& > div[data-card-close='level1']": Css.brb4.$,
+          // spaces
+          "& > div[data-spacer='level0']": Css.hPx(4).add({ gridColumn: "span 3" }).$,
+          "& > div[data-spacer='level1']": Css.hPx(4).bgGray500.add({ gridColumn: "span 3" }).$,
+          "& > div[data-spacer='level1'] > div": Css.hPx(4).bgGray200.$,
+          // backgrounds
+          "& div[data-level='level1']": Css.bgGray500.$,
+          "& div[data-level='level2']": Css.bgGray200.$,
+          "& div[data-level='level3']": Css.bgGreen200.$,
+        }}
+      >
+        {/* Grand-parent row */}
+        <div data-card-open="level1" />
+        <div css={Css.display("contents").$}>
+          <div data-level="level1">Milestone 1</div>
+          <div data-level="level1">Milestone 1</div>
+          <div data-level="level1">Milestone 1</div>
+        </div>
+
+        <div data-spacer="level1" />
+
+        {/* Child row */}
+        <div data-card-open="level2">
+          <div />
+        </div>
+        <div data-level="open2 close2" css={Css.display("contents").$}>
+          <div>
+            <div data-level="level1" css={Css.pl1.$}>
+              <div data-level="level2">Group 1</div>
+            </div>
+          </div>
+          <div data-level="level2">Group 1</div>
+          <div data-level="level1" css={Css.pr1.$}>
+            <div data-level="level2">Group 1</div>
+          </div>
+        </div>
+        <div data-card-close="level2">
+          <div />
+        </div>
+
+        <div data-spacer="level1" />
+
+        {/* Child row */}
+        <div data-card-open="level2">
+          <div />
+        </div>
+        <div css={Css.display("contents").$}>
+          <div>
+            <div data-level="level1" css={Css.pl1.$}>
+              <div data-level="level2">Group 2</div>
+            </div>
+          </div>
+          <div data-level="level2">Group 2</div>
+          <div>
+            <div data-level="level1" css={Css.pr1.$}>
+              <div data-level="level2">Group 2</div>
+            </div>
+          </div>
+        </div>
+
+        {/* 1st Grandchild row. */}
+        <div data-card-open="level3">
+          <div>
+            <div />
+          </div>
+        </div>
+        <div css={Css.display("contents").$}>
+          <div>
+            <div data-level="level1" css={Css.pl1.$}>
+              <div data-level="level2" css={Css.pl1.$}>
+                <div data-level="level3">Task 1</div>
+              </div>
+            </div>
+          </div>
+          <div data-level="level3">Task 1</div>
+          <div>
+            <div data-level="level1" css={Css.pr1.$}>
+              <div data-level="level2" css={Css.pr1.$}>
+                <div data-level="level3">Task 3</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div data-card-close="level3">
+          <div>
+            <div />
+          </div>
+        </div>
+
+        <div data-spacer="level1" css={Css.px1.$}>
+          <div data-spacer="level2" />
+        </div>
+
+        {/* 2nd Grandchild row. */}
+        <div data-card-open="level3">
+          <div>
+            <div />
+          </div>
+        </div>
+        <div css={Css.display("contents").$}>
+          <div>
+            <div data-level="level1" css={Css.pl1.$}>
+              <div data-level="level2" css={Css.pl1.$}>
+                <div data-level="level3">Task 2</div>
+              </div>
+            </div>
+          </div>
+          <div data-level="level3">Task 1</div>
+          <div>
+            <div data-level="level1" css={Css.pr1.$}>
+              <div data-level="level2" css={Css.pr1.$}>
+                <div data-level="level3">Task 2</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div data-card-close="level3">
+          <div>
+            <div />
+          </div>
+        </div>
+        <div data-card-close="level2">
+          <div />
+        </div>
+
+        <div data-spacer="level1" />
+
+        {/* Child row, could be "last grand-child" as well as "last child" */}
+        <div data-card-open="level2">
+          <div />
+        </div>
+        <div css={Css.display("contents").$}>
+          <div>
+            <div data-level="level1" css={Css.pl1.$}>
+              <div data-level="level2">Group 3</div>
+            </div>
+          </div>
+          <div data-level="level2">Group 3</div>
+          <div>
+            <div data-level="level1" css={Css.pr1.$}>
+              <div data-level="level2">Group 3</div>
+            </div>
+          </div>
+        </div>
+        <div data-card-close="level2">
+          <div />
+        </div>
+        <div data-card-close="level1" />
+
+        <div data-spacer="level0" />
+
+        <div data-card-open="level1" />
+        <div css={Css.display("contents").$}>
+          <div data-level="level1">Milestone 1</div>
+          <div data-level="level1">Milestone 1</div>
+          <div data-level="level1">Milestone 1</div>
+        </div>
+        <div data-card-close="level1" />
+      </div>
+    </div>
+  );
+}
+
+export function OneOffInlineTable() {
+  const items: { code: string; name: string; quantity: number }[] = [
+    { code: "AAA", name: "Aaa", quantity: 1 },
+    { code: "BBB", name: "Bbb", quantity: 2 },
+    { code: "Ccc", name: "Ccc", quantity: 3 },
+  ];
+  return (
+    <div
+      css={{
+        ...Css.dig.gtc("auto auto auto").rg1.cg3.gray700.bgGray300.br4.p1.$,
+        "& > div:nth-of-type(-n+3)": Css.tinyEm.$,
+        "& > div:nth-of-type(n+4)": Css.xs.$,
+        "& > div:nth-of-type(3n)": Css.tr.$,
+      }}
+    >
+      <div>Code</div>
+      <div>Item</div>
+      <div>Qty</div>
+      {items.map((item) => {
+        return (
+          <Fragment key={item.code}>
+            <div>{item.code}</div>
+            <div>{item.name}</div>
+            <div>{item.quantity}</div>
+          </Fragment>
+        );
+      })}
+    </div>
   );
 }
 

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -295,10 +295,11 @@ export function NestedCardsFirstCell() {
           "& > div[data-card-close='level3'] > div > div > div": Css.brb4.$,
           "& > div[data-card-close='level2'] > div > div": Css.brb4.$,
           "& > div[data-card-close='level1'] > div": Css.brb4.$,
-          // spaces
-          "& > div[data-spacer='level0']": Css.hPx(4).add({ gridColumn: "span 3" }).$,
-          "& > div[data-spacer='level1']": Css.hPx(4).bgGray500.add({ gridColumn: "span 3" }).$,
-          "& > div[data-spacer='level1'] > div": Css.hPx(4).bgGray200.$,
+          // spacers
+          "& > div[data-spacer]": Css.add({ gridColumn: "span 3" }).hPx(4).$,
+          "& > div[data-spacer] div": Css.hPx(4).px1.$,
+          "& > div[data-spacer] > div": Css.bgGray500.$,
+          "& > div[data-spacer] > div > div": Css.bgGray200.$,
           // backgrounds
           "& div[data-level='level1']": Css.bgGray500.$,
           "& div[data-level='level2']": Css.bgGray200.$,
@@ -315,7 +316,10 @@ export function NestedCardsFirstCell() {
           <div data-level="level1">Milestone 1</div>
         </div>
 
-        <div data-spacer="level1" />
+        {/*Row is not closing, so spacer level1.*/}
+        <div data-spacer="true">
+          <div />
+        </div>
 
         {/* Child row */}
         <div data-card-open="level2">
@@ -323,11 +327,9 @@ export function NestedCardsFirstCell() {
             <div />
           </div>
         </div>
-        <div data-level="open2 close2" css={Css.display("contents").$}>
-          <div>
-            <div data-level="level1" css={Css.pl1.$}>
-              <div data-level="level2">Group 1</div>
-            </div>
+        <div css={Css.display("contents").$}>
+          <div data-level="level1" css={Css.pl1.$}>
+            <div data-level="level2">Group 1</div>
           </div>
           <div data-level="level2">Group 1</div>
           <div data-level="level1" css={Css.pr1.$}>
@@ -340,7 +342,10 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
 
-        <div data-spacer="level1" />
+        {/*Row has closed, so spacer level1.*/}
+        <div data-spacer="true">
+          <div />
+        </div>
 
         {/* Child row */}
         <div data-card-open="level2">
@@ -349,16 +354,19 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
         <div css={Css.display("contents").$}>
-          <div>
-            <div data-level="level1" css={Css.pl1.$}>
-              <div data-level="level2">Group 2</div>
-            </div>
+          <div data-level="level1" css={Css.pl1.$}>
+            <div data-level="level2">Group 2</div>
           </div>
           <div data-level="level2">Group 2</div>
+          <div data-level="level1" css={Css.pr1.$}>
+            <div data-level="level2">Group 2</div>
+          </div>
+        </div>
+
+        {/*Row is not closing, so spacer level2.*/}
+        <div data-spacer="true">
           <div>
-            <div data-level="level1" css={Css.pr1.$}>
-              <div data-level="level2">Group 2</div>
-            </div>
+            <div />
           </div>
         </div>
 
@@ -371,19 +379,15 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
         <div css={Css.display("contents").$}>
-          <div>
-            <div data-level="level1" css={Css.pl1.$}>
-              <div data-level="level2" css={Css.pl1.$}>
-                <div data-level="level3">Task 1</div>
-              </div>
+          <div data-level="level1" css={Css.pl1.$}>
+            <div data-level="level2" css={Css.pl1.$}>
+              <div data-level="level3">Task 1</div>
             </div>
           </div>
           <div data-level="level3">Task 1</div>
-          <div>
-            <div data-level="level1" css={Css.pr1.$}>
-              <div data-level="level2" css={Css.pr1.$}>
-                <div data-level="level3">Task 1</div>
-              </div>
+          <div data-level="level1" css={Css.pr1.$}>
+            <div data-level="level2" css={Css.pr1.$}>
+              <div data-level="level3">Task 1</div>
             </div>
           </div>
         </div>
@@ -395,8 +399,11 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
 
-        <div data-spacer="level1" css={Css.px1.$}>
-          <div data-spacer="level2" />
+        {/*Row is not closing, so spacer level2.*/}
+        <div data-spacer="true">
+          <div>
+            <div />
+          </div>
         </div>
 
         {/* 2nd Grandchild row. */}
@@ -408,19 +415,15 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
         <div css={Css.display("contents").$}>
-          <div>
-            <div data-level="level1" css={Css.pl1.$}>
-              <div data-level="level2" css={Css.pl1.$}>
-                <div data-level="level3">Task 2</div>
-              </div>
+          <div data-level="level1" css={Css.pl1.$}>
+            <div data-level="level2" css={Css.pl1.$}>
+              <div data-level="level3">Task 2</div>
             </div>
           </div>
           <div data-level="level3">Task 2</div>
-          <div>
-            <div data-level="level1" css={Css.pr1.$}>
-              <div data-level="level2" css={Css.pr1.$}>
-                <div data-level="level3">Task 2</div>
-              </div>
+          <div data-level="level1" css={Css.pr1.$}>
+            <div data-level="level2" css={Css.pr1.$}>
+              <div data-level="level3">Task 2</div>
             </div>
           </div>
         </div>
@@ -437,7 +440,10 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
 
-        <div data-spacer="level1" />
+        {/*Child has closed, so spacer level1.*/}
+        <div data-spacer="true">
+          <div />
+        </div>
 
         {/* Child row, could be "last grand-child" as well as "last child" */}
         <div data-card-open="level2">
@@ -446,16 +452,12 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
         <div css={Css.display("contents").$}>
-          <div>
-            <div data-level="level1" css={Css.pl1.$}>
-              <div data-level="level2">Group 3</div>
-            </div>
+          <div data-level="level1" css={Css.pl1.$}>
+            <div data-level="level2">Group 3</div>
           </div>
           <div data-level="level2">Group 3</div>
-          <div>
-            <div data-level="level1" css={Css.pr1.$}>
-              <div data-level="level2">Group 3</div>
-            </div>
+          <div data-level="level1" css={Css.pr1.$}>
+            <div data-level="level2">Group 3</div>
           </div>
         </div>
         <div data-card-close="level2">
@@ -467,7 +469,8 @@ export function NestedCardsFirstCell() {
           <div />
         </div>
 
-        <div data-spacer="level0" />
+        {/*Child has closed, so spacer level0.*/}
+        <div data-spacer="true" />
 
         <div data-card-open="level1">
           <div />

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -220,7 +220,7 @@ export function NestedCards() {
     }),
   };
   const spacing = { brPx: 4, pxPx: 8, spacerPx: 8 };
-  const nestedStyle: GridStyle = {
+  const nestedStyle: GridStyle<NestedRow> = {
     nestedCards: {
       parent: { bgColor: Palette.Gray500, ...spacing },
       child: { bgColor: Palette.Gray200, bColor: Palette.Gray600, ...spacing },

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -281,25 +281,16 @@ export function NestedCardsFirstCell() {
           "& > [data-card-close]": Css.add({ gridColumn: "span 3" }).$,
           "& > [data-card-open] div": Css.hPx(4).px1.$,
           "& > [data-card-close] div": Css.hPx(4).px1.$,
-          // open/close backgrounds
-          "& > div[data-card-open] > div": Css.bgGray500.$,
-          "& > div[data-card-open] > div > div": Css.bgGray200.$,
-          "& > div[data-card-open] > div > div > div": Css.bgGreen200.$,
-          "& > div[data-card-close] > div > div > div": Css.bgGreen200.$,
-          "& > div[data-card-close] > div > div": Css.bgGray200.$,
-          "& > div[data-card-close] > div": Css.bgGray500.$,
           // open/close corners
           "& > div[data-card-open='level1'] > div": Css.brt4.$,
           "& > div[data-card-open='level2'] > div > div": Css.brt4.$,
-          "& > div[data-card-open='level3'] > div> div > div": Css.brt4.$,
+          "& > div[data-card-open='level3'] > div > div > div": Css.brt4.$,
           "& > div[data-card-close='level3'] > div > div > div": Css.brb4.$,
           "& > div[data-card-close='level2'] > div > div": Css.brb4.$,
           "& > div[data-card-close='level1'] > div": Css.brb4.$,
           // spacers
           "& > div[data-spacer]": Css.add({ gridColumn: "span 3" }).hPx(4).$,
           "& > div[data-spacer] div": Css.hPx(4).px1.$,
-          "& > div[data-spacer] > div": Css.bgGray500.$,
-          "& > div[data-spacer] > div > div": Css.bgGray200.$,
           // backgrounds
           "& div[data-level='level1']": Css.bgGray500.$,
           "& div[data-level='level2']": Css.bgGray200.$,
@@ -308,7 +299,7 @@ export function NestedCardsFirstCell() {
       >
         {/* Grand-parent row */}
         <div data-card-open="level1">
-          <div />
+          <div data-level="level1" />
         </div>
         <div css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
@@ -322,13 +313,13 @@ export function NestedCardsFirstCell() {
 
         {/*Row is not closing, so spacer level1.*/}
         <div data-spacer="true">
-          <div />
+          <div data-level="level1" />
         </div>
 
         {/* Child row */}
         <div data-card-open="level2">
-          <div>
-            <div />
+          <div data-level="level1">
+            <div data-level="level2" />
           </div>
         </div>
         <div css={Css.display("contents").$}>
@@ -345,20 +336,20 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
         <div data-card-close="level2">
-          <div>
-            <div />
+          <div data-level="level1">
+            <div data-level="level2" />
           </div>
         </div>
 
         {/*Row has closed, so spacer level1.*/}
         <div data-spacer="true">
-          <div />
+          <div data-level="level1" />
         </div>
 
         {/* Child row */}
         <div data-card-open="level2">
-          <div>
-            <div />
+          <div data-level="level1">
+            <div data-level="level2" />
           </div>
         </div>
         <div css={Css.display("contents").$}>
@@ -377,16 +368,16 @@ export function NestedCardsFirstCell() {
 
         {/*Row is not closing, so spacer level2.*/}
         <div data-spacer="true">
-          <div>
-            <div />
+          <div data-level="level1">
+            <div data-level="level2" />
           </div>
         </div>
 
         {/* 1st Grandchild row. */}
         <div data-card-open="level3">
-          <div>
-            <div>
-              <div />
+          <div data-level="level1">
+            <div data-level="level2">
+              <div data-level="level3" />
             </div>
           </div>
         </div>
@@ -408,25 +399,25 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
         <div data-card-close="level3">
-          <div>
-            <div>
-              <div />
+          <div data-level="level1">
+            <div data-level="level2">
+              <div data-level="level3" />
             </div>
           </div>
         </div>
 
         {/*Row is not closing, so spacer level2.*/}
         <div data-spacer="true">
-          <div>
-            <div />
+          <div data-level="level1">
+            <div data-level="level2" />
           </div>
         </div>
 
         {/* 2nd Grandchild row. */}
         <div data-card-open="level3">
-          <div>
-            <div>
-              <div />
+          <div data-level="level1">
+            <div data-level="level2">
+              <div data-level="level3" />
             </div>
           </div>
         </div>
@@ -448,27 +439,27 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
         <div data-card-close="level3">
-          <div>
-            <div>
-              <div />
+          <div data-level="level1">
+            <div data-level="level2">
+              <div data-level="level3" />
             </div>
           </div>
         </div>
         <div data-card-close="level2">
-          <div>
-            <div />
+          <div data-level="level1">
+            <div data-level="level2" />
           </div>
         </div>
 
         {/*Child has closed, so spacer level1.*/}
         <div data-spacer="true">
-          <div />
+          <div data-level="level1" />
         </div>
 
         {/* Child row, could be "last grand-child" as well as "last child" */}
         <div data-card-open="level2">
-          <div>
-            <div />
+          <div data-level="level1">
+            <div data-level="level2" />
           </div>
         </div>
         <div css={Css.display("contents").$}>
@@ -485,19 +476,19 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
         <div data-card-close="level2">
-          <div>
-            <div />
+          <div data-level="level1">
+            <div data-level="level2" />
           </div>
         </div>
         <div data-card-close="level1">
-          <div />
+          <div data-level="level1" />
         </div>
 
         {/*Child has closed, so spacer level0.*/}
         <div data-spacer="true" />
 
         <div data-card-open="level1">
-          <div />
+          <div data-level="level1" />
         </div>
         <div css={Css.display("contents").$}>
           <div data-level="level1" css={Css.pl1.$}>
@@ -509,7 +500,7 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
         <div data-card-close="level1">
-          <div />
+          <div data-level="level1" />
         </div>
       </div>
     </div>

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -14,6 +14,7 @@ import {
   GridDataRow,
   GridRowLookup,
   GridRowStyles,
+  GridStyle,
   GridTable,
   Icon,
   IconButton,
@@ -200,21 +201,52 @@ export function NestedRows() {
   );
 }
 
+export function Nested() {
+  const arrowColumn = actionColumn<NestedRow>({
+    header: (row) => <CollapseToggle row={row} />,
+    parent: (row) => <CollapseToggle row={row} />,
+    child: (row) => <CollapseToggle row={row} />,
+    grandChild: () => "",
+    w: 0,
+  });
+  const nameColumn: GridColumn<NestedRow> = {
+    header: () => "Name",
+    parent: (row) => ({
+      content: <div>{row.name}</div>,
+      value: row.name,
+    }),
+    child: (row) => ({
+      content: <div css={Css.ml2.$}>{row.name}</div>,
+      value: row.name,
+    }),
+    grandChild: (row) => ({
+      content: <div css={Css.ml4.$}>{row.name}</div>,
+      value: row.name,
+    }),
+  };
+  const spacing = { brPx: 4, pxPx: 8, spacerPx: 8 };
+  const nestedStyle: GridStyle = {
+    nestedCards: {
+      parent: { bgColor: Palette.Gray500, ...spacing },
+      child: { bgColor: Palette.Gray200, bColor: Palette.Gray100, ...spacing },
+      grandChild: { bgColor: Palette.Green200, ...spacing },
+    },
+  };
+
+  return (
+    <GridTable
+      columns={[arrowColumn, nameColumn]}
+      {...{ rows }}
+      style={nestedStyle}
+      sorting={{ on: "client", initial: [1, "ASC"] }}
+    />
+  );
+}
+
 // Every row by-definition opens or closes a card.
 // Every row has a space between.
 
 export function NestedCardsProofOfConcept() {
-  const gridStyle = {
-    nestedCards: {
-      0: { bg: Palette.Gray500 },
-      1: { bg: Palette.Gray200, border: Palette.Gray100 },
-      2: { bg: Palette.Green200 },
-      br: 4, // 4px border radius
-      px: 8, // 1 increment x padding within each
-      py: 8, // 1 increment y spacing between rows
-    },
-  };
-
   // Combine rows into a single "kind: chrome" div that goes between
   // each real row.
 

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -162,6 +162,8 @@ const rows: GridDataRow<NestedRow>[] = [
         ...{ kind: "child", id: "p1c2", name: "child p1c2" },
         children: [{ kind: "grandChild", id: "p1c2g1", name: "grandchild p1c2g1" }],
       },
+      // Put this "grandchild" in the 2nd level to show heterogeneous levels
+      { kind: "grandChild", id: "p1g1", name: "grandchild p1g1" },
     ],
   },
   // a parent with just a child

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -201,7 +201,7 @@ export function NestedRows() {
   );
 }
 
-export function Nested() {
+export function NestedCards() {
   const arrowColumn = actionColumn<NestedRow>({
     header: (row) => <CollapseToggle row={row} />,
     parent: (row) => <CollapseToggle row={row} />,

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -277,22 +277,24 @@ export function NestedCardsFirstCell() {
         css={{
           ...Css.dg.gtc("100px 100px 100px").$,
           // All open/close rows are 4px
-          "& > [data-card-open]": Css.hPx(4).add({ gridColumn: "span 3" }).$,
-          "& > [data-card-close]": Css.hPx(4).add({ gridColumn: "span 3" }).$,
-          // three levels of open
-          "& > div[data-card-open]": Css.hPx(4).bgGray500.px1.$,
-          "& > div[data-card-open] > div": Css.hPx(4).bgGray200.px1.$,
-          "& > div[data-card-open] > div > div": Css.hPx(4).bgGreen200.px1.$,
-          "& > div[data-card-close] > div > div": Css.hPx(4).bgGreen200.px1.$,
-          "& > div[data-card-close] > div": Css.hPx(4).bgGray200.px1.$,
-          "& > div[data-card-close]": Css.hPx(4).bgGray500.px1.$,
-          // open corners
-          "& > div[data-card-open='level1']": Css.brt4.$,
-          "& > div[data-card-open='level2'] > div": Css.brt4.$,
-          "& > div[data-card-open='level3'] > div > div": Css.brt4.$,
-          "& > div[data-card-close='level3'] > div > div": Css.brb4.$,
-          "& > div[data-card-close='level2'] > div": Css.brb4.$,
-          "& > div[data-card-close='level1']": Css.brb4.$,
+          "& > [data-card-open]": Css.add({ gridColumn: "span 3" }).$,
+          "& > [data-card-close]": Css.add({ gridColumn: "span 3" }).$,
+          "& > [data-card-open] div": Css.hPx(4).px1.$,
+          "& > [data-card-close] div": Css.hPx(4).px1.$,
+          // open/close backgrounds
+          "& > div[data-card-open] > div": Css.bgGray500.$,
+          "& > div[data-card-open] > div > div": Css.bgGray200.$,
+          "& > div[data-card-open] > div > div > div": Css.bgGreen200.$,
+          "& > div[data-card-close] > div > div > div": Css.bgGreen200.$,
+          "& > div[data-card-close] > div > div": Css.bgGray200.$,
+          "& > div[data-card-close] > div": Css.bgGray500.$,
+          // open/close corners
+          "& > div[data-card-open='level1'] > div": Css.brt4.$,
+          "& > div[data-card-open='level2'] > div > div": Css.brt4.$,
+          "& > div[data-card-open='level3'] > div> div > div": Css.brt4.$,
+          "& > div[data-card-close='level3'] > div > div > div": Css.brb4.$,
+          "& > div[data-card-close='level2'] > div > div": Css.brb4.$,
+          "& > div[data-card-close='level1'] > div": Css.brb4.$,
           // spaces
           "& > div[data-spacer='level0']": Css.hPx(4).add({ gridColumn: "span 3" }).$,
           "& > div[data-spacer='level1']": Css.hPx(4).bgGray500.add({ gridColumn: "span 3" }).$,
@@ -304,7 +306,9 @@ export function NestedCardsFirstCell() {
         }}
       >
         {/* Grand-parent row */}
-        <div data-card-open="level1" />
+        <div data-card-open="level1">
+          <div />
+        </div>
         <div css={Css.display("contents").$}>
           <div data-level="level1">Milestone 1</div>
           <div data-level="level1">Milestone 1</div>
@@ -315,7 +319,9 @@ export function NestedCardsFirstCell() {
 
         {/* Child row */}
         <div data-card-open="level2">
-          <div />
+          <div>
+            <div />
+          </div>
         </div>
         <div data-level="open2 close2" css={Css.display("contents").$}>
           <div>
@@ -329,14 +335,18 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
         <div data-card-close="level2">
-          <div />
+          <div>
+            <div />
+          </div>
         </div>
 
         <div data-spacer="level1" />
 
         {/* Child row */}
         <div data-card-open="level2">
-          <div />
+          <div>
+            <div />
+          </div>
         </div>
         <div css={Css.display("contents").$}>
           <div>
@@ -355,7 +365,9 @@ export function NestedCardsFirstCell() {
         {/* 1st Grandchild row. */}
         <div data-card-open="level3">
           <div>
-            <div />
+            <div>
+              <div />
+            </div>
           </div>
         </div>
         <div css={Css.display("contents").$}>
@@ -370,14 +382,16 @@ export function NestedCardsFirstCell() {
           <div>
             <div data-level="level1" css={Css.pr1.$}>
               <div data-level="level2" css={Css.pr1.$}>
-                <div data-level="level3">Task 3</div>
+                <div data-level="level3">Task 1</div>
               </div>
             </div>
           </div>
         </div>
         <div data-card-close="level3">
           <div>
-            <div />
+            <div>
+              <div />
+            </div>
           </div>
         </div>
 
@@ -388,7 +402,9 @@ export function NestedCardsFirstCell() {
         {/* 2nd Grandchild row. */}
         <div data-card-open="level3">
           <div>
-            <div />
+            <div>
+              <div />
+            </div>
           </div>
         </div>
         <div css={Css.display("contents").$}>
@@ -399,7 +415,7 @@ export function NestedCardsFirstCell() {
               </div>
             </div>
           </div>
-          <div data-level="level3">Task 1</div>
+          <div data-level="level3">Task 2</div>
           <div>
             <div data-level="level1" css={Css.pr1.$}>
               <div data-level="level2" css={Css.pr1.$}>
@@ -410,18 +426,24 @@ export function NestedCardsFirstCell() {
         </div>
         <div data-card-close="level3">
           <div>
-            <div />
+            <div>
+              <div />
+            </div>
           </div>
         </div>
         <div data-card-close="level2">
-          <div />
+          <div>
+            <div />
+          </div>
         </div>
 
         <div data-spacer="level1" />
 
         {/* Child row, could be "last grand-child" as well as "last child" */}
         <div data-card-open="level2">
-          <div />
+          <div>
+            <div />
+          </div>
         </div>
         <div css={Css.display("contents").$}>
           <div>
@@ -437,19 +459,27 @@ export function NestedCardsFirstCell() {
           </div>
         </div>
         <div data-card-close="level2">
+          <div>
+            <div />
+          </div>
+        </div>
+        <div data-card-close="level1">
           <div />
         </div>
-        <div data-card-close="level1" />
 
         <div data-spacer="level0" />
 
-        <div data-card-open="level1" />
+        <div data-card-open="level1">
+          <div />
+        </div>
         <div css={Css.display("contents").$}>
           <div data-level="level1">Milestone 1</div>
           <div data-level="level1">Milestone 1</div>
           <div data-level="level1">Milestone 1</div>
         </div>
-        <div data-card-close="level1" />
+        <div data-card-close="level1">
+          <div />
+        </div>
       </div>
     </div>
   );

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1,19 +1,21 @@
 import React, { MutableRefObject, useContext } from "react";
+import { GridRowLookup } from "src/components/Table/GridRowLookup";
 import {
   GridCollapseContext,
   GridColumn,
   GridDataRow,
-  GridRowLookup,
   GridRowStyles,
   GridTable,
   matchesFilter,
   setRunningInJest,
+} from "src/components/Table/GridTable";
+import {
   simpleDataRows,
   simpleHeader,
   SimpleHeaderAndDataOf,
   SimpleHeaderAndDataWith,
   simpleRows,
-} from "src/components/Table/GridTable";
+} from "src/components/Table/simpleHelpers";
 import { Css, Palette } from "src/Css";
 import { cell, click, render, row } from "src/utils/rtl";
 

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -39,7 +39,7 @@ export function setRunningInJest() {
 }
 
 /** Completely static look & feel, i.e. nothing that is based on row kinds/content. */
-export interface GridStyle {
+export interface GridStyle<R extends Kinded = {}> {
   /** Applied to the base div element. */
   rootCss?: Properties;
   /** Applied with the owl operator between rows for rendering border lines. */
@@ -64,8 +64,8 @@ export interface GridStyle {
   rowHoverColor?: string;
   /** Styling for nested cards (see `cardStyle` if you only need a flat list of cards). */
   nestedCards?: {
-    // Map of kind --> card style. We don't current have `K` to make this type checked.
-    [kind: string]: NestedCardStyle;
+    // Map of kind --> card style.
+    [P in Exclude<R["kind"], "header">]: NestedCardStyle;
   };
 }
 

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -21,6 +21,16 @@ import { Css, Margin, Only, Palette, Properties, Xss } from "src/Css";
 import { useTestIds } from "src/utils/useTestIds";
 import tinycolor from "tinycolor2";
 
+/**
+ * Our internal sorting state.
+ *
+ * `S` is, for whatever current column we're sorting by, either it's:
+ *
+ * a) `serverSideSortKey` if we're server-side sorting, or
+ * b) it's index in the `columns` array, if client-side sorting
+ */
+type SortState<S> = readonly [S, Direction];
+
 export type Kinded = { kind: string };
 
 export type GridTableXss = Xss<Margin>;

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -332,15 +332,17 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
     const openCards: NestedCardStyle[] = [];
     // Take the current buffer of close row(s), spacers, and open row, and creates a single chrome DOM row
     function flushChromeRow(): void {
-      filteredRows.push([
-        undefined,
-        <div css={Css.add({ gridColumn: `span ${columns.length}` }).$}>
-          {chromeContent.map((c, i) => (
-            <Fragment key={i}>{c}</Fragment>
-          ))}
-        </div>,
-      ]);
-      chromeContent = [];
+      if (chromeContent.length > 0) {
+        filteredRows.push([
+          undefined,
+          <div css={Css.add({ gridColumn: `span ${columns.length}` }).$}>
+            {chromeContent.map((c, i) => (
+              <Fragment key={i}>{c}</Fragment>
+            ))}
+          </div>,
+        ]);
+        chromeContent = [];
+      }
     }
 
     // Depth-first to filter

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -37,7 +37,7 @@ export function setRunningInJest() {
 }
 
 /** Completely static look & feel, i.e. nothing that is based on row kinds/content. */
-export interface GridStyle<R extends Kinded = { kind: string }> {
+export interface GridStyle {
   /** Applied to the base div element. */
   rootCss?: Properties;
   /** Applied with the owl operator between rows for rendering border lines. */
@@ -61,10 +61,7 @@ export interface GridStyle<R extends Kinded = { kind: string }> {
   /** Applied on hover if a row has a rowLink/onClick set. */
   rowHoverColor?: string;
   /** Styling for nested cards (see `cardStyle` if you only need a flat list of cards). */
-  nestedCards?: {
-    // Map of kind --> card style.
-    [P in Exclude<R["kind"], "header">]: NestedCardStyle;
-  };
+  nestedCards?: Record<string, NestedCardStyle>;
 }
 
 /**
@@ -219,7 +216,7 @@ export interface GridTableProps<R extends Kinded, S, X> {
   /** Sets the rows to be wrapped by mobx observers. */
   observeRows?: boolean;
   /** A combination of CSS settings to set the static look & feel (vs. rowStyles which is per-row styling). */
-  style?: GridStyle<R>;
+  style?: GridStyle;
   /**
    * If provided, collapsed rows on the table persists when the page is reloaded.
    *

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -18,6 +18,7 @@ import { Components, Virtuoso, VirtuosoHandle } from "react-virtuoso";
 import { navLink } from "src/components/CssReset";
 import { Icon } from "src/components/Icon";
 import { createRowLookup, GridRowLookup } from "src/components/Table/GridRowLookup";
+import { addCardPadding, makeOpenOrCloseCard, makeSpacer } from "src/components/Table/nestedCards";
 import { Css, Margin, Only, Palette, Properties, Xss } from "src/Css";
 import { useTestIds } from "src/utils/useTestIds";
 import tinycolor from "tinycolor2";
@@ -1338,59 +1339,4 @@ function canClientSideSort(value: any): boolean {
   return (
     value === null || t === "undefined" || t === "number" || t === "string" || t === "boolean" || value instanceof Date
   );
-}
-
-export function makeOpenOrCloseCard(openCards: NestedCardStyle[], kind: "open" | "close"): JSX.Element {
-  let div: any = null;
-  const place = kind === "open" ? "Top" : "Bottom";
-  const btOrBb = kind === "open" ? "bt" : "bb";
-  [...openCards].reverse().forEach((card) => {
-    div = (
-      <div
-        css={{
-          ...Css.bgColor(card.bgColor).pxPx(card.pxPx).$,
-          ...(!div &&
-            Css.add({
-              [`border${place}RightRadius`]: `${card.brPx}px`,
-              [`border${place}LeftRadius`]: `${card.brPx}px`,
-            }).hPx(card.brPx).$),
-          ...(card.bColor && Css.bc(card.bColor).bl.br.if(div)[btOrBb].$),
-        }}
-      >
-        {div}
-      </div>
-    );
-  });
-  return div;
-}
-
-/** For the first or last cell, nest them in divs that re-create the outer card padding + background. */
-export function addCardPadding(columns: GridColumn<any>[], openCards: NestedCardStyle[], idx: number, div: any): any {
-  const addLeft = idx === 0;
-  const addRight = idx === columns.length - 1;
-  if (!addLeft && !addRight) {
-    return div;
-  }
-  [...openCards].reverse().forEach((card) => {
-    div = (
-      <div
-        css={{
-          ...Css.bgColor(card.bgColor).if(!!card.bColor).bc(card.bColor).$,
-          ...(addLeft && Css.plPx(card.pxPx).if(!!card.bColor).bl.$),
-          ...(addRight && Css.prPx(card.pxPx).if(!!card.bColor).br.$),
-        }}
-      >
-        {div}
-      </div>
-    );
-  });
-  return div;
-}
-
-export function makeSpacer(current: NestedCardStyle, openCards: NestedCardStyle[]) {
-  let div = <div css={Css.hPx(current.spacerPx).$} />;
-  [...openCards].reverse().forEach((card) => {
-    div = <div css={Css.bgColor(card.bgColor).pxPx(card.pxPx).if(!!card.bColor).bc(card.bColor).bl.br.$}>{div}</div>;
-  });
-  return div;
 }

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -870,10 +870,8 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
 
         let rendered = renderFn(idx, cellCss, content, row, rowStyle);
         // Sneak in card padding for the 1st / last cells
-        if (card && idx === 0) {
-          rendered = addCardPadding(openCards, rendered, "left");
-        } else if (card && idx === columns.length - 1) {
-          rendered = addCardPadding(openCards, rendered, "right");
+        if (card) {
+          rendered = addCardPadding(columns, openCards, idx, rendered);
         }
         return rendered;
       })}
@@ -1367,9 +1365,24 @@ export function makeOpenOrCloseCard(openCards: NestedCardStyle[], kind: "open" |
 }
 
 /** For the first or last cell, nest them in divs that re-create the outer card padding + background. */
-export function addCardPadding(openCards: NestedCardStyle[], div: any, kind: "left" | "right"): any {
+export function addCardPadding(columns: GridColumn<any>[], openCards: NestedCardStyle[], idx: number, div: any): any {
+  const addLeft = idx === 0;
+  const addRight = idx === columns.length - 1;
+  if (!addLeft && !addRight) {
+    return div;
+  }
   [...openCards].reverse().forEach((card) => {
-    div = <div css={Css.bgColor(card.bgColor).pxPx(card.pxPx).if(!!card.bColor).bc(card.bColor).bl.br.$}>{div}</div>;
+    div = (
+      <div
+        css={{
+          ...Css.bgColor(card.bgColor).if(!!card.bColor).bc(card.bColor).$,
+          ...(addLeft && Css.plPx(card.pxPx).if(!!card.bColor).bl.$),
+          ...(addRight && Css.prPx(card.pxPx).if(!!card.bColor).br.$),
+        }}
+      >
+        {div}
+      </div>
+    );
   });
   return div;
 }

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -18,7 +18,7 @@ import { Components, Virtuoso, VirtuosoHandle } from "react-virtuoso";
 import { navLink } from "src/components/CssReset";
 import { Icon } from "src/components/Icon";
 import { createRowLookup, GridRowLookup } from "src/components/Table/GridRowLookup";
-import { addCardPadding, makeOpenOrCloseCard, makeSpacer } from "src/components/Table/nestedCards";
+import { makeOpenOrCloseCard, makeSpacer, maybeAddCardPadding } from "src/components/Table/nestedCards";
 import { Css, Margin, Only, Palette, Properties, Xss } from "src/Css";
 import { useTestIds } from "src/utils/useTestIds";
 import tinycolor from "tinycolor2";
@@ -872,7 +872,7 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
         let rendered = renderFn(idx, cellCss, content, row, rowStyle);
         // Sneak in card padding for the 1st / last cells
         if (card) {
-          rendered = addCardPadding(columns, openCards, idx, rendered);
+          rendered = maybeAddCardPadding(columns, openCards, idx, rendered);
         }
         return rendered;
       })}

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -834,9 +834,6 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
           // Then apply any header-specific override
           ...(isHeader && style.headerCellCss),
           ...(isHeader && stickyHeader && Css.sticky.top(stickyOffset).z1.$),
-          ...(card && Css.bgColor(card.bgColor).$),
-          ...(card && idx === 0 && card.bColor && Css.bc(card.bColor).bl.$),
-          ...(card && idx === columns.length - 1 && card.bColor && Css.bc(card.bColor).br.$),
           // And finally the specific cell's css (if any from GridCellContent)
           ...rowStyleCellCss,
         };
@@ -1351,8 +1348,6 @@ export function makeOpenOrCloseCard(openCards: NestedCardStyle[], kind: "open" |
 /** For the first or last cell, nest them in divs that re-create the outer card padding + background. */
 export function addCardPadding(openCards: NestedCardStyle[], div: any, kind: "left" | "right"): any {
   const copy = [...openCards];
-  // We don't need to wrap the current card (we draw any borders directly on the cell)
-  copy.pop();
   copy.reverse().forEach((card) => {
     div = <div css={Css.bgColor(card.bgColor).pxPx(card.pxPx).if(!!card.bColor).bc(card.bColor).bl.br.$}>{div}</div>;
   });

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -326,13 +326,13 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
 
     // Depth-first to filter
     function visit(row: GridDataRow<R>): void {
-      const passesFilter =
+      const matches =
         filters.length === 0 ||
         filters.every((filter) =>
           columns.map((c) => applyRowFn(c, row)).some((maybeContent) => matchesFilter(maybeContent, filter)),
         );
       // Even if we don't pass the filter, one of our children might, so we continue on after this check
-      if (passesFilter) {
+      if (matches) {
         nestedCards && nestedCards.beginRow(row);
         filteredRows.push([row, makeRowComponent(row)]);
       }

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -39,7 +39,7 @@ export function setRunningInJest() {
 }
 
 /** Completely static look & feel, i.e. nothing that is based on row kinds/content. */
-export interface GridStyle<R extends Kinded = {}> {
+export interface GridStyle<R extends Kinded = { kind: "header" }> {
   /** Applied to the base div element. */
   rootCss?: Properties;
   /** Applied with the owl operator between rows for rendering border lines. */
@@ -221,7 +221,7 @@ export interface GridTableProps<R extends Kinded, S, X> {
   /** Sets the rows to be wrapped by mobx observers. */
   observeRows?: boolean;
   /** A combination of CSS settings to set the static look & feel (vs. rowStyles which is per-row styling). */
-  style?: GridStyle;
+  style?: GridStyle<R>;
   /**
    * If provided, collapsed rows on the table persists when the page is reloaded.
    *
@@ -327,11 +327,11 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
     const filteredRows: RowTuple<R>[] = [];
 
     // Misc state to track our nested card-ification, i.e. interleaved actual rows + chrome rows
-    const nestedCardStyle = style.nestedCards;
+    const nestedCardStyle = (style.nestedCards || {}) as Record<string, NestedCardStyle>;
     // A stack of the current cards we're showing
     const openCards: NestedCardStyle[] | null = !!nestedCardStyle ? [] : null;
     // Just a helper boolean condition of "are nesting cards yes/no"
-    const nestedCards = !!nestedCardStyle && openCards !== null;
+    const nestedCards = !!style.nestedCards && openCards !== null;
     let chromeContent: JSX.Element[] = [];
     // Take the current buffer of close row(s), spacers, and open row, and creates a single chrome DOM row
     function flushChromeRow(): void {

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -313,7 +313,8 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
             isCollapsed,
             toggleCollapsedId,
             // TODO: How will this effect with memoization?
-            openCards: [...openCards],
+            // At least for non-nested card tables, we make this null so it will be fine.
+            openCards: openCards && [...openCards],
             ...sortProps,
           }}
         />
@@ -326,10 +327,11 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
 
     // Misc state to track our nested card-ification, i.e. interleaved actual rows + chrome rows
     const nestedCardStyle = style.nestedCards;
-    const nestedCards = !!nestedCardStyle;
-    let chromeContent: JSX.Element[] = [];
     // A stack of the current cards we're showing
-    const openCards: NestedCardStyle[] = [];
+    const openCards: NestedCardStyle[] | null = !!nestedCardStyle ? [] : null;
+    // Just a helper boolean condition of "are nesting cards yes/no"
+    const nestedCards = !!nestedCardStyle && openCards !== null;
+    let chromeContent: JSX.Element[] = [];
     // Take the current buffer of close row(s), spacers, and open row, and creates a single chrome DOM row
     function flushChromeRow(): void {
       if (chromeContent.length > 0) {
@@ -773,7 +775,7 @@ interface GridRowProps<R extends Kinded, S> {
   setSortKey?: (value: S) => void;
   isCollapsed: boolean;
   toggleCollapsedId: (id: string) => void;
-  openCards: NestedCardStyle[];
+  openCards: NestedCardStyle[] | null;
 }
 
 // We extract GridRow to its own mini-component primarily so we can React.memo'ize it.
@@ -829,7 +831,7 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
 
         ensureClientSideSortValueIsSortable(sorting, isHeader, column, idx, maybeContent);
 
-        const card = openCards.length > 0 && openCards[openCards.length - 1];
+        const card = openCards && openCards.length > 0 && openCards[openCards.length - 1];
 
         // Note that it seems expensive to calc a per-cell class name/CSS-in-JS output,
         // vs. setting global/table-wide CSS like `style.cellCss` on the root grid div with

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -1,3 +1,34 @@
 export * from "./CollapseToggle";
 export * from "./columns";
-export * from "./GridTable";
+export type { GridRowLookup } from "./GridRowLookup";
+export {
+  ASC,
+  cardStyle,
+  condensedStyle,
+  defaultStyle,
+  DESC,
+  GridTable,
+  setDefaultStyle,
+  setGridTableDefaults,
+} from "./GridTable";
+export type {
+  Direction,
+  GridCellAlignment,
+  GridCellContent,
+  GridCollapseContext,
+  GridColumn,
+  GridDataRow,
+  GridRowStyles,
+  GridSortConfig,
+  GridSortContext,
+  GridStyle,
+  GridTableDefaults,
+  GridTableProps,
+  GridTableXss,
+  Kinded,
+  RowStyle,
+  setRunningInJest,
+  SortHeader,
+} from "./GridTable";
+export { simpleDataRows, simpleHeader, simpleRows } from "./simpleHelpers";
+export type { SimpleHeaderAndDataOf, SimpleHeaderAndDataWith } from "./simpleHelpers";

--- a/src/components/Table/nestedCards.test.tsx
+++ b/src/components/Table/nestedCards.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { NestedCardStyle } from "src/components/Table/GridTable";
-import { addCardPadding, makeOpenOrCloseCard } from "src/components/Table/nestedCards";
+import { makeOpenOrCloseCard, maybeAddCardPadding } from "src/components/Table/nestedCards";
 import { Palette } from "src/Css";
 import { render } from "src/utils/rtl";
 
@@ -83,7 +83,7 @@ describe("nestedCards", () => {
 
   it("can add left padding w/two levels", async () => {
     const r = await render(
-      addCardPadding([{} as any, {} as any], [parentCardStyle, childCardStyle], 0, <div>content</div>),
+      maybeAddCardPadding([{} as any, {} as any], [parentCardStyle, childCardStyle], 0, <div>content</div>),
     );
     expect(r.firstElement).toMatchInlineSnapshot(`
       .emotion-0 {
@@ -119,7 +119,7 @@ describe("nestedCards", () => {
 
   it("can add right padding w/two levels", async () => {
     const r = await render(
-      addCardPadding([{} as any, {} as any], [parentCardStyle, childCardStyle], 1, <div>content</div>),
+      maybeAddCardPadding([{} as any, {} as any], [parentCardStyle, childCardStyle], 1, <div>content</div>),
     );
     expect(r.firstElement).toMatchInlineSnapshot(`
       .emotion-0 {
@@ -154,7 +154,7 @@ describe("nestedCards", () => {
   });
 
   it("can add left and right padding w/two levels if only one column", async () => {
-    const r = await render(addCardPadding([{} as any], [parentCardStyle, childCardStyle], 0, <div>content</div>));
+    const r = await render(maybeAddCardPadding([{} as any], [parentCardStyle, childCardStyle], 0, <div>content</div>));
     expect(r.firstElement).toMatchInlineSnapshot(`
       .emotion-0 {
         background-color: rgba(247,245,245,1);

--- a/src/components/Table/nestedCards.test.tsx
+++ b/src/components/Table/nestedCards.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { addCardPadding, makeOpenOrCloseCard, NestedCardStyle } from "src/components/Table/GridTable";
+import { NestedCardStyle } from "src/components/Table/GridTable";
+import { addCardPadding, makeOpenOrCloseCard } from "src/components/Table/nestedCards";
 import { Palette } from "src/Css";
 import { render } from "src/utils/rtl";
 
@@ -18,7 +19,7 @@ const childCardStyle: NestedCardStyle = {
   spacerPx: 6,
 };
 
-describe("GridTable nestedCards", () => {
+describe("nestedCards", () => {
   it("can make open card w/one level", async () => {
     const r = await render(makeOpenOrCloseCard([parentCardStyle], "open"));
     expect(r.firstElement).toMatchInlineSnapshot(`

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -161,7 +161,7 @@ export function maybeCreateChromeRow(
   if (chromeBuffer.length > 0) {
     filteredRows.push([
       undefined,
-      <div css={Css.add({ gridColumn: `span ${columns.length}` }).$}>
+      <div css={Css.gc(`span ${columns.length}`).$}>
         {chromeBuffer.map((c, i) => (
           <Fragment key={i}>{c}</Fragment>
         ))}

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -51,7 +51,12 @@ export function makeOpenOrCloseCard(openCards: NestedCardStyle[], kind: "open" |
  * For the first or last cell of actual content, wrap them in divs that re-create the
  * outer cards' padding + background.
  */
-export function addCardPadding(columns: GridColumn<any>[], openCards: NestedCardStyle[], idx: number, div: any): any {
+export function maybeAddCardPadding(
+  columns: GridColumn<any>[],
+  openCards: NestedCardStyle[],
+  idx: number,
+  div: any,
+): any {
   const addLeft = idx === 0;
   const addRight = idx === columns.length - 1;
   if (!addLeft && !addRight) {

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -83,13 +83,13 @@ export function makeOpenOrCloseCard(openCards: NestedCardStyle[], kind: "open" |
       <div
         css={{
           ...Css.bgColor(card.bgColor).pxPx(card.pxPx).$,
-          // Only the 1st div needs border radius.
+          // Only the 1st div needs border left/right radius + border top/bottom.
           ...(!div &&
             Css.add({
               [`border${place}RightRadius`]: `${card.brPx}px`,
               [`border${place}LeftRadius`]: `${card.brPx}px`,
             }).hPx(card.brPx).$),
-          ...(card.bColor && Css.bc(card.bColor).bl.br.if(div)[btOrBb].$),
+          ...(card.bColor && Css.bc(card.bColor).bl.br.if(!div)[btOrBb].$),
         }}
       >
         {div}

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -1,0 +1,85 @@
+import { GridColumn, NestedCardStyle } from "src/components/Table/GridTable";
+import { Css } from "src/Css";
+
+// Util methods for our nested card DOM shenanigans.
+
+/**
+ * Draws the rounded corners (either open or close) for a new card.
+ *
+ * We have to do this as synthetic rows to support:
+ *
+ * - parent card 1 open
+ * - parent card 1 content
+ * - ...N child cards...
+ * - parent card 1 close
+ *
+ * I.e. due to the flatness of our DOM, we inherently have to add a "close"
+ * row separate from the card's actual content.
+ */
+export function makeOpenOrCloseCard(openCards: NestedCardStyle[], kind: "open" | "close"): JSX.Element {
+  let div: any = null;
+  const place = kind === "open" ? "Top" : "Bottom";
+  const btOrBb = kind === "open" ? "bt" : "bb";
+  // Create nesting for the all open cards, i.e.:
+  //
+  // | card1 | card2  --------------   card2 | card1 |
+  // | card1 | card2 / ... card3 ... \ card2 | card1 |
+  // | card1 | card2 | ... card3 ... | card2 | card1 |
+  //
+  [...openCards].reverse().forEach((card) => {
+    div = (
+      <div
+        css={{
+          ...Css.bgColor(card.bgColor).pxPx(card.pxPx).$,
+          // Only the 1st div needs border radius.
+          ...(!div &&
+            Css.add({
+              [`border${place}RightRadius`]: `${card.brPx}px`,
+              [`border${place}LeftRadius`]: `${card.brPx}px`,
+            }).hPx(card.brPx).$),
+          ...(card.bColor && Css.bc(card.bColor).bl.br.if(div)[btOrBb].$),
+        }}
+      >
+        {div}
+      </div>
+    );
+  });
+  return div;
+}
+
+/**
+ * For the first or last cell of actual content, wrap them in divs that re-create the
+ * outer cards' padding + background.
+ */
+export function addCardPadding(columns: GridColumn<any>[], openCards: NestedCardStyle[], idx: number, div: any): any {
+  const addLeft = idx === 0;
+  const addRight = idx === columns.length - 1;
+  if (!addLeft && !addRight) {
+    return div;
+  }
+  [...openCards].reverse().forEach((card) => {
+    div = (
+      <div
+        css={{
+          ...Css.bgColor(card.bgColor).if(!!card.bColor).bc(card.bColor).$,
+          ...(addLeft && Css.plPx(card.pxPx).if(!!card.bColor).bl.$),
+          ...(addRight && Css.prPx(card.pxPx).if(!!card.bColor).br.$),
+        }}
+      >
+        {div}
+      </div>
+    );
+  });
+  return div;
+}
+
+/** Create a spacer between rows of children. */
+export function makeSpacer(current: NestedCardStyle, openCards: NestedCardStyle[]) {
+  let div = <div css={Css.hPx(current.spacerPx).$} />;
+  // Start at the current/inside card, and wrap outward padding + borders.
+  // | card1 | card2 | ... card3 ... | card2 | card1 |
+  [...openCards].reverse().forEach((card) => {
+    div = <div css={Css.bgColor(card.bgColor).pxPx(card.pxPx).if(!!card.bColor).bc(card.bColor).bl.br.$}>{div}</div>;
+  });
+  return div;
+}

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -112,7 +112,10 @@ export function maybeAddCardPadding(
   const isFirst = idx === 0;
   const isFinal = idx === columns.length - 1;
   if (!isFirst && !isFinal) {
-    return div;
+    // Even if we don't need the nested color+padding of each open card, at
+    // least add the background color of the closed open card.
+    const card = openCards[openCards.length - 1];
+    return !card ? div : <div css={Css.bgColor(card.bgColor).$}>{div}</div>;
   }
   [...openCards].reverse().forEach((card) => {
     div = (

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -22,8 +22,8 @@ export class NestedCards {
   private chromeBuffer: JSX.Element[] = [];
   private styles: Record<string, NestedCardStyle>;
 
-  constructor(private columns: GridColumn<any>[], private filteredRows: RowTuple<any>[], style: GridStyle<any>) {
-    this.styles = (style.nestedCards || {}) as Record<string, NestedCardStyle>;
+  constructor(private columns: GridColumn<any>[], private filteredRows: RowTuple<any>[], style: GridStyle) {
+    this.styles = style.nestedCards || {};
   }
 
   beginRow(row: GridDataRow<any>) {

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -1,6 +1,6 @@
 import { fail } from "@homebound/form-state/dist/utils";
-import React, { Fragment } from "react";
-import { GridColumn, GridDataRow, GridStyle, NestedCardStyle, RowTuple } from "src/components/Table/GridTable";
+import React, { Fragment, ReactElement } from "react";
+import { GridColumn, GridDataRow, GridStyle, Kinded, NestedCardStyle, RowTuple } from "src/components/Table/GridTable";
 import { Css } from "src/Css";
 
 /**
@@ -170,4 +170,8 @@ export function maybeCreateChromeRow(
     // clear the buffer
     chromeBuffer.splice(0, chromeBuffer.length);
   }
+}
+
+export function dropChromeRows<R extends Kinded>(filteredRows: RowTuple<R>[]): [GridDataRow<R>, ReactElement][] {
+  return filteredRows.filter(([r]) => !!r) as [GridDataRow<R>, ReactElement][];
 }

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -1,4 +1,5 @@
-import { GridColumn, NestedCardStyle } from "src/components/Table/GridTable";
+import React, { Fragment } from "react";
+import { GridColumn, NestedCardStyle, RowTuple } from "src/components/Table/GridTable";
 import { Css } from "src/Css";
 
 // Util methods for our nested card DOM shenanigans.
@@ -87,4 +88,35 @@ export function makeSpacer(current: NestedCardStyle, openCards: NestedCardStyle[
     div = <div css={Css.bgColor(card.bgColor).pxPx(card.pxPx).if(!!card.bColor).bc(card.bColor).bl.br.$}>{div}</div>;
   });
   return div;
+}
+
+/**
+ * Takes the current buffer of close row(s), spacers, and open row, and creates a single chrome DOM row.
+ *
+ * This allows a minimal amount of DOM overhead, insofar as to the css-grid or react-virtuoso we only
+ * 1 extra DOM node between each row of content to achieve our nested card look & feel, i.e.:
+ *
+ * - chrome row (open)
+ * - card1 content row
+ * - chrome row (card2 open)
+ * - nested card2 content row
+ * - chrome row (card2 close, card1 cloard)
+ */
+export function maybeCreateChromeRow(
+  columns: GridColumn<any>[],
+  filteredRows: RowTuple<any>[],
+  chromeBuffer: JSX.Element[],
+): void {
+  if (chromeBuffer.length > 0) {
+    filteredRows.push([
+      undefined,
+      <div css={Css.add({ gridColumn: `span ${columns.length}` }).$}>
+        {chromeBuffer.map((c, i) => (
+          <Fragment key={i}>{c}</Fragment>
+        ))}
+      </div>,
+    ]);
+    // clear the buffer
+    chromeBuffer.splice(0, chromeBuffer.length);
+  }
 }

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -57,9 +57,9 @@ export function maybeAddCardPadding(
   idx: number,
   div: any,
 ): any {
-  const addLeft = idx === 0;
-  const addRight = idx === columns.length - 1;
-  if (!addLeft && !addRight) {
+  const isFirst = idx === 0;
+  const isFinal = idx === columns.length - 1;
+  if (!isFirst && !isFinal) {
     return div;
   }
   [...openCards].reverse().forEach((card) => {
@@ -67,8 +67,8 @@ export function maybeAddCardPadding(
       <div
         css={{
           ...Css.bgColor(card.bgColor).if(!!card.bColor).bc(card.bColor).$,
-          ...(addLeft && Css.plPx(card.pxPx).if(!!card.bColor).bl.$),
-          ...(addRight && Css.prPx(card.pxPx).if(!!card.bColor).br.$),
+          ...(isFirst && Css.plPx(card.pxPx).if(!!card.bColor).bl.$),
+          ...(isFinal && Css.prPx(card.pxPx).if(!!card.bColor).br.$),
         }}
       >
         {div}

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -6,10 +6,10 @@ import { Css } from "src/Css";
 /**
  * A helper class to create our nested card DOM shenanigans.
  *
- * This acts as a one-off visitor that accepts for "begin row", "between row",
- * "end row" calls from GridTable while it's translating the user's nested
+ * This acts as a one-off visitor that accepts "begin row", "between row",
+ * "end row" calls from GridTable while its translating the user's nested
  * GridDataRows into a flat list of RowTuples, and interjects fake/chrome
- * rows into `filteredList` as necessary.
+ * rows into `filteredRows` as necessary.
  *
  * Note that this class only handles *between row* chrome and that within
  * a content row itself, the nested padding is handled separately by the
@@ -27,8 +27,7 @@ export class NestedCards {
   }
 
   beginRow(row: GridDataRow<any>) {
-    // Maybe make a new chrome
-    this.openCards.push(this.styles[row.kind] || fail(`no card style for ${row.kind}`));
+    this.openCards.push(this.getStyle(row));
     this.chromeBuffer.push(makeOpenOrCloseCard(this.openCards, "open"));
     maybeCreateChromeRow(this.columns, this.filteredRows, this.chromeBuffer);
   }
@@ -39,7 +38,7 @@ export class NestedCards {
   }
 
   betweenChildren(row: GridDataRow<any>) {
-    this.chromeBuffer.push(makeSpacer(this.styles[row.kind] || fail(`No kind for ${row.kind}`), this.openCards));
+    this.chromeBuffer.push(makeSpacer(this.getStyle(row), this.openCards));
   }
 
   done() {
@@ -49,6 +48,10 @@ export class NestedCards {
   /** Return a stable copy of the cards, so it won't change as we keep going. */
   currentOpenCards() {
     return [...this.openCards];
+  }
+
+  private getStyle(row: GridDataRow<any>): NestedCardStyle {
+    return this.styles[row.kind] || fail(`No kind for ${row.kind}`);
   }
 }
 

--- a/src/components/Table/simpleHelpers.ts
+++ b/src/components/Table/simpleHelpers.ts
@@ -1,0 +1,36 @@
+import { GridDataRow } from "src/components/Table/GridTable";
+
+/** A helper for making `Row` type aliases of simple/flat tables that are just header + data. */
+export type SimpleHeaderAndDataOf<T> = { kind: "header" } | ({ kind: "data" } & T);
+
+/**
+ * A helper for making `Row` type aliases of simple/flat tables that are just header + data.
+ *
+ * Unlike `SimpleHeaderAndDataOf`, we keep `T` in a separate `data`, which is useful
+ * when rows are mobx proxies and we need proxy accesses to happen within the column
+ * rendering.
+ */
+export type SimpleHeaderAndDataWith<T> =
+  | { kind: "header" }
+  // We put `id` here so that GridColumn can match against `extends { data, id }`,
+  // kinda looks like we should combine Row and GridDataRow, i.e. Rows always have ids,
+  // they already have kinds, and need to have ids when passed to rows anyway...
+  | { kind: "data"; data: T; id: string };
+
+/** A const for a marker header row. */
+export const simpleHeader = { kind: "header" as const, id: "header" };
+
+export function simpleRows<R extends SimpleHeaderAndDataOf<D>, D>(
+  data: Array<D & { id: string }> | undefined = [],
+): GridDataRow<R>[] {
+  // @ts-ignore
+  return [simpleHeader, ...data.map((c) => ({ kind: "data" as const, ...c }))];
+}
+
+/** Like `simpleRows` but for `SimpleHeaderAndDataWith`. */
+export function simpleDataRows<R extends SimpleHeaderAndDataWith<D>, D>(
+  data: Array<D & { id: string }> | undefined = [],
+): GridDataRow<R>[] {
+  // @ts-ignore Not sure why this doesn't type-check, something esoteric with the DiscriminateUnion type
+  return [simpleHeader, ...data.map((data) => ({ kind: "data" as const, data, id: data.id }))];
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,5 @@
 export * from "src/components/Table/GridTable";
-export { addCardPadding, makeOpenOrCloseCard, makeSpacer } from "src/components/Table/nestedCards";
+export { makeOpenOrCloseCard, makeSpacer, maybeAddCardPadding } from "src/components/Table/nestedCards";
 export * from "./Alert";
 export { BeamProvider } from "./BeamContext";
 export * from "./Button";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from "src/components/Table/GridTable";
+export { addCardPadding, makeOpenOrCloseCard, makeSpacer } from "src/components/Table/nestedCards";
 export * from "./Alert";
 export { BeamProvider } from "./BeamContext";
 export * from "./Button";

--- a/truss/index.ts
+++ b/truss/index.ts
@@ -40,8 +40,8 @@ const sections: Sections = {
     newMethodsForProp("fontFamily", {
       sansSerif: "'Inter', sans-serif",
     }),
-  borderRadius: () =>
-    newMethodsForProp("borderRadius", {
+  borderRadius: () => [
+    ...newMethodsForProp("borderRadius", {
       br0: "0",
       br4: "4px",
       br8: "8px",
@@ -50,6 +50,9 @@ const sections: Sections = {
       br24: "24px",
       br100: "100%",
     }),
+    newMethod("brt4", { borderTopRightRadius: "4px", borderTopLeftRadius: "4px" }),
+    newMethod("brb4", { borderBottomRightRadius: "4px", borderBottomLeftRadius: "4px" }),
+  ],
   animation: () => [newMethod("transition", { transition })],
   boxShadow: () =>
     newMethodsForProp("boxShadow", {

--- a/truss/package-lock.json
+++ b/truss/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "dependencies": {
-        "@homebound/truss": "^1.98.0",
+        "@homebound/truss": "^1.99.0",
         "@types/node": "^14.0.14",
         "ts-node": "^8.10.2",
         "typescript": "^3.9.6"
       }
     },
     "node_modules/@homebound/truss": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/@homebound/truss/-/truss-1.98.0.tgz",
-      "integrity": "sha512-l6WnKuYpOYfpRpftLpzMlb5Wu/XeUkOPDQ17CR3SoEuleZ75CMG+5xiTLU4w1+JlcRTCJEibUjhbupJ/9Smkzw==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/@homebound/truss/-/truss-1.99.0.tgz",
+      "integrity": "sha512-tEH35rtv22wJ+dnVn9FMV+jhLatN2xCWeNJjvyt5lMWY2ZKUm246At/q1S1c4+Ga/iM0latqv58qLRxi/JbUsQ==",
       "dependencies": {
         "csstype": "^2.6.10",
         "prettier": "^2.0.5",
@@ -149,9 +149,9 @@
   },
   "dependencies": {
     "@homebound/truss": {
-      "version": "1.98.0",
-      "resolved": "https://registry.npmjs.org/@homebound/truss/-/truss-1.98.0.tgz",
-      "integrity": "sha512-l6WnKuYpOYfpRpftLpzMlb5Wu/XeUkOPDQ17CR3SoEuleZ75CMG+5xiTLU4w1+JlcRTCJEibUjhbupJ/9Smkzw==",
+      "version": "1.99.0",
+      "resolved": "https://registry.npmjs.org/@homebound/truss/-/truss-1.99.0.tgz",
+      "integrity": "sha512-tEH35rtv22wJ+dnVn9FMV+jhLatN2xCWeNJjvyt5lMWY2ZKUm246At/q1S1c4+Ga/iM0latqv58qLRxi/JbUsQ==",
       "requires": {
         "csstype": "^2.6.10",
         "prettier": "^2.0.5",

--- a/truss/package.json
+++ b/truss/package.json
@@ -3,7 +3,7 @@
     "generate": "ts-node ./index.ts"
   },
   "dependencies": {
-    "@homebound/truss": "^1.98.0",
+    "@homebound/truss": "^1.99.0",
     "@types/node": "^14.0.14",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -160,6 +160,13 @@
   dependencies:
     "@babel/types" "^7.12.13"
 
+"@babel/helper-annotate-as-pure@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.15.4.tgz#3d0e43b00c5e49fdb6c57e421601a7a658d5f835"
+  integrity sha512-QwrtdNvUNsPCj2lfNQacsGSQvGX8ee1ttrBrcozUP2Sv/jylewBP/8QFe6ZkBsC8T/GYWonNAWJV4aRR9AL2DA==
+  dependencies:
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.12.13":
   version "7.12.13"
   resolved "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.12.13.tgz"
@@ -198,6 +205,18 @@
     "@babel/helper-optimise-call-expression" "^7.12.13"
     "@babel/helper-replace-supers" "^7.13.0"
     "@babel/helper-split-export-declaration" "^7.12.13"
+
+"@babel/helper-create-class-features-plugin@^7.14.5", "@babel/helper-create-class-features-plugin@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.4.tgz#7f977c17bd12a5fba363cb19bea090394bf37d2e"
+  integrity sha512-7ZmzFi+DwJx6A7mHRwbuucEYpyBwmh2Ca0RvI6z2+WLZYCqV0JOaLb+u0zbtmDicebgKBZgqbYfLaKNqSgv5Pw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.15.4"
+    "@babel/helper-function-name" "^7.15.4"
+    "@babel/helper-member-expression-to-functions" "^7.15.4"
+    "@babel/helper-optimise-call-expression" "^7.15.4"
+    "@babel/helper-replace-supers" "^7.15.4"
+    "@babel/helper-split-export-declaration" "^7.15.4"
 
 "@babel/helper-create-regexp-features-plugin@^7.12.13":
   version "7.12.17"
@@ -392,6 +411,11 @@
   resolved "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz"
   integrity sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ==
 
+"@babel/helper-plugin-utils@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
+  integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
+
 "@babel/helper-remap-async-to-generator@^7.13.0":
   version "7.13.0"
   resolved "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.13.0.tgz"
@@ -579,6 +603,14 @@
   dependencies:
     "@babel/helper-create-class-features-plugin" "^7.13.0"
     "@babel/helper-plugin-utils" "^7.13.0"
+
+"@babel/plugin-proposal-class-properties@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.14.5.tgz#40d1ee140c5b1e31a350f4f5eed945096559b42e"
+  integrity sha512-q/PLpv5Ko4dVc1LYMpCY7RVAAO4uk55qPwrIuJ5QJ8c6cVuAmhu7I/49JOppXL6gXf7ZHzpRVEUZdYoPLM04Gg==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.14.5"
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-proposal-decorators@^7.12.12":
   version "7.13.15"
@@ -837,6 +869,13 @@
   integrity sha512-cHP3u1JiUiG2LFDKbXnwVad81GvfyIOmCD6HIEId6ojrY0Drfy2q1jw7BwN7dE84+kTnBjLkXoL3IEy/3JPu2w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.12.13"
+
+"@babel/plugin-syntax-typescript@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz#b82c6ce471b165b5ce420cf92914d6fb46225716"
+  integrity sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
 
 "@babel/plugin-transform-arrow-functions@^7.12.1", "@babel/plugin-transform-arrow-functions@^7.13.0":
   version "7.13.0"
@@ -1121,6 +1160,15 @@
     "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/plugin-syntax-typescript" "^7.12.13"
 
+"@babel/plugin-transform-typescript@^7.15.0":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.4.tgz#db7a062dcf8be5fc096bc0eeb40a13fbfa1fa251"
+  integrity sha512-sM1/FEjwYjXvMwu1PJStH11kJ154zd/lpY56NQJ5qH2D0mabMv1CAy/kdvS9RP4Xgfj9fBBA3JiSLdDHgXdzOA==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.15.4"
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/plugin-syntax-typescript" "^7.14.5"
+
 "@babel/plugin-transform-unicode-escapes@^7.12.13":
   version "7.12.13"
   resolved "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.12.13.tgz"
@@ -1251,6 +1299,15 @@
     "@babel/helper-plugin-utils" "^7.13.0"
     "@babel/helper-validator-option" "^7.12.17"
     "@babel/plugin-transform-typescript" "^7.13.0"
+
+"@babel/preset-typescript@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.15.0.tgz#e8fca638a1a0f64f14e1119f7fe4500277840945"
+  integrity sha512-lt0Y/8V3y06Wq/8H/u0WakrqciZ7Fz7mwPDHWUJAXlABL5hiUG42BNlRXiELNjeWjO5rWmnNKlx+yzJvxezHow==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-validator-option" "^7.14.5"
+    "@babel/plugin-transform-typescript" "^7.15.0"
 
 "@babel/register@^7.12.1":
   version "7.13.14"
@@ -6108,10 +6165,10 @@ chownr@^2.0.0:
   resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-chromatic@^5.6.3:
-  version "5.7.1"
-  resolved "https://registry.npmjs.org/chromatic/-/chromatic-5.7.1.tgz"
-  integrity sha512-At5qZotlA5E7MQncIMbyyniZxAO4XRIHRmz/4V2a9OFtyE8OvpNBOnfaRiLGoEZiZy7eWz/PmU5yTFNc++ISVQ==
+chromatic@^5.9.2:
+  version "5.9.2"
+  resolved "https://registry.yarnpkg.com/chromatic/-/chromatic-5.9.2.tgz#2a9ad2c2f2e5f98be9cf3e4707d43808cbc450df"
+  integrity sha512-h7+LPo5j2yHUaQIpaJzM7SXfkdEE9I7/rI6TWSeURwCrUggptVjj/+T4X2rmuqD5TfCp9HyHvtRObRl4PVWfNw==
   dependencies:
     "@actions/core" "^1.2.4"
     "@actions/github" "^4.0.0"
@@ -6127,6 +6184,7 @@ chromatic@^5.6.3:
     execa "^5.0.0"
     fake-tag "^2.0.0"
     fs-extra "^9.1.0"
+    https-proxy-agent "^5.0.0"
     jsonfile "^6.0.1"
     junit-report-builder "2.1.0"
     listr "0.14.3"
@@ -6141,6 +6199,7 @@ chromatic@^5.6.3:
     progress-stream "^2.0.0"
     semver "^7.3.4"
     slash "^3.0.0"
+    string-argv "^0.3.1"
     strip-ansi "6.0.0"
     tmp-promise "3.0.2"
     tree-kill "^1.2.2"
@@ -14418,6 +14477,11 @@ strict-uri-encode@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz"
   integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
+
+string-argv@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
+  integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
 string-length@^4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1455,10 +1455,10 @@
     react-router "^5.1.2"
     use-query-params "^1.2.2"
 
-"@homebound/rtl-utils@^2.50.0":
-  version "2.50.0"
-  resolved "https://registry.yarnpkg.com/@homebound/rtl-utils/-/rtl-utils-2.50.0.tgz#76adb2c1da36dfe48d4e1a116beee678ad52dcd0"
-  integrity sha512-bQnfqhO6FiQeajoowS4I8GK1fJuhzM06vwiaMkK//7oGlE41+BKXMzc3m1cYsb4NGFaQfv1lkVNhg/dUIPNh8g==
+"@homebound/rtl-utils@^2.51.0":
+  version "2.51.0"
+  resolved "https://registry.yarnpkg.com/@homebound/rtl-utils/-/rtl-utils-2.51.0.tgz#7fe076fa642acfbf9d9c607d19b7c6e9ad2263b2"
+  integrity sha512-vS4WHtxKCAVmj8Rqf7Q/NvPkBKRBTZm0hICRvjZRaPwHsYgSfZHYc7fRdavvFmWevm6PYEWzVR0TPQXO0Nb7yw==
   dependencies:
     "@testing-library/react" "^12.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -57,6 +57,11 @@
   resolved "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.15.tgz"
   integrity sha512-ltnibHKR1VnrU4ymHyQ/CXtNXI6yZC0oJThyW78Hft8XndANwi+9H+UIklBDraIjFEJzw8wmcM427oDd9KS5wA==
 
+"@babel/compat-data@^7.15.0":
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.15.0.tgz#2dbaf8b85334796cafbb0f5793a90a2fc010b176"
+  integrity sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==
+
 "@babel/core@7.12.9":
   version "7.12.9"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz"
@@ -79,7 +84,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.12.10", "@babel/core@^7.13.1", "@babel/core@^7.7.5":
+"@babel/core@^7.1.0", "@babel/core@^7.12.10", "@babel/core@^7.7.5":
   version "7.13.15"
   resolved "https://registry.npmjs.org/@babel/core/-/core-7.13.15.tgz"
   integrity sha512-6GXmNYeNjS2Uz+uls5jalOemgIhnTMeaXo+yBUA72kC2uX/8VW6XyhVIo2L8/q0goKQA3EVKx0KOQpVKSeWadQ==
@@ -93,6 +98,27 @@
     "@babel/template" "^7.12.13"
     "@babel/traverse" "^7.13.15"
     "@babel/types" "^7.13.14"
+    convert-source-map "^1.7.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.1.2"
+    semver "^6.3.0"
+    source-map "^0.5.0"
+
+"@babel/core@^7.15.5":
+  version "7.15.5"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.15.5.tgz#f8ed9ace730722544609f90c9bb49162dc3bf5b9"
+  integrity sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.15.4"
+    "@babel/helper-compilation-targets" "^7.15.4"
+    "@babel/helper-module-transforms" "^7.15.4"
+    "@babel/helpers" "^7.15.4"
+    "@babel/parser" "^7.15.5"
+    "@babel/template" "^7.15.4"
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.4"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -115,6 +141,15 @@
   integrity sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==
   dependencies:
     "@babel/types" "^7.14.5"
+    jsesc "^2.5.1"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.15.4.tgz#85acb159a267ca6324f9793986991ee2022a05b0"
+  integrity sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==
+  dependencies:
+    "@babel/types" "^7.15.4"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -141,6 +176,16 @@
     "@babel/compat-data" "^7.13.12"
     "@babel/helper-validator-option" "^7.12.17"
     browserslist "^4.14.5"
+    semver "^6.3.0"
+
+"@babel/helper-compilation-targets@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz#cf6d94f30fbefc139123e27dd6b02f65aeedb7b9"
+  integrity sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==
+  dependencies:
+    "@babel/compat-data" "^7.15.0"
+    "@babel/helper-validator-option" "^7.14.5"
+    browserslist "^4.16.6"
     semver "^6.3.0"
 
 "@babel/helper-create-class-features-plugin@^7.13.0", "@babel/helper-create-class-features-plugin@^7.13.11":
@@ -215,6 +260,15 @@
     "@babel/template" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/helper-function-name@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz#845744dafc4381a4a5fb6afa6c3d36f98a787ebc"
+  integrity sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.15.4"
+    "@babel/template" "^7.15.4"
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-get-function-arity@^7.12.13":
   version "7.12.13"
   resolved "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz"
@@ -228,6 +282,13 @@
   integrity sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==
   dependencies:
     "@babel/types" "^7.14.5"
+
+"@babel/helper-get-function-arity@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.15.4.tgz#098818934a137fce78b536a3e015864be1e2879b"
+  integrity sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==
+  dependencies:
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-hoist-variables@^7.13.0":
   version "7.13.0"
@@ -244,6 +305,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-hoist-variables@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz#09993a3259c0e918f99d104261dfdfc033f178df"
+  integrity sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==
+  dependencies:
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-member-expression-to-functions@^7.13.0", "@babel/helper-member-expression-to-functions@^7.13.12":
   version "7.13.12"
   resolved "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz"
@@ -251,12 +319,26 @@
   dependencies:
     "@babel/types" "^7.13.12"
 
+"@babel/helper-member-expression-to-functions@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz#bfd34dc9bba9824a4658b0317ec2fd571a51e6ef"
+  integrity sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==
+  dependencies:
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.13", "@babel/helper-module-imports@^7.13.12":
   version "7.13.12"
   resolved "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz"
   integrity sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==
   dependencies:
     "@babel/types" "^7.13.12"
+
+"@babel/helper-module-imports@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz#e18007d230632dea19b47853b984476e7b4e103f"
+  integrity sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==
+  dependencies:
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-module-transforms@^7.12.1", "@babel/helper-module-transforms@^7.13.0", "@babel/helper-module-transforms@^7.13.14":
   version "7.13.14"
@@ -272,12 +354,33 @@
     "@babel/traverse" "^7.13.13"
     "@babel/types" "^7.13.14"
 
+"@babel/helper-module-transforms@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.15.4.tgz#962cc629a7f7f9a082dd62d0307fa75fe8788d7c"
+  integrity sha512-9fHHSGE9zTC++KuXLZcB5FKgvlV83Ox+NLUmQTawovwlJ85+QMhk1CnVk406CQVj97LaWod6KVjl2Sfgw9Aktw==
+  dependencies:
+    "@babel/helper-module-imports" "^7.15.4"
+    "@babel/helper-replace-supers" "^7.15.4"
+    "@babel/helper-simple-access" "^7.15.4"
+    "@babel/helper-split-export-declaration" "^7.15.4"
+    "@babel/helper-validator-identifier" "^7.14.9"
+    "@babel/template" "^7.15.4"
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-optimise-call-expression@^7.12.13":
   version "7.12.13"
   resolved "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz"
   integrity sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==
   dependencies:
     "@babel/types" "^7.12.13"
+
+"@babel/helper-optimise-call-expression@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.15.4.tgz#f310a5121a3b9cc52d9ab19122bd729822dee171"
+  integrity sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==
+  dependencies:
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-plugin-utils@7.10.4":
   version "7.10.4"
@@ -308,12 +411,29 @@
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.12"
 
+"@babel/helper-replace-supers@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz#52a8ab26ba918c7f6dee28628b07071ac7b7347a"
+  integrity sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^7.15.4"
+    "@babel/helper-optimise-call-expression" "^7.15.4"
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-simple-access@^7.12.13", "@babel/helper-simple-access@^7.13.12":
   version "7.13.12"
   resolved "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz"
   integrity sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==
   dependencies:
     "@babel/types" "^7.13.12"
+
+"@babel/helper-simple-access@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz#ac368905abf1de8e9781434b635d8f8674bcc13b"
+  integrity sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==
+  dependencies:
+    "@babel/types" "^7.15.4"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
   version "7.12.1"
@@ -336,6 +456,13 @@
   dependencies:
     "@babel/types" "^7.14.5"
 
+"@babel/helper-split-export-declaration@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz#aecab92dcdbef6a10aa3b62ab204b085f776e257"
+  integrity sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==
+  dependencies:
+    "@babel/types" "^7.15.4"
+
 "@babel/helper-validator-identifier@^7.12.11":
   version "7.12.11"
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz"
@@ -346,10 +473,20 @@
   resolved "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz"
   integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
 
+"@babel/helper-validator-identifier@^7.14.9":
+  version "7.14.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz#6654d171b2024f6d8ee151bf2509699919131d48"
+  integrity sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==
+
 "@babel/helper-validator-option@^7.12.17":
   version "7.12.17"
   resolved "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz"
   integrity sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw==
+
+"@babel/helper-validator-option@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
+  integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
 
 "@babel/helper-wrap-function@^7.13.0":
   version "7.13.0"
@@ -369,6 +506,15 @@
     "@babel/template" "^7.12.13"
     "@babel/traverse" "^7.13.0"
     "@babel/types" "^7.13.0"
+
+"@babel/helpers@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.15.4.tgz#5f40f02050a3027121a3cf48d497c05c555eaf43"
+  integrity sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==
+  dependencies:
+    "@babel/template" "^7.15.4"
+    "@babel/traverse" "^7.15.4"
+    "@babel/types" "^7.15.4"
 
 "@babel/highlight@^7.10.4", "@babel/highlight@^7.12.13":
   version "7.13.10"
@@ -402,6 +548,11 @@
   version "7.14.7"
   resolved "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz"
   integrity sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==
+
+"@babel/parser@^7.15.4", "@babel/parser@^7.15.5":
+  version "7.15.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.5.tgz#d33a58ca69facc05b26adfe4abebfed56c1c2dac"
+  integrity sha512-2hQstc6I7T6tQsWzlboMh3SgMRPaS4H6H7cPQsJkdzTzEGqQrpLDsE2BGASU5sBPoEQyHzeqU6C8uKbFeEk6sg==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.13.12":
   version "7.13.12"
@@ -1145,6 +1296,15 @@
     "@babel/parser" "^7.14.5"
     "@babel/types" "^7.14.5"
 
+"@babel/template@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.15.4.tgz#51898d35dcf3faa670c4ee6afcfd517ee139f194"
+  integrity sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/parser" "^7.15.4"
+    "@babel/types" "^7.15.4"
+
 "@babel/traverse@^7.1.0", "@babel/traverse@^7.12.9", "@babel/traverse@^7.13.0", "@babel/traverse@^7.13.13", "@babel/traverse@^7.13.15", "@babel/traverse@^7.7.0":
   version "7.13.15"
   resolved "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.15.tgz"
@@ -1174,6 +1334,21 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
+"@babel/traverse@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.15.4.tgz#ff8510367a144bfbff552d9e18e28f3e2889c22d"
+  integrity sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==
+  dependencies:
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.15.4"
+    "@babel/helper-function-name" "^7.15.4"
+    "@babel/helper-hoist-variables" "^7.15.4"
+    "@babel/helper-split-export-declaration" "^7.15.4"
+    "@babel/parser" "^7.15.4"
+    "@babel/types" "^7.15.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.12.1", "@babel/types@^7.12.13", "@babel/types@^7.12.7", "@babel/types@^7.13.0", "@babel/types@^7.13.12", "@babel/types@^7.13.14", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
   version "7.13.14"
   resolved "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz"
@@ -1189,6 +1364,14 @@
   integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.14.5"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.15.4":
+  version "7.15.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.15.4.tgz#74eeb86dbd6748d2741396557b9860e57fce0a0d"
+  integrity sha512-0f1HJFuGmmbrKTCZtbm3cU+b/AqdEYk5toj5iQur58xkVMlS0JWaKxTBSmCXd47uiN7vbcozAupm6Mvs80GNhw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
 "@base2/pretty-print-object@1.0.0":
@@ -5580,6 +5763,17 @@ browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.16.3:
     escalade "^3.1.1"
     node-releases "^1.1.70"
 
+browserslist@^4.16.6:
+  version "4.17.0"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.17.0.tgz#1fcd81ec75b41d6d4994fb0831b92ac18c01649c"
+  integrity sha512-g2BJ2a0nEYvEFQC208q8mVAhfNwpZ5Mu8BwgtCdZKO3qx98HChmeg448fPdUzld8aFmfLgVh7yymqV+q1lJZ5g==
+  dependencies:
+    caniuse-lite "^1.0.30001254"
+    colorette "^1.3.0"
+    electron-to-chromium "^1.3.830"
+    escalade "^3.1.1"
+    node-releases "^1.1.75"
+
 bs-logger@0.x:
   version "0.2.6"
   resolved "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz"
@@ -5751,6 +5945,11 @@ caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.300011
   version "1.0.30001208"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001208.tgz"
   integrity sha512-OE5UE4+nBOro8Dyvv0lfx+SRtfVIOM9uhKqFmJeUbGriqhhStgp1A0OyBpgy3OUF8AhYCT+PVwPC1gMl2ZcQMA==
+
+caniuse-lite@^1.0.30001254:
+  version "1.0.30001255"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001255.tgz#f3b09b59ab52e39e751a569523618f47c4298ca0"
+  integrity sha512-F+A3N9jTZL882f/fg/WWVnKSu6IOo3ueLz4zwaOPbPYHNmM/ZaDUyzyJwS1mZhX7Ex5jqTyW599Gdelh5PDYLQ==
 
 capital-case@^1.0.4:
   version "1.0.4"
@@ -6154,6 +6353,11 @@ colorette@^1.2.1:
   version "1.2.2"
   resolved "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
+
+colorette@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.3.0.tgz#ff45d2f0edb244069d3b772adeb04fed38d0a0af"
+  integrity sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==
 
 colors@1.0.3:
   version "1.0.3"
@@ -7116,6 +7320,11 @@ electron-to-chromium@^1.3.564, electron-to-chromium@^1.3.649:
   version "1.3.710"
   resolved "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.710.tgz"
   integrity sha512-b3r0E2o4yc7mNmBeJviejF1rEx49PUBi+2NPa7jHEX3arkAXnVgLhR0YmV8oi6/Qf3HH2a8xzQmCjHNH0IpXWQ==
+
+electron-to-chromium@^1.3.830:
+  version "1.3.830"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.830.tgz#40e3144204f8ca11b2cebec83cf14c20d3499236"
+  integrity sha512-gBN7wNAxV5vl1430dG+XRcQhD4pIeYeak6p6rjdCtlz5wWNwDad8jwvphe5oi1chL5MV6RNRikfffBBiFuj+rQ==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -11355,6 +11564,11 @@ node-releases@^1.1.61, node-releases@^1.1.70:
   version "1.1.71"
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz"
   integrity sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==
+
+node-releases@^1.1.75:
+  version "1.1.75"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.75.tgz#6dd8c876b9897a1b8e5a02de26afa79bb54ebbfe"
+  integrity sha512-Qe5OUajvqrqDSy6wrWFmMwfJ0jVgwiw4T3KqmbTcZ62qW0gQkheXYhcFM1+lOVcGUoRxcEcfyvFMAnDgaF1VWw==
 
 nopt@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Screenshot from the story (the story only has a single `name` column):

![image](https://user-images.githubusercontent.com/6401/132249817-aa8318b3-37f6-4cec-b9fa-9997df37cf36.png)

Here with a `gap1` turned on to show the DOM structure:

![image](https://user-images.githubusercontent.com/6401/132249904-700f4e8f-ee24-4bc7-a183-a36237cc672d.png)

So the DOM is still flat, and we alternate "content rows" and "chrome rows" (that have the open/close rounded borders + spacers).

And note that even though this chrome row is a single div to css grid/react-virtuoso:

![image](https://user-images.githubusercontent.com/6401/132250322-0e8183f9-8a4a-45f8-804c-640db5944b5e.png)

It is 1 outer div + three inner divs: close the previous row, add a spacer between cards, open the new row.

Also for the content rows:

![image](https://user-images.githubusercontent.com/6401/132250413-09106c04-d73d-4fd3-95bc-298eff6a31e3.png)
 
The 1st and last cells (in this case it's the same cell b/c there is only 1 column) have N-levels of pad-left/pad-right added around their normal `GridColumn`-generated output, which achieves the nudging-in look.

Other than that, everything is still stock gridtable.
