### PR TITLE
feat: Allow non-card kinds in nested cards.

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -166,7 +166,7 @@ const rows: GridDataRow<NestedRow>[] = [
       // Put this "grandchild" in the 2nd level to show heterogeneous levels
       { kind: "grandChild", id: "p1g1", name: "grandchild p1g1" },
       // Put this "kind" into the 2nd level to show it doesn't have to be a card
-      { kind: "add", id: "add" },
+      { kind: "add", id: "add", pin: "last" },
     ],
   },
   // a parent with just a child

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -143,7 +143,8 @@ type HeaderRow = { kind: "header" };
 type ParentRow = { kind: "parent"; id: string; name: string };
 type ChildRow = { kind: "child"; id: string; name: string };
 type GrandChildRow = { kind: "grandChild"; id: string; name: string };
-type NestedRow = HeaderRow | ParentRow | ChildRow | GrandChildRow;
+type AddRow = { kind: "add" };
+type NestedRow = HeaderRow | ParentRow | ChildRow | GrandChildRow | AddRow;
 
 const rows: GridDataRow<NestedRow>[] = [
   { kind: "header", id: "header" },
@@ -164,6 +165,8 @@ const rows: GridDataRow<NestedRow>[] = [
       },
       // Put this "grandchild" in the 2nd level to show heterogeneous levels
       { kind: "grandChild", id: "p1g1", name: "grandchild p1g1" },
+      // Put this "kind" into the 2nd level to show it doesn't have to be a card
+      { kind: "add", id: "add" },
     ],
   },
   // a parent with just a child
@@ -181,6 +184,7 @@ export function NestedRows() {
     parent: (row) => <CollapseToggle row={row} />,
     child: (row) => <CollapseToggle row={row} />,
     grandChild: () => "",
+    add: () => "",
     w: 0,
   });
   const nameColumn: GridColumn<NestedRow> = {
@@ -197,6 +201,7 @@ export function NestedRows() {
       content: <div css={Css.ml4.$}>{row.name}</div>,
       value: row.name,
     }),
+    add: () => "Add",
   };
   return (
     <GridTable columns={[arrowColumn, nameColumn]} {...{ rows }} sorting={{ on: "client", initial: [1, "ASC"] }} />
@@ -218,13 +223,18 @@ export function NestedCards() {
       content: <div css={Css.xs.$}>{row.name}</div>,
       value: row.name,
     }),
+    add: () => "Add",
   };
   const spacing = { brPx: 4, pxPx: 8, spacerPx: 8 };
   const nestedStyle: GridStyle = {
     nestedCards: {
-      parent: { bgColor: Palette.Gray500, ...spacing },
-      child: { bgColor: Palette.Gray200, bColor: Palette.Gray600, ...spacing },
-      grandChild: { bgColor: Palette.Green200, bColor: Palette.Green400, ...spacing },
+      topLevelSpacerPx: 8,
+      kinds: {
+        parent: { bgColor: Palette.Gray500, ...spacing },
+        child: { bgColor: Palette.Gray200, bColor: Palette.Gray600, ...spacing },
+        grandChild: { bgColor: Palette.Green200, bColor: Palette.Green400, ...spacing },
+        // Purposefully leave out the `add` kind
+      },
     },
   };
 

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -537,6 +537,48 @@ describe("GridTable", () => {
       // Then it is shown as initially sorted desc
       expect(sortHeader_icon_0()).toHaveAttribute("data-icon", "sortDown");
     });
+
+    it("can pin rows first", async () => {
+      // Given the table is using client-side sorting
+      const r = await render(
+        <GridTable<Row>
+          columns={[nameColumn]}
+          sorting={{ on: "client" }}
+          rows={[
+            simpleHeader,
+            // And the 1st row is pinned first
+            { kind: "data", id: "2", name: "b", value: 2, pin: "first" },
+            { kind: "data", id: "3", name: "c", value: 3 },
+            { kind: "data", id: "1", name: "a", value: 1 },
+          ]}
+        />,
+      );
+      // Then the `value: 2` row stayed first
+      expect(cell(r, 1, 0)).toHaveTextContent("b");
+      expect(cell(r, 2, 0)).toHaveTextContent("a");
+      expect(cell(r, 3, 0)).toHaveTextContent("c");
+    });
+
+    it("can pin rows last", async () => {
+      // Given the table is using client-side sorting
+      const r = await render(
+        <GridTable<Row>
+          columns={[nameColumn]}
+          sorting={{ on: "client" }}
+          rows={[
+            simpleHeader,
+            { kind: "data", id: "3", name: "c", value: 3 },
+            { kind: "data", id: "2", name: "b", value: 2 },
+            // And the last row is pinned first
+            { kind: "data", id: "1", name: "a", value: 1, pin: "last" },
+          ]}
+        />,
+      );
+      // Then the `value: 1` row stayed last
+      expect(cell(r, 1, 0)).toHaveTextContent("b");
+      expect(cell(r, 2, 0)).toHaveTextContent("c");
+      expect(cell(r, 3, 0)).toHaveTextContent("a");
+    });
   });
 
   it("can handle onClick for rows", async () => {

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -370,7 +370,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
       });
     }
 
-    // If nestedCards is set, we assume the top-level kind is a card
+    // If nestedCards is set, we assume the top-level kind is a card, and so should add spacers between them
     visitRows(maybeSorted, !!nestedCards);
     nestedCards && nestedCards.done();
 

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -358,7 +358,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
       isCard && nestedCards && nestedCards.closeCard();
     }
 
-    function visitRows(rows: GridDataRow<R>[], addSpacerBetweenCards: boolean): void {
+    function visitRows(rows: GridDataRow<R>[], addSpacer: boolean): void {
       const length = rows.length;
       rows.forEach((row, i) => {
         if (row.kind === "header") {
@@ -366,7 +366,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
           return;
         }
         visit(row);
-        addSpacerBetweenCards && nestedCards && i !== length - 1 && nestedCards.addSpacerBetweenCards();
+        addSpacer && nestedCards && i !== length - 1 && nestedCards.addSpacerBetweenChildren();
       });
     }
 

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -741,6 +741,8 @@ export type GridDataRow<R extends Kinded> = {
   id: string;
   /** A list of parent/grand-parent ids for collapsing parent/child rows. */
   children?: GridDataRow<R>[];
+  /** Whether to pin this sort to the first/last of its parent's children. */
+  pin?: "first" | "last";
 } & DiscriminateUnion<R, "kind", R["kind"]>;
 
 interface GridRowProps<R extends Kinded, S> {

--- a/src/components/Table/nestedCards.test.tsx
+++ b/src/components/Table/nestedCards.test.tsx
@@ -19,7 +19,7 @@ const childCardStyle: NestedCardStyle = {
   spacerPx: 6,
 };
 
-describe("nestedCards", () => {
+describe("NestedCards", () => {
   it("can make open card w/one level", async () => {
     const r = await render(makeOpenOrCloseCard([parentCardStyle], "open"));
     expect(r.firstElement).toMatchInlineSnapshot(`

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -44,7 +44,7 @@ export class NestedCards {
 
   addSpacerBetweenChildren() {
     const openCard = this.openCards[this.openCards.length - 1];
-    // If we're between two top-level cards, we may not have, so fallback on topLevelSpacerPx
+    // If we're between two top-level cards, there is no open card, so fallback on topLevelSpacerPx
     const height = openCard?.spacerPx || this.style.nestedCards!.topLevelSpacerPx;
     this.chromeBuffer.push(makeSpacer(height, this.openCards));
   }

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -42,7 +42,7 @@ export class NestedCards {
     this.openCards.pop();
   }
 
-  addSpacerBetweenCards() {
+  addSpacerBetweenChildren() {
     const openCard = this.openCards[this.openCards.length - 1];
     // If we're between two top-level cards, we may not have, so fallback on topLevelSpacerPx
     const height = openCard?.spacerPx || this.style.nestedCards!.topLevelSpacerPx;

--- a/src/components/Table/sortRows.ts
+++ b/src/components/Table/sortRows.ts
@@ -44,7 +44,11 @@ function sortBatch<R extends Kinded>(
     const v2 = sortValue(applyRowFn(column, b));
     const v1e = v1 === null || v1 === undefined;
     const v2e = v2 === null || v2 === undefined;
-    if ((v1e && v2e) || v1 === v2) {
+    if (a.pin || b.pin) {
+      const ap = a.pin === "first" ? -1 : a.pin === "last" ? 1 : 0;
+      const bp = b.pin === "first" ? -1 : a.pin === "last" ? 1 : 0;
+      return ap === bp ? 0 : ap < bp ? -1 : 1;
+    } else if ((v1e && v2e) || v1 === v2) {
       return 0;
     } else if (v1e || v1 < v2) {
       return invert ? 1 : -1;


### PR DESCRIPTION
I.e. the "add task" use case.

![image](https://user-images.githubusercontent.com/6401/132998031-2166ebf3-1f66-43cd-954d-e81db89ae791.png)

Note that "Add" is getting pulled to the top, even though it's the "last child" when passed in, by the client-side sorting (because "Add" comes from "child g1c1").

So we'll either need to implement the "don't sort levels one or two" logic, or IMO what I'd prefer is something more like tagging rows as special i.e. `{ kind: "add", pin: "first" | "last" }` where the client-side sorting would recognize rows with the `pin` key set and automatically shove them first/last as appropriate, either before/after the otherwise normally sorted children. 

---

Update: I was looking for a distraction from the chores I'm supposed to be doing, so went ahead and added `GridDataRow.pin` so now Add will stay last.

