### PR TITLE
fix: Allow forcing tabs to show even if only one is enabled

### DIFF
--- a/src/components/Tabs.test.tsx
+++ b/src/components/Tabs.test.tsx
@@ -91,15 +91,15 @@ describe("TabsWithContent", () => {
     expect(r.tab_panel().textContent).toBe("Tab 1 Content");
   });
 
-  it("shows all the tabs if 'forceShow' is defined, but only a single tab is enabled ", async () => {
+  it("shows all the tabs if 'alwaysShowAllTabs' is defined, but only a single tab is enabled ", async () => {
     // Given only the 1st tab is enabled
     const testTabs: Tab<TabValue>[] = [
       { name: "Tab 1", value: "tab1", render: () => <TestTabContent content="Tab 1 Content" /> },
       { name: "Tab 2", value: "tab2", disabled: true, render: () => <TestTabContent content="Tab 2 Content" /> },
     ];
-    // And defining `forceShow`
+    // And defining `alwaysShowAllTabs`
     const r = await render(
-      <TabsWithContent forceShow tabs={testTabs} onChange={() => {}} selected="tab1" />,
+      <TabsWithContent alwaysShowAllTabs tabs={testTabs} onChange={() => {}} selected="tab1" />,
       withRouter(),
     );
     // Then all tabs should be shown in the DOM

--- a/src/components/Tabs.test.tsx
+++ b/src/components/Tabs.test.tsx
@@ -91,6 +91,21 @@ describe("TabsWithContent", () => {
     expect(r.tab_panel().textContent).toBe("Tab 1 Content");
   });
 
+  it("shows all the tabs if 'forceShow' is defined, but only a single tab is enabled ", async () => {
+    // Given only the 1st tab is enabled
+    const testTabs: Tab<TabValue>[] = [
+      { name: "Tab 1", value: "tab1", render: () => <TestTabContent content="Tab 1 Content" /> },
+      { name: "Tab 2", value: "tab2", disabled: true, render: () => <TestTabContent content="Tab 2 Content" /> },
+    ];
+    // And defining `forceShow`
+    const r = await render(
+      <TabsWithContent forceShow tabs={testTabs} onChange={() => {}} selected="tab1" />,
+      withRouter(),
+    );
+    // Then all tabs should be shown in the DOM
+    expect(r.queryAllByRole("tab")).toHaveLength(2);
+  });
+
   it("renders tabs as links", async () => {
     const router = withRouter("/tab1");
     // Given tabs with `path` values

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -31,7 +31,7 @@ export interface TabsProps<V extends string, X> {
   onChange: (value: V) => void;
   contentXss?: X;
   // Allow for showing the tabs even if there is only one enabled tab
-  forceShow?: boolean;
+  alwaysShowAllTabs?: boolean;
 }
 
 // Tabs can be rendered as Links (omit "onChange") and we'll use React-Router for matching (omit "selected")/
@@ -57,8 +57,8 @@ export interface RouteTab<V extends string = string> extends Omit<Tab<V>, "value
 export function TabsWithContent<V extends string, X extends Only<TabsContentXss, X>>(
   props: TabsProps<V, X> | RouteTabsProps<V, X>,
 ) {
-  // Hide the tabs if only one tab is enabled, and `forceShow` is not true
-  const hideTabs = props.forceShow
+  // Hide the tabs if only one tab is enabled, and `alwaysShowAllTabs` is not true
+  const hideTabs = props.alwaysShowAllTabs
     ? false
     : (props.tabs as any[]).filter((t: RouteTab<V> | Tab<V>) => !t.disabled).length === 1;
   return (
@@ -139,7 +139,7 @@ export function Tabs<V extends string>(props: TabsProps<V, {}> | RouteTabsProps<
   }
 
   // We also check this in TabsWithContent, but if someone is using Tabs standalone, check it here as well
-  const hideTabs = props.forceShow ? false : (props.tabs as any[]).filter((t) => !t.disabled).length === 1;
+  const hideTabs = props.alwaysShowAllTabs ? false : (props.tabs as any[]).filter((t) => !t.disabled).length === 1;
   if (hideTabs) {
     return <></>;
   }

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -30,6 +30,8 @@ export interface TabsProps<V extends string, X> {
   tabs: Tab<V>[];
   onChange: (value: V) => void;
   contentXss?: X;
+  // Allow for showing the tabs even if there is only one enabled tab
+  forceShow?: boolean;
 }
 
 // Tabs can be rendered as Links (omit "onChange") and we'll use React-Router for matching (omit "selected")/
@@ -55,10 +57,13 @@ export interface RouteTab<V extends string = string> extends Omit<Tab<V>, "value
 export function TabsWithContent<V extends string, X extends Only<TabsContentXss, X>>(
   props: TabsProps<V, X> | RouteTabsProps<V, X>,
 ) {
-  const onlyOneTabEnabled = (props.tabs as any[]).filter((t: RouteTab<V> | Tab<V>) => !t.disabled).length === 1;
+  // Hide the tabs if only one tab is enabled, and `forceShow` is not true
+  const hideTabs = props.forceShow
+    ? false
+    : (props.tabs as any[]).filter((t: RouteTab<V> | Tab<V>) => !t.disabled).length === 1;
   return (
     <>
-      {!onlyOneTabEnabled && <Tabs {...props} />}
+      {!hideTabs && <Tabs {...props} />}
       <TabContent {...props} />
     </>
   );
@@ -134,8 +139,8 @@ export function Tabs<V extends string>(props: TabsProps<V, {}> | RouteTabsProps<
   }
 
   // We also check this in TabsWithContent, but if someone is using Tabs standalone, check it here as well
-  const onlyOneTabEnabled = (props.tabs as any[]).filter((t) => !t.disabled).length === 1;
-  if (onlyOneTabEnabled) {
+  const hideTabs = props.forceShow ? false : (props.tabs as any[]).filter((t) => !t.disabled).length === 1;
+  if (hideTabs) {
     return <></>;
   }
 


### PR DESCRIPTION
This is to support an existing requirement in Blueprint where Stage Tabs may be hiding the Planning stage, and the Construction stage may be disabled, making PreCon the only active stage. In this case, as part of Product requirements (which may be outdated) we want to show both the Pre-Con and disabled Construction tabs. Regardless if the requirements are outdated, I think allowing showing the single enabled tab is useful.