### PR TITLE
feat: Allow TextField to be 'clearable'

### DIFF
--- a/src/inputs/TextField.stories.tsx
+++ b/src/inputs/TextField.stories.tsx
@@ -40,6 +40,7 @@ export function TextFieldStyles() {
           value="Brandon"
           helperText="Some really long helper text that we expect to wrap."
         />
+        <TestTextField label="Name Clearable" value="Brandon" clearable />
       </div>
 
       <div css={Css.df.fdc.childGap2.$}>
@@ -56,6 +57,7 @@ export function TextFieldStyles() {
           helperText="Some really long helper text that we expect to wrap."
         />
         <ValidationTextField compact value="not a valid email" label="Email" />
+        <TestTextField compact label="Name Clearable" value="Brandon" clearable />
       </div>
     </div>
   );

--- a/src/inputs/TextField.test.tsx
+++ b/src/inputs/TextField.test.tsx
@@ -2,6 +2,7 @@ import { render, type } from "@homebound/rtl-utils";
 import { fireEvent } from "@testing-library/react";
 import { useState } from "react";
 import { TextField, TextFieldProps } from "src/inputs";
+import { click } from "src/utils/rtl";
 
 let lastSet: any = undefined;
 
@@ -45,6 +46,23 @@ describe("TextFieldTest", () => {
     fireEvent.blur(r.name());
     expect(onFocus).not.toHaveBeenCalled();
     expect(onBlur).not.toHaveBeenCalled();
+  });
+
+  it("is clearable", async () => {
+    // Given an input that has the "clear" button
+    const r = await render(<TestTextField value="foo" clearable />);
+    // The "clear" button should not be shown until input is focused
+    expect(r.queryByTestId("xCircle")).toBeFalsy();
+    // When focused on the input
+    fireEvent.focus(r.name());
+    // Then the clear button is shown.
+    expect(r.xCircle()).toBeTruthy();
+
+    expect(r.name()).toHaveValue("foo");
+    // When clicking the clear button
+    click(r.xCircle);
+    // Then the value should be removed
+    expect(r.name()).toHaveValue("");
   });
 });
 

--- a/src/inputs/TextField.tsx
+++ b/src/inputs/TextField.tsx
@@ -7,6 +7,7 @@ import { BeamTextFieldProps } from "src/interfaces";
 export interface TextFieldProps extends BeamTextFieldProps {
   compact?: boolean;
   inlineLabel?: boolean;
+  clearable?: boolean;
 }
 
 export function TextField(props: TextFieldProps) {

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -10,10 +10,11 @@ import React, {
   useState,
 } from "react";
 import { chain, mergeProps, useFocusWithin, useHover } from "react-aria";
+import { IconButton } from "src/components";
 import { HelperText } from "src/components/HelperText";
 import { InlineLabel, Label } from "src/components/Label";
 import { usePresentationContext } from "src/components/PresentationContext";
-import { Css, px, Xss } from "src/Css";
+import { Css, Palette, px, Xss } from "src/Css";
 import { getLabelSuffix } from "src/forms/labelUtils";
 import { ErrorMessage } from "src/inputs/ErrorMessage";
 import { BeamTextFieldProps, TextFieldInternalProps } from "src/interfaces";
@@ -48,6 +49,7 @@ interface TextFieldBaseProps
   startAdornment?: ReactNode;
   inlineLabel?: boolean;
   contrast?: boolean;
+  clearable?: boolean;
   // TextArea specific
   minHeight?: number;
 }
@@ -79,6 +81,7 @@ export function TextFieldBase(props: TextFieldBaseProps) {
     contrast = false,
     borderless = fieldProps?.borderless ?? false,
     minHeight = 96,
+    clearable = false,
     ...otherProps
   } = props;
   const internalProps: TextFieldInternalProps = (props as any).internalProps || {};
@@ -214,6 +217,9 @@ export function TextFieldBase(props: TextFieldBaseProps) {
             }}
             {...tid}
           />
+          {isFocused && clearable && onChange && inputProps.value && (
+            <IconButton icon="xCircle" color={Palette.Gray700} onClick={() => onChange(undefined)} />
+          )}
           {!multiline && endAdornment && <span css={Css.df.aic.pl1.fs0.$}>{endAdornment}</span>}
         </div>
       )}


### PR DESCRIPTION
Adds 'clearable' prop for TextField which is only shown when the field has a value and the user focuses on the input. This allows the user to quickly remove value of the input.