### PR TITLE
fix: Add OpenModal.keepOpen for doing tape-style measurements.

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { useEffect } from "react";
-import { Button, ModalFooter, ModalHeader, ModalProps, useModal } from "src/components/index";
+import { Button, ModalBody, ModalFooter, ModalHeader, ModalProps, OpenModal, useModal } from "src/components/index";
 import { Modal } from "src/components/Modal/Modal";
 import { TestModalContent, TestModalFilterTable } from "src/components/Modal/TestModalContent";
 import { noop } from "src/utils/index";
@@ -23,6 +23,7 @@ export const FilterableStaticHeight = () => (
   <ModalFilterTableExample size={{ width: "md", height: 600 }} forceScrolling={true} />
 );
 export const HeaderWithComponents = () => <ModalExample size="lg" withTag />;
+
 export const ButtonsInFooter = () => {
   const { openModal } = useModal();
   const open = () =>
@@ -40,6 +41,30 @@ export const ButtonsInFooter = () => {
   // Immediately open the modal for Chromatic snapshots
   useEffect(open, [openModal]);
   return <Button label="Open" onClick={open} />;
+};
+
+export const OpenModalTest = () => {
+  return (
+    <OpenModal>
+      <>
+        <ModalHeader>Add</ModalHeader>
+        <ModalBody>Body</ModalBody>
+        <ModalFooter>Footer</ModalFooter>
+      </>
+    </OpenModal>
+  );
+};
+
+export const OpenModalKeepOpen = () => {
+  return (
+    <OpenModal keepOpen={true}>
+      <>
+        <ModalHeader>Add</ModalHeader>
+        <ModalBody>Body</ModalBody>
+        <ModalFooter> Footer </ModalFooter>
+      </>
+    </OpenModal>
+  );
 };
 
 interface ModalExampleProps extends Pick<ModalProps, "size" | "forceScrolling"> {

--- a/src/components/Modal/OpenModal.tsx
+++ b/src/components/Modal/OpenModal.tsx
@@ -1,11 +1,20 @@
 import { useEffect } from "react";
-import { ModalProps } from "src/components/Modal/Modal";
+import { Modal, ModalProps } from "src/components/Modal/Modal";
 import { useModal } from "src/components/Modal/useModal";
 
+export interface OpenModalProps {
+  /** The custom modal content to show. */
+  children: JSX.Element;
+  /** The size to use. */
+  size?: ModalProps["size"];
+  /** Whether to force the modal to stay open. This is useful for stories where ruler/tape extensions cause the modal to close. */
+  keepOpen?: boolean;
+}
+
 /**
- * A component for testing open modals in unit tests.
+ * A component for testing open modals in stories and unit tests.
  *
- * Current, calling `render(<ModalComponent />)` in a test currently doesn't work, because
+ * Currently, calling `render(<ModalComponent />)` in a test currently doesn't work, because
  * nothing has called `useModal` to get the header & footer mounted into the DOM.
  *
  * So instead tests can call:
@@ -21,9 +30,17 @@ import { useModal } from "src/components/Modal/useModal";
  * And `OpenModal` will do a boilerplate `openModal` call, so that the content
  * shows up in the DOM as expected.
  */
-export function OpenModal(props: { children: JSX.Element; size?: ModalProps["size"] }): JSX.Element {
+export function OpenModal(props: OpenModalProps): JSX.Element {
   const { openModal } = useModal();
-  const { size, children } = props;
-  useEffect(() => openModal({ size, content: children }), [openModal, size, children]);
-  return <div>dummy content</div>;
+  const { size, children, keepOpen } = props;
+  useEffect(() => {
+    if (!keepOpen) {
+      openModal({ size, content: children });
+    }
+  }, [keepOpen, openModal, size, children]);
+  if (keepOpen) {
+    return <Modal size={size} content={children} />;
+  } else {
+    return <div>dummy content</div>;
+  }
 }


### PR DESCRIPTION
I went through much gnashing of teeth to very specifically pad form elements in a modal, particularly b/c all of the tape / measure / etc. extensions I found (for both chrome and FF), and also FF's built-in measure feature, all would cause the modal to close.

This adds a `keepOpen` prop to `OpenModal` that skips the `openModal`/`closeModal` hook and just redirectly renders the `Modal` in the DOM.

I'm planning on making this the default for any story that uses `modal: true` in blueprint, b/c I figure testing close is not really that important in stories.