### PR TITLE
fix: Modal min-height should not be based on defined modal height

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -78,7 +78,12 @@ export function Modal(props: ModalProps) {
         <FocusScope contain restoreFocus autoFocus>
           <div
             css={
-              Css.br24.bgWhite.bshModal.maxh("90vh").df.fdc.wPx(width).mh(px(height)).if(isFixedHeight).hPx(height).$
+              Css.br24.bgWhite.bshModal
+                .maxh("90vh")
+                .df.fdc.wPx(width)
+                .mh(px(defaultMinHeight))
+                .if(isFixedHeight)
+                .hPx(height).$
             }
             ref={ref}
             {...overlayProps}


### PR DESCRIPTION
min-height for a modal should be consistent no matter whether there is a defined height or not. If a height is defined, then that height will be set via the `height` and will still respect the `maxh(90vh)` to ensure the modal cannot be taller than the viewport.