### PR TITLE
fix: Support setting padding as part of nested scrolling layout

### DIFF
--- a/src/components/Layout/FullBleed.tsx
+++ b/src/components/Layout/FullBleed.tsx
@@ -1,0 +1,16 @@
+import { cloneElement, ReactElement } from "react";
+import { useScrollableParent } from "src/components/Layout/ScrollableParent";
+import { Css, px } from "src/Css";
+
+/** Provides a way to extend the full width of the ScrollableParent */
+export function FullBleed({ children, omitPadding = false }: { children: ReactElement; omitPadding?: boolean }) {
+  const { paddingX } = useScrollableParent();
+  return !paddingX
+    ? children
+    : cloneElement(children, {
+        style: Css.mlPx(paddingX * -1)
+          .w(`calc(100% + ${px(paddingX * 2)})`)
+          .if(!omitPadding)
+          .pxPx(paddingX).$,
+      });
+}

--- a/src/components/Layout/FullBleed.tsx
+++ b/src/components/Layout/FullBleed.tsx
@@ -1,6 +1,6 @@
 import { cloneElement, ReactElement } from "react";
 import { useScrollableParent } from "src/components/Layout/ScrollableParent";
-import { Css, px } from "src/Css";
+import { Css } from "src/Css";
 
 /** Provides a way to extend the full width of the ScrollableParent */
 export function FullBleed({ children, omitPadding = false }: { children: ReactElement; omitPadding?: boolean }) {
@@ -8,8 +8,7 @@ export function FullBleed({ children, omitPadding = false }: { children: ReactEl
   return !paddingX
     ? children
     : cloneElement(children, {
-        style: Css.mlPx(paddingX * -1)
-          .w(`calc(100% + ${px(paddingX * 2)})`)
+        style: Css.mxPx(paddingX * -1)
           .if(!omitPadding)
           .pxPx(paddingX).$,
       });

--- a/src/components/Layout/FullBleed.tsx
+++ b/src/components/Layout/FullBleed.tsx
@@ -4,12 +4,10 @@ import { Css } from "src/Css";
 
 /** Provides a way to extend the full width of the ScrollableParent */
 export function FullBleed({ children, omitPadding = false }: { children: ReactElement; omitPadding?: boolean }) {
-  const { paddingX } = useScrollableParent();
-  return !paddingX
+  const { pr, pl } = useScrollableParent();
+  return !pr && !pl
     ? children
     : cloneElement(children, {
-        style: Css.mxPx(paddingX * -1)
-          .if(!omitPadding)
-          .pxPx(paddingX).$,
+        style: Css.ml(`-${pl}`).mr(`-${pr}`).if(!omitPadding).pl(pl).pr(pr).$,
       });
 }

--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -1,8 +1,9 @@
 import { Meta } from "@storybook/react";
 import { PropsWithChildren, ReactNode, useState } from "react";
 import { IconButton } from "src/components/IconButton";
+import { FullBleed } from "src/components/Layout/FullBleed";
 import { Tab, TabsWithContent } from "src/components/Tabs";
-import { Css } from "src/Css";
+import { Css, increment } from "src/Css";
 import { FormLines } from "src/forms";
 import { PreventBrowserScroll, ScrollableContent, ScrollableParent } from "src/index";
 import { NumberField } from "src/inputs";
@@ -35,13 +36,11 @@ export function WithoutScrollContainer() {
   return (
     <TestLayout>
       <TestHeader title="Change Event - Mud Room" />
-      <div css={consistentPadding}>
-        <p css={Css.py1.$}>
-          This is page "forgot" to use the Nested Scrolling components, though still can scroll thanks to an overflow
-          auto fallback.
-        </p>
-        <TableExample />
-      </div>
+      <p css={Css.py1.$}>
+        This is page "forgot" to use the Nested Scrolling components, though still can scroll thanks to an overflow auto
+        fallback.
+      </p>
+      <TableExample />
     </TestLayout>
   );
 }
@@ -53,16 +52,14 @@ export function EditableTableSize() {
   return (
     <TestProjectLayout>
       <TestHeader title="Change Event - Mud Room" />
-      <div css={{ ...consistentPadding, ...Css.py1.$ }}>
+      <div css={Css.py1.$}>
         <FormLines width="sm">
           <NumberField label="Number of rows" value={rows} onChange={(n) => n && setRows(n)} compact />
           <NumberField label="Number of columns" value={cols} onChange={(n) => n && setCols(n)} compact />
         </FormLines>
       </div>
       <ScrollableContent>
-        <div css={consistentPadding}>
-          <ScrollableTableExample numCols={cols} numRows={rows} />
-        </div>
+        <ScrollableTableExample numCols={cols} numRows={rows} />
       </ScrollableContent>
     </TestProjectLayout>
   );
@@ -80,7 +77,7 @@ function ExamplePageComponent({ contentAboveTable }: { contentAboveTable?: boole
       {/* Probably will move away from `usePageHeader` and instead go to this. */}
       <TestHeader title="Change Event - Mud Room" />
 
-      <div css={{ ...consistentPadding, ...Css.py1.$ }}>
+      <div css={Css.py1.$}>
         <TabsWithContent selected={selectedTab} tabs={tabs} onChange={(t) => setSelectedTab(t)} />
       </div>
     </>
@@ -90,18 +87,16 @@ function ExamplePageComponent({ contentAboveTable }: { contentAboveTable?: boole
 function OverviewExample() {
   return (
     <ScrollableContent>
-      <div css={consistentPadding}>
-        <h1 css={Css.lgEm.mb3.$}>Detail</h1>
-        {zeroTo(10).map((i) => (
-          <p css={Css.mb3.$}>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
-            dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex
-            ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat
-            nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit
-            anim id est laborum.
-          </p>
-        ))}
-      </div>
+      <h1 css={Css.lgEm.mb3.$}>Detail</h1>
+      {zeroTo(10).map((i) => (
+        <p css={Css.mb3.$}>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+          magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+          consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+          est laborum.
+        </p>
+      ))}
     </ScrollableContent>
   );
 }
@@ -109,15 +104,13 @@ function OverviewExample() {
 function HistoryExample() {
   return (
     <>
-      <div css={{ ...Css.lgEm.$, ...consistentPadding }}>History</div>
+      <div css={Css.lgEm.$}>History</div>
       <ScrollableContent>
-        <div css={consistentPadding}>
-          <ul css={Css.df.fdc.childGap2.$}>
-            {zeroTo(20).map((i) => (
-              <li>History Item {i + 1}</li>
-            ))}
-          </ul>
-        </div>
+        <ul css={Css.df.fdc.childGap2.$}>
+          {zeroTo(20).map((i) => (
+            <li>History Item {i + 1}</li>
+          ))}
+        </ul>
       </ScrollableContent>
     </>
   );
@@ -126,9 +119,7 @@ function HistoryExample() {
 function ScrollableTableExample({ numCols, numRows }: { numCols?: number; numRows?: number }) {
   return (
     <ScrollableContent>
-      <div css={consistentPadding}>
-        <TableExample numCols={numCols} numRows={numRows} />
-      </div>
+      <TableExample numCols={numCols} numRows={numRows} />
     </ScrollableContent>
   );
 }
@@ -165,20 +156,23 @@ function TestLayout({ children }: PropsWithChildren<{}>) {
   return (
     <PreventBrowserScroll>
       <TestTopNav />
-      <ScrollableParent>{children}</ScrollableParent>
+      <ScrollableParent paddingX={increment(3)}>{children}</ScrollableParent>
     </PreventBrowserScroll>
   );
 }
 
 function TestProjectLayout({ children }: PropsWithChildren<{}>) {
   return (
-    <TestLayout>
+    <PreventBrowserScroll>
+      <TestTopNav />
       {/* Required to use `overflowHidden` as the prevent the `TestLayout`'s scrollbar from kicking in. */}
       <div css={Css.df.overflowHidden.$}>
         <TestSideNav />
-        <ScrollableParent xss={Css.fg1.$}>{children}</ScrollableParent>
+        <ScrollableParent xss={Css.fg1.$} paddingX={increment(3)}>
+          {children}
+        </ScrollableParent>
       </div>
-    </TestLayout>
+    </PreventBrowserScroll>
   );
 }
 
@@ -189,17 +183,22 @@ function TestTopNav() {
 function TestSideNav() {
   const [showNav, setShowNav] = useState(true);
   return (
-    <ScrollableParent xss={Css.transition.br.bGray200.fg0.fs0.ml0.wPx(224).if(!showNav).mlPx(-186).$}>
+    <ScrollableParent
+      paddingX={increment(2)}
+      xss={Css.transition.br.bGray200.fg0.fs0.wPx(224).if(!showNav).mlPx(-186).$}
+    >
       <div css={Css.relative.$}>
-        <div css={Css.absolute.top1.rightPx(4).bgGray50.df.aic.jcc.$}>
+        <div css={Css.absolute.top1.rightPx(-12).bgGray50.df.aic.jcc.$}>
           <IconButton icon={showNav ? "menuClose" : "menuOpen"} onClick={() => setShowNav(!showNav)} />
         </div>
         {showNav && (
           <>
-            <h2 css={Css.bb.bGray200.px2.py3.$}>Scrollable Side Navigation</h2>
+            <FullBleed>
+              <h2 css={Css.bb.bGray200.py3.$}>Scrollable Side Navigation</h2>
+            </FullBleed>
             <ScrollableContent>
               <nav>
-                <ul css={Css.listReset.df.fdc.childGap5.mt2.px2.$}>
+                <ul css={Css.listReset.df.fdc.childGap5.mt2.$}>
                   {zeroTo(20).map((i) => (
                     <li key={i}>Side Navigation Item</li>
                   ))}
@@ -214,12 +213,12 @@ function TestSideNav() {
   );
 }
 
-const consistentPadding = Css.px3.$;
-
 function TestHeader({ title }: { title: ReactNode }) {
   return (
-    <header css={{ ...Css.py2.bb.bGray200.$, ...consistentPadding }}>
-      <h1 css={Css.xlEm.$}>{title}</h1>
-    </header>
+    <FullBleed>
+      <header css={{ ...Css.py2.bb.bGray200.$ }}>
+        <h1 css={Css.xlEm.$}>{title}</h1>
+      </header>
+    </FullBleed>
   );
 }

--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -3,7 +3,7 @@ import { PropsWithChildren, ReactNode, useState } from "react";
 import { IconButton } from "src/components/IconButton";
 import { FullBleed } from "src/components/Layout/FullBleed";
 import { Tab, TabsWithContent } from "src/components/Tabs";
-import { Css, increment } from "src/Css";
+import { Css } from "src/Css";
 import { FormLines } from "src/forms";
 import { PreventBrowserScroll, ScrollableContent, ScrollableParent } from "src/index";
 import { NumberField } from "src/inputs";
@@ -65,7 +65,7 @@ export function EditableTableSize() {
   );
 }
 
-function ExamplePageComponent({ contentAboveTable }: { contentAboveTable?: boolean }) {
+function ExamplePageComponent() {
   const [selectedTab, setSelectedTab] = useState("lineItems");
   const tabs: Tab[] = [
     { value: "overview", name: "Overview", render: () => <OverviewExample /> },
@@ -156,7 +156,7 @@ function TestLayout({ children }: PropsWithChildren<{}>) {
   return (
     <PreventBrowserScroll>
       <TestTopNav />
-      <ScrollableParent paddingX={increment(3)}>{children}</ScrollableParent>
+      <ScrollableParent xss={Css.px(3).$}>{children}</ScrollableParent>
     </PreventBrowserScroll>
   );
 }
@@ -168,9 +168,7 @@ function TestProjectLayout({ children }: PropsWithChildren<{}>) {
       {/* Required to use `overflowHidden` as the prevent the `TestLayout`'s scrollbar from kicking in. */}
       <div css={Css.df.overflowHidden.$}>
         <TestSideNav />
-        <ScrollableParent xss={Css.fg1.$} paddingX={increment(3)}>
-          {children}
-        </ScrollableParent>
+        <ScrollableParent xss={Css.fg1.px3.$}>{children}</ScrollableParent>
       </div>
     </PreventBrowserScroll>
   );
@@ -183,10 +181,7 @@ function TestTopNav() {
 function TestSideNav() {
   const [showNav, setShowNav] = useState(true);
   return (
-    <ScrollableParent
-      paddingX={increment(2)}
-      xss={Css.transition.br.bGray200.fg0.fs0.wPx(224).if(!showNav).mlPx(-186).$}
-    >
+    <ScrollableParent xss={Css.transition.br.bGray200.fg0.fs0.wPx(224).px2.if(!showNav).mlPx(-186).$}>
       <div css={Css.relative.$}>
         <div css={Css.absolute.top1.rightPx(-12).bgGray50.df.aic.jcc.$}>
           <IconButton icon={showNav ? "menuClose" : "menuOpen"} onClick={() => setShowNav(!showNav)} />

--- a/src/components/Layout/ScrollableParent.tsx
+++ b/src/components/Layout/ScrollableParent.tsx
@@ -3,21 +3,24 @@ import { Css, Properties } from "src/Css";
 
 interface ScrollableParentContextProps {
   scrollableEl: HTMLElement;
+  paddingX: number;
 }
 
 const ScrollableParentContext = createContext<ScrollableParentContextProps>({
   scrollableEl: document.createElement("div"),
+  paddingX: 0,
 });
 
 // Allow any css to be applied to the ScrollableParent container.
 interface ScrollableParentContextProviderProps {
   xss?: Properties;
+  paddingX?: number;
 }
 
-export function ScrollableParent({ children, xss }: PropsWithChildren<ScrollableParentContextProviderProps>) {
+export function ScrollableParent({ children, xss, paddingX }: PropsWithChildren<ScrollableParentContextProviderProps>) {
   const scrollableEl = useMemo(() => document.createElement("div"), []);
   const scrollableRef = useRef<HTMLDivElement | null>(null);
-  const context: ScrollableParentContextProps = { scrollableEl };
+  const context: ScrollableParentContextProps = { scrollableEl, paddingX: paddingX ?? 0 };
 
   useEffect(() => {
     scrollableRef.current!.appendChild(scrollableEl);
@@ -29,8 +32,9 @@ export function ScrollableParent({ children, xss }: PropsWithChildren<Scrollable
        * Otherwise, the flex-item's min-height/width is based on the content of the flex-item, which maybe overflow the container.
        * See https://stackoverflow.com/questions/42130384/why-should-i-specify-height-0-even-if-i-specified-flex-basis-0-in-css3-flexbox */}
       <div css={{ ...Css.mh0.mw0.df.fdc.$, ...xss }}>
-        {children}
-        <div css={Css.overflowAuto.$} ref={scrollableRef}></div>
+        <div css={Css.pxPx(context.paddingX).$}>{children}</div>
+        {/* Set fg1 to take up the remaining space in the viewport.*/}
+        <div css={{ ...Css.overflowAuto.$, ...Css.pxPx(context.paddingX).$ }} ref={scrollableRef}></div>
       </div>
     </ScrollableParentContext.Provider>
   );

--- a/src/components/Layout/ScrollableParent.tsx
+++ b/src/components/Layout/ScrollableParent.tsx
@@ -3,24 +3,26 @@ import { Css, Properties } from "src/Css";
 
 interface ScrollableParentContextProps {
   scrollableEl: HTMLElement;
-  paddingX: number;
+  pr: string | number;
+  pl: string | number;
 }
 
 const ScrollableParentContext = createContext<ScrollableParentContextProps>({
   scrollableEl: document.createElement("div"),
-  paddingX: 0,
+  pr: 0,
+  pl: 0,
 });
 
 // Allow any css to be applied to the ScrollableParent container.
 interface ScrollableParentContextProviderProps {
   xss?: Properties;
-  paddingX?: number;
 }
 
-export function ScrollableParent({ children, xss, paddingX }: PropsWithChildren<ScrollableParentContextProviderProps>) {
+export function ScrollableParent({ children, xss }: PropsWithChildren<ScrollableParentContextProviderProps>) {
   const scrollableEl = useMemo(() => document.createElement("div"), []);
   const scrollableRef = useRef<HTMLDivElement | null>(null);
-  const context: ScrollableParentContextProps = { scrollableEl, paddingX: paddingX ?? 0 };
+  const { paddingLeft, paddingRight, ...otherXss } = xss || {};
+  const context: ScrollableParentContextProps = { scrollableEl, pl: paddingLeft ?? 0, pr: paddingRight ?? 0 };
 
   useEffect(() => {
     scrollableRef.current!.appendChild(scrollableEl);
@@ -31,10 +33,10 @@ export function ScrollableParent({ children, xss, paddingX }: PropsWithChildren<
       {/* mh0/mw0 will respect the flexbox boundaries of the "flex-direction" if set on a parent.
        * Otherwise, the flex-item's min-height/width is based on the content of the flex-item, which maybe overflow the container.
        * See https://stackoverflow.com/questions/42130384/why-should-i-specify-height-0-even-if-i-specified-flex-basis-0-in-css3-flexbox */}
-      <div css={{ ...Css.mh0.mw0.df.fdc.$, ...xss }}>
-        <div css={Css.pxPx(context.paddingX).$}>{children}</div>
+      <div css={{ ...Css.mh0.mw0.df.fdc.$, ...otherXss }}>
+        <div css={Css.pl(context.pl).pr(context.pr).$}>{children}</div>
         {/* Set fg1 to take up the remaining space in the viewport.*/}
-        <div css={{ ...Css.overflowAuto.$, ...Css.pxPx(context.paddingX).$ }} ref={scrollableRef}></div>
+        <div css={{ ...Css.overflowAuto.$, ...Css.pl(context.pl).pr(context.pr).$ }} ref={scrollableRef}></div>
       </div>
     </ScrollableParentContext.Provider>
   );


### PR DESCRIPTION
As I started to pull `<ScrollableParent />` and `<ScrollContent />` components into Blueprint, I found it quite cumbersome to define the consistent padding between all the pages. This change allows for setting that consistent padding, but also provides a `<FullBleed />` component that utilizes the set padding to have the component expand the full width of the `<ScrollableParent />`