### PR TITLE
feat: 'text' variant for Button

### DIFF
--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -128,6 +128,23 @@ export function ButtonVariations(args: ButtonProps) {
           <Button {...args} icon="trash" size="lg" variant="danger" disabled label="Disabled" />
         </div>
       </div>
+
+      <div>
+        <h2>Text</h2>
+        <div css={buttonRowStyles}>
+          <Button {...args} variant="text" label="Text Button" />
+          <Button {...args} variant="text" disabled label="Disabled" />
+        </div>
+        <div css={buttonRowStyles}>
+          <Button {...args} icon="plus" variant="text" label="Text Button" />
+          <Button {...args} icon="plus" variant="text" disabled label="Disabled" />
+        </div>
+        <div css={buttonRowStyles}>
+          <p css={Css.sm.$}>
+            Example of a <Button {...args} variant="text" label="Text Button" /> placed inline within other text.
+          </p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -101,6 +101,10 @@ export function Button(props: ButtonProps) {
 }
 
 function getButtonStyles(variant: ButtonVariant, size: ButtonSize) {
+  if (variant === "text") {
+    // The text variant does not support the 'size'. The 'size' prop only effects the button's height and padding which is not relevant for this variant.
+    return variantStyles[variant];
+  }
   return {
     ...variantStyles[variant],
     baseStyles: { ...variantStyles[variant].baseStyles, ...sizeStyles[size] },
@@ -136,6 +140,13 @@ const variantStyles: Record<ButtonVariant, { baseStyles: {}; hoverStyles: {}; di
       pressedStyles: Css.bgRed900.$,
       disabledStyles: Css.bgRed200.$,
     },
+
+    text: {
+      baseStyles: Css.lightBlue700.$,
+      hoverStyles: {},
+      pressedStyles: {},
+      disabledStyles: Css.lightBlue300.$,
+    },
   };
 
 const sizeStyles: Record<ButtonSize, {}> = {
@@ -151,4 +162,4 @@ const iconStyles: Record<ButtonSize, IconProps["xss"]> = {
 };
 
 type ButtonSize = "sm" | "md" | "lg";
-type ButtonVariant = "primary" | "secondary" | "tertiary" | "danger";
+type ButtonVariant = "primary" | "secondary" | "tertiary" | "danger" | "text";

--- a/src/components/Filters/MultiFilter.stories.tsx
+++ b/src/components/Filters/MultiFilter.stories.tsx
@@ -4,7 +4,7 @@ import { Filters } from "src/components/index";
 
 export default {
   component: Filters,
-  title: "Components/Filters",
+  title: "Components/MultiFilters",
   decorators: [],
 } as Meta;
 

--- a/src/components/Filters/SingleFilter.stories.tsx
+++ b/src/components/Filters/SingleFilter.stories.tsx
@@ -4,7 +4,7 @@ import { Filters } from "src/components/index";
 
 export default {
   component: Filters,
-  title: "Components/Filters",
+  title: "Components/SingleFilters",
   decorators: [],
 } as Meta;
 


### PR DESCRIPTION
The text variant will not supply any padding and is made to look like regular text. It uses the same default button styling for font-size, weight, etc.