### PR TITLE
fix: Rename DateField value prop 'date' to 'value'"

### DIFF
--- a/src/components/Filters/DateFilter.stories.tsx
+++ b/src/components/Filters/DateFilter.stories.tsx
@@ -13,15 +13,15 @@ export default {
 export function DateFilterInPage() {
   const filter = taskDueFilter("date");
   // Mimics the container of the "in page" filters to demonstrate the field can shrink in size.
-  return <div css={Css.df.aic.$}>{filter.render({ op: "BEFORE", date: jan2 }, () => {}, {}, false, false)}</div>;
+  return <div css={Css.df.aic.$}>{filter.render({ op: "BEFORE", value: jan2 }, () => {}, {}, false, false)}</div>;
 }
 
 export function DateFilterInModal() {
   const filter = taskDueFilter("date");
-  return filter.render({ op: "BEFORE", date: jan2 }, () => {}, {}, true, false);
+  return filter.render({ op: "BEFORE", value: jan2 }, () => {}, {}, true, false);
 }
 
 export function DateFilterVertical() {
   const filter = taskDueFilter("date");
-  return filter.render({ op: "BEFORE", date: jan2 }, () => {}, {}, false, true);
+  return filter.render({ op: "BEFORE", value: jan2 }, () => {}, {}, false, true);
 }

--- a/src/components/Filters/DateFilter.test.tsx
+++ b/src/components/Filters/DateFilter.test.tsx
@@ -28,7 +28,7 @@ describe("DateFilter", () => {
     // And we type in a new date
     type(r.filter_taskDue_dateField, "10/31/21");
     // Then the filter should be set (intentionally omitting the time value from the 'date' value)
-    expect(r.filter_value()).toHaveTextContent('{"date":{"op":"ON","date":"2021-10-31T');
+    expect(r.filter_value()).toHaveTextContent('{"date":{"op":"ON","value":"2021-10-31T');
     // When we select Any
     fireEvent.focus(r.filter_taskDue_dateOperation());
     click(r.getByRole("option", { name: "Any" }));

--- a/src/components/Filters/DateFilter.tsx
+++ b/src/components/Filters/DateFilter.tsx
@@ -15,7 +15,7 @@ export type DateFilterProps<O, V extends Value, DV extends DateFilterValue<V>> =
   defaultValue?: DV;
 };
 
-export type DateFilterValue<V extends Value> = { op: V; date: Date };
+export type DateFilterValue<V extends Value> = { op: V; value: Date };
 
 export function dateFilter<O, V extends Key>(
   props: DateFilterProps<O, V, DateFilterValue<V>>,
@@ -60,7 +60,7 @@ class DateFilter<O, V extends Key, DV extends DateFilterValue<V>>
               value={value?.op}
               onSelect={(op) =>
                 // default the selected date to today if it doesn't exist in the filter's value
-                setValue(op ? ({ op, date: value?.date ? new Date(value.date) : new Date() } as DV) : undefined)
+                setValue(op ? ({ op, value: value?.value ? new Date(value.value) : new Date() } as DV) : undefined)
               }
               label={inModal ? `${label} date filter operation` : label}
               inlineLabel={!inModal && !vertical}
@@ -85,9 +85,9 @@ class DateFilter<O, V extends Key, DV extends DateFilterValue<V>>
               borderless
               compact
               inlineLabel
-              value={value?.date ? new Date(value.date) : new Date()}
+              value={value?.value ? new Date(value.value) : new Date()}
               label="Date"
-              onChange={(d) => setValue({ ...value, date: d })}
+              onChange={(d) => setValue({ ...value, value: d })}
               disabled={!value}
               {...tid[`${defaultTestId(this.label)}_dateField`]}
               onFocus={() => setFocusedEl("date")}

--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -113,7 +113,7 @@ function TestFilterPage({ vertical }: { vertical?: boolean }) {
       getOperationLabel: (o) => o.label,
       getOperationValue: (o) => o.value,
       // Providing a default value, otherwise the default date in the DateField will be today's date, which will cause storybook diffs every day.
-      defaultValue: { op: "BEFORE", date: jan1 },
+      defaultValue: { op: "BEFORE", value: jan1 },
     });
 
     const isTest = toggleFilter({ label: "Only show test projects" });


### PR DESCRIPTION
This is to better match the APIs and reduce the amount of mapping between objects