### PR TITLE
fix: Better simpleRows type.

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "ts-node": "^9.1.1",
     "tslib": "^2.1.0",
     "ttypescript": "^1.5.12",
-    "typescript": "^4.3.5",
+    "typescript": "^4.4.2",
     "typescript-transform-paths": "^3.2.1",
     "watch": "^1.0.2",
     "xstate": "^4.23.0"

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -39,16 +39,16 @@ export type SimpleHeaderAndDataWith<T> =
 /** A const for a marker header row. */
 export const simpleHeader = { kind: "header" as const, id: "header" };
 
-export function simpleRows<T extends { id: string }, R extends { kind: "header" | "data" }>(
-  data: T[] | undefined = [],
+export function simpleRows<R extends SimpleHeaderAndDataOf<D>, D>(
+  data: Array<D & { id: string }> | undefined = [],
 ): GridDataRow<R>[] {
-  // @ts-ignore Not sure why this doesn't type-check, something esoteric with the DiscriminateUnion type
+  // @ts-ignore
   return [simpleHeader, ...data.map((c) => ({ kind: "data" as const, ...c }))];
 }
 
 /** Like `simpleRows` but for `SimpleHeaderAndDataWith`. */
-export function simpleDataRows<T extends { id: string }, R extends { kind: "header" | "data" }>(
-  data: T[] | undefined = [],
+export function simpleDataRows<R extends SimpleHeaderAndDataWith<D>, D>(
+  data: Array<D & { id: string }> | undefined = [],
 ): GridDataRow<R>[] {
   // @ts-ignore Not sure why this doesn't type-check, something esoteric with the DiscriminateUnion type
   return [simpleHeader, ...data.map((data) => ({ kind: "data" as const, data, id: data.id }))];

--- a/yarn.lock
+++ b/yarn.lock
@@ -14995,10 +14995,10 @@ typescript-transform-paths@^3.2.1:
   dependencies:
     minimatch "^3.0.4"
 
-typescript@^4.3.5:
-  version "4.3.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
+  integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
 uglify-js@^3.1.4:
   version "3.13.3"


### PR DESCRIPTION
Something about TypeScript 4.4 made the type inference for `simpleRows` wonky, and this fixes it... :shrug: 