### PR TITLE
fix: Do not allow ListBox to show on top of trigger element

### DIFF
--- a/src/components/internal/Option.tsx
+++ b/src/components/internal/Option.tsx
@@ -37,11 +37,7 @@ export function Option<T>({
       key: item.key,
       isDisabled,
       isSelected,
-      // If this is true, then a user can: 1) press down to open the select menu,
-      // 2) have the menu drawn under their mouse cursor, 3) release their press
-      // and useSelectableItem will fire onPress/select and cause the
-      // accidentally-selected item to be added to the list.
-      shouldSelectOnPressUp: false,
+      shouldSelectOnPressUp: true,
       shouldFocusOnHover: true,
       shouldUseVirtualFocus: true,
     },

--- a/src/inputs/internal/SelectFieldBase.tsx
+++ b/src/inputs/internal/SelectFieldBase.tsx
@@ -245,6 +245,7 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
     shouldFlip: true,
     isOpen: state.isOpen,
     onClose: state.close,
+    placement: "bottom",
   });
 
   positionProps.style = {
@@ -291,6 +292,7 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
         >
           <ListBox
             {...listBoxProps}
+            positionProps={positionProps}
             state={state}
             compact={compact}
             listBoxRef={listBoxRef}


### PR DESCRIPTION
A bug was originally discovered when triggering the ListBox on top of the SelectField where an option would be immediately selected due to selection happening onPointerUp and the ListBox being triggered onPointerDown. This was originally fixed by setting 'shouldSelectOnPressUp: false' for the Options within the ListBox. Though, this traded one bug for another. Recently discovered was that the subsequent onPointerDown event fired after selecting an Option could have adverse effects, such as trigger a modal to close if the ListBox was rendered on top of the Modal's underlay element.

To address this issue, we went back to the root problem and now prevent the Menu from ever rendering above its trigger element. This is done by utilizing the OverlayPosition props, which include a 'maxHeight' property we use to define the ListBox's height. This ensures it will only take up the space available between the trigger and the edge of the viewport. A height is needed to be set due to the virtualization library used to render the ListBox's options.