### PR TITLE
feat: ChipTextField

### DIFF
--- a/src/inputs/ChipTextField.stories.tsx
+++ b/src/inputs/ChipTextField.stories.tsx
@@ -1,0 +1,39 @@
+import { action } from "@storybook/addon-actions";
+import { useState } from "react";
+import { PresentationProvider } from "src/components";
+import { Css } from "src/Css";
+import { ChipTextField } from "src/inputs/ChipTextField";
+
+export default {
+  component: ChipTextField,
+  title: "inputs/ChipTextField",
+};
+
+export function Example() {
+  const [value, setValue] = useState("Add new");
+  const [value2, setValue2] = useState("Add new");
+  return (
+    <div>
+      <h1 css={Css.xl.$}>Default</h1>
+      <ChipTextField
+        value={value}
+        label="Chip Field"
+        onChange={setValue}
+        onFocus={action("onFocus")}
+        onBlur={action("onBlur")}
+        required
+      />
+      <h1 css={Css.mt3.xl.$}>Within PresentationProvider with smaller Font Size set to 'xs'</h1>
+      <PresentationProvider fieldProps={{ typeScale: "xs" }}>
+        <ChipTextField
+          value={value2}
+          label="Chip Field"
+          onChange={setValue2}
+          onFocus={action("onFocus")}
+          onBlur={action("onBlur")}
+          required
+        />
+      </PresentationProvider>
+    </div>
+  );
+}

--- a/src/inputs/ChipTextField.test.tsx
+++ b/src/inputs/ChipTextField.test.tsx
@@ -6,13 +6,10 @@ import { render } from "src/utils/rtl";
 describe("ChipTextField", () => {
   it("renders", async () => {
     // Given the input
-    const r = await render(
-      <ChipTextField label="Test Label" value="Test value" placeholder="Test placeholder" required onChange={noop} />,
-    );
+    const r = await render(<ChipTextField label="Test Label" value="Test value" required onChange={noop} />);
     // Then all fields should be properly set
-    expect(r.chipInput())
-      .toHaveValue("Test value")
-      .toHaveAttribute("placeholder", "Test placeholder")
+    expect(r.chipField())
+      .toHaveTextContent("Test value")
       .toHaveAttribute("aria-label", "Test Label")
       .toHaveAttribute("aria-required", "true");
   });
@@ -28,16 +25,16 @@ describe("ChipTextField", () => {
     );
 
     // When firing the events on the input, then expect the callbacks to be invoked
-    fireEvent.focus(r.chipInput());
+    fireEvent.focus(r.chipField());
     expect(onFocus).toBeCalledTimes(1);
 
-    fireEvent.blur(r.chipInput());
+    fireEvent.blur(r.chipField());
     expect(onBlur).toBeCalledTimes(1);
 
-    fireEvent.keyDown(r.chipInput(), { key: "Enter" });
+    fireEvent.keyDown(r.chipField(), { key: "Enter" });
     expect(onEnter).toBeCalledTimes(1);
 
-    fireEvent.input(r.chipInput(), { target: { value: "New Value" } });
+    fireEvent.input(r.chipField(), { target: { textContent: "New Value" } });
     expect(onChange).toBeCalledWith("New Value");
   });
 
@@ -46,12 +43,12 @@ describe("ChipTextField", () => {
     // Given the Chip Input
     const r = await render(<ChipTextField label="Test Label" onChange={noop} onBlur={onBlur} />);
     // With focus
-    r.chipInput().focus();
-    expect(r.chipInput()).toHaveFocus();
+    r.chipField().focus();
+    expect(r.chipField()).toHaveFocus();
     // When pressing the escape key
-    fireEvent.keyDown(r.chipInput(), { key: "Escape" });
+    fireEvent.keyDown(r.chipField(), { key: "Escape" });
     // Then the element should no longer have focus
-    expect(r.chipInput()).not.toHaveFocus();
+    expect(r.chipField()).not.toHaveFocus();
     // And onBlur should have been called
     expect(onBlur).toBeCalledTimes(1);
   });
@@ -61,12 +58,12 @@ describe("ChipTextField", () => {
     // Given the Chip Input
     const r = await render(<ChipTextField label="Test Label" onChange={noop} blurOnEscape={false} onBlur={onBlur} />);
     // With focus
-    r.chipInput().focus();
-    expect(r.chipInput()).toHaveFocus();
+    r.chipField().focus();
+    expect(r.chipField()).toHaveFocus();
     // When pressing the escape key
-    fireEvent.keyDown(r.chipInput(), { key: "Escape" });
+    fireEvent.keyDown(r.chipField(), { key: "Escape" });
     // Then the element should still have focus
-    expect(r.chipInput()).toHaveFocus();
+    expect(r.chipField()).toHaveFocus();
     // And onBlur should not be called
     expect(onBlur).not.toBeCalled();
   });

--- a/src/inputs/ChipTextField.test.tsx
+++ b/src/inputs/ChipTextField.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent } from "@testing-library/react";
+import { ChipTextField } from "src/inputs/ChipTextField";
+import { noop } from "src/utils";
+import { render } from "src/utils/rtl";
+
+describe("ChipTextField", () => {
+  it("renders", async () => {
+    // Given the input
+    const r = await render(
+      <ChipTextField label="Test Label" value="Test value" placeholder="Test placeholder" required onChange={noop} />,
+    );
+    // Then all fields should be properly set
+    expect(r.chipInput())
+      .toHaveValue("Test value")
+      .toHaveAttribute("placeholder", "Test placeholder")
+      .toHaveAttribute("aria-label", "Test Label")
+      .toHaveAttribute("aria-required", "true");
+  });
+
+  it("fires callbacks", async () => {
+    // Given the component with callback functions
+    const onChange = jest.fn();
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    const onEnter = jest.fn();
+    const r = await render(
+      <ChipTextField label="Test Label" onChange={onChange} onBlur={onBlur} onFocus={onFocus} onEnter={onEnter} />,
+    );
+
+    // When firing the events on the input, then expect the callbacks to be invoked
+    fireEvent.focus(r.chipInput());
+    expect(onFocus).toBeCalledTimes(1);
+
+    fireEvent.blur(r.chipInput());
+    expect(onBlur).toBeCalledTimes(1);
+
+    fireEvent.keyDown(r.chipInput(), { key: "Enter" });
+    expect(onEnter).toBeCalledTimes(1);
+
+    fireEvent.input(r.chipInput(), { target: { value: "New Value" } });
+    expect(onChange).toBeCalledWith("New Value");
+  });
+
+  it("removes focus from input and calls onBlur when pressing escape", async () => {
+    const onBlur = jest.fn();
+    // Given the Chip Input
+    const r = await render(<ChipTextField label="Test Label" onChange={noop} onBlur={onBlur} />);
+    // With focus
+    r.chipInput().focus();
+    expect(r.chipInput()).toHaveFocus();
+    // When pressing the escape key
+    fireEvent.keyDown(r.chipInput(), { key: "Escape" });
+    // Then the element should no longer have focus
+    expect(r.chipInput()).not.toHaveFocus();
+    // And onBlur should have been called
+    expect(onBlur).toBeCalledTimes(1);
+  });
+
+  it("does not removes focus or call onBlur from input when pressing escape disabled", async () => {
+    const onBlur = jest.fn();
+    // Given the Chip Input
+    const r = await render(<ChipTextField label="Test Label" onChange={noop} blurOnEscape={false} onBlur={onBlur} />);
+    // With focus
+    r.chipInput().focus();
+    expect(r.chipInput()).toHaveFocus();
+    // When pressing the escape key
+    fireEvent.keyDown(r.chipInput(), { key: "Escape" });
+    // Then the element should still have focus
+    expect(r.chipInput()).toHaveFocus();
+    // And onBlur should not be called
+    expect(onBlur).not.toBeCalled();
+  });
+});

