### PR TITLE
feat: Generalize toggleFilter for non-boolean on/off values.

### DIFF
--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -62,7 +62,7 @@ export function Filter() {
 
     const isTest = toggleFilter({ label: "Only show test projects" });
 
-    const doNotUse = toggleFilter({ label: "Hide 'Do Not Show'", enabledValue: false });
+    const doNotUse = toggleFilter({ label: "Hide 'Do Not Show'", onValue: false });
 
     return {
       marketId,

--- a/src/components/Filters/ToggleFilter.test.tsx
+++ b/src/components/Filters/ToggleFilter.test.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { toggleFilter } from "src/components/Filters";
+import { ToggleFilterProps } from "src/components/Filters/ToggleFilter";
+import { click, render } from "src/utils/rtl";
+import { useTestIds } from "src/utils/useTestIds";
+
+describe("ToggleFilter", () => {
+  it("uses true/undefined by default", async () => {
+    // Given a default boolean filter
+    const r = await render(<TestFilter toggleFilter={{}} />);
+    // It's initially empty
+    expect(r.filter_filter()).not.toBeChecked();
+    expect(r.value()).toHaveTextContent("undefined");
+    // And when they click it, we turn true
+    click(r.filter_filter());
+    expect(r.filter_filter()).toBeChecked();
+    expect(r.value()).toHaveTextContent("true");
+    // And when they click it again, we go back to undefined
+    click(r.filter_filter());
+    expect(r.filter_filter()).not.toBeChecked();
+    expect(r.value()).toHaveTextContent("undefined");
+  });
+
+  it("can use false/undefined when onValue is set", async () => {
+    // Given a default boolean filter
+    const r = await render(<TestFilter toggleFilter={{ onValue: false }} />);
+    // It's initially empty
+    expect(r.filter_filter()).not.toBeChecked();
+    expect(r.value()).toHaveTextContent("undefined");
+    // And when they click it, we turn true
+    click(r.filter_filter());
+    expect(r.filter_filter()).toBeChecked();
+    expect(r.value()).toHaveTextContent("false");
+    // And when they click it again, we go back to undefined
+    click(r.filter_filter());
+    expect(r.filter_filter()).not.toBeChecked();
+    expect(r.value()).toHaveTextContent("undefined");
+  });
+
+  it("can use true/false when offValue is set", async () => {
+    // Given a default boolean filter
+    const r = await render(<TestFilter toggleFilter={{ offValue: false }} />);
+    // It's initially empty
+    expect(r.filter_filter()).not.toBeChecked();
+    expect(r.value()).toHaveTextContent("false");
+    // And when they click it, we turn true
+    click(r.filter_filter());
+    expect(r.filter_filter()).toBeChecked();
+    expect(r.value()).toHaveTextContent("true");
+    // And when they click it again, we go back to false
+    click(r.filter_filter());
+    expect(r.filter_filter()).not.toBeChecked();
+    expect(r.value()).toHaveTextContent("false");
+  });
+
+  it("can use foo/bar when onValue/offValue are both set", async () => {
+    // Given a default boolean filter
+    const r = await render(<TestFilter toggleFilter={{ onValue: "foo", offValue: "bar" }} />);
+    // It's initially empty
+    expect(r.filter_filter()).not.toBeChecked();
+    expect(r.value()).toHaveTextContent("bar");
+    // And when they click it, we turn true
+    click(r.filter_filter());
+    expect(r.filter_filter()).toBeChecked();
+    expect(r.value()).toHaveTextContent("foo");
+    // And when they click it again, we go back to false
+    click(r.filter_filter());
+    expect(r.filter_filter()).not.toBeChecked();
+    expect(r.value()).toHaveTextContent("bar");
+  });
+});
+
+function TestFilter<V>(props: { toggleFilter: ToggleFilterProps<V> }) {
+  const filter = toggleFilter(props.toggleFilter)("filter");
+  const [value, setValue] = useState<V | undefined>(filter.defaultValue);
+  const tid = useTestIds({}, "filter");
+  return (
+    <div>
+      {filter.render(value, setValue, tid, false)}
+      <div data-testid="value">{typeof value !== "string" ? String(value) : value}</div>
+    </div>
+  );
+}

--- a/src/components/Filters/ToggleFilter.test.tsx
+++ b/src/components/Filters/ToggleFilter.test.tsx
@@ -68,11 +68,29 @@ describe("ToggleFilter", () => {
     expect(r.filter_filter()).not.toBeChecked();
     expect(r.value()).toHaveTextContent("bar");
   });
+
+  it("can default to checked", async () => {
+    // Given a default boolean filter
+    const r = await render(
+      <TestFilter
+        toggleFilter={{}}
+        // That has a persisted value coming in from usePersistedFilter
+        persistedValue={true}
+      />,
+    );
+    // It's initially checked
+    expect(r.filter_filter()).toBeChecked();
+    expect(r.value()).toHaveTextContent("true");
+    // And when they click it, we turn false
+    click(r.filter_filter());
+    expect(r.filter_filter()).not.toBeChecked();
+    expect(r.value()).toHaveTextContent("undefined");
+  });
 });
 
