### PR TITLE
feat: Support 'emptyCell' GridStyle.

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -10,6 +10,7 @@ import {
   condensedStyle,
   dateColumn,
   defaultStyle,
+  emptyCell,
   GridColumn,
   GridDataRow,
   GridRowLookup,
@@ -684,9 +685,10 @@ export function CustomEmptyCell() {
   const nameColumn: GridColumn<Row> = { header: "Name", data: ({ name }) => name };
   const valueColumn: GridColumn<Row> = { header: "Value", data: ({ value }) => value };
   const actionColumn: GridColumn<Row> = { header: "Action", data: () => <div>Actions</div> };
+  const fourthColumn: GridColumn<Row> = { header: "Really Empty", data: () => emptyCell };
   return (
     <GridTable<Row>
-      columns={[nameColumn, valueColumn, actionColumn]}
+      columns={[nameColumn, valueColumn, actionColumn, fourthColumn]}
       style={{ ...condensedStyle, emptyCell: <>&mdash;</> }}
       rows={[
         { kind: "header", id: "header" },

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -33,7 +33,7 @@ export default {
   parameters: { layout: "fullscreen", backgrounds: { default: "white" } },
 } as Meta;
 
-type Data = { name: string; value: number };
+type Data = { name: string | undefined; value: number | undefined };
 type Row = SimpleHeaderAndDataOf<Data>;
 
 export function ClientSideSorting() {
@@ -644,6 +644,7 @@ export function ColSpan() {
     header: "ID",
     data: ({ id }) => id,
     // Not putting the colspan here just as a POC that we can colspan somewhere other than from the first column.
+    // We should expect this to show the `emptyCell` fallback
     total: "",
   });
   const nameCol = column<ColspanRow>({
@@ -666,6 +667,7 @@ export function ColSpan() {
   return (
     <GridTable<ColspanRow>
       columns={[idCol, nameCol, detailCol, dateCol, priceCol]}
+      style={{ ...condensedStyle, emptyCell: <>&mdash;</> }}
       rows={[
         simpleHeader,
         { kind: "data", id: "1", name: "Foo", role: "Manager", date: "11/29/85", priceInCents: 113_00 },
@@ -673,6 +675,24 @@ export function ColSpan() {
         { kind: "data", id: "3", name: "Biz", role: "Engineer", date: "11/08/18", priceInCents: 80_65 },
         { kind: "data", id: "4", name: "Baz", role: "Contractor", date: "04/21/21", priceInCents: 12_365_00 },
         { kind: "total", id: "total", totalPriceInCents: 14_083_64 },
+      ]}
+    />
+  );
+}
+
+export function CustomEmptyCell() {
+  const nameColumn: GridColumn<Row> = { header: "Name", data: ({ name }) => name };
+  const valueColumn: GridColumn<Row> = { header: "Value", data: ({ value }) => value };
+  const actionColumn: GridColumn<Row> = { header: "Action", data: () => <div>Actions</div> };
+  return (
+    <GridTable<Row>
+      columns={[nameColumn, valueColumn, actionColumn]}
+      style={{ ...condensedStyle, emptyCell: <>&mdash;</> }}
+      rows={[
+        { kind: "header", id: "header" },
+        { kind: "data", id: "1", name: "c", value: 1 },
+        { kind: "data", id: "2", name: "b", value: undefined },
+        { kind: "data", id: "3", name: "", value: 3 },
       ]}
     />
   );

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1043,7 +1043,10 @@ describe("GridTable", () => {
     // Then the cells with missing content have the `emptyCell` node applied.
     expect(cell(r, 1, 0).textContent).toBe("empty");
     expect(cell(r, 1, 1).textContent).toBe("empty");
+    expect(cell(r, 2, 0).textContent).toBe("a");
     expect(cell(r, 2, 1).textContent).toBe("empty");
+    expect(cell(r, 3, 0).textContent).toBe("c");
+    expect(cell(r, 3, 1).textContent).toBe("1");
   });
 
   it("can show an actually empty cell using 'emptyCell' const", async () => {
@@ -1059,6 +1062,7 @@ describe("GridTable", () => {
     );
     // Then the cell in this column should actually be empty
     expect(cell(r, 1, 0)).toBeEmptyDOMElement();
+    expect(cell(r, 1, 1).textContent).toBe("1");
   });
 });
 

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1023,6 +1023,26 @@ describe("GridTable", () => {
     // Then we still get back the header row
     expect(rows).toEqual([simpleHeader]);
   });
+
+  it("can apply emptyCell to missing content", async () => {
+    // Given the table with a specified emptyCell
+    const r = await render(
+      <GridTable<Row>
+        columns={[nameColumn, valueColumn]}
+        style={{ emptyCell: <>empty</> }}
+        rows={[
+          simpleHeader,
+          // And some content is undefined and empty strings
+          { kind: "data", id: "2", name: "", value: 2 },
+          { kind: "data", id: "1", name: "a", value: undefined },
+          { kind: "data", id: "3", name: "c", value: 1 },
+        ]}
+      />,
+    );
+    // Then the cells with missing content have the `emptyCell` node applied.
+    expect(cell(r, 1, 0).textContent).toBe("empty");
+    expect(cell(r, 2, 1).textContent).toBe("empty");
+  });
 });
 
 function Collapse() {

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -3,6 +3,7 @@ import { GridRowLookup } from "src/components/Table/GridRowLookup";
 import {
   calcDivGridColumns,
   calcVirtualGridColumns,
+  emptyCell,
   GridCollapseContext,
   GridColumn,
   GridDataRow,
@@ -22,7 +23,7 @@ import { Css, Palette } from "src/Css";
 import { cell, click, render, row } from "src/utils/rtl";
 
 // Most of our tests use this simple Row and 2 columns
-type Data = { name: string; value: number | undefined };
+type Data = { name: string; value: number | undefined | null };
 type Row = SimpleHeaderAndDataOf<Data>;
 
 const nameColumn: GridColumn<Row> = { header: () => "Name", data: ({ name }) => name };
@@ -1032,16 +1033,32 @@ describe("GridTable", () => {
         style={{ emptyCell: <>empty</> }}
         rows={[
           simpleHeader,
-          // And some content is undefined and empty strings
-          { kind: "data", id: "2", name: "", value: 2 },
-          { kind: "data", id: "1", name: "a", value: undefined },
+          // And some content is null, undefined, and empty strings
+          { kind: "data", id: "1", name: "", value: null },
+          { kind: "data", id: "2", name: "a", value: undefined },
           { kind: "data", id: "3", name: "c", value: 1 },
         ]}
       />,
     );
     // Then the cells with missing content have the `emptyCell` node applied.
     expect(cell(r, 1, 0).textContent).toBe("empty");
+    expect(cell(r, 1, 1).textContent).toBe("empty");
     expect(cell(r, 2, 1).textContent).toBe("empty");
+  });
+
+  it("can show an actually empty cell using 'emptyCell' const", async () => {
+    // Given the table with a column that defines the `kind: data` as an empty cell
+    const nameColumn: GridColumn<Row> = { header: () => "Name", data: emptyCell };
+    // And a table where the there is an `emptyCell` style specified
+    const r = await render(
+      <GridTable<Row>
+        columns={[nameColumn, valueColumn]}
+        style={{ emptyCell: <>empty</> }}
+        rows={[simpleHeader, { kind: "data", id: "1", name: "a", value: 1 }]}
+      />,
+    );
+    // Then the cell in this column should actually be empty
+    expect(cell(r, 1, 0)).toBeEmptyDOMElement();
   });
 });
 

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -29,6 +29,7 @@ export type GridTableXss = Xss<Margin>;
 export const ASC = "ASC" as const;
 export const DESC = "DESC" as const;
 export type Direction = "ASC" | "DESC";
+export const emptyCell: () => ReactNode = () => <></>;
 
 let runningInJest = false;
 
@@ -1024,17 +1025,22 @@ function toContent(
 ): ReactNode {
   if (typeof content === "string" && isHeader && canSortColumn) {
     return <SortHeader content={content} />;
-  } else if (isContentAndSettings(content)) {
-    return content.content;
-  } else if (style.emptyCell && !content) {
+  } else if (style.emptyCell && isContentEmpty(content)) {
     // If the content is empty and the user specified an `emptyCell` node, return that.
     return style.emptyCell;
+  } else if (isContentAndSettings(content)) {
+    return content.content;
   }
   return content;
 }
 
 function isContentAndSettings(content: ReactNode | GridCellContent): content is GridCellContent {
   return typeof content === "object" && !!content && "content" in content;
+}
+
+const emptyValues = ["", null, undefined] as any[];
+function isContentEmpty(content: ReactNode | GridCellContent): boolean {
+  return emptyValues.includes(isContentAndSettings(content) ? content.content : content);
 }
 
 /** Return the content for a given column def applied to a given row. */

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -63,6 +63,8 @@ export interface GridStyle {
   rowHoverColor?: string;
   /** Styling for our special "nested card" output mode. */
   nestedCards?: NestedCardsStyle;
+  /** Default content to put into an empty cell */
+  emptyCell?: ReactNode;
 }
 
 export interface NestedCardsStyle {
@@ -938,7 +940,7 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
         const canSortColumn =
           (sorting?.on === "client" && column.clientSideSort !== false) ||
           (sorting?.on === "server" && !!column.serverSideSortKey);
-        const content = toContent(maybeContent, isHeader, canSortColumn);
+        const content = toContent(maybeContent, isHeader, canSortColumn, style);
 
         ensureClientSideSortValueIsSortable(sorting, isHeader, column, columnIndex, maybeContent);
 
@@ -1014,11 +1016,19 @@ const ObservedGridRow = React.memo((props: GridRowProps<any, any>) => (
 ));
 
 /** If a column def return just string text for a given row, apply some default styling. */
-function toContent(content: ReactNode | GridCellContent, isHeader: boolean, canSortColumn: boolean): ReactNode {
+function toContent(
+  content: ReactNode | GridCellContent,
+  isHeader: boolean,
+  canSortColumn: boolean,
+  style: GridStyle,
+): ReactNode {
   if (typeof content === "string" && isHeader && canSortColumn) {
     return <SortHeader content={content} />;
   } else if (isContentAndSettings(content)) {
     return content.content;
+  } else if (style.emptyCell && !content) {
+    // If the content is empty and the user specified an `emptyCell` node, return that.
+    return style.emptyCell;
   }
   return content;
 }


### PR DESCRIPTION
Allows implementer to define a default empty cell value for the whole table. For instance, in many tables in Blueprint we want to show the "-" character if there is no data for that cell