--- a/src/inputs/ChipTextField.tsx
+++ b/src/inputs/ChipTextField.tsx
@@ -1,5 +1,5 @@
-import { InputHTMLAttributes, KeyboardEvent, useRef, useState } from "react";
-import { useFocus, useTextField } from "react-aria";
+import { KeyboardEvent, useRef, useState } from "react";
+import { useFocus } from "react-aria";
 import { usePresentationContext } from "src/components/PresentationContext";
 import { Css } from "src/Css";
 import { maybeCall, useTestIds } from "src/utils";
@@ -11,8 +11,6 @@ interface ChipTextFieldProps {
   value?: string;
   // Whether the input is required. Adds aria-required attribute
   required?: boolean;
-  // Sets input's placeholder attribute
-  placeholder?: string;
   // Whether to call `onBlur` when the user presses the "Escape" key while focused on the input.
   // @default `true`
   blurOnEscape?: false;
@@ -28,47 +26,63 @@ interface ChipTextFieldProps {
 
 // A TextField styled to look like a Chip
 export function ChipTextField(props: ChipTextFieldProps) {
-  const { onFocus, onBlur, onEnter, required, label, blurOnEscape = true, ...otherProps } = props;
+  const { onFocus, onBlur, onEnter, onChange, required, label, value, blurOnEscape = true } = props;
   const { fieldProps } = usePresentationContext();
-  const tid = useTestIds(props, "chipInput");
+  // Use a ref for the value to not cause a re-render when it changes, avoiding cursor position resetting.
+  const valueRef = useRef(value);
+  const tid = useTestIds(props, "chipField");
   const [isFocused, setIsFocused] = useState(false);
   const { focusProps } = useFocus({
     onFocus: (e) => {
-      (e.target as HTMLInputElement).select();
+      if (fieldRef.current) {
+        // The range/selection logic is to select the text within the field on focus
+        const range = document.createRange();
+        range.selectNodeContents(fieldRef.current);
+        const selection = window.getSelection();
+        if (selection) {
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
+      }
       maybeCall(onFocus);
     },
     onBlur: () => maybeCall(onBlur),
     onFocusChange: setIsFocused,
   });
 
-  const textFieldProps = {
-    ...otherProps,
-    isRequired: required,
-    "aria-label": label,
-    onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Enter") {
-        maybeCall(onEnter);
-      } else if (blurOnEscape && e.key === "Escape") {
-        (e.target as HTMLInputElement).blur();
-      }
-    },
-  };
-
-  const inputRef = useRef<HTMLInputElement>(null);
-  const { inputProps } = useTextField(textFieldProps, inputRef);
+  const fieldRef = useRef<HTMLSpanElement>(null);
   const typeScale = fieldProps?.typeScale ?? "sm";
 
+  // React doesn't like contentEditable because it takes the children of the node out of React's scope. This is fine in this case as it is just a text value and we are managing it.
   return (
-    <input
-      {...(inputProps as InputHTMLAttributes<HTMLInputElement>)}
+    <span
+      ref={fieldRef}
+      contentEditable
+      suppressContentEditableWarning={true}
+      aria-required={required}
+      aria-label={label}
+      onKeyDown={(e: KeyboardEvent<HTMLElement>) => {
+        if (e.key === "Enter") {
+          e.preventDefault();
+          maybeCall(onEnter);
+        } else if (blurOnEscape && e.key === "Escape") {
+          (e.target as HTMLElement).blur();
+        }
+      }}
+      onInput={(e: KeyboardEvent<HTMLElement>) => {
+        // Prevent user from pasting content that has new line characters and replace with empty space.
+        const target = e.target as HTMLElement;
+        target.textContent = target.textContent?.replace(/[\n\r]/g, " ") ?? "";
+        onChange(target.textContent ?? "");
+      }}
       {...focusProps}
-      ref={inputRef}
       css={{
-        ...Css[typeScale].dif.aic.br16.pl1.pxPx(10).pyPx(2).gray900.bgGray300.outline0.$,
+        ...Css[typeScale].dib.br16.pl1.pxPx(10).pyPx(2).gray900.bgGray300.outline0.mwPx(32).$,
         ...(isFocused ? Css.bshFocus.$ : {}),
       }}
       {...tid}
-      size={props.value?.length ?? 1}
-    />
+    >
+      {valueRef.current}
+    </span>
   );
 }

--- a/src/inputs/ChipTextField.tsx
+++ b/src/inputs/ChipTextField.tsx
@@ -1,0 +1,74 @@
+import { InputHTMLAttributes, KeyboardEvent, useRef, useState } from "react";
+import { useFocus, useTextField } from "react-aria";
+import { usePresentationContext } from "src/components/PresentationContext";
+import { Css } from "src/Css";
+import { maybeCall, useTestIds } from "src/utils";
+
+interface ChipTextFieldProps {
+  // Label is not visible in the component, but required for accessibility purposes
+  label: string;
+  // Current value of the input element
+  value?: string;
+  // Whether the input is required. Adds aria-required attribute
+  required?: boolean;
+  // Sets input's placeholder attribute
+  placeholder?: string;
+  // Whether to call `onBlur` when the user presses the "Escape" key while focused on the input.
+  // @default `true`
+  blurOnEscape?: false;
+  // Callback fired when the user changes the value of the input
+  onChange: (value: string) => void;
+  // Callback fired when focus removes from the input
+  onBlur?: () => void;
+  // Callback fired when focus is set to the input
+  onFocus?: () => void;
+  // Callback when the user presses the "Enter" key while focused on the input
+  onEnter?: () => void;
+}
+
+// A TextField styled to look like a Chip
+export function ChipTextField(props: ChipTextFieldProps) {
+  const { onFocus, onBlur, onEnter, required, label, blurOnEscape = true, ...otherProps } = props;
+  const { fieldProps } = usePresentationContext();
+  const tid = useTestIds(props, "chipInput");
+  const [isFocused, setIsFocused] = useState(false);
+  const { focusProps } = useFocus({
+    onFocus: (e) => {
+      (e.target as HTMLInputElement).select();
+      maybeCall(onFocus);
+    },
+    onBlur: () => maybeCall(onBlur),
+    onFocusChange: setIsFocused,
+  });
+
+  const textFieldProps = {
+    ...otherProps,
+    isRequired: required,
+    "aria-label": label,
+    onKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        maybeCall(onEnter);
+      } else if (blurOnEscape && e.key === "Escape") {
+        (e.target as HTMLInputElement).blur();
+      }
+    },
+  };
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { inputProps } = useTextField(textFieldProps, inputRef);
+  const typeScale = fieldProps?.typeScale ?? "sm";
+
+  return (
+    <input
+      {...(inputProps as InputHTMLAttributes<HTMLInputElement>)}
+      {...focusProps}
+      ref={inputRef}
+      css={{
+        ...Css[typeScale].dif.aic.br16.pl1.pxPx(10).pyPx(2).gray900.bgGray300.outline0.$,
+        ...(isFocused ? Css.bshFocus.$ : {}),
+      }}
+      {...tid}
+      size={props.value?.length ?? 1}
+    />
+  );
+}


### PR DESCRIPTION
ChipTextField is expected to be used in SchedulesV2 when creating a new Subcategory. It is mostly a self contained form, which is why we handle an onEnter (for "Save") and listening to the "Escape" key to blur the field.