-function TestFilter<V>(props: { toggleFilter: ToggleFilterProps<V> }) {
+function TestFilter<V>(props: { toggleFilter: ToggleFilterProps<V>; persistedValue?: V }) {
   const filter = toggleFilter(props.toggleFilter)("filter");
-  const [value, setValue] = useState<V | undefined>(filter.defaultValue);
+  const [value, setValue] = useState<V | undefined>(props.persistedValue || filter.defaultValue);
   const tid = useTestIds({}, "filter");
   return (
     <div>

--- a/src/components/Filters/ToggleFilter.tsx
+++ b/src/components/Filters/ToggleFilter.tsx
@@ -19,8 +19,6 @@ export type ToggleFilterProps<V> = {
  * `on === false` and off === undefined`.
  *
  * Or you can set on/off directly, by passing both `onValue` and `offValue`.
- *
- * @param props
  */
 export function toggleFilter<V>(props: ToggleFilterProps<V>): (key: string) => Filter<V> {
   return (key) =>

--- a/src/components/Filters/ToggleFilter.tsx
+++ b/src/components/Filters/ToggleFilter.tsx
@@ -18,7 +18,8 @@ export type ToggleFilterProps<V> = {
  * You can flip the on/off values by passing `onValue: false`, in which case
  * `on === false` and off === undefined`.
  *
- * Or you can set on/off directly, by passing both `onValue` and `offValue`.
+ * Or you can set on/off directly, by passing both `onValue` and `offValue`, even to
+ * non-boolean values, i.e. `onValue: "foo", offValue: "bar"`.
  */
 export function toggleFilter<V>(props: ToggleFilterProps<V>): (key: string) => Filter<V> {
   return (key) =>

--- a/src/components/Filters/ToggleFilter.tsx
+++ b/src/components/Filters/ToggleFilter.tsx
@@ -21,7 +21,7 @@ export type ToggleFilterProps<V> = {
  * Or you can set on/off directly, by passing both `onValue` and `offValue`, even to
  * non-boolean values, i.e. `onValue: "foo", offValue: "bar"`.
  */
-export function toggleFilter<V>(props: ToggleFilterProps<V>): (key: string) => Filter<V> {
+export function toggleFilter<V = boolean>(props: ToggleFilterProps<V>): (key: string) => Filter<V> {
   return (key) =>
     new ToggleFilter(key, {
       // If the user has set the offValue, that should be the default b/c we're only a two-state


### PR DESCRIPTION
We don't need it immediately, but just following up the trend from @Chieze-Franklin 's PR, it seems like `toggleFilter` would really use any values for "on" / "off" instead of just booleans.