### PR TITLE
fix: Remove FocusScope on DatePickerOverlay

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -23,6 +23,7 @@ export const FilterableStaticHeight = () => (
   <ModalFilterTableExample size={{ width: "md", height: 600 }} forceScrolling={true} />
 );
 export const HeaderWithComponents = () => <ModalExample size="lg" withTag />;
+export const WithDatePicker = () => <ModalExample withDateField />;
 
 export const ButtonsInFooter = () => {
   const { openModal } = useModal();
@@ -71,17 +72,23 @@ interface ModalExampleProps extends Pick<ModalProps, "size" | "forceScrolling"> 
   initNumSentences?: number;
   showLeftAction?: boolean;
   withTag?: boolean;
+  withDateField?: boolean;
 }
 
 function ModalExample(props: ModalExampleProps) {
-  const { size, showLeftAction, initNumSentences = 1, forceScrolling, withTag } = props;
+  const { size, showLeftAction, initNumSentences = 1, forceScrolling, withTag, withDateField } = props;
   const { openModal } = useModal();
   const open = () =>
     openModal({
       size,
       forceScrolling,
       content: (
-        <TestModalContent initNumSentences={initNumSentences} showLeftAction={showLeftAction} withTag={withTag} />
+        <TestModalContent
+          initNumSentences={initNumSentences}
+          showLeftAction={showLeftAction}
+          withTag={withTag}
+          withDateField={withDateField}
+        />
       ),
     });
   // Immediately open the modal for Chromatic snapshots

--- a/src/components/Modal/TestModalContent.tsx
+++ b/src/components/Modal/TestModalContent.tsx
@@ -7,15 +7,22 @@ import { useModal } from "src/components/Modal/useModal";
 import { GridColumn, GridDataRow, GridTable, simpleHeader, SimpleHeaderAndDataOf } from "src/components/Table";
 import { Tag } from "src/components/Tag";
 import { Css } from "src/Css";
-import { TextField } from "src/inputs";
+import { jan1 } from "src/forms/formStateDomain";
+import { DateField, TextField } from "src/inputs";
 
 /** A fake modal content component that we share across the modal and superdrawer stories. */
-export function TestModalContent(props: { initNumSentences?: number; showLeftAction?: boolean; withTag?: boolean }) {
+export function TestModalContent(props: {
+  initNumSentences?: number;
+  showLeftAction?: boolean;
+  withTag?: boolean;
+  withDateField?: boolean;
+}) {
   const { closeModal } = useModal();
-  const { initNumSentences = 1, showLeftAction } = props;
+  const { initNumSentences = 1, showLeftAction, withDateField } = props;
   const [numSentences, setNumSentences] = useState(initNumSentences);
   const [primaryDisabled, setPrimaryDisabled] = useState(false);
   const [leftActionDisabled, setLeftActionDisabled] = useState(false);
+  const [date, setDate] = useState(jan1);
   return (
     <>
       <ModalHeader>
@@ -40,6 +47,7 @@ export function TestModalContent(props: { initNumSentences?: number; showLeftAct
           </div>
           <p>{"The body content of the modal. This content can be anything!".repeat(numSentences)}</p>
         </div>
+        {withDateField && <DateField value={date} label="Date" onChange={setDate} />}
       </ModalBody>
       <ModalFooter xss={showLeftAction ? Css.jcsb.$ : undefined}>
         {showLeftAction && (

--- a/src/inputs/internal/DatePickerOverlay.tsx
+++ b/src/inputs/internal/DatePickerOverlay.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { FocusScope } from "react-aria";
 import DayPicker, { NavbarElementProps, WeekdayElementProps } from "react-day-picker";
 import { OverlayTriggerState } from "react-stately";
 import { IconButton } from "src/components";
@@ -23,44 +22,39 @@ export function DatePickerOverlay(props: DatePickerOverlayProps) {
   const tid = useTestIds(props, "datePicker");
 
   return (
-    // Wrap in `FocusScope` to move focus immediately into this overlay (autoFocus).
-    // This allows the DateField to work properly within a Modal, which has its own FocusScope and did not like allowing the user to interact with another overlay.
-    // Also using `contain` to ensure tabbing only moves within this overlay, otherwise you could tab out of the overlay and it'd stay open.
-    <FocusScope contain autoFocus>
-      <div
-        css={{
-          ...Css.bgWhite.xs.br4.bshModal.$,
-          ...(isPositionedAbove ? Css.mbPx(4).$ : Css.mtPx(4).$),
-          // The S / M / T / W ... heading
-          "& .DayPicker-Weekday": Css.pPx(8).xs.gray400.important.$,
-          // Un-collapse the borders so we can hover each cell
-          "& .DayPicker-Month": Css.add({ borderCollapse: "separate" }).$,
-          // // Make the boxes smaller, this ends up being 32x32 which matches figma
-          "& .DayPicker-Day": Css.pPx(8).xs.ba.bWhite.br4.$,
-          // For today, use a background
-          "& .DayPicker-Day--today": Css.bgGray100.$,
-          // For selected, use a background - `--outside` modifier is set on placeholder days not within the viewed month
-          "& .DayPicker-Day--selected:not(.DayPicker-Day--outside)": Css.bgLightBlue700.white.$,
-          // For pressed
-          "& .DayPicker-Day:active": Css.bgGray400.$,
-          // Make the month title, i.e. "May 2021", match figma; pyPx nudge matches the NavbarElement nudging
-          "& .DayPicker-Caption > div": Css.base.pyPx(2).$,
+    <div
+      css={{
+        ...Css.bgWhite.xs.br4.bshModal.$,
+        ...(isPositionedAbove ? Css.mbPx(4).$ : Css.mtPx(4).$),
+        // The S / M / T / W ... heading
+        "& .DayPicker-Weekday": Css.pPx(8).xs.gray400.important.$,
+        // Un-collapse the borders so we can hover each cell
+        "& .DayPicker-Month": Css.add({ borderCollapse: "separate" }).$,
+        // // Make the boxes smaller, this ends up being 32x32 which matches figma
+        "& .DayPicker-Day": Css.pPx(8).xs.ba.bWhite.br4.$,
+        // For today, use a background
+        "& .DayPicker-Day--today": Css.bgGray100.$,
+        // For selected, use a background - `--outside` modifier is set on placeholder days not within the viewed month
+        "& .DayPicker-Day--selected:not(.DayPicker-Day--outside)": Css.bgLightBlue700.white.$,
+        // For pressed
+        "& .DayPicker-Day:active": Css.bgGray400.$,
+        // Make the month title, i.e. "May 2021", match figma; pyPx nudge matches the NavbarElement nudging
+        "& .DayPicker-Caption > div": Css.base.pyPx(2).$,
+      }}
+      {...tid}
+    >
+      <DayPicker
+        navbarElement={NavbarElement}
+        weekdayElement={Weekday}
+        selectedDays={[value]}
+        initialMonth={value ?? new Date()}
+        onDayClick={(day) => {
+          // Set the day value, and close the picker.
+          onChange(day);
+          state.close();
         }}
-        {...tid}
-      >
-        <DayPicker
-          navbarElement={NavbarElement}
-          weekdayElement={Weekday}
-          selectedDays={[value]}
-          initialMonth={value ?? new Date()}
-          onDayClick={(day) => {
-            // Set the day value, and close the picker.
-            onChange(day);
-            state.close();
-          }}
-        />
-      </div>
-    </FocusScope>
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
Previously, I thought FocusScope was required to allow the DateField to properly work within a Modal, which is why it was added. Turns out it is not an issue. Removing this FocusScope allows for the focus now to stay within the DateField's input.