### PR TITLE
fix: SingleSelectFilter and MultiSelectFilter `defaultValue` prop not working

### DIFF
--- a/src/components/Filters/MultiFilter.test.tsx
+++ b/src/components/Filters/MultiFilter.test.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react";
+import { FilterDefs, Filters } from "src/components/Filters";
+import { ProjectFilter, stageFilter, stageFilterDefaultValue } from "src/components/Filters/testDomain";
+import { render } from "src/utils/rtl";
+
+describe("MultiSelectFilter", () => {
+  it("shows All by default", async () => {
+    const r = await render(<TestFilters defs={{ stage: stageFilter }} />);
+    expect(r.filter_stage()).toHaveValue("All");
+  });
+
+  it("shows defaultValue when given", async () => {
+    // Given a MultiSelectFilter with a default value
+    // When rendering
+    const r = await render(<TestFilters defs={{ stage: stageFilterDefaultValue }} />);
+    // Then expect the value to match the default value
+    expect(r.filter_stage()).toHaveValue("Two");
+  });
+});
+
+function TestFilters(props: { defs: FilterDefs<ProjectFilter> }) {
+  const { defs } = props;
+  const [filter, setFilter] = useState<ProjectFilter>({});
+  return (
+    <div>
+      <Filters filterDefs={defs} filter={filter} onChange={setFilter} />
+      <div data-testid="filter_value">{JSON.stringify(filter)}</div>
+    </div>
+  );
+}

--- a/src/components/Filters/MultiFilter.tsx
+++ b/src/components/Filters/MultiFilter.tsx
@@ -47,7 +47,7 @@ class MultiFilter<O, V extends Value> extends BaseFilter<V[], MultiFilterProps<O
         {...props}
         compact={!vertical}
         label={this.label}
-        values={value || []}
+        values={value || defaultValue || []}
         hideLabel={inModal}
         inlineLabel={!inModal && !vertical}
         sizeToContent={!inModal && !vertical}

--- a/src/components/Filters/SingleFilter.test.tsx
+++ b/src/components/Filters/SingleFilter.test.tsx
@@ -2,7 +2,7 @@ import { click } from "@homebound/rtl-utils";
 import { fireEvent } from "@testing-library/react";
 import { useState } from "react";
 import { FilterDefs, Filters } from "src/components/Filters";
-import { ProjectFilter, stageSingleFilter } from "src/components/Filters/testDomain";
+import { ProjectFilter, stageSingleFilter, stageSingleFilterDefaultValue } from "src/components/Filters/testDomain";
 import { render } from "src/utils/rtl";
 
 describe("SingleSelectFilter", () => {
@@ -22,6 +22,14 @@ describe("SingleSelectFilter", () => {
     click(r.getByRole("option", { name: "All" }));
     // Then it is unset
     expect(r.filter_value()).toHaveTextContent(`{}`);
+  });
+
+  it("shows defaultValue when given", async () => {
+    // Given a SelectFilter with a default value
+    // When rendering
+    const r = await render(<TestFilters defs={{ stageSingle: stageSingleFilterDefaultValue }} />);
+    // Then expect the value to match the default value
+    expect(r.filter_stageSingle()).toHaveValue("One");
   });
 });
 

--- a/src/components/Filters/SingleFilter.tsx
+++ b/src/components/Filters/SingleFilter.tsx
@@ -36,7 +36,7 @@ class SingleFilter<O, V extends Key> extends BaseFilter<V, SingleFilterProps<O, 
         getOptionValue={(o) => (o === allOption ? (undefined as any as V) : getOptionValue(o))}
         getOptionLabel={(o) => (o === allOption ? "All" : getOptionLabel(o))}
         compact={!vertical}
-        value={value}
+        value={value || defaultValue}
         label={this.label}
         inlineLabel={!inModal && !vertical}
         hideLabel={inModal}

--- a/src/components/Filters/testDomain.ts
+++ b/src/components/Filters/testDomain.ts
@@ -59,8 +59,22 @@ export const stageFilter: StageFilter = multiFilter({
   getOptionLabel: (s) => s.name,
 });
 
+export const stageFilterDefaultValue: StageFilter = multiFilter({
+  options: stageOptions,
+  defaultValue: [stageOptions[1].code],
+  getOptionValue: (s) => s.code,
+  getOptionLabel: (s) => s.name,
+});
+
 export const stageSingleFilter: StageSingleFilter = singleFilter({
   options: stageOptions,
+  getOptionValue: (s) => s.code,
+  getOptionLabel: (s) => s.name,
+});
+
+export const stageSingleFilterDefaultValue: StageSingleFilter = singleFilter({
+  options: stageOptions,
+  defaultValue: stageOptions[0].code,
   getOptionValue: (s) => s.code,
   getOptionLabel: (s) => s.name,
 });


### PR DESCRIPTION
When using the `defaultValue` prop for the Single and Multi Select Filter, no values would appear since the default value was not being given to the underlying `value` prop.