### PR TITLE
feat: Fields should blur on interactions

### DIFF
--- a/src/inputs/ChipSelectField.test.tsx
+++ b/src/inputs/ChipSelectField.test.tsx
@@ -36,7 +36,10 @@ describe("ChipSelectField", () => {
   it("is clearable", async () => {
     // Given a ChipSelectField that is clearable
     const onSelect = jest.fn();
-    const r = await render(<TestComponent label="Label" value="s:2" options={sports} clearable onSelect={onSelect} />);
+    const onBlur = jest.fn();
+    const r = await render(
+      <TestComponent label="Label" value="s:2" options={sports} clearable onSelect={onSelect} onBlur={onBlur} />,
+    );
     // With an existing value
     expect(r.chipSelectField()).toHaveTextContent("Soccer");
     // When clicking the clear button
@@ -47,6 +50,8 @@ describe("ChipSelectField", () => {
     expect(r.queryByTestId("chipSelectField_clearButton")).toBeFalsy();
     // And onSelect to be called
     expect(onSelect).toBeCalledWith([undefined, undefined]);
+    // And the `onBlur` callback is triggered
+    expect(onBlur).toBeCalledTimes(1);
   });
 
   it("can select options", async () => {
@@ -100,9 +105,7 @@ describe("ChipSelectField", () => {
     click(r.getByRole("option", { name: "Basketball" }));
     // Then the focus is returned to the field
     expect(onFocus).toBeCalledTimes(2);
-    // When firing the onBlur event
-    fireEvent.blur(r.chipSelectField());
-    // Then expect blur is now able to be called
+    // And immediately blurred.
     expect(onBlur).toBeCalledTimes(1);
   });
 

--- a/src/inputs/ChipSelectField.test.tsx
+++ b/src/inputs/ChipSelectField.test.tsx
@@ -96,8 +96,8 @@ describe("ChipSelectField", () => {
     click(r.chipSelectField);
     // And onFocus should have been called
     expect(onFocus).toBeCalledTimes(1);
-    // And when firing the blur event while the menu is opened,
-    fireEvent.blur(r.chipSelectField());
+    // And when firing the blur event with a related target being an element within the menu
+    fireEvent.blur(r.chipSelectField(), { relatedTarget: r.getByRole("option", { name: "Basketball" }) });
     // Then the onBlur event should not be called
     expect(onBlur).toBeCalledTimes(0);
 

--- a/src/inputs/ChipSelectField.tsx
+++ b/src/inputs/ChipSelectField.tsx
@@ -142,10 +142,14 @@ export function ChipSelectField<O, V extends Value>(
       if (selectedItem) {
         onSelect(key as V, selectedItem);
       }
+      // Per UX, when a field is selected then we want to call our `onBlur` callback and remove the focus styles. The field _is_ still in focus, but that is only to retain tab position in the DOM.
+      setIsFocused(false);
+      maybeCall(onBlur);
     },
     onOpenChange: (isOpen) => {
       if (!isOpen && buttonRef.current) {
-        // When closing reset the focus to the button element.
+        // When closing reset the focus to the button element. This is to retain "tab position" in the document, allowing hte user to hit "Tab" and move to the next tabbable element.
+        // If the menu closed due to a user selecting an option, then the field will not visually appear focused.
         buttonRef.current.focus();
       }
     },
@@ -232,6 +236,7 @@ export function ChipSelectField<O, V extends Value>(
             }}
             onClick={() => {
               onSelect(undefined as any, undefined as any);
+              maybeCall(onBlur);
               setIsClearFocused(false);
             }}
             aria-label="Remove"

--- a/src/inputs/ChipSelectField.tsx
+++ b/src/inputs/ChipSelectField.tsx
@@ -59,7 +59,8 @@ export function ChipSelectField<O, V extends Value>(
   const isDisabled = !!disabled;
   const showClearButton = !disabled && clearable && !!value;
   const chipStyles = Css[typeScale].tl.bgGray300.gray900.br16.pxPx(10).pyPx(2).$;
-  const [isFocused, setIsFocused] = useState(false);
+  // Controls showing the focus border styles.
+  const [visualFocus, setVisualFocus] = useState(false);
   const [isClearFocused, setIsClearFocused] = useState(false);
   const { focusProps } = useFocus({
     onFocus: (e) => {
@@ -70,10 +71,16 @@ export function ChipSelectField<O, V extends Value>(
 
       maybeCall(onFocus);
     },
-    // Do not call onBlur if we just opened the menu
-    onBlur: () => !state.isOpen && maybeCall(onBlur),
-    // Do not change focus state if select menu is opened
-    onFocusChange: (isFocused) => !state.isOpen && setIsFocused(isFocused),
+    onBlur: (e) => {
+      // Do not call onBlur if focus moved to within the Popover
+      if (popoverRef.current && popoverRef.current.contains(e.relatedTarget as HTMLElement)) {
+        return;
+      }
+
+      maybeCall(onBlur);
+    },
+    // Do not change visual focus state if select menu is opened
+    onFocusChange: (isFocused) => !state.isOpen && setVisualFocus(isFocused),
   });
   const { focusProps: clearFocusProps } = useFocus({ onFocusChange: setIsClearFocused });
 
@@ -126,13 +133,13 @@ export function ChipSelectField<O, V extends Value>(
     isDisabled,
     items: listData.items,
     children: selectChildren,
+    autoFocus: true,
   };
 
   const state = useSelectState<any>({
     ...selectHookProps,
-    autoFocus: false,
     selectedKey: valueToKey(value),
-    disallowEmptySelection: true,
+    disallowEmptySelection: false,
     onSelectionChange: (key) => {
       if (key === createNewOpt.id) {
         setShowInput(true);
@@ -142,15 +149,19 @@ export function ChipSelectField<O, V extends Value>(
       if (selectedItem) {
         onSelect(key as V, selectedItem);
       }
-      // Per UX, when a field is selected then we want to call our `onBlur` callback and remove the focus styles. The field _is_ still in focus, but that is only to retain tab position in the DOM.
-      setIsFocused(false);
+      // Per UX, when an option is selected then we want to call our `onBlur` callback and remove the focus styles. The field _is_ still in focus but that is only to retain tab position in the DOM.
+      // We cannot simply call `buttonRef.current.blur()` here because `state.isOpen === true` and we keep the visualFocus shown when the menu is open.
+      setVisualFocus(false);
       maybeCall(onBlur);
     },
     onOpenChange: (isOpen) => {
-      if (!isOpen && buttonRef.current) {
-        // When closing reset the focus to the button element. This is to retain "tab position" in the document, allowing hte user to hit "Tab" and move to the next tabbable element.
+      if (!isOpen) {
+        // When closing, reset the focus to the button element. This is to retain "tab position" in the document, allowing hte user to hit "Tab" and move to the next tabbable element.
         // If the menu closed due to a user selecting an option, then the field will not visually appear focused.
-        buttonRef.current.focus();
+        buttonRef.current?.focus();
+      } else {
+        // If opened, set visual focus to true. It is possible to be in a state where the browser focus is on this element, but we are not "visually" focused (see `onSelectionChange`). If the user opens the menu again, we should trigger the visual focus.
+        setVisualFocus(true);
       }
     },
   });
@@ -204,7 +215,7 @@ export function ChipSelectField<O, V extends Value>(
         css={{
           ...chipStyles,
           ...Css.dif.relative.p0.mwPx(32).if(!value).bgGray200.$,
-          ...(isFocused ? Css.bshFocus.$ : {}),
+          ...(visualFocus ? Css.bshFocus.$ : {}),
           ...(showInput ? Css.dn.$ : {}),
         }}
       >
@@ -225,8 +236,6 @@ export function ChipSelectField<O, V extends Value>(
           </span>
         </button>
         {showClearButton && (
-          // Apply a tabIndex=-1 to remove need for addresses this focus behavior separately from the rest of the button.
-          // This will require the user to click on the button if they want to remove it.
           <button
             {...clearFocusProps}
             css={{
@@ -262,6 +271,7 @@ export function ChipSelectField<O, V extends Value>(
             getOptionLabel={getOptionLabel}
             getOptionValue={getOptionValue}
             positionProps={overlayProps}
+            positionOffset={8}
           />
         </Popover>
       )}

--- a/src/inputs/DateField.test.tsx
+++ b/src/inputs/DateField.test.tsx
@@ -115,8 +115,8 @@ describe("DateField", () => {
     expect(r.date_datePicker()).toBeTruthy();
 
     // Fire the blur event with the date picker as the related target. This should not fire `onBlur`, but will set the proper focus state internally.
-    expect(onBlur).toBeCalledTimes(0);
     fireEvent.blur(r.date(), { relatedTarget: r.date_datePicker() });
+    expect(onBlur).toBeCalledTimes(0);
 
     // And when selecting a date - React-Day-Picker uses role="gridcell" for all dates. Choose the first of these, which should be `jan1`
     click(r.queryAllByRole("gridcell")[0]);

--- a/src/inputs/DateField.test.tsx
+++ b/src/inputs/DateField.test.tsx
@@ -103,15 +103,20 @@ describe("DateField", () => {
     expect(onBlur).toBeCalledTimes(1);
   });
 
-  it("can select dates", async () => {
+  it("can select dates and calls onBlur", async () => {
     // Given a DateField with `jan2` as our date
     const onChange = jest.fn();
-    const r = await render(<DateField value={jan2} label="Date" onChange={onChange} />);
+    const onBlur = jest.fn();
+    const r = await render(<DateField value={jan2} label="Date" onChange={onChange} onBlur={onBlur} />);
 
     // When triggering the Date Picker
     fireEvent.focus(r.date());
     // Then the Date Picker should be shown
     expect(r.date_datePicker()).toBeTruthy();
+
+    // Fire the blur event with the date picker as the related target. This should not fire `onBlur`, but will set the proper focus state internally.
+    expect(onBlur).toBeCalledTimes(0);
+    fireEvent.blur(r.date(), { relatedTarget: r.date_datePicker() });
 
     // And when selecting a date - React-Day-Picker uses role="gridcell" for all dates. Choose the first of these, which should be `jan1`
     click(r.queryAllByRole("gridcell")[0]);
@@ -121,6 +126,22 @@ describe("DateField", () => {
     expect(r.date()).toHaveValue("01/01/20");
     expect(onChange).toBeCalledTimes(1);
     expect(new Date(onChange.mock.calls[0][0]).toDateString()).toEqual(jan1.toDateString());
+    // And the date picker closes
+    expect(onBlur).toBeCalledTimes(1);
+  });
+
+  it("fires on blur when pressing Enter key", async () => {
+    // Given a DateField with `jan2` as our date
+    const onBlur = jest.fn();
+    const r = await render(<DateField value={jan2} label="Date" onChange={noop} onBlur={onBlur} />);
+    // When changing the input value to an valid date
+    r.date().focus();
+    // And when hitting the Enter key
+    fireEvent.keyDown(r.date(), { key: "Enter" });
+    // Then field should be no longer in focus
+    expect(r.date()).not.toHaveFocus();
+    // And the onBlur callback should be triggered
+    expect(onBlur).toBeCalledTimes(1);
   });
 
   it("resets to previous date if user enters invalid value and does not fire onChange", async () => {

--- a/src/inputs/DateField.tsx
+++ b/src/inputs/DateField.tsx
@@ -117,6 +117,12 @@ export function DateField(props: DateFieldProps) {
         state.close();
         maybeCall(onBlur);
       },
+      onKeyDown: (e) => {
+        if (e.key === "Enter") {
+          // Blur the field when the user hits the enter key - as if they are "committing" the value and done with the field
+          inputRef.current?.blur();
+        }
+      },
     },
     inputRef,
   );

--- a/src/inputs/NumberField.test.tsx
+++ b/src/inputs/NumberField.test.tsx
@@ -120,6 +120,21 @@ describe("NumberFieldTest", () => {
     expect(r.percent()).toHaveValue("+123%");
     expect(r.zeroPercent()).toHaveValue("0%");
   });
+
+  it("can blur on Enter", async () => {
+    const onBlur = jest.fn();
+    // Given a numberfield
+    const r = await render(<TestNumberField label="Age" value={10} onBlur={onBlur} />);
+    // With focus
+    r.age().focus();
+    expect(r.age()).toHaveFocus();
+    // When hitting the Enter key
+    fireEvent.keyDown(r.age(), { key: "Enter" });
+    // Then the field should no longer have focus
+    expect(r.age()).not.toHaveFocus();
+    // And onBlur should be called
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("parseRawInput function", () => {

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -101,6 +101,12 @@ export function NumberField(props: NumberFieldProps) {
     onBlur: () => {
       valueRef.current = { wip: false };
     },
+    onKeyDown: (e) => {
+      if (e.key === "Enter") {
+        // Blur the field when the user hits the enter key - as if they are "committing" the value and done with the field
+        inputRef.current?.blur();
+      }
+    },
     validationState: errorMsg !== undefined ? "invalid" : "valid",
     label: label,
     isDisabled: disabled,

--- a/src/inputs/SelectField.test.tsx
+++ b/src/inputs/SelectField.test.tsx
@@ -14,7 +14,8 @@ describe("SelectFieldTest", () => {
 
   it("can set a value", async () => {
     // Given a MultiSelectField
-    const { getByRole, age } = await render(
+    const onBlur = jest.fn();
+    const r = await render(
       <TestSelectField
         label="Age"
         value={"1"}
@@ -22,15 +23,21 @@ describe("SelectFieldTest", () => {
         getOptionLabel={(o) => o.name}
         getOptionValue={(o) => o.id}
         data-testid="age"
+        onBlur={onBlur}
       />,
     );
     // That initially has "One" selected
-    expect(age()).toHaveValue("One");
-    // When we select the 3rd option
-    fireEvent.focus(age());
-    click(getByRole("option", { name: "Three" }));
+    expect(r.age()).toHaveValue("One");
+    // When we focus the field to open the menu
+    r.age().focus();
+    expect(r.age()).toHaveFocus();
+    // And we select the 3rd option
+    click(r.getByRole("option", { name: "Three" }));
     // Then onSelect was called
     expect(onSelect).toHaveBeenCalledWith("3");
+    // And the field is no longer in focus
+    expect(r.age()).not.toHaveFocus();
+    expect(onBlur).toHaveBeenCalledTimes(1);
   });
 
   it("does not fire focus/blur when readOnly", async () => {

--- a/src/inputs/TextAreaField.test.tsx
+++ b/src/inputs/TextAreaField.test.tsx
@@ -32,6 +32,16 @@ describe("TextAreaFieldTest", () => {
     expect(onFocus).not.toHaveBeenCalled();
     expect(onBlur).not.toHaveBeenCalled();
   });
+
+  it("fires blur when preventNewLines is set and hitting the Enter key", async () => {
+    const onBlur = jest.fn();
+    const r = await render(<TestTextAreaField value="foo" onBlur={onBlur} preventNewLines />);
+    r.note().focus();
+    expect(r.note()).toHaveFocus();
+    fireEvent.keyDown(r.note(), { key: "Enter" });
+    expect(r.note()).not.toHaveFocus();
+    expect(onBlur).toBeCalledTimes(1);
+  });
 });
 
 function TestTextAreaField<X extends Only<TextFieldXss, X>>(props: Omit<TextAreaFieldProps<X>, "onChange" | "label">) {

--- a/src/inputs/TextAreaField.tsx
+++ b/src/inputs/TextAreaField.tsx
@@ -53,8 +53,10 @@ export function TextAreaField<X extends Only<TextFieldXss, X>>(props: TextAreaFi
         ? {
             onKeyDown: (e) => {
               // Prevent user from typing the new line character
-              if (e.keyCode === 13) {
+              if (e.key === "Enter") {
                 e.preventDefault();
+                // And then leave the field
+                inputRef.current?.blur();
               }
             },
             onInput: (e) => {

--- a/src/inputs/TextField.test.tsx
+++ b/src/inputs/TextField.test.tsx
@@ -82,6 +82,21 @@ describe("TextFieldTest", () => {
     // And onFocus callback to be called
     expect(onFocus).toHaveBeenCalledTimes(1);
   });
+
+  it("can blur on Enter", async () => {
+    const onBlur = jest.fn();
+    // Given a textfield
+    const r = await render(<TestTextField value="foo" onBlur={onBlur} />);
+    // With focus
+    r.name().focus();
+    expect(r.name()).toHaveFocus();
+    // When hitting the Enter key
+    fireEvent.keyDown(r.name(), { key: "Enter" });
+    // Then the field should no longer have focus
+    expect(r.name()).not.toHaveFocus();
+    // And onBlur should be called
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
 });
 
 function TestTextField<X extends Only<TextFieldXss, X>>(props: Omit<TextFieldProps<X>, "onChange" | "label">) {

--- a/src/inputs/TextField.tsx
+++ b/src/inputs/TextField.tsx
@@ -34,7 +34,18 @@ export function TextField<X extends Only<TextFieldXss, X>>(props: TextFieldProps
     value,
   };
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const { labelProps, inputProps } = useTextField(textFieldProps, inputRef);
+  const { labelProps, inputProps } = useTextField(
+    {
+      ...textFieldProps,
+      onKeyDown: (e) => {
+        if (e.key === "Enter") {
+          // Blur the field when the user hits the enter key - as if they are "committing" the value and done with the field
+          inputRef.current?.blur();
+        }
+      },
+    },
+    inputRef,
+  );
 
   // Construct our TextFieldApi to give access to some imperative methods
   if (api) {

--- a/src/inputs/internal/SelectFieldBase.tsx
+++ b/src/inputs/internal/SelectFieldBase.tsx
@@ -120,6 +120,8 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
         selectedKeys: [firstKey] as Key[],
         selectedOptions: firstSelectedOption ? [firstSelectedOption] : [],
       });
+      // When a single select menu item changes, then blur the field
+      inputRef.current?.blur();
     }
     selectionChanged && onSelect(([...keys.values()] as Key[]).map(keyToValue) as V[]);
   }


### PR DESCRIPTION
SelectField, ChipSelectField, and DateField should blur whenever a user changes the value.
TextField, TextAreaField (with preventNewLines), NumberField, and DateField should blur when the user hits the Enter key