### PR TITLE
fix: Allow propagation of onPointerDown event through Popover when open

### DIFF
--- a/src/components/internal/Popover.tsx
+++ b/src/components/internal/Popover.tsx
@@ -15,9 +15,16 @@ export function Popover(props: PopoverProps) {
   const { overlayProps } = useOverlay(
     {
       onClose,
-      shouldCloseOnBlur: false,
       isOpen,
       isDismissable: true,
+      shouldCloseOnInteractOutside: () => {
+        // By default when passing `isDismissable: true` then Popover will `stopPropagation` of the PointerDown event, which is used nearly everywhere in React-Aria (like for clicking buttons)
+        // We do not want that propagation to be stopped, but we still want the overlay to be dismissable.
+        // When providing `isDimissable: true`, then you can also provide this callback function, `shouldCloseOnInteractOutside`
+        // By returning `false` in this function it will no longer call `stopPropagation`, but it also will not call `onHide` for us, so we need to call `onClose` ourselves.
+        onClose();
+        return false;
+      },
     },
     popoverRef,
   );


### PR DESCRIPTION
Try it out with the Filters component: 
https://60466f7d43c37c0021788867-jgwefxrlvi.chromatic.com/?path=/story/components-filters--filter