### PR TITLE
fix: ChipSelectField and ListBox updates

### DIFF
--- a/src/inputs/ChipSelectField.test.tsx
+++ b/src/inputs/ChipSelectField.test.tsx
@@ -118,12 +118,21 @@ describe("ChipSelectField", () => {
     // Given a ChipSelectField with the onCreateNew prop
     const newOpt = { id: "s:100", name: "New Sport" };
     const onCreateNew = jest.fn();
+    const onBlur = jest.fn();
     const r = await render(
-      <TestComponent label="Label" value="s:2" options={sports} onCreateNew={async (str) => onCreateNew(str)} />,
+      <TestComponent
+        label="Label"
+        value="s:2"
+        options={sports}
+        onCreateNew={async (str) => onCreateNew(str)}
+        onBlur={onBlur}
+      />,
     );
     // When selecting the "Create new" option
     click(r.chipSelectField);
     click(r.getByRole("option", { name: "Create new" }));
+    // Then onBlur should be called initially when the ChipInputField is shown
+    expect(onBlur).toBeCalledTimes(1);
     // Then expect the select field to be removed and input field to show
     expect(r.chipSelectField_createNewField()).toBeTruthy();
     expect(r.queryByTestId("chipSelectField")).not.toBeVisible();
@@ -137,6 +146,8 @@ describe("ChipSelectField", () => {
     expect(r.queryByTestId("chipSelectField_createNewField")).toBeFalsy();
     // And onCreateNew to be called with text field value
     expect(onCreateNew).toBeCalledWith(newOpt.name);
+    // And triggers onBlur again
+    expect(onBlur).toBeCalledTimes(2);
   });
 
   it("can escape out of Add New field", async () => {

--- a/src/inputs/internal/ListBox.tsx
+++ b/src/inputs/internal/ListBox.tsx
@@ -1,11 +1,11 @@
-import React, { Key, MutableRefObject, useEffect, useRef, useState } from "react";
+import React, { Key, MutableRefObject, useState } from "react";
 import { useListBox } from "react-aria";
 import { SelectState } from "react-stately";
-import { Virtuoso } from "react-virtuoso";
-import { VirtuosoHandle } from "react-virtuoso/dist/components";
 import { ToggleChip } from "src/components/ToggleChip";
 import { Css } from "src/Css";
-import { Option } from "src/inputs/internal/Option";
+import { persistentItemHeight, sectionSeparatorHeight } from "src/inputs/internal/constants";
+import { ListBoxSection } from "src/inputs/internal/ListBoxSection";
+import { VirtualizedOptions } from "src/inputs/internal/VirtualizedOptions";
 
 interface ListBoxProps<O, V extends Key> {
   listBoxRef: MutableRefObject<HTMLDivElement | null>;
@@ -15,7 +15,6 @@ interface ListBoxProps<O, V extends Key> {
   getOptionValue: (opt: O) => V;
   contrast?: boolean;
   positionProps: React.HTMLAttributes<Element>;
-  positionOffset?: number;
 }
 
 /** A ListBox is an internal component used by SelectField and MultiSelectField to display the list of options */
@@ -28,35 +27,32 @@ export function ListBox<O, V extends Key>(props: ListBoxProps<O, V>) {
     getOptionValue,
     contrast = false,
     positionProps,
-    positionOffset = 4,
   } = props;
-  const { listBoxProps } = useListBox(
-    { disallowEmptySelection: true, shouldFocusOnHover: true, ...props },
-    state,
-    listBoxRef,
-  );
-
+  const { listBoxProps } = useListBox({ disallowEmptySelection: true, ...props }, state, listBoxRef);
   const positionMaxHeight = positionProps.style?.maxHeight;
-  // The maxListHeight will be based on the value defined by the positionProps returned from `useOverlayPosition` (which will always be a defined as a `number` based on React-Aria's `calculatePosition`).
-  // If `maxHeight` is set use that, otherwise use `273` as a default (`42px` is the min-height of each option, so this allows
-  // 6.5 options in view at a time (doing `.5` so the user can easily tell if there are more).
-  const maxListHeight = positionMaxHeight && typeof positionMaxHeight === "number" ? positionMaxHeight : 273;
-  const [listHeight, setListHeight] = useState(maxListHeight);
+  // The popoverMaxHeight will be based on the value defined by the positionProps returned from `useOverlayPosition` (which will always be a defined as a `number` based on React-Aria's `calculatePosition`).
+  // If `maxHeight` is set use that, otherwise use `maxPopoverHeight` as a default, per UX guidelines.
+  // (`positionMaxHeight` should always be set and defined as a number, but we need to do these type checks to make TS happy)
+  const popoverMaxHeight =
+    positionMaxHeight && typeof positionMaxHeight === "number"
+      ? Math.min(positionMaxHeight, maxPopoverHeight)
+      : maxPopoverHeight;
+  const [popoverHeight, setPopoverHeight] = useState(popoverMaxHeight);
   const isMultiSelect = state.selectionManager.selectionMode === "multiple";
-  const virtuosoRef = useRef<VirtuosoHandle>(null);
-  const focusedItem = state.collection.getItem(state.selectionManager.focusedKey);
-
-  // Handle scrolling to the item in focus when navigating options via Keyboard
-  useEffect(() => {
-    if (virtuosoRef.current && focusedItem?.index) {
-      virtuosoRef.current.scrollToIndex({ index: focusedItem.index, align: "center" });
-    }
-  }, [focusedItem]);
+  const firstItem = state.collection.at(0);
+  const hasSections = firstItem && firstItem.type === "section";
+  const onListHeightChange = (height: number) => {
+    // Using Math.min to choose between the smaller height, either the total height of the List (`height` arg), or the maximum height defined by the space allotted on screen or our hard coded max.
+    // If there are ListBoxSections, then we assume it is the persistent section with a single item and account for that height.
+    setPopoverHeight(
+      Math.min(popoverMaxHeight, hasSections ? height + persistentItemHeight + sectionSeparatorHeight : height),
+    );
+  };
 
   return (
     <div
       css={{
-        ...Css.bgWhite.br4.w100.bshBasic.myPx(positionOffset).if(contrast).bgGray700.$,
+        ...Css.bgWhite.br4.w100.bshBasic.if(contrast).bgGray700.$,
         "&:hover": Css.bshHover.$,
       }}
       ref={listBoxRef}
@@ -76,24 +72,31 @@ export function ListBox<O, V extends Key>(props: ListBoxProps<O, V>) {
           ))}
         </ul>
       )}
-      <ul css={Css.listReset.hPx(Math.min(maxListHeight, listHeight)).$}>
-        <Virtuoso
-          ref={virtuosoRef}
-          totalListHeightChanged={setListHeight}
-          totalCount={state.collection.size}
-          // We don't really need to set this, but it's handy for tests, which would
-          // otherwise render just 1 row. A better way to do this would be to jest.mock
-          // out Virtuoso with an impl that just rendered everything, but doing this for now.
-          initialItemCount={5}
-          itemContent={(idx) => {
-            // MapIterator doesn't have at/index lookup so make a copy
-            const keys = [...state.collection.getKeys()];
-            const item = state.collection.getItem(keys[idx]);
-            if (item) {
-              return <Option key={item.key} item={item} state={state} contrast={contrast} />;
-            }
-          }}
-        />
+
+      <ul css={Css.listReset.hPx(popoverHeight).$}>
+        {hasSections ? (
+          [...state.collection].map((section) => (
+            <ListBoxSection
+              key={section.key}
+              section={section}
+              state={state}
+              contrast={contrast}
+              onListHeightChange={onListHeightChange}
+              popoverHeight={popoverHeight}
+              // Only scroll on focus if using VirtualFocus (used for ComboBoxState (SelectField), but not SelectState (ChipSelectField))
+              scrollOnFocus={(props as any).shouldUseVirtualFocus}
+            />
+          ))
+        ) : (
+          <VirtualizedOptions
+            state={state}
+            items={[...state.collection]}
+            onListHeightChange={onListHeightChange}
+            contrast={contrast}
+            // Only scroll on focus if using VirtualFocus (used for ComboBoxState (SelectField), but not SelectState (ChipSelectField))
+            scrollOnFocus={(props as any).shouldUseVirtualFocus}
+          />
+        )}
       </ul>
     </div>
   );
@@ -122,3 +125,6 @@ function ListBoxChip<O, V extends Key>(props: ListBoxChipProps<O, V>) {
     </li>
   );
 }
