### PR TITLE
fix: Break mid word in Chips and Tags when truncated

### DIFF
--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -20,7 +20,7 @@ export function Chip<X extends Only<Xss<Margin>, X>>(props: ChipProps<X>) {
       {...tid}
       title={text}
     >
-      <span css={Css.lineClamp1.$}>{text}</span>
+      <span css={Css.lineClamp1.breakAll.$}>{text}</span>
     </span>
   );
 }

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -19,7 +19,7 @@ export function Tag<X extends Only<Xss<TagXss>, X>>({ text, type, xss, ...otherP
     <span {...tid} css={{ ...Css.dib.tinyEm.ttu.px1.pyPx(4).gray900.br4.$, ...typeStyles, ...xss }} title={text}>
       {/* Nesting `lineClamp` styles as the padding bottom set would expose the remainder of the text if applied on the same element */}
       {/* Using `lineClamp1` instead of `truncate` as `truncate` requires a width set to properly truncate and `lineClamp` can smartly do it based on the parent's width */}
-      <span css={Css.lineClamp1.$}>{text}</span>
+      <span css={Css.lineClamp1.breakAll.$}>{text}</span>
     </span>
   );
 }

--- a/src/components/ToggleChip.tsx
+++ b/src/components/ToggleChip.tsx
@@ -33,7 +33,7 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
       onClick={onClick}
       {...tid}
     >
-      <span css={Css.prPx(6).tl.lineClamp1.if(disabled).prPx(4).$} title={text}>
+      <span css={Css.prPx(6).tl.lineClamp1.breakAll.if(disabled).prPx(4).$} title={text}>
         {text}
       </span>
       {!disabled && (

--- a/src/inputs/ChipSelectField.tsx
+++ b/src/inputs/ChipSelectField.tsx
@@ -113,7 +113,7 @@ export function ChipSelectField<O, V extends Value>(
         {isPersistent ? (
           label
         ) : (
-          <span css={{ ...Css.lineClamp1.$, ...chipStyles }} title={label}>
+          <span css={{ ...Css.lineClamp1.breakAll.$, ...chipStyles }} title={label}>
             {label}
           </span>
         )}
@@ -216,7 +216,7 @@ export function ChipSelectField<O, V extends Value>(
           title={state.selectedItem ? state.selectedItem.textValue : placeholder}
           {...tid}
         >
-          <span {...valueProps} css={Css.lineClamp1.$}>
+          <span {...valueProps} css={Css.lineClamp1.breakAll.$}>
             {state.selectedItem ? state.selectedItem.textValue : placeholder}
           </span>
         </button>


### PR DESCRIPTION
The result reveals more of the content of the Chip's/Tag's text, utilizing all of the space of the available to the Chip/Tag.