### PR TITLE
feat: Support endAdornment in Tab for decorations other than icons

### DIFF
--- a/src/components/Tabs.stories.tsx
+++ b/src/components/Tabs.stories.tsx
@@ -59,6 +59,22 @@ export function TabsWithIconAndMargin() {
   return <TabsWithContent tabs={tabsWithIconsAndContent} onChange={setTab} selected={tab} contentXss={Css.m3.$} />;
 }
 
+export function TabsWithEndAdornment() {
+  const redCircle = <div css={Css.br8.bgRed400.wPx(16).hPx(16).$} />;
+  const greenCircle = <div css={Css.br8.bgGreen400.wPx(16).hPx(16).$} />;
+  const tabsWithAdornment: Tab<TabValue>[] = [
+    { name: "Tab 1", value: "tab1", endAdornment: redCircle, render: () => <TestTabContent content="Tab 1 Content" /> },
+    {
+      name: "Tab 2",
+      value: "tab2",
+      endAdornment: greenCircle,
+      render: () => <TestTabContent content="Tab 2 Content" />,
+    },
+  ];
+  const [tab, setTab] = useState<TabValue>("tab1");
+  return <TabsWithContent tabs={tabsWithAdornment} onChange={setTab} selected={tab} contentXss={Css.m3.$} />;
+}
+
 export function TabsSeparateFromContent() {
   const [tab, setTab] = useState<TabValue>("tab1");
   return (

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -13,7 +13,10 @@ import { Icon } from "./Icon";
 export interface Tab<V extends string = string> {
   name: string;
   value: V;
+  // Suffixes label with specified Icon. If `icon` and `endAdornment` are supplied, only the `icon` will be displayed
   icon?: IconKey;
+  // Suffixes label with specified node. Expected to be used for cases where the decoration is not just an icon.
+  endAdornment?: ReactNode;
   disabled?: boolean;
   render: () => ReactNode;
 }
@@ -34,7 +37,7 @@ export interface RouteTabsProps<V extends string, X> extends Omit<TabsProps<V, X
   tabs: RouteTab<V>[];
 }
 // A Route Tab has a `href` prop rather than a `value` prop
-export interface RouteTab<V extends string> extends Omit<Tab<V>, "value"> {
+export interface RouteTab<V extends string = string> extends Omit<Tab<V>, "value"> {
   href: V;
   // This is a React-Router path(s) to match the current URL to. Matching on the path(s) is what dictates which TabContent to render
   path: string | string[];
@@ -171,7 +174,7 @@ interface TabImplProps<V extends string> extends BeamFocusableProps {
 
 function TabImpl<V extends string>(props: TabImplProps<V>) {
   const { tab, onClick, active, onKeyUp, onBlur, focusProps, isFocusVisible = false, ...others } = props;
-  const { disabled: isDisabled = false, name: label, icon } = tab;
+  const { disabled: isDisabled = false, name: label, icon, endAdornment } = tab;
   const { hoverProps, isHovered } = useHover({ isDisabled });
   const { baseStyles, activeStyles, focusRingStyles, hoverStyles, disabledStyles, activeHoverStyles } = useMemo(
     () => getTabStyles(),
@@ -205,11 +208,7 @@ function TabImpl<V extends string>(props: TabImplProps<V>) {
   const tabLabel = (
     <>
       {label}
-      {icon && (
-        <span css={Css.ml1.$}>
-          <Icon icon={icon} />
-        </span>
-      )}
+      {(icon || endAdornment) && <span css={Css.ml1.$}>{icon ? <Icon icon={icon} /> : endAdornment}</span>}
     </>
   );
 


### PR DESCRIPTION
In order to migrate Blueprint's existing tabs to Beam, then we need to support more than just a Icon as the decoration on the tab.