+
+// UX specified maximum height for a ListBox (in pixels)
+const maxPopoverHeight = 512;

--- a/src/inputs/internal/ListBoxSection.tsx
+++ b/src/inputs/internal/ListBoxSection.tsx
@@ -1,0 +1,51 @@
+import { Node } from "@react-types/shared";
+import React from "react";
+import { useListBoxSection, useSeparator } from "react-aria";
+import { SelectState } from "react-stately";
+import { Css } from "src/Css";
+import { persistentItemHeight, sectionSeparatorHeight } from "src/inputs/internal/constants";
+import { Option } from "src/inputs/internal/Option";
+import { VirtualizedOptions } from "src/inputs/internal/VirtualizedOptions";
+
+interface ListBoxSectionProps<O> {
+  section: Node<O>;
+  state: SelectState<O>;
+  contrast: boolean;
+  onListHeightChange: (height: number) => void;
+  popoverHeight: number;
+  scrollOnFocus?: boolean;
+}
+export function ListBoxSection<O>(props: ListBoxSectionProps<O>) {
+  const { section, state, contrast, onListHeightChange, popoverHeight, scrollOnFocus } = props;
+  const { itemProps, groupProps } = useListBoxSection(section);
+  const { separatorProps } = useSeparator({ elementType: "li" });
+  const isPersistentSection = section.key !== state.collection.getFirstKey();
+  const childNodes = [...section.childNodes];
+
+  return (
+    <>
+      {isPersistentSection && <li {...separatorProps} css={Css.bt.bGray200.$} />}
+      <li {...itemProps} css={Css.if(!isPersistentSection).overflowAuto.$}>
+        {/* Styles assume only one Persistent Item is ever shown. Will need to adjust if that ever changes */}
+        <ul
+          css={
+            Css.listReset.if(!isPersistentSection).hPx(popoverHeight - sectionSeparatorHeight - persistentItemHeight).$
+          }
+          {...groupProps}
+        >
+          {isPersistentSection ? (
+            childNodes.map((item) => <Option key={item.key} item={item} state={state} contrast={contrast} />)
+          ) : (
+            <VirtualizedOptions
+              state={state}
+              items={childNodes}
+              onListHeightChange={onListHeightChange}
+              contrast={contrast}
+              scrollOnFocus={scrollOnFocus}
+            />
+          )}
+        </ul>
+      </li>
+    </>
+  );
+}

