### PR TITLE
fix: Update spacing and scrolling styles after QA with design

### DIFF
--- a/src/components/Layout/ScrollableParent.tsx
+++ b/src/components/Layout/ScrollableParent.tsx
@@ -61,9 +61,23 @@ export function ScrollableParent(props: PropsWithChildren<ScrollableParentContex
        * Otherwise, the flex-item's min-height/width is based on the content of the flex-item, which maybe overflow the container.
        * See https://stackoverflow.com/questions/42130384/why-should-i-specify-height-0-even-if-i-specified-flex-basis-0-in-css3-flexbox */}
       <Tag css={{ ...Css.mh0.mw0.fg1.df.fdc.$, ...otherXss }}>
-        <div css={Css.pl(context.pl).pr(context.pr).if(!hasScrollableContent).h100.overflowAuto.$}>{children}</div>
+        {/* Use `overflow: overlay` to prevent scrollbar from pushing content in when rendered. This is only supported in Webkit browsers, so we also keep `overflow: auto` as a fallback for other browsers.*/}
+        {/* `overlay` needs to be applied using `addIn` otherwise the two `overflow` properties will be merged. */}
+        <div
+          css={
+            Css.pl(context.pl)
+              .pr(context.pr)
+              .if(!hasScrollableContent)
+              .h100.overflowAuto.addIn("&", Css.if(!hasScrollableContent).add("overflow", "overlay").$).$
+          }
+        >
+          {children}
+        </div>
         {/* Set fg1 to take up the remaining space in the viewport.*/}
-        <div css={Css.fg1.overflowAuto.pl(context.pl).pr(context.pr).$} ref={scrollableRef}></div>
+        <div
+          css={Css.fg1.overflowAuto.pl(context.pl).pr(context.pr).addIn("&", Css.add("overflow", "overlay").$).$}
+          ref={scrollableRef}
+        />
       </Tag>
     </ScrollableParentContext.Provider>
   );

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -80,7 +80,7 @@ export function TabContent<V extends string>(props: Omit<TabsProps<V, {}>, "onCh
       role="tabpanel"
       tabIndex={0}
       {...tid.panel}
-      css={{ ...Css.mt2.$, ...contentXss }}
+      css={{ ...Css.mt3.$, ...contentXss }}
     >
       {isRouteTab(selectedTab) ? <Route path={selectedTab.path} render={selectedTab.render} /> : selectedTab.render()}
     </div>


### PR DESCRIPTION
Margin between tabs and tab content should be 24px.

Adding in `overflow: overlay` even though it is only supported in Webkit browsers, though that is the majority of our users. Keeping `overflow: auto` defined as a fallback for any browser that does not support overflow: overlay. 'overlay' will prevent the scrollbars from pushing content in when are needed, which pushes the content inwards.