### PR TITLE
fix: Fix XSS support in TextField and TextAreaField

### DIFF
--- a/src/forms/BoundTextAreaField.tsx
+++ b/src/forms/BoundTextAreaField.tsx
@@ -1,11 +1,13 @@
 import { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
+import { Only } from "src/Css";
 import { TextAreaField, TextAreaFieldProps } from "src/inputs";
+import { TextFieldXss } from "src/interfaces";
 import { useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
 
-export type BoundTextAreaFieldProps = Omit<
-  TextAreaFieldProps,
+export type BoundTextAreaFieldProps<X> = Omit<
+  TextAreaFieldProps<X>,
   "value" | "onChange" | "onBlur" | "onFocus" | "label"
 > & {
   // Make optional as it'll create a label from the field's key if not present
@@ -16,7 +18,7 @@ export type BoundTextAreaFieldProps = Omit<
 };
 
 /** Wraps `TextAreaField` and binds it to a form field. */
-export function BoundTextAreaField(props: BoundTextAreaFieldProps) {
+export function BoundTextAreaField<X extends Only<TextFieldXss, X>>(props: BoundTextAreaFieldProps<X>) {
   const { field, readOnly, onChange = (value) => field.set(value), label = defaultLabel(field.key), ...others } = props;
   const testId = useTestIds(props, field.key);
   return (

--- a/src/forms/BoundTextField.tsx
+++ b/src/forms/BoundTextField.tsx
@@ -1,10 +1,12 @@
 import { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
+import { Only } from "src/Css";
 import { TextField, TextFieldProps } from "src/inputs";
+import { TextFieldXss } from "src/interfaces";
 import { useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
 
-export type BoundTextFieldProps = Omit<TextFieldProps, "value" | "onChange" | "onBlur" | "onFocus" | "label"> & {
+export type BoundTextFieldProps<X> = Omit<TextFieldProps<X>, "value" | "onChange" | "onBlur" | "onFocus" | "label"> & {
   // Make optional as it'll create a label from the field's key if not present
   label?: string;
   field: FieldState<any, string | null | undefined>;
@@ -13,7 +15,7 @@ export type BoundTextFieldProps = Omit<TextFieldProps, "value" | "onChange" | "o
 };
 
 /** Wraps `TextField` and binds it to a form field. */
-export function BoundTextField(props: BoundTextFieldProps) {
+export function BoundTextField<X extends Only<TextFieldXss, X>>(props: BoundTextFieldProps<X>) {
   const { field, readOnly, onChange = (value) => field.set(value), label = defaultLabel(field.key), ...others } = props;
   const testId = useTestIds(props, field.key);
   return (

--- a/src/inputs/TextAreaField.stories.tsx
+++ b/src/inputs/TextAreaField.stories.tsx
@@ -1,8 +1,9 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
 import { useMemo, useState } from "react";
-import { Css } from "src/Css";
+import { Css, Only } from "src/Css";
 import { TextAreaField, TextAreaFieldProps, TextField } from "src/inputs";
+import { TextFieldXss } from "src/interfaces";
 
 export default {
   component: TextAreaField,
@@ -25,6 +26,9 @@ export function TextAreaStyles() {
         />
         <ValidationTextArea value="Not enough characters" />
         <TextField label="Regular Field For Reference" value="value" onChange={() => {}} />
+
+        <h1 css={Css.lg.$}>Modified for Blueprint To Do Title</h1>
+        <TestTextArea label="Title" value="Test title" preventNewLines hideLabel borderless xss={Css.xl2Em.$} />
       </div>
     </div>
   );
@@ -68,7 +72,7 @@ export function SchedulesV2TaskName() {
   );
 }
 
-function TestTextArea(props: Omit<TextAreaFieldProps, "onChange">) {
+function TestTextArea<X extends Only<TextFieldXss, X>>(props: Omit<TextAreaFieldProps<X>, "onChange">) {
   const { value, ...others } = props;
   const [internalValue, setValue] = useState(value);
   return (

--- a/src/inputs/TextAreaField.test.tsx
+++ b/src/inputs/TextAreaField.test.tsx
@@ -1,7 +1,9 @@
 import { render, type } from "@homebound/rtl-utils";
 import { fireEvent } from "@testing-library/react";
 import { useState } from "react";
+import { Only } from "src/Css";
 import { TextAreaField, TextAreaFieldProps } from "src/inputs";
+import { TextFieldXss } from "src/interfaces";
 
 let lastSet: any = undefined;
 
@@ -32,7 +34,7 @@ describe("TextAreaFieldTest", () => {
   });
 });
 
-function TestTextAreaField(props: Omit<TextAreaFieldProps, "onChange" | "label">) {
+function TestTextAreaField<X extends Only<TextFieldXss, X>>(props: Omit<TextAreaFieldProps<X>, "onChange" | "label">) {
   const { value, ...otherProps } = props;
   const [internalValue, setValue] = useState(value);
   return (

--- a/src/inputs/TextAreaField.tsx
+++ b/src/inputs/TextAreaField.tsx
@@ -1,17 +1,18 @@
 import { useLayoutEffect } from "@react-aria/utils";
 import { useCallback, useRef } from "react";
 import { mergeProps, useTextField } from "react-aria";
+import { Only } from "src/Css";
 import { TextFieldBase } from "src/inputs/TextFieldBase";
-import { BeamTextFieldProps } from "src/interfaces";
+import { BeamTextFieldProps, TextFieldXss } from "src/interfaces";
 
 // Exported for test purposes
-export interface TextAreaFieldProps extends BeamTextFieldProps {
+export interface TextAreaFieldProps<X> extends BeamTextFieldProps<X> {
   // Does not allow the user to enter new line characters and removes minimum height for textarea.
   preventNewLines?: boolean;
 }
 
 /** Returns a <textarea /> element that auto-adjusts height based on the field's value */
-export function TextAreaField(props: TextAreaFieldProps) {
+export function TextAreaField<X extends Only<TextFieldXss, X>>(props: TextAreaFieldProps<X>) {
   const { value = "", disabled = false, readOnly = false, onBlur, onFocus, preventNewLines, ...otherProps } = props;
   const textFieldProps = { ...otherProps, value, isDisabled: disabled, isReadOnly: readOnly };
   const inputRef = useRef<HTMLTextAreaElement | null>(null);

--- a/src/inputs/TextField.stories.tsx
+++ b/src/inputs/TextField.stories.tsx
@@ -1,8 +1,9 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
 import { useMemo, useState } from "react";
-import { Css } from "src/Css";
+import { Css, Only } from "src/Css";
 import { TextField, TextFieldProps } from "src/inputs";
+import { TextFieldXss } from "src/interfaces";
 
 export default {
   component: TextField,
@@ -85,7 +86,7 @@ export function TextFieldReadOnly() {
   );
 }
 
-function TestTextField(props: Omit<TextFieldProps, "onChange">) {
+function TestTextField<X extends Only<TextFieldXss, X>>(props: Omit<TextFieldProps<X>, "onChange">) {
   const { value, ...otherProps } = props;
   const [internalValue, setValue] = useState(value);
   return (
@@ -99,7 +100,7 @@ function TestTextField(props: Omit<TextFieldProps, "onChange">) {
   );
 }
 
-function ValidationTextField(props: Omit<TextFieldProps, "onChange">) {
+function ValidationTextField<X extends Only<TextFieldXss, X>>(props: Omit<TextFieldProps<X>, "onChange">) {
   const { value, ...otherProps } = props;
   const [internalValue, setValue] = useState<string | undefined>(value);
   // Validates that the input's value is a properly formatted email address.

--- a/src/inputs/TextField.test.tsx
+++ b/src/inputs/TextField.test.tsx
@@ -1,7 +1,9 @@
 import { render, type } from "@homebound/rtl-utils";
 import { fireEvent } from "@testing-library/react";
 import { useState } from "react";
+import { Only } from "src/Css";
 import { TextField, TextFieldProps } from "src/inputs";
+import { TextFieldXss } from "src/interfaces";
 import { click } from "src/utils/rtl";
 
 let lastSet: any = undefined;
@@ -66,7 +68,7 @@ describe("TextFieldTest", () => {
   });
 });
 
-function TestTextField(props: Omit<TextFieldProps, "onChange" | "label">) {
+function TestTextField<X extends Only<TextFieldXss, X>>(props: Omit<TextFieldProps<X>, "onChange" | "label">) {
   const { value, ...otherProps } = props;
   const [internalValue, setValue] = useState(value);
   return (

--- a/src/inputs/TextField.tsx
+++ b/src/inputs/TextField.tsx
@@ -1,16 +1,17 @@
 import { useRef } from "react";
 import { mergeProps, useTextField } from "react-aria";
+import { Only } from "src/Css";
 import { TextFieldBase } from "src/inputs/TextFieldBase";
-import { BeamTextFieldProps } from "src/interfaces";
+import { BeamTextFieldProps, TextFieldXss } from "src/interfaces";
 
 // exported for testing purposes
-export interface TextFieldProps extends BeamTextFieldProps {
+export interface TextFieldProps<X> extends BeamTextFieldProps<X> {
   compact?: boolean;
   inlineLabel?: boolean;
   clearable?: boolean;
 }
 
-export function TextField(props: TextFieldProps) {
+export function TextField<X extends Only<TextFieldXss, X>>(props: TextFieldProps<X>) {
   const {
     disabled: isDisabled = false,
     readOnly = false,

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -14,16 +14,16 @@ import { IconButton } from "src/components";
 import { HelperText } from "src/components/HelperText";
 import { InlineLabel, Label } from "src/components/Label";
 import { usePresentationContext } from "src/components/PresentationContext";
-import { Css, Palette, px, Xss } from "src/Css";
+import { Css, Only, Palette, px } from "src/Css";
 import { getLabelSuffix } from "src/forms/labelUtils";
 import { ErrorMessage } from "src/inputs/ErrorMessage";
-import { BeamTextFieldProps, TextFieldInternalProps } from "src/interfaces";
+import { BeamTextFieldProps, TextFieldInternalProps, TextFieldXss } from "src/interfaces";
 import { defaultTestId } from "src/utils/defaultTestId";
 import { useTestIds } from "src/utils/useTestIds";
 
-interface TextFieldBaseProps
+interface TextFieldBaseProps<X>
   extends Pick<
-      BeamTextFieldProps,
+      BeamTextFieldProps<X>,
       | "label"
       | "required"
       | "readOnly"
@@ -35,16 +35,15 @@ interface TextFieldBaseProps
       | "placeholder"
       | "compact"
       | "borderless"
+      | "xss"
     >,
-    Partial<Pick<BeamTextFieldProps, "onChange">> {
+    Partial<Pick<BeamTextFieldProps<X>, "onChange">> {
   labelProps?: LabelHTMLAttributes<HTMLLabelElement>;
   inputProps: InputHTMLAttributes<HTMLInputElement> | TextareaHTMLAttributes<HTMLTextAreaElement>;
   inputRef?: MutableRefObject<HTMLInputElement | HTMLTextAreaElement | null>;
   inputWrapRef?: MutableRefObject<HTMLDivElement | null>;
   multiline?: boolean;
   groupProps?: NumberFieldAria["groupProps"];
-  /** Styles overrides */
-  xss?: Xss<"textAlign" | "fontWeight" | "justifyContent">;
   endAdornment?: ReactNode;
   startAdornment?: ReactNode;
   inlineLabel?: boolean;
@@ -55,7 +54,7 @@ interface TextFieldBaseProps
 }
 
 // Used by both TextField and TextArea
-export function TextFieldBase(props: TextFieldBaseProps) {
+export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldBaseProps<X>) {
   const { fieldProps } = usePresentationContext();
   const {
     label,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,6 +1,7 @@
 import type { PressEvent } from "@react-types/shared";
 import { ReactNode } from "react";
 import { PresentationFieldProps } from "src/components/PresentationContext";
+import { Xss } from "src/Css";
 
 /** Base Interfaced */
 export interface BeamFocusableProps {
@@ -23,7 +24,9 @@ export interface BeamButtonProps {
   openInNew?: boolean;
 }
 
-export interface BeamTextFieldProps extends BeamFocusableProps, PresentationFieldProps {
+export type TextFieldXss = Xss<"textAlign" | "justifyContent" | "fontWeight" | "fontSize" | "lineHeight">;
+
+export interface BeamTextFieldProps<X> extends BeamFocusableProps, PresentationFieldProps {
   /** Whether the interactive element is disabled. */
   disabled?: boolean;
   errorMsg?: string;
@@ -42,6 +45,8 @@ export interface BeamTextFieldProps extends BeamFocusableProps, PresentationFiel
   onFocus?: () => void;
   readOnly?: boolean;
   placeholder?: string;
+  /** Styles overrides */
+  xss?: X;
 }
 
 export interface TextFieldInternalProps {


### PR DESCRIPTION
Bring XSS support further up the chain to allow it to be set when calling TextField or TextAreaField.
Support font-weight, font-size, and line-height in order to allow for changing font size.
Use 'Only' type to ensure other styles in xss with throw TS error.