--- a/src/inputs/internal/ListBoxSection.tsx
+++ b/src/inputs/internal/ListBoxSection.tsx
@@ -15,6 +15,9 @@ interface ListBoxSectionProps<O> {
   popoverHeight: number;
   scrollOnFocus?: boolean;
 }
+
+// Creates a section of options within a ListBox.
+// Currently only expects two possible sections; 1. The list of options, and 2. A persistent action (in that order).
 export function ListBoxSection<O>(props: ListBoxSectionProps<O>) {
   const { section, state, contrast, onListHeightChange, popoverHeight, scrollOnFocus } = props;
   const { itemProps, groupProps } = useListBoxSection(section);

--- a/src/inputs/internal/Option.tsx
+++ b/src/inputs/internal/Option.tsx
@@ -33,6 +33,7 @@ export function Option<O>(props: OptionProps<O>) {
     ref,
   );
 
+  // Additional onKeyDown logic to ensure the  the virtualized list (in <VirtualizedOptions />) scrolls to keep the "focused" option in view
   const onKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (!scrollToIndex || !(e.key === "ArrowDown" || e.key === "ArrowUp")) {

--- a/src/inputs/internal/SelectFieldBase.tsx
+++ b/src/inputs/internal/SelectFieldBase.tsx
@@ -253,6 +253,7 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
     isOpen: state.isOpen,
     onClose: state.close,
     placement: "bottom left",
+    offset: borderless ? 8 : 4,
   });
 
   positionProps.style = {
@@ -311,8 +312,6 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
             getOptionLabel={getOptionLabel}
             getOptionValue={(o) => valueToKey(getOptionValue(o))}
             contrast={contrast}
-            // If the field is set as `borderless`, then the focus state is done with a box-shadow and set further away from the input. If this happens then we want the ListBox to be positioned further away as well.
-            positionOffset={borderless ? 8 : undefined}
           />
         </Popover>
       )}

--- a/src/inputs/internal/VirtualizedOptions.tsx
+++ b/src/inputs/internal/VirtualizedOptions.tsx
@@ -1,0 +1,62 @@
+import { Node } from "@react-types/shared";
+import React, { useEffect, useRef } from "react";
+import { SelectState } from "react-stately";
+import { Virtuoso } from "react-virtuoso";
+import { VirtuosoHandle } from "react-virtuoso/dist/components";
+import { Option } from "src/inputs/internal/Option";
+
+interface VirtualizedOptionsProps<O> {
+  state: SelectState<O>;
+  items: Node<O>[];
+  onListHeightChange: (height: number) => void;
+  contrast: boolean;
+  // Whether we should auto-scroll to the item in focus. Should only be used when Options are using "virtual focus". Should not be used if focus is triggered on clicking an element.
+  scrollOnFocus?: boolean;
+}
+
+// Displays ListBox options in a virtualized container for performance reasons
+export function VirtualizedOptions<O>(props: VirtualizedOptionsProps<O>) {
+  const { state, items, onListHeightChange, contrast, scrollOnFocus } = props;
+  const virtuosoRef = useRef<VirtuosoHandle>(null);
+  const focusedItem = state.collection.getItem(state.selectionManager.focusedKey);
+  const selectedItem =
+    state.selectionManager.selectedKeys.size > 0
+      ? state.collection.getItem([...state.selectionManager.selectedKeys.values()][0])
+      : undefined;
+
+  // Handle scrolling to the item in focus when navigating options via Keyboard - this should only be applied when using a "virtual focus", such as a ComboBox where the browser's focus remains in the <input /> element.
+  useEffect(() => {
+    if (scrollOnFocus && virtuosoRef.current && focusedItem?.index) {
+      virtuosoRef.current.scrollToIndex({ index: focusedItem.index, align: "center" });
+    }
+  }, [focusedItem]);
+
+  return (
+    <Virtuoso
+      ref={virtuosoRef}
+      totalListHeightChanged={onListHeightChange}
+      totalCount={items.length}
+      // Ensure the selected item is visible when the list renders
+      initialTopMostItemIndex={selectedItem ? selectedItem.index : 0}
+      // We don't really need to set this, but it's handy for tests, which would
+      // otherwise render just 1 row. A better way to do this would be to jest.mock
+      // out Virtuoso with an impl that just rendered everything, but doing this for now.
+      initialItemCount={5}
+      itemContent={(idx) => {
+        const item = items[idx];
+        if (item) {
+          return (
+            <Option
+              key={item.key}
+              item={item}
+              state={state}
+              contrast={contrast}
+              // Only send scrollToIndex functionality forward if we are not auto-scrolling on focus.
+              scrollToIndex={scrollOnFocus ? undefined : virtuosoRef.current?.scrollToIndex}
+            />
+          );
+        }
+      }}
+    />
+  );
+}

--- a/src/inputs/internal/constants.ts
+++ b/src/inputs/internal/constants.ts
@@ -1,0 +1,2 @@
+export const persistentItemHeight = 42;
+export const sectionSeparatorHeight = 1;


### PR DESCRIPTION
ListBox now supports two sections, (1) Options, and (2) Persistent Actions. The Options section will scroll independently of the Persistent Actions, make the Actions always visible.
Sections will only be rendered if necessary, otherwise it will just be a flat list of options as it works today. If the onCreateNew prop is passed to ChipSelectField, then we'll create the two sections. Right now there are a lot of assumptions in the code that we'll only ever have at most two sections, and that the second section is the Persistent Actions, and there will only ever be a single persistent action. Prototype, period. :)

Bugs fixed:
- Auto scroll to focused item ONLY if using virutal focus (i.e. in SelectField where we use a Combobox and the browser focus stays within the input field). This fixes an issue where the ListBox was scrolling when trying to click on an option for the ChipSelectField. This was due to the focus moving as the user clicks and our auto-scroll repositioning the options. We now handle scrolling Virtuoso in the Option component itself if not using a virutal focus.
- Use 'offset' prop in 'useOverlayPosition' to properly position the ListBox. Our previous way of doing this would create issues when the menu opened above the trigger.
- Call 'onBlur' after user removes ChipTextField, regardless of whether they created a new option or not. If a new option was created, this should trigger formState's auto save behavior. Adds tests to ensure this is called with expected values.

Updates:
- Max height of Listbox has been set to 512px, per design request.