### PR TITLE
fix: NumberField to support displaying plus sign for positive numbers.

### DIFF
--- a/src/inputs/NumberField.test.tsx
+++ b/src/inputs/NumberField.test.tsx
@@ -96,6 +96,30 @@ describe("NumberFieldTest", () => {
     type(r.days, "1");
     expect(r.days()).toHaveValue("1 day");
   });
+
+  it("does not allow for decimal values in days type", async () => {
+    const r = await render(<TestNumberField label="Days" type="days" value={2} />);
+    expect(r.days()).toHaveValue("2 days");
+    type(r.days, "1.23");
+    expect(r.days()).toHaveValue("1 day");
+  });
+
+  it("displays direction of positive values and no direction display for zero", async () => {
+    const r = await render(
+      <>
+        <TestNumberField label="Days" type="days" value={123} displayDirection />
+        <TestNumberField label="Cents" type="cents" value={456} displayDirection />
+        <TestNumberField label="Basis Points" type="basisPoints" value={789} displayDirection />
+        <TestNumberField label="Percent" type="percent" value={123} displayDirection />
+        <TestNumberField label="Zero Percent" type="percent" value={0} displayDirection />
+      </>,
+    );
+    expect(r.days()).toHaveValue("+123 days");
+    expect(r.cents()).toHaveValue("+$4.56");
+    expect(r.basisPoints()).toHaveValue("+7.89%");
+    expect(r.percent()).toHaveValue("+123%");
+    expect(r.zeroPercent()).toHaveValue("0%");
+  });
 });
 
 describe("parseRawInput function", () => {

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -26,6 +26,8 @@ export interface NumberFieldProps {
   readOnly?: boolean;
   /** Styles overrides */
   xss?: Xss<"textAlign" | "justifyContent">;
+  // If set, all positive values will be prefixed with "+". (Zero will not show +/-)
+  displayDirection?: boolean;
 }
 
 export function NumberField(props: NumberFieldProps) {
@@ -45,22 +47,24 @@ export function NumberField(props: NumberFieldProps) {
     value,
     onChange,
     xss,
+    displayDirection = false,
     ...otherProps
   } = props;
 
   const factor = type === "percent" || type === "cents" ? 100 : type === "basisPoints" ? 10_000 : 1;
+  const signDisplay = displayDirection ? "exceptZero" : "auto";
 
   // If formatOptions isn't memo'd, a useEffect in useNumberStateField will cause jank,
   // see: https://github.com/adobe/react-spectrum/issues/1893.
   const formatOptions: Intl.NumberFormatOptions | undefined = useMemo(() => {
     return type === "percent"
-      ? { style: "percent" }
+      ? { style: "percent", signDisplay }
       : type === "basisPoints"
-      ? { style: "percent", minimumFractionDigits: 2 }
+      ? { style: "percent", minimumFractionDigits: 2, signDisplay }
       : type === "cents"
-      ? { style: "currency", currency: "USD", minimumFractionDigits: 2 }
+      ? { style: "currency", currency: "USD", minimumFractionDigits: 2, signDisplay }
       : type === "days"
-      ? { style: "unit", unit: "day", unitDisplay: "long" }
+      ? { style: "unit", unit: "day", unitDisplay: "long", maximumFractionDigits: 0, signDisplay }
       : undefined;
   }, [type]);
 


### PR DESCRIPTION
Additional change: 'days' type does not allow for decimal values - integers only.