### PR TITLE
fix: Avoid unnecessary whitespace

### DIFF
--- a/src/components/Tabs.stories.tsx
+++ b/src/components/Tabs.stories.tsx
@@ -167,13 +167,18 @@ export const OneTabWithActions = () => {
     {
       name: "Tab 1",
       value: "tab1",
-      render: () => <TabWithActions actions={["Add New", "Edit"]}>Tab Content</TabWithActions>,
+      render: () => (
+        <TabWithActions actions={["Add New", "Edit"]}>
+          <div css={Css.bgGray100.bt.bGray800.p2.$}>Tab Content</div>
+        </TabWithActions>
+      ),
     },
   ];
   return (
     <>
       <Tabs tabs={testTabs} onChange={setSelectedTab} selected={selectedTab} ariaLabel="Sample Tabs" />
-      <TabContent tabs={testTabs} selected={selectedTab} />
+      {/* The tabs will be hidden, which causes the TabContent default top margin to be removed. But we are adding in actions, so add the margin back in ourselves. */}
+      <TabContent contentXss={Css.mt3.$} tabs={testTabs} selected={selectedTab} />
     </>
   );
 };


### PR DESCRIPTION
Tab panel element is always rendered, which eliminates the possibility of TabContent benefiting from collapsable margins. This resulted in the margin-top: 24px being applied under an empty Tab Panel element, and causing extra white space. With this change if the tabs are hidden, then the TabContent will not apply a margin-top definition.

_Caveat_: If the user supplies TabActions and the Tabs are hidden, then we will not have space between the Tab Actions and the Tab Content. This is probably fine for the most part as the Actions are right aligned, and the content will more than likely be left aligned. If it becomes an issue the user can always conditionally apply their own defined margin for the TabContent via `contentXss`, or set `alwaysShowAllTabs` to true, and that'd take care of the spacing issues. Would be nice to handle this all in the component, but conditionally setting styles based on a portal's contents is a bit tricky requires additional re-renders. IMO, not really worth it.
Other idea I had to keep the spacing would be to render the TabActions portal div in the TabContent component if no Tabs were being shown. Not sure if I like the idea of having a portal show up in two different places.