### PR TITLE
POC - Unsorted Table

### DIFF
--- a/src/components/Table/useSortState.ts
+++ b/src/components/Table/useSortState.ts
@@ -42,7 +42,7 @@ export function useSortState<R extends Kinded, S>(
       const [newKey, newDirection] =
         // If clickedKey === currentKey, then toggle direction
         clickedKey === currentKey
-          ? [currentKey, currentDirection === ASC ? DESC : ASC]
+          ? [currentKey, currentDirection === ASC ? DESC : currentDirection === DESC ? undefined : ASC]
           : // Otherwise, use the new key, and default to ascending
             [clickedKey, ASC];
       setSortState([newKey, newDirection]);


### PR DESCRIPTION
This is a very minimal exploration on adding to the table headers the ability on the 3rd click to unsort/return the sort back to the original state.

In the .gif below, it doesn't seem to be going back to the original state may be due to the `currentKey` not being reset... There is more to explore here for sure, just wanted to get something out to start a conversation 😄 

![CleanShot 2021-12-02 at 10 59 56](https://user-images.githubusercontent.com/3606121/144457588-58414597-8dc8-4876-94f1-8fd89f2d0261.gif)

*As you can see, when unsorting the value column the rows don't seem to go back to their original state.*
