### PR TITLE
feat: useHover hook

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from "./useComputed";
 export * from "./useGroupBy";
+export * from "./useHover";
 export * from "./usePersistedFilter";
 export * from "./useQueryState";
 export * from "./useSessionStorage";

--- a/src/hooks/useHover.ts
+++ b/src/hooks/useHover.ts
@@ -1,0 +1,20 @@
+import { HTMLAttributes } from "react";
+import { useHover as AriaUseHover } from "react-aria";
+import { Callback } from "src/types";
+
+interface useHoverProps {
+  // Handler that is called when a hover interaction starts
+  onHoverStart?: Callback;
+  // Handler that is called when a hover interaction ends
+  onHoverEnd?: Callback;
+  // Handler that is called when hover state changes
+  onHoverChange?: (isHovering: boolean) => void;
+  // If the hover events should be disabled
+  disabled?: boolean;
+}
+
+// Handles hover pointer interactions for an element.
+export function useHover(props: useHoverProps): { hoverProps: HTMLAttributes<HTMLElement>; isHovered: boolean } {
+  const { disabled: isDisabled, ...others } = props;
+  return AriaUseHover({ isDisabled, ...others });
+}


### PR DESCRIPTION
New hook 'useHover' which mimics the functionality from React-Aria's useHover hook.
This is a helpful hook for changing state of a child element when the parent element has been hovered.