### PR TITLE
fix: All Chip components to only be one line of text

### DIFF
--- a/src/components/Chip.test.tsx
+++ b/src/components/Chip.test.tsx
@@ -5,6 +5,7 @@ describe("Chip", () => {
   it("renders", async () => {
     const r = await render(<Chip text="Chip text content" />);
     expect(r.chip().textContent).toBe("Chip text content");
+    expect(r.chip()).toHaveAttribute("title", "Chip text content");
   });
 
   it("can set custom testids", async () => {

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -18,8 +18,9 @@ export function Chip<X extends Only<Xss<Margin>, X>>(props: ChipProps<X>) {
         ...xss,
       }}
       {...tid}
+      title={text}
     >
-      {text}
+      <span css={Css.lineClamp1.$}>{text}</span>
     </span>
   );
 }

--- a/src/components/ToggleChip.tsx
+++ b/src/components/ToggleChip.tsx
@@ -33,7 +33,9 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
       onClick={onClick}
       {...tid}
     >
-      <span css={Css.prPx(6).tl.if(disabled).prPx(4).$}>{text}</span>
+      <span css={Css.prPx(6).tl.lineClamp1.if(disabled).prPx(4).$} title={text}>
+        {text}
+      </span>
       {!disabled && (
         <span css={Css.fs0.br16.bgGray400.$}>
           <Icon icon="x" color={Palette.Gray700} />

--- a/src/inputs/ChipSelectField.stories.tsx
+++ b/src/inputs/ChipSelectField.stories.tsx
@@ -18,10 +18,11 @@ export function Example() {
     { id: "ts:1", code: TaskStatus.NotStarted, name: "Not Started" },
     { id: "ts:2", code: TaskStatus.InProgress, name: "In Progress" },
     { id: "ts:3", code: TaskStatus.Complete, name: "Complete" },
-    { id: "ts:5", code: TaskStatus.OnHold, name: "On Hold" },
+    { id: "ts:5", code: TaskStatus.OnHold, name: "On Hold ".repeat(10) },
     { id: "ts:6", code: TaskStatus.Delayed, name: "Delayed" },
   ]);
   const [value, setValue] = useState<string>(taskStatuses[0].id);
+  const [value2, setValue2] = useState<string>(taskStatuses[3].id);
 
   return (
     <div>
@@ -47,6 +48,19 @@ export function Example() {
           placeholder="+ Task Status"
         />
       </div>
+      <div css={Css.wPx(250).$}>
+        <h1>Truncation demo</h1>
+        <ChipSelectField
+          label="Test"
+          onSelect={(v) => setValue2(v)}
+          options={taskStatuses}
+          value={value2}
+          clearable
+          onFocus={action("onFocus")}
+          onBlur={action("onBlur")}
+          placeholder="+ Task Status"
+        />
+      </div>
 
       <h1 css={Css.mt4.$}>Chip SelectField With Presentation typeScale of "xs"</h1>
       <PresentationProvider fieldProps={{ typeScale: "xs" }}>
@@ -65,6 +79,19 @@ export function Example() {
             onSelect={(v) => setValue(v)}
             options={taskStatuses}
             value={value}
+            clearable
+            onFocus={action("onFocus")}
+            onBlur={action("onBlur")}
+            placeholder="+ Task Status"
+          />
+        </div>
+        <div css={Css.wPx(250).$}>
+          <h1>Truncation demo</h1>
+          <ChipSelectField
+            label="Test"
+            onSelect={(v) => setValue2(v)}
+            options={taskStatuses}
+            value={value2}
             clearable
             onFocus={action("onFocus")}
             onBlur={action("onBlur")}

--- a/src/inputs/ChipSelectField.test.tsx
+++ b/src/inputs/ChipSelectField.test.tsx
@@ -11,7 +11,7 @@ describe("ChipSelectField", () => {
     // Given a ChipSelectField
     const r = await render(<TestComponent label="Test Label" value="s:2" options={sports} />);
     // Then the initial value should display
-    expect(r.chipSelectField()).toHaveTextContent("Soccer");
+    expect(r.chipSelectField()).toHaveTextContent("Soccer").toHaveAttribute("title", "Soccer");
     // And the label should display
     expect(r.chipSelectField_label()).toHaveTextContent("Test Label");
   });
@@ -57,6 +57,7 @@ describe("ChipSelectField", () => {
     expect(r.chipSelectField()).toHaveTextContent("Soccer");
     // When selecting a new value
     click(r.chipSelectField);
+    expect(r.getByRole("option", { name: "Basketball" }).firstChild).toHaveAttribute("title", "Basketball");
     click(r.getByRole("option", { name: "Basketball" }));
     // Then the field's value updates
     expect(r.chipSelectField()).toHaveTextContent("Basketball");

--- a/src/inputs/ChipSelectField.tsx
+++ b/src/inputs/ChipSelectField.tsx
@@ -73,13 +73,15 @@ export function ChipSelectField<O, V extends Value>(
   const popoverRef = useRef<HTMLDivElement>(null);
   const listBoxRef = useRef(null);
 
-  const chipStyles = Css[typeScale].bgGray300.gray900.br16.pxPx(10).pyPx(2).$;
+  const chipStyles = Css[typeScale].tl.bgGray300.gray900.br16.pxPx(10).pyPx(2).$;
 
   const selectChildren = useMemo(
     () =>
       options.map((o) => (
         <Item key={valueToKey(getOptionValue(o))} textValue={getOptionLabel(o)}>
-          <span css={chipStyles}>{getOptionLabel(o)}</span>
+          <span css={{ ...Css.lineClamp1.$, ...chipStyles }} title={getOptionLabel(o)}>
+            {getOptionLabel(o)}
+          </span>
         </Item>
       )),
     [options],
@@ -133,7 +135,7 @@ export function ChipSelectField<O, V extends Value>(
       <div
         css={{
           ...chipStyles,
-          ...Css.dif.p0.mwPx(32).if(!value).bgGray200.$,
+          ...Css.dif.relative.p0.mwPx(32).if(!value).bgGray200.$,
           ...(isFocused ? Css.bshFocus.$ : {}),
         }}
       >
@@ -142,12 +144,15 @@ export function ChipSelectField<O, V extends Value>(
           {...mergeProps(focusProps, buttonProps)}
           ref={buttonRef}
           css={{
-            ...Css.br16.pxPx(10).pyPx(2).outline0.if(showClearButton).prPx(4).borderRadius("16px 0 0 16px").$,
+            ...Css.tl.br16.pxPx(10).pyPx(2).outline0.if(showClearButton).prPx(4).borderRadius("16px 0 0 16px").$,
             "&:hover": Css.bgGray400.if(!value).bgGray300.$,
           }}
+          title={state.selectedItem ? state.selectedItem.textValue : placeholder}
           {...tid}
         >
-          <span {...valueProps}>{state.selectedItem ? state.selectedItem.textValue : placeholder}</span>
+          <span {...valueProps} css={Css.lineClamp1.$}>
+            {state.selectedItem ? state.selectedItem.textValue : placeholder}
+          </span>
         </button>
         {showClearButton && (
           // Apply a tabIndex=-1 to remove need for addresses this focus behavior separately from the rest of the button.


### PR DESCRIPTION
If the text within a Chip exceeds the width allotted to it, then it will use an ellipsis. A title attribute is also tied to the Chip to display the full value of the chip on hover.