### PR TITLE
fix: RichTextField to initialize based on trix supplied init event

### DIFF
--- a/src/components/IconButton.stories.tsx
+++ b/src/components/IconButton.stories.tsx
@@ -1,6 +1,6 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
-import { Css, IconButton as IconButton, IconButtonProps, iconButtonStylesHover, Icons, Palette } from "src";
+import { Css, IconButton, IconButtonProps, iconButtonStylesHover, Icons, Palette } from "src";
 import { withRouter } from "src/utils/sb";
 
 export default {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -39,7 +39,16 @@ export function Modal(props: ModalProps) {
   const { modalBodyDiv, modalFooterDiv, modalHeaderDiv, drawerContentStack } = useBeamContext();
   const { closeModal } = ourUseModal();
   const { overlayProps, underlayProps } = useOverlay(
-    { ...props, isOpen: true, onClose: closeModal, isDismissable: true },
+    {
+      ...props,
+      isOpen: true,
+      onClose: closeModal,
+      isDismissable: true,
+      shouldCloseOnInteractOutside: (el) => {
+        // Do not close the Modal if the user is interacting with the Tribute mentions dropdown (via RichTextField).
+        return !el.closest(".tribute-container");
+      },
+    },
     ref,
   );
   const { modalProps } = useModal();

--- a/src/components/Modal/TestModalContent.tsx
+++ b/src/components/Modal/TestModalContent.tsx
@@ -8,7 +8,7 @@ import { GridColumn, GridDataRow, GridTable, simpleHeader, SimpleHeaderAndDataOf
 import { Tag } from "src/components/Tag";
 import { Css } from "src/Css";
 import { jan1 } from "src/forms/formStateDomain";
-import { DateField, TextField } from "src/inputs";
+import { DateField, RichTextField, TextField } from "src/inputs";
 
 /** A fake modal content component that we share across the modal and superdrawer stories. */
 export function TestModalContent(props: {
@@ -22,7 +22,9 @@ export function TestModalContent(props: {
   const [numSentences, setNumSentences] = useState(initNumSentences);
   const [primaryDisabled, setPrimaryDisabled] = useState(false);
   const [leftActionDisabled, setLeftActionDisabled] = useState(false);
+  const [showRTE, setShowRTE] = useState(true);
   const [date, setDate] = useState(jan1);
+  const [rte, setRTE] = useState<string | undefined>("Init value");
   return (
     <>
       <ModalHeader>
@@ -41,6 +43,7 @@ export function TestModalContent(props: {
             <Button label="More" onClick={() => setNumSentences(numSentences + 2)} />
             <Button label="Clear" onClick={() => setNumSentences(0)} />
             <Button label="Primary" onClick={() => setPrimaryDisabled(!primaryDisabled)} />
+            <Button label="setShowRTE" onClick={() => setShowRTE(true)} />
             {showLeftAction && (
               <Button label="Left Action" onClick={() => setLeftActionDisabled(!leftActionDisabled)} />
             )}
@@ -48,6 +51,15 @@ export function TestModalContent(props: {
           <p>{"The body content of the modal. This content can be anything!".repeat(numSentences)}</p>
         </div>
         {withDateField && <DateField value={date} label="Date" onChange={setDate} />}
+
+        {showRTE && (
+          <RichTextField
+            value={rte}
+            onChange={(html) => {
+              setRTE(html);
+            }}
+          />
+        )}
       </ModalBody>
       <ModalFooter xss={showLeftAction ? Css.jcsb.$ : undefined}>
         {showLeftAction && (

--- a/src/components/Modal/TestModalContent.tsx
+++ b/src/components/Modal/TestModalContent.tsx
@@ -8,7 +8,7 @@ import { GridColumn, GridDataRow, GridTable, simpleHeader, SimpleHeaderAndDataOf
 import { Tag } from "src/components/Tag";
 import { Css } from "src/Css";
 import { jan1 } from "src/forms/formStateDomain";
-import { DateField, RichTextField, TextField } from "src/inputs";
+import { DateField, TextField } from "src/inputs";
 
 /** A fake modal content component that we share across the modal and superdrawer stories. */
 export function TestModalContent(props: {
@@ -22,9 +22,7 @@ export function TestModalContent(props: {
   const [numSentences, setNumSentences] = useState(initNumSentences);
   const [primaryDisabled, setPrimaryDisabled] = useState(false);
   const [leftActionDisabled, setLeftActionDisabled] = useState(false);
-  const [showRTE, setShowRTE] = useState(true);
   const [date, setDate] = useState(jan1);
-  const [rte, setRTE] = useState<string | undefined>("Init value");
   return (
     <>
       <ModalHeader>
@@ -43,7 +41,6 @@ export function TestModalContent(props: {
             <Button label="More" onClick={() => setNumSentences(numSentences + 2)} />
             <Button label="Clear" onClick={() => setNumSentences(0)} />
             <Button label="Primary" onClick={() => setPrimaryDisabled(!primaryDisabled)} />
-            <Button label="setShowRTE" onClick={() => setShowRTE(true)} />
             {showLeftAction && (
               <Button label="Left Action" onClick={() => setLeftActionDisabled(!leftActionDisabled)} />
             )}
@@ -51,15 +48,6 @@ export function TestModalContent(props: {
           <p>{"The body content of the modal. This content can be anything!".repeat(numSentences)}</p>
         </div>
         {withDateField && <DateField value={date} label="Date" onChange={setDate} />}
-
-        {showRTE && (
-          <RichTextField
-            value={rte}
-            onChange={(html) => {
-              setRTE(html);
-            }}
-          />
-        )}
       </ModalBody>
       <ModalFooter xss={showLeftAction ? Css.jcsb.$ : undefined}>
         {showLeftAction && (

--- a/src/inputs/RichTextField.tsx
+++ b/src/inputs/RichTextField.tsx
@@ -107,6 +107,7 @@ export function RichTextField(props: RichTextFieldProps) {
     }
 
     // Attaching listener to the `window` to we're listening prior to render.
+    // The <trix-editor /> web component's `trix-initialize` event may fire before a `useEffect` hook in the component is executed, making it difficult ot attach the event listener locally.
     window.addEventListener("trix-initialize", onEditorInit);
     return id;
   }, []);


### PR DESCRIPTION
Removing the document.getElementById call to grab the editor element and replacing with a useRef. This wasn't safe as when using the RichTextField within a Portal (such as a Modal) it was possible that the element for the editor is not yet in the DOM.
Now listening to the 'trix-initialize' event in order to set the editor ref and call 'loadHTML'. This is not immediately available off of the element's ref because the 'editor' is attached to the 'trix-editor' web component using 'requestAnimationFrame', which waits for the event loop to clear before running its execution (similar to a setTimeout(..., 0))