### PR TITLE
fix: Remove cloneElement from Tooltip to avoid

### DIFF
--- a/src/components/ButtonMenu.stories.tsx
+++ b/src/components/ButtonMenu.stories.tsx
@@ -96,3 +96,13 @@ export function DisabledMenu() {
     />
   );
 }
+
+export function WithTooltip() {
+  const menuItems: MenuItem[] = [
+    { label: "Menu Item 1", onClick: action("Menu Item 1") },
+    { label: "Menu Item 2", onClick: action("Menu Item 2") },
+    { label: "Menu Item 3", onClick: action("Menu Item 3") },
+  ];
+
+  return <ButtonMenu trigger={{ label: "Menu trigger" }} items={menuItems} tooltip="Tool tip text" />;
+}

--- a/src/components/ButtonMenu.tsx
+++ b/src/components/ButtonMenu.tsx
@@ -26,10 +26,12 @@ interface ButtonMenuProps {
   defaultOpen?: boolean;
   /** Whether the Button is disabled. If a ReactNode, it's treated as a "disabled reason" that's shown in a tooltip. */
   disabled?: boolean | ReactNode;
+  /** Text to be shown via a tooltip when the user hovers over the button */
+  tooltip?: ReactNode;
 }
 
 export function ButtonMenu(props: ButtonMenuProps) {
-  const { trigger, items, placement, persistentItems, defaultOpen, disabled } = props;
+  const { trigger, items, placement, persistentItems, defaultOpen, disabled, tooltip } = props;
   const state = useMenuTriggerState({ isOpen: defaultOpen });
   const buttonRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef(null);
@@ -74,6 +76,7 @@ export function ButtonMenu(props: ButtonMenuProps) {
           buttonRef={buttonRef}
           endAdornment={<Icon icon={state.isOpen ? "chevronUp" : "chevronDown"} />}
           disabled={disabled}
+          tooltip={tooltip}
           {...tid}
         />
       ) : (

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, ReactElement, ReactNode, useRef, useState } from "react";
+import React, { ReactElement, ReactNode, useRef, useState } from "react";
 import { mergeProps, useTooltip, useTooltipTrigger } from "react-aria";
 import { createPortal } from "react-dom";
 import { usePopper } from "react-popper";
@@ -28,7 +28,9 @@ export function Tooltip(props: TooltipProps) {
 
   return (
     <>
-      {cloneElement(children, { ref: triggerRef, ...triggerProps })}
+      <span ref={triggerRef} {...triggerProps}>
+        {children}
+      </span>
       {state.isOpen && (
         <Popper
           {...mergeProps(_tooltipProps, tooltipProps)}


### PR DESCRIPTION
The previous implementation to clone the element resulted in loss of functionality for the cloned element as the tooltip trigger props would overwrite pointer events tied to the element.
Now wrapping in our own span to provide the tooltip actions and keeps the existing children component/element as is.