### PR TITLE
[POC] - Draggable & Add In Place POC

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -258,6 +258,58 @@ export function NestedCardsThreeLevels() {
   );
 }
 
+export function NestedCardsThreeLevelsDraggable() {
+  const nameColumn: GridColumn<NestedRow> = {
+    header: () => "Name",
+    parent: (row) => ({
+      content: <div css={Css.base.$}>{row.name}</div>,
+      value: row.name,
+    }),
+    child: (row) => ({
+      content: <div css={Css.sm.$}>{row.name}</div>,
+      value: row.name,
+    }),
+    grandChild: (row) => ({
+      content: <div css={Css.xs.$}>{row.name}</div>,
+      value: row.name,
+    }),
+    add: () => "Add",
+  };
+  const actionColumn: GridColumn<NestedRow> = {
+    header: () => "Action",
+    parent: () => "",
+    child: () => "",
+    grandChild: () => <div css={Css.xs.$}>Delete</div>,
+    add: () => "",
+    clientSideSort: false,
+  };
+  const spacing = { brPx: 4, pxPx: 4 };
+  const nestedStyle: GridStyle = {
+    nestedCards: {
+      firstLastColumnWidth: 24,
+      spacerPx: 8,
+      kinds: {
+        parent: { bgColor: Palette.Gray500, ...spacing },
+        child: { bgColor: Palette.Gray200, bColor: Palette.Gray600, ...spacing },
+        grandChild: { bgColor: Palette.Green200, bColor: Palette.Green400, ...spacing },
+        // Purposefully leave out the `add` kind
+      },
+    },
+  };
+
+  return (
+    <div css={Css.df.fdc.vh100.$}>
+      <GridTable
+        as="virtualFixed"
+        columns={[nameColumn, nameColumn, actionColumn]}
+        {...{ rows }}
+        style={nestedStyle}
+        sorting={{ on: "client", initial: [0, "ASC"] }}
+      />
+    </div>
+  );
+}
+
 export function NestedCardsTwoLevels() {
   const nameColumn: GridColumn<NestedRow> = {
     header: () => "Name",

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -274,7 +274,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
     const nestedCards = !!style.nestedCards && new NestedCards(columns, filteredRows, style);
 
     // Depth-first to filter
-    function visit(row: GridDataRow<R>, prev: GridDataRow<R> | undefined, next: GridDataRow<R> | undefined): void {
+    function visit(row: GridDataRow<R>): void {
       const matches =
         filters.length === 0 ||
         row.pin ||
@@ -290,7 +290,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
 
       const isCollapsed = collapsedIds.includes(row.id);
       if (!isCollapsed && !!row.children?.length) {
-        nestedCards && matches && nestedCards.addSpacer(prev, next);
+        nestedCards && matches && nestedCards.addSpacer(undefined, row.children[0]);
         visitRows(row.children, isCard);
       }
 
@@ -301,15 +301,17 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
       const length = rows.length;
       rows.forEach((row, i) => {
         if (row.kind === "header") {
+          addSpacer && nestedCards && nestedCards.addSpacer(undefined, rows[i + 1]);
           nestedCards && nestedCards.maybeOpenCard(row);
           headerRows.push([row, makeRowComponent(row)]);
           nestedCards && nestedCards.closeCard();
           return;
         }
 
-        visit(row, rows[i - 1], rows[i + 1]);
-        addSpacer && nestedCards && i !== length - 1 && nestedCards.addSpacer();
+        visit(row);
+        addSpacer && nestedCards && i !== length - 1 && nestedCards.addSpacer(rows[i], rows[i + 1]);
       });
+      addSpacer && nestedCards && nestedCards.addSpacer(rows[rows.length - 1], undefined);
     }
 
     function makeRowComponent(row: GridDataRow<R>): JSX.Element {

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -1,3 +1,4 @@
+import { Global } from "@emotion/react";
 import memoizeOne from "memoize-one";
 import { Observer } from "mobx-react";
 import React, {
@@ -311,6 +312,8 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
         visit(row);
         addSpacer && nestedCards && i !== length - 1 && nestedCards.addSpacer(rows[i], rows[i + 1]);
       });
+
+      // Add spacer after a card
       addSpacer && nestedCards && nestedCards.addSpacer(rows[rows.length - 1], undefined);
     }
 
@@ -396,6 +399,11 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
   const _as = as === "virtual" && runningInJest ? "div" : as;
   return (
     <PresentationProvider fieldProps={{ hideLabel: true, numberAlignment: "right", compact: true }}>
+      <Global
+        styles={{
+          ".row-drag-hover": Css.bgLightBlue100.important.$,
+        }}
+      />
       {renders[_as](
         style,
         id,

--- a/src/components/Table/SchedulesV2.stories.tsx
+++ b/src/components/Table/SchedulesV2.stories.tsx
@@ -203,6 +203,7 @@ export function SchedulesV2() {
     <div css={Css.h("100vh").$}>
       <PresentationProvider fieldProps={{ borderless: true, typeScale: "xs" }}>
         <GridTable<Row>
+          as="virtualFixed"
           rows={rows}
           columns={[
             arrowColumn,
@@ -224,9 +225,6 @@ export function SchedulesV2() {
               cellCss: Css.py1.$,
             },
           }}
-          // FIXME: `firstNonHeaderRowCss` does not work when virtual is enabled
-          // Possible fix is to use an ref/class/id for this row
-          // as="virtual"
           stickyHeader
         />
       </PresentationProvider>
@@ -290,9 +288,6 @@ export function Draggable1() {
           <Spacer />
         </>
       ))}
-
-      {/* Grid Items - Headers */}
-      {/* Grid Items - Rows */}
     </div>
   );
 }

--- a/src/components/Table/SchedulesV2.stories.tsx
+++ b/src/components/Table/SchedulesV2.stories.tsx
@@ -251,34 +251,48 @@ SchedulesV2.storyName = "SchedulesV2";
  */
 export function Draggable1() {
   const columns = ["Task", "Start", "End", "Duration", "Milestone"];
-  const rows = zeroTo(5).map((i) => columns.map((c) => `${c}#${i}`));
+  const rows = zeroTo(5).map((i) => columns.map((c) => `${c} #${i}`));
+
+  const Spacer = () => (
+    <div
+      css={Css.hPx(10).$}
+      onDragOver={(e) => (e.currentTarget.style.backgroundColor = "red")}
+      onDragLeave={(e) => (e.currentTarget.style.backgroundColor = "white")}
+    ></div>
+  );
 
   return (
-    // Grid Container
-    <div css={Css.dg.gtc(`repeat(${columns.length}, 1fr)`).$}>
-      {/* Grid Items - Headers */}
-      {columns.map((column) => (
-        <div key={column.toString()} css={Css.bgGray100.bb.mb1.$}>
-          {column}
-        </div>
-      ))}
-      {/* Grid Items - Rows */}
+    // Table
+    <div css={Css.w100.$}>
+      {/* Header */}
+      <div css={Css.bgGray100.bb.p1.df.$}>
+        {columns.map((column) => (
+          <div key={column.toString()} css={Css.w(`${100 / columns.length}%`).$}>
+            {column}
+          </div>
+        ))}
+      </div>
+
+      {/* Header + Row Spacer */}
+      <Spacer />
+
+      {/* Rows */}
       {rows.map((row) => (
-        <div
-          key={row.toString()}
-          style={{
-            cursor: "grab",
-            paddingTop: "10px",
-            // This allows us to wrap all of the children for a single row
-            display: "contents",
-          }}
-          draggable
-        >
-          {row.map((cell) => (
-            <div key={cell.toString()}>{cell}</div>
-          ))}
-        </div>
+        <>
+          <div key={row.toString()} css={Css.ba.cursorPointer.df.$} draggable>
+            {row.map((cell) => (
+              <div key={cell.toString()} css={Css.w(`${100 / columns.length}%`).$}>
+                {cell}
+              </div>
+            ))}
+          </div>
+          {/* Bottom Spacer */}
+          <Spacer />
+        </>
       ))}
+
+      {/* Grid Items - Headers */}
+      {/* Grid Items - Rows */}
     </div>
   );
 }

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -54,7 +54,7 @@ export class NestedCards {
   }
 
   addSpacer(below: GridDataRow<any> | undefined, above: GridDataRow<any> | undefined) {
-    this.chromeBuffer.push(makeSpacer(this.styles.spacerPx, this.openCards, below, above));
+    this.chromeBuffer.push(Spacer(this.styles.spacerPx, this.openCards, below, above));
   }
 
   done() {
@@ -146,14 +146,24 @@ export function maybeAddCardPadding(openCards: Array<NestedCard<any>>, column: "
  * Our height is not based on `openCards`, b/c for the top-most level, we won't
  * have any open cards, but still want a space between top-level cards.
  */
-export function makeSpacer(
+export function Spacer(
   height: number,
   openCards: Array<NestedCard<any>>,
   below: GridDataRow<any> | undefined,
   above: GridDataRow<any> | undefined,
 ) {
-  const noOpenCards = openCards.length == 0;
+  const noOpenCards = openCards.length === 0;
   const parentId = noOpenCards ? "root" : openCards[openCards.length - 1].row.id;
+
+  // TODO: Currently hardcoding these styles. Should pass down the variable
+  const visuallyDraggableProps = {
+    onDragEnter: (e) => {
+      e.currentTarget.classList.add("row-drag-hover");
+    },
+    onDragLeave: (e) => {
+      e.currentTarget.classList.remove("row-drag-hover");
+    },
+  };
 
   let div = (
     <div
@@ -182,24 +192,7 @@ export function makeSpacer(
           console.log(row);
         },
       }}
-      {...(noOpenCards && {
-        onClick: (e) => {
-          console.log(`
-            ParentId: ${e.currentTarget.dataset.parentId}\n
-            Dropped AboveRowId: ${above?.id}
-            Dropped BelowRowId: ${below?.id}
-          `);
-        },
-        onDragEnter: (e) => {
-          e.currentTarget.style.backgroundColor = "red";
-        },
-        onDragLeave: (e) => {
-          // Restore previous styles
-          // Before changing the background, save the current styles
-          // @ts-ignore
-          // TODO: Restore the orig styles
-        },
-      })}
+      {...(noOpenCards && visuallyDraggableProps)}
     />
   );
 
@@ -211,17 +204,7 @@ export function makeSpacer(
 
     div = (
       <div
-        {...(isShallowestDiv && {
-          onDragEnter: (e) => {
-            e.currentTarget.style.backgroundColor = "red";
-          },
-          onDragLeave: (e) => {
-            // Restore previous styles
-            // Before changing the background, save the current styles
-            // @ts-ignore
-            // TODO: Restore the orig styles
-          },
-        })}
+        {...(isShallowestDiv && visuallyDraggableProps)}
         data-parentid={isShallowestDiv ? arr[0].row.id : undefined}
         css={Css.bgColor(style.bgColor).pxPx(style.pxPx).if(!!style.bColor).bc(style.bColor).bl.br.$}
       >

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -53,8 +53,8 @@ export class NestedCards {
     this.openCards.pop();
   }
 
-  addSpacer(prev: GridDataRow<R> | undefined, next: GridDataRow<R> | undefined) {
-    this.chromeBuffer.push(makeSpacer(this.styles.spacerPx, this.openCards, prev, next));
+  addSpacer(below: GridDataRow<any> | undefined, above: GridDataRow<any> | undefined) {
+    this.chromeBuffer.push(makeSpacer(this.styles.spacerPx, this.openCards, below, above));
   }
 
   done() {
@@ -149,8 +149,8 @@ export function maybeAddCardPadding(openCards: Array<NestedCard<any>>, column: "
 export function makeSpacer(
   height: number,
   openCards: Array<NestedCard<any>>,
-  prev: GridDataRow<any> | undefined,
-  next: GridDataRow<any> | undefined,
+  below: GridDataRow<any> | undefined,
+  above: GridDataRow<any> | undefined,
 ) {
   const noOpenCards = openCards.length == 0;
   const parentId = noOpenCards ? "root" : openCards[openCards.length - 1].row.id;
@@ -160,6 +160,13 @@ export function makeSpacer(
       css={Css.hPx(height).$}
       data-parent-id={parentId}
       {...{
+        onClick: (e) => {
+          console.log(`
+            ParentId: ${e.currentTarget.dataset.parentId}\n
+            Dropped AboveRowId: ${above?.id}
+            Dropped BelowRowId: ${below?.id}
+          `);
+        },
         onDragOver: (e) => e.preventDefault(),
         onDrop: (e) => {
           // The row data being dropped
@@ -169,13 +176,20 @@ export function makeSpacer(
           console.log(`
             DroppedId: ${row.id}\n
             ParentId: ${e.currentTarget.dataset.parentId}\n
-            AboveRowId: ${prev?.id}
-            BelowRowId: ${next?.id}
+            AboveRowId: ${below?.id}
+            BelowRowId: ${above?.id}
           `);
           console.log(row);
         },
       }}
       {...(noOpenCards && {
+        onClick: (e) => {
+          console.log(`
+            ParentId: ${e.currentTarget.dataset.parentId}\n
+            Dropped AboveRowId: ${above?.id}
+            Dropped BelowRowId: ${below?.id}
+          `);
+        },
         onDragEnter: (e) => {
           e.currentTarget.style.backgroundColor = "red";
         },


### PR DESCRIPTION
This is a POC WIP of potentially how "Drag and Drop" and the "Add in Place" could be introduced into Beam GridTables. Thanks to @chr1sjf0x for the great pairing on this ideation! 

The general changes are as follow:

1. Create a new renderer that removes `display: contents` (this allows the use of the HTML attribute `draggable`)
2. Add spacer row to the last element in a card so that we can add the dragging and add in place functionality to the spacer row only.
3. Pass contextual information to the NestedCard class to help store the parent, above and below ID's for each row. This is what is used to pass positional information to the callback.

If you are interested in taking this for a spin, the Storybook SchedulesV2 example shows in the console relevant outputs when dragging any element over a spacer row.