### PR TITLE
feat: Tabs support routes

### DIFF
--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -6,12 +6,12 @@ import { Css } from "src/Css";
 import { FormLines } from "src/forms";
 import { PreventBrowserScroll, ScrollableContent, ScrollableParent } from "src/index";
 import { NumberField } from "src/inputs";
-import { withBeamDecorator, withDimensions, zeroTo } from "src/utils/sb";
+import { withBeamDecorator, withDimensions, withRouter, zeroTo } from "src/utils/sb";
 
 export default {
   component: ScrollableParent,
   title: "Components/NestedScroll",
-  decorators: [withBeamDecorator, withDimensions()],
+  decorators: [withBeamDecorator, withDimensions(), withRouter()],
   parameters: { layout: "fullscreen" },
 } as Meta;
 

--- a/src/components/Tabs.stories.tsx
+++ b/src/components/Tabs.stories.tsx
@@ -1,8 +1,12 @@
 import { Meta } from "@storybook/react";
 import { Fragment, useState } from "react";
+import { Route, useHistory, useLocation } from "react-router";
+import { Link } from "react-router-dom";
+import { Button } from "src/components/Button";
 import { Css } from "src/Css";
+import { withRouter } from "src/utils/sb";
 import { Icon } from "./Icon";
-import { getTabStyles, Tab, TabContent, Tabs, TabsWithContent } from "./Tabs";
+import { getTabStyles, RouteTab, Tab, TabContent, Tabs, TabsWithContent } from "./Tabs";
 import { TabValue, TestTabContent, testTabs } from "./testData";
 
 export default {
@@ -12,6 +16,7 @@ export default {
     // To better view the icon hover state
     backgrounds: { default: "white" },
   },
+  decorators: [withRouter()],
 } as Meta;
 
 export function TabBaseStates() {
@@ -49,21 +54,109 @@ export function TabsSeparateFromContent() {
   );
 }
 
+export function TabsAsLinks() {
+  return <TestComponent />;
+}
+TabsAsLinks.decorators = [withRouter("/ce:1", "/:ceId")];
+
+function TestComponent() {
+  const location = useLocation();
+  const history = useHistory();
+  const routeTabs: RouteTab<string>[] = [
+    {
+      name: "Tab 1",
+      value: "/ce:1/overview",
+      path: ["/:ceId/overview", "/:ceId"],
+      render: () => (
+        <TestTabContent
+          content={
+            <>
+              <h1>Tab 1 Content</h1>
+              <div>
+                <pre css={Css.dib.$}>tab.path = ["/:ceId/overview", "/:ceId"]</pre>
+              </div>
+            </>
+          }
+        />
+      ),
+    },
+    {
+      name: "Tab 2",
+      value: "/ce:1/line-items",
+      path: ["/:ceId/line-items", "/:ceId/line-items/*"],
+      render: () => (
+        <TestTabContent
+          content={
+            <>
+              <h1>Tab 2 Content</h1>
+              <div>
+                <pre css={Css.dib.$}>tab.path = ["/:ceId/line-items", "/:ceId/line-items/*"]</pre>
+              </div>
+              <div css={Css.mt2.$}>
+                <p>Click below to load a sub route of this tab, which should keep this tab as "active"</p>
+                <Link to="/ce:1/line-items/celi:1/overview">Line Item Details</Link>
+                <div>
+                  <Route path="/:ceId/line-items/:celiId">Loaded Line Items Overview!</Route>
+                </div>
+              </div>
+            </>
+          }
+        />
+      ),
+    },
+    {
+      name: "Tab 3",
+      value: "/ce:1/history",
+      path: "/:ceId/history",
+      render: () => (
+        <TestTabContent
+          content={
+            <>
+              <h1>Tab 3 Content</h1>
+              <div>
+                <pre css={Css.dib.$}>tab.path = "/:ceId/history"</pre>
+              </div>
+            </>
+          }
+        />
+      ),
+    },
+    {
+      name: "Disabled Tab",
+      value: "/ce:1/disabled",
+      path: "/:ceId/disabled",
+      disabled: true,
+      render: () => <TestTabContent content="Disabled Tab" />,
+    },
+  ];
+  return (
+    <div>
+      <div css={Css.bb.bGray200.py1.mb2.$}>
+        <div>
+          <strong>Current URL:</strong> <pre css={Css.dib.$}>{location?.pathname}</pre>
+        </div>
+        <Button label="Reset to root path" onClick={() => history.push("/:ceId")} /> (Will match Tab 1)
+      </div>
+      <TabsWithContent tabs={routeTabs} />
+    </div>
+  );
+}
+
 export const TabsHiddenIfOnlyOneActive = () => {
   const testTabs: Tab<TabValue>[] = [
-    { name: "Tab 1", value: "tab1", render: () => <TestTabContent title="Tab 1 Content" /> },
-    { name: "Tab 2", value: "tab2", disabled: true, render: () => <TestTabContent title="Tab 2 Content" /> },
-    { name: "Tab 3", value: "tab3", disabled: true, render: () => <TestTabContent title="Tab 3 Content" /> },
-    { name: "Tab 4", value: "tab4", disabled: true, render: () => <TestTabContent title="Tab 4 Content" /> },
+    { name: "Tab 1", value: "tab1", render: () => <TestTabContent content="Tab 1 Content" /> },
+    { name: "Tab 2", value: "tab2", disabled: true, render: () => <TestTabContent content="Tab 2 Content" /> },
+    { name: "Tab 3", value: "tab3", disabled: true, render: () => <TestTabContent content="Tab 3 Content" /> },
+    { name: "Tab 4", value: "tab4", disabled: true, render: () => <TestTabContent content="Tab 4 Content" /> },
   ];
   return <TabsWithContent tabs={testTabs} onChange={() => {}} selected={"tab1"} ariaLabel="Sample Tabs" />;
 };
 
 const tabsWithIconsAndContent: Tab<TabValue>[] = [
-  { name: "Tab 1", value: "tab1", icon: "camera", render: () => <TestTabContent title="Tab 1 Content" /> },
-  { name: "Tab 2", value: "tab2", icon: "dollar", render: () => <TestTabContent title="Tab 2 Content" /> },
-  { name: "Tab 3", value: "tab3", icon: "check", render: () => <TestTabContent title="Tab 3 Content" /> },
-  { name: "Tab 4", value: "tab4", icon: "plus", render: () => <TestTabContent title="Tab 4 Content" /> },
+  { name: "Tab 1", value: "tab1", icon: "camera", render: () => <TestTabContent content="Tab 1 Content" /> },
+  { name: "Tab 2", value: "tab2", icon: "dollar", render: () => <TestTabContent content="Tab 2 Content" /> },
+  { name: "Tab 3", value: "tab3", icon: "check", render: () => <TestTabContent content="Tab 3 Content" /> },
+  { name: "Tab 4", value: "tab4", icon: "plus", render: () => <TestTabContent content="Tab 4 Content" /> },
 ];
 
 function getChildren(label: string) {

--- a/src/components/Tabs.stories.tsx
+++ b/src/components/Tabs.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { Fragment, useState } from "react";
-import { Route, useHistory, useLocation } from "react-router";
+import { Route, useHistory, useLocation, useParams } from "react-router";
 import { Link } from "react-router-dom";
 import { Button } from "src/components/Button";
 import { Css } from "src/Css";
@@ -22,13 +22,29 @@ export default {
 export function TabBaseStates() {
   const styles = getTabStyles();
   return (
-    <div css={Css.df.fdc.childGap2.$}>
-      <div css={{ ...styles.baseStyles, ...styles.activeStyles }}>{getChildren("active")}</div>
-      <div css={{ ...styles.baseStyles, ...styles.focusRingStyles }}>{getChildren("focus ring")}</div>
-      <div css={styles.baseStyles}>{getChildren("default")}</div>
-      <div css={{ ...styles.baseStyles, ...styles.disabledStyles }}>{getChildren("disabled")}</div>
-      <div css={{ ...styles.baseStyles, ...styles.hoverStyles }}>{getChildren("hovered")}</div>
-      <div css={{ ...styles.baseStyles, ...styles.activeHoverStyles }}>{getChildren("active hover")}</div>
+    <div css={Css.df.childGap5.$}>
+      <div css={Css.df.fdc.childGap2.$}>
+        <h2>
+          Rendered as <pre css={Css.dib.$}>&lt;Button /&gt;</pre>
+        </h2>
+        <div css={{ ...styles.baseStyles, ...styles.activeStyles }}>{getChildren("active")}</div>
+        <div css={{ ...styles.baseStyles, ...styles.focusRingStyles }}>{getChildren("focus ring")}</div>
+        <div css={styles.baseStyles}>{getChildren("default")}</div>
+        <div css={{ ...styles.baseStyles, ...styles.disabledStyles }}>{getChildren("disabled")}</div>
+        <div css={{ ...styles.baseStyles, ...styles.hoverStyles }}>{getChildren("hovered")}</div>
+        <div css={{ ...styles.baseStyles, ...styles.activeHoverStyles }}>{getChildren("active hover")}</div>
+      </div>
+      <div css={Css.df.fdc.childGap2.$}>
+        <h2>
+          Rendered as <pre css={Css.dib.$}>&lt;a /&gt;</pre>
+        </h2>
+        <div css={{ ...styles.baseStyles, ...styles.activeStyles }}>{getChildren("active")}</div>
+        <div css={{ ...styles.baseStyles, ...styles.focusRingStyles }}>{getChildren("focus ring")}</div>
+        <div css={styles.baseStyles}>{getChildren("default")}</div>
+        <div css={{ ...styles.baseStyles, ...styles.disabledStyles }}>{getChildren("disabled")}</div>
+        <div css={{ ...styles.baseStyles, ...styles.hoverStyles }}>{getChildren("hovered")}</div>
+        <div css={{ ...styles.baseStyles, ...styles.activeHoverStyles }}>{getChildren("active hover")}</div>
+      </div>
     </div>
   );
 }
@@ -57,7 +73,8 @@ export function TabsSeparateFromContent() {
 export function TabsAsLinks() {
   return <TestComponent />;
 }
-TabsAsLinks.decorators = [withRouter("/ce:1", "/:ceId")];
+// Use `/` as the root path in order to ensure the Tab's component provides a <Route /> wrapper for matching.
+TabsAsLinks.decorators = [withRouter("/ce:2", "/")];
 
 function TestComponent() {
   const location = useLocation();
@@ -65,65 +82,25 @@ function TestComponent() {
   const routeTabs: RouteTab<string>[] = [
     {
       name: "Tab 1",
-      value: "/ce:1/overview",
+      href: "/ce:2/overview",
       path: ["/:ceId/overview", "/:ceId"],
-      render: () => (
-        <TestTabContent
-          content={
-            <>
-              <h1>Tab 1 Content</h1>
-              <div>
-                <pre css={Css.dib.$}>tab.path = ["/:ceId/overview", "/:ceId"]</pre>
-              </div>
-            </>
-          }
-        />
-      ),
+      render: () => <RouteTab1 />,
     },
     {
       name: "Tab 2",
-      value: "/ce:1/line-items",
+      href: "/ce:2/line-items",
       path: ["/:ceId/line-items", "/:ceId/line-items/*"],
-      render: () => (
-        <TestTabContent
-          content={
-            <>
-              <h1>Tab 2 Content</h1>
-              <div>
-                <pre css={Css.dib.$}>tab.path = ["/:ceId/line-items", "/:ceId/line-items/*"]</pre>
-              </div>
-              <div css={Css.mt2.$}>
-                <p>Click below to load a sub route of this tab, which should keep this tab as "active"</p>
-                <Link to="/ce:1/line-items/celi:1/overview">Line Item Details</Link>
-                <div>
-                  <Route path="/:ceId/line-items/:celiId">Loaded Line Items Overview!</Route>
-                </div>
-              </div>
-            </>
-          }
-        />
-      ),
+      render: () => <RouteTab2 />,
     },
     {
       name: "Tab 3",
-      value: "/ce:1/history",
+      href: "/ce:2/history",
       path: "/:ceId/history",
-      render: () => (
-        <TestTabContent
-          content={
-            <>
-              <h1>Tab 3 Content</h1>
-              <div>
-                <pre css={Css.dib.$}>tab.path = "/:ceId/history"</pre>
-              </div>
-            </>
-          }
-        />
-      ),
+      render: () => <RouteTab3 />,
     },
     {
       name: "Disabled Tab",
-      value: "/ce:1/disabled",
+      href: "/ce:2/disabled",
       path: "/:ceId/disabled",
       disabled: true,
       render: () => <TestTabContent content="Disabled Tab" />,
@@ -135,7 +112,7 @@ function TestComponent() {
         <div>
           <strong>Current URL:</strong> <pre css={Css.dib.$}>{location?.pathname}</pre>
         </div>
-        <Button label="Reset to root path" onClick={() => history.push("/:ceId")} /> (Will match Tab 1)
+        <Button label="Reset to root path" onClick={() => history.push("/ce:2")} /> (Will match Tab 1)
       </div>
       <TabsWithContent tabs={routeTabs} />
     </div>
@@ -165,5 +142,51 @@ function getChildren(label: string) {
       {label}
       <Icon icon="checkCircle" css={Css.ml1.$} />
     </Fragment>
+  );
+}
+
+function RouteTab1() {
+  const { ceId } = useParams<{ ceId: string }>();
+  return (
+    <>
+      <h1 css={Css.lgEm.$}>Tab 1 Content</h1>
+      <h2>Params ceId = {ceId}</h2>
+      <div>
+        <pre css={Css.dib.$}>tab.path = ["/:ceId/overview", "/:ceId"]</pre>
+      </div>
+    </>
+  );
+}
+
+function RouteTab2() {
+  const { ceId } = useParams<{ ceId: string }>();
+  return (
+    <>
+      <h1 css={Css.lgEm.$}>Tab 2 Content</h1>
+      <h2>Params ceId = {ceId}</h2>
+      <div>
+        <pre css={Css.dib.$}>tab.path = ["/:ceId/line-items", "/:ceId/line-items/*"]</pre>
+      </div>
+      <div css={Css.mt2.$}>
+        <p>Click below to load a sub route of this tab, which should keep this tab as "active"</p>
+        <Link to="/ce:1/line-items/celi:1/overview">Line Item Details</Link>
+        <div>
+          <Route path="/:ceId/line-items/:celiId">Loaded Line Items Overview!</Route>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function RouteTab3() {
+  const { ceId } = useParams<{ ceId: string }>();
+  return (
+    <>
+      <h1 css={Css.lgEm.$}>Tab 3 Content</h1>
+      <h2>Params ceId = {ceId}</h2>
+      <div>
+        <pre css={Css.dib.$}>tab.path = "/:ceId/history"</pre>
+      </div>
+    </>
   );
 }

--- a/src/components/Tabs.test.tsx
+++ b/src/components/Tabs.test.tsx
@@ -1,13 +1,13 @@
 import { fireEvent } from "@testing-library/react";
 import { useState } from "react";
 import { Palette } from "src/Css";
-import { click, render } from "src/utils/rtl";
-import { getNextTabValue, Tab, TabsWithContent } from "./Tabs";
+import { click, render, withRouter } from "src/utils/rtl";
+import { getNextTabValue, RouteTab, Tab, TabsWithContent } from "./Tabs";
 import { TabValue, TestTabContent, testTabs } from "./testData";
 
 describe("TabsWithContent", () => {
   it("should display content of selected tab", async () => {
-    const r = await render(<TestTabs />);
+    const r = await render(<TestTabs />, withRouter());
     // tab panel should initially display Tab 1 Content
     expect(r.tab_panel()).toHaveTextContent("Tab 1 Content");
     // when we click on the 4th tab
@@ -18,7 +18,7 @@ describe("TabsWithContent", () => {
 
   it("should update the active tab", async () => {
     // Given we start out on tab1
-    const r = await render(<TestTabs />);
+    const r = await render(<TestTabs />, withRouter());
     expect(r.tabs_tab1()).toHaveStyleRule("color", Palette.LightBlue700);
     // when an external state change moves us to the 2nd tab
     click(r.goToTab2);
@@ -28,7 +28,7 @@ describe("TabsWithContent", () => {
 
   it("should reset the active tab on blur", async () => {
     // Given we start out on tab1
-    const r = await render(<TestTabs />);
+    const r = await render(<TestTabs />, withRouter());
     expect(r.tabs_tab1()).toHaveStyleRule("color", Palette.LightBlue700);
     // And we've moved to the 2nd tab
     fireEvent.keyUp(r.tabs_tab2(), { key: "ArrowRight" });
@@ -41,7 +41,7 @@ describe("TabsWithContent", () => {
 
   it("cannot click on disabled tabs", async () => {
     // Given we start out on tab1
-    const r = await render(<TestTabs />);
+    const r = await render(<TestTabs />, withRouter());
     expect(r.tabs_tab1()).toHaveStyleRule("color", Palette.LightBlue700);
     // And we try to click on the 3rd disabled tab
     click(r.tabs_tab3);
@@ -78,16 +78,76 @@ describe("TabsWithContent", () => {
   it("hides the tabs if only a single tab is enabled", async () => {
     // Given only the 1st tab is enabled
     const testTabs: Tab<TabValue>[] = [
-      { name: "Tab 1", value: "tab1", render: () => <TestTabContent title="Tab 1 Content" /> },
-      { name: "Tab 2", value: "tab2", disabled: true, render: () => <TestTabContent title="Tab 2 Content" /> },
-      { name: "Tab 3", value: "tab3", disabled: true, render: () => <TestTabContent title="Tab 3 Content" /> },
-      { name: "Tab 4", value: "tab4", disabled: true, render: () => <TestTabContent title="Tab 4 Content" /> },
+      { name: "Tab 1", value: "tab1", render: () => <TestTabContent content="Tab 1 Content" /> },
+      { name: "Tab 2", value: "tab2", disabled: true, render: () => <TestTabContent content="Tab 2 Content" /> },
+      { name: "Tab 3", value: "tab3", disabled: true, render: () => <TestTabContent content="Tab 3 Content" /> },
+      { name: "Tab 4", value: "tab4", disabled: true, render: () => <TestTabContent content="Tab 4 Content" /> },
     ];
-    const r = await render(<TabsWithContent tabs={testTabs} onChange={() => {}} selected="tab1" />);
+    const r = await render(<TabsWithContent tabs={testTabs} onChange={() => {}} selected="tab1" />, withRouter());
     // Then the tabs are not even in the dom
     expect(() => r.tabs_tab1()).toThrow("Unable to find an element");
     // But the selected tab's content is shown
     expect(r.tab_panel().textContent).toBe("Tab 1 Content");
+  });
+
+  it("renders tabs as links", async () => {
+    const router = withRouter("/tab1");
+    // Given tabs with `path` values
+    const testTabs: RouteTab<string>[] = [
+      { name: "Tab 1", path: "/tab1", value: "/tab1", render: () => <TestTabContent content="Tab 1 Content" /> },
+      { name: "Tab 2", path: "/tab2", value: "/tab2", render: () => <TestTabContent content="Tab 2 Content" /> },
+    ];
+    const r = await render(<TabsWithContent tabs={testTabs} />, router);
+
+    // Then the tab elements are links with expected `href` values
+    expect(r.tabs_tab1().tagName).toBe("A");
+    expect(r.tabs_tab1()).toHaveAttribute("href", "/tab1");
+    expect(r.tabs_tab2().tagName).toBe("A");
+    expect(r.tabs_tab2()).toHaveAttribute("href", "/tab2");
+  });
+
+  it("can match tab based on multiple paths", async () => {
+    // Given a route
+    const router = withRouter("/ce:1", "/:ceId");
+    // And a tab that supports multiple routes
+    const testTabs: RouteTab<string>[] = [
+      {
+        name: "Tab 1",
+        path: "/:ceId/line-items",
+        value: "/ce:1/line-items",
+        render: () => <TestTabContent content="Tab 1 Content" />,
+      },
+      {
+        name: "Tab 2",
+        path: ["/:ceId", "/:ceId/overview"],
+        value: "/ce:1/overview",
+        render: () => <TestTabContent content="Tab 2 Content" />,
+      },
+    ];
+    const r = await render(<TabsWithContent tabs={testTabs} />, router);
+
+    // Then expect the second tab to be active
+    expect(r.tab_panel().textContent).toBe("Tab 2 Content");
+  });
+
+  it("can navigate between tabs when rendered as links", async () => {
+    // Given Route-able tabs, rendered at the first tab's route
+    const router = withRouter("/tab1", "/");
+    const testTabs: RouteTab<string>[] = [
+      { name: "Tab 1", path: "/tab1", value: "/tab1", render: () => <TestTabContent content="Tab 1 Content" /> },
+      { name: "Tab 2", path: "/tab2", value: "/tab2", render: () => <TestTabContent content="Tab 2 Content" /> },
+    ];
+    const r = await render(<TabsWithContent tabs={testTabs} />, router);
+
+    // Then expect the first tab to be active
+    expect(r.tab_panel().textContent).toBe("Tab 1 Content");
+
+    // When clicking the second tab
+    click(r.tabs_tab2);
+
+    // Then expect the URL to be updated and the tab panel to show the selected tab's content
+    expect(router.history.location.pathname).toBe("/tab2");
+    expect(r.tab_panel().textContent).toBe("Tab 2 Content");
   });
 });
 

--- a/src/components/testData.tsx
+++ b/src/components/testData.tsx
@@ -1,14 +1,15 @@
+import { ReactNode } from "react";
 import { Tab } from "./Tabs";
 
 export type TabValue = "tab1" | "tab2" | "tab3" | "tab4";
 
 export const testTabs: Tab<TabValue>[] = [
-  { name: "Tab 1", value: "tab1", render: () => <TestTabContent title="Tab 1 Content" /> },
-  { name: "Tab 2", value: "tab2", render: () => <TestTabContent title="Tab 2 Content" /> },
-  { name: "Tab 3", value: "tab3", disabled: true, render: () => <TestTabContent title="Tab 3 Content" /> },
-  { name: "Tab 4", value: "tab4", render: () => <TestTabContent title="Tab 4 Content" /> },
+  { name: "Tab 1", value: "tab1", render: () => <TestTabContent content="Tab 1 Content" /> },
+  { name: "Tab 2", value: "tab2", render: () => <TestTabContent content="Tab 2 Content" /> },
+  { name: "Tab 3", value: "tab3", disabled: true, render: () => <TestTabContent content="Tab 3 Content" /> },
+  { name: "Tab 4", value: "tab4", render: () => <TestTabContent content="Tab 4 Content" /> },
 ];
 
-export function TestTabContent({ title }: { title: string }) {
-  return <div>{title}</div>;
+export function TestTabContent({ content }: { content: ReactNode }) {
+  return <div>{content}</div>;
 }


### PR DESCRIPTION
Allows Tabs to accept a 'path' property which will render the Tab component as a link, using React Router to navigate between tabs.
Selected tab will be based on the route instead of passing a "selected" property into the Tabs component.
Change default Tab element to be a Button which will allow for native 'on Enter key' handling in DOM. In order to achieve this we also need to properly set focus on the element as the user navigates between them via Keyboard.