### PR TITLE
fix: Add tinycolor as a direct dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@react-hook/resize-observer": "^1.2.2",
+    "@types/tinycolor2": "^1.4.2",
     "change-case": "^4.1.2",
     "date-fns": "^2.21.3",
     "dompurify": "^2.3.0",
@@ -46,6 +47,7 @@
     "react-router-dom": "^5.2.0",
     "react-stately": "^3.7.0",
     "react-virtuoso": "^1.9.0",
+    "tinycolor2": "^1.4.2",
     "tributejs": "^5.1.3",
     "trix": "^1.3.1",
     "use-query-params": "^1.2.2"
@@ -54,8 +56,7 @@
     "@emotion/react": ">=11",
     "mobx-react": ">=7",
     "react": ">=16",
-    "react-router-dom": ">=5.2",
-    "tinycolor2": ">=1.4"
+    "react-router-dom": ">=5.2"
   },
   "peerDependenciesMeta": {
     "mobx-react": {
@@ -63,9 +64,6 @@
     },
     "react-router-dom": {
       "optional": false
-    },
-    "tinycolor2": {
-      "optional": true
     }
   },
   "devDependencies": {
@@ -92,7 +90,6 @@
     "@types/react": "^17.0.5",
     "@types/react-dom": "^16.9.11",
     "@types/react-router-dom": "^5.1.7",
-    "@types/tinycolor2": "^1.4.2",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
     "babel-eslint": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14943,9 +14943,9 @@ tiny-warning@^1.0.0, tiny-warning@^1.0.3:
   resolved "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
-tinycolor2@^1.4.1:
+tinycolor2@^1.4.2:
   version "1.4.2"
-  resolved "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz"
+  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.2.tgz#3f6a4d1071ad07676d7fa472e1fac40a719d8803"
   integrity sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==
 
 tmp-promise@3.0.2:


### PR DESCRIPTION
I was originally thinking it'd be cute to have it be optional, b/c I think only certain row-hover codepaths in GridTable use it, but meh, it's simpler to just always require it (I'm pruning unused-looking-ish dependencies from internal-frontend).