### PR TITLE
feat: Add FormHeading proof-of-concept.

### DIFF
--- a/src/forms/FormHeading.stories.tsx
+++ b/src/forms/FormHeading.stories.tsx
@@ -1,0 +1,20 @@
+import { Meta } from "@storybook/react";
+import { FormHeading } from "src/forms/FormHeading";
+import { FormLines } from "src/forms/FormLines";
+import { TextField } from "src/inputs/TextField";
+
+export default {
+  component: FormHeading,
+  title: "Forms/Form Heading",
+} as Meta;
+
+export function Headings() {
+  return (
+    <FormLines>
+      <FormHeading title="First Heading" />
+      <TextField label="First" value="first" onChange={() => {}} />
+      <FormHeading title="Second Heading" />
+      <TextField label="Last" value="last" onChange={() => {}} />
+    </FormLines>
+  );
+}

--- a/src/forms/FormHeading.tsx
+++ b/src/forms/FormHeading.tsx
@@ -10,7 +10,7 @@ export interface FormHeadingProps {
 export function FormHeading(props: FormHeadingProps) {
   const { title, xss, isFirst = false } = props;
   return (
-    <div
+    <h3
       css={{
         ...Css.baseEm.$,
         // Add space before the heading, but only if it's not first.
@@ -19,7 +19,7 @@ export function FormHeading(props: FormHeadingProps) {
       }}
     >
       {title}
-    </div>
+    </h3>
   );
 }
 

--- a/src/forms/FormHeading.tsx
+++ b/src/forms/FormHeading.tsx
@@ -1,0 +1,27 @@
+import { Css, Margin, Xss } from "src/Css";
+
+export interface FormHeadingProps {
+  title: string;
+  xss?: Xss<Margin>;
+  // This is passed automatically by FormLines
+  isFirst?: boolean;
+}
+
+export function FormHeading(props: FormHeadingProps) {
+  const { title, xss, isFirst = false } = props;
+  return (
+    <div
+      css={{
+        ...Css.baseEm.$,
+        // Add space before the heading, but only if it's not first.
+        ...(!isFirst && Css.mt4.$),
+        ...xss,
+      }}
+    >
+      {title}
+    </div>
+  );
+}
+
+// https://github.com/gaearon/react-hot-loader/issues/304#issuecomment-456569720
+FormHeading.isFormHeading = true;


### PR DESCRIPTION
Our `FormHeadings` are consistently `baseEm`, which is almost so tiny to just `Css...` it's not worth component-izing. But, I dunno, I like it...

I'm also trying out a `cloneElement`-based approach for doing "only `mt4` the 2nd FormHeading".

Maybe should use `not nth-type-of` selectors or something, but I think that would require a hard-coded CSS class name for the selector to add margin only to `FormHeading`s and not other children.

I've been wanting to at least get this `cloneElement` approach working for awhile now, so admittedly ~80% of my motivation for this PR was using it as a good test case for `cloneElement` hacking. :-) 