### PR TITLE
fix: Remove hardcoded width from NavLink side variant

### DIFF
--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -83,7 +83,7 @@ const navLinkVariantStyles: Record<
   { baseStyles: {}; hoverStyles: {}; disabledStyles: {}; focusRingStyles: {}; activeStyles: {}; pressedStyles: {} }
 > = {
   side: {
-    baseStyles: { ...baseStyles, ...Css.wPx(184).gray700.$ },
+    baseStyles: { ...baseStyles, ...Css.gray700.$ },
     activeStyles: Css.lightBlue700.bgLightBlue50.$,
     disabledStyles: Css.gray400.cursorNotAllowed.$,
     focusRingStyles: Css.bgLightBlue50.bshFocus.$,


### PR DESCRIPTION
The width isn't really necessary. Having a hard coded with is more trouble than its worth, and the size should be flexible based on content and parent element.