### PR TITLE
perf: no JSX in visitRows => 100x improvement

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -215,7 +215,7 @@ export function NestedRows() {
   );
 }
 
-export function NestedCardsThreeLevelsSorted() {
+export function NestedCardsThreeLevels() {
   return <NestedCards rows={rowsWithHeader} sorting={{ on: "client", initial: [0, "ASC"] }} />;
 }
 
@@ -267,7 +267,7 @@ export function NestedCardsTwoLevels() {
       children: [{ kind: "child", id: "p2c1", name: "child p2c1" }],
     },
   ];
-  return <NestedCards rows={rows} style={nestedStyle} />;
+  return <NestedCards rows={rows} style={nestedStyle} sorting={{ on: "client", initial: [0, "ASC"] }} />;
 }
 
 type NestedCardsProps = Pick<GridTableProps<NestedRow, any, any>, "rows" | "as" | "sorting" | "style">;

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -221,7 +221,7 @@ export function NestedCardsThreeLevels() {
 
 export function NestedCardsThreeLevelsVirtualizedAtScale() {
   return (
-    <div css={Css.df.fdc.h(200).$}>
+    <div css={Css.df.fdc.vh100.$}>
       Rendering {rows.length * 500} rows virtualized
       <NestedCards rows={[header, ...zeroTo(100).flatMap(() => rows)]} as={"virtual"} />
     </div>
@@ -230,7 +230,7 @@ export function NestedCardsThreeLevelsVirtualizedAtScale() {
 
 export function NestedCardsThreeLevelsVirtualizedAtScaleSorted() {
   return (
-    <div css={Css.df.fdc.h(200).$}>
+    <div css={Css.df.fdc.vh100.$}>
       Rendering {rows.length * 500} rows virtualized & sorted
       <NestedCards
         rows={[header, ...zeroTo(100).flatMap(() => rows)]}

--- a/src/components/Table/nestedCards.test.tsx
+++ b/src/components/Table/nestedCards.test.tsx
@@ -18,7 +18,7 @@ const childCardStyle: NestedCardStyle = {
 
 describe("NestedCards", () => {
   it("can make open card w/one level", async () => {
-    const r = await render(makeOpenOrCloseCard([parentCardStyle], "open"));
+    const r = await render(makeOpenOrCloseCard([parentCardStyle], "open")());
     expect(r.firstElement).toMatchInlineSnapshot(`
       .emotion-0 {
         background-color: rgba(247,245,245,1);
@@ -42,7 +42,7 @@ describe("NestedCards", () => {
   });
 
   it("can make open card w/two levels", async () => {
-    const r = await render(makeOpenOrCloseCard([parentCardStyle, childCardStyle], "open"));
+    const r = await render(makeOpenOrCloseCard([parentCardStyle, childCardStyle], "open")());
     expect(r.firstElement).toMatchInlineSnapshot(`
       .emotion-0 {
         background-color: rgba(247,245,245,1);

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -82,6 +82,7 @@ export class NestedCards {
  * row separate from the card's actual content.
  */
 export function makeOpenOrCloseCard(openCards: NestedCardStyle[], kind: "open" | "close"): Chrome {
+  const scopeCards = [...openCards];
   return () => {
     let div: any = <div />;
     const place = kind === "open" ? "Top" : "Bottom";
@@ -92,7 +93,7 @@ export function makeOpenOrCloseCard(openCards: NestedCardStyle[], kind: "open" |
     // | card1 | card2 / ... card3 ... \ card2 | card1 |
     // | card1 | card2 | ... card3 ... | card2 | card1 |
     //
-    [...openCards].reverse().forEach((card, i) => {
+    [...scopeCards].reverse().forEach((card, i) => {
       const first = i === 0;
       div = (
         <div
@@ -149,11 +150,12 @@ export function maybeAddCardPadding(openCards: NestedCardStyle[], column: "first
  * have any open cards, but still want a space between top-level cards.
  */
 export function makeSpacer(height: number, openCards: NestedCardStyle[]): Chrome {
+  const scopeCards = [...openCards];
   return () => {
     let div = <div css={Css.hPx(height).$} />;
     // Start at the current/inside card, and wrap outward padding + borders.
     // | card1 | card2 | ... card3 ... | card2 | card1 |
-    [...openCards].reverse().forEach((card) => {
+    [...scopeCards].reverse().forEach((card) => {
       div = <div css={Css.bgColor(card.bgColor).pxPx(card.pxPx).if(!!card.bColor).bc(card.bColor).bl.br.$}>{div}</div>;
     });
     return div;
@@ -182,13 +184,6 @@ export function maybeCreateChromeRow(
       undefined,
       // We add 2 to account for our dedicated open/close columns
       <ChromeRow chromeBuffer={[...chromeBuffer]} columns={columns.length} />,
-      // () => (
-      //   <div css={Css.gc(`span ${columns.length + 2}`).$} data-chrome="true">
-      //     {chromeBuffer.map((c, i) => (
-      //       <Fragment key={i}>{c()}</Fragment>
-      //     ))}
-      //   </div>
-      // ),
     ]);
     // clear the buffer
     chromeBuffer.splice(0, chromeBuffer.length);

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -180,11 +180,7 @@ export function maybeCreateChromeRow(
   chromeBuffer: ChromeBuffer,
 ): void {
   if (chromeBuffer.length > 0) {
-    filteredRows.push([
-      undefined,
-      // We add 2 to account for our dedicated open/close columns
-      <ChromeRow chromeBuffer={[...chromeBuffer]} columns={columns.length} />,
-    ]);
+    filteredRows.push([undefined, <ChromeRow chromeBuffer={[...chromeBuffer]} columns={columns.length} />]);
     // clear the buffer
     chromeBuffer.splice(0, chromeBuffer.length);
   }
@@ -196,6 +192,7 @@ interface ChromeRowProps {
 }
 export function ChromeRow({ chromeBuffer, columns }: ChromeRowProps) {
   return (
+    // We add 2 to account for our dedicated open/close columns
     <div css={Css.gc(`span ${columns + 2}`).$} data-chrome="true">
       {chromeBuffer.map((c, i) => (
         <Fragment key={i}>{c()}</Fragment>

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -22,11 +22,15 @@ import { Css } from "src/Css";
  * a content row itself, the nested padding is handled separately by the
  * GridRow component.
  */
+
+type Chrome = () => JSX.Element;
+type ChromeBuffer = Chrome[];
+
 export class NestedCards {
   // A stack of the current cards we're showing
   private readonly openCards: Array<NestedCardStyle> = [];
   // A buffer of the open/close/spacer rows we need between each content row.
-  private readonly chromeBuffer: JSX.Element[] = [];
+  private readonly chromeBuffer: ChromeBuffer = [];
   private readonly styles: NestedCardsStyle;
 
   constructor(private columns: GridColumn<any>[], private filteredRows: RowTuple<any>[], private style: GridStyle) {
@@ -77,36 +81,38 @@ export class NestedCards {
  * I.e. due to the flatness of our DOM, we inherently have to add a "close"
  * row separate from the card's actual content.
  */
-export function makeOpenOrCloseCard(openCards: NestedCardStyle[], kind: "open" | "close"): JSX.Element {
-  let div: any = <div />;
-  const place = kind === "open" ? "Top" : "Bottom";
-  const btOrBb = kind === "open" ? "bt" : "bb";
-  // Create nesting for the all open cards, i.e.:
-  //
-  // | card1 | card2  --------------   card2 | card1 |
-  // | card1 | card2 / ... card3 ... \ card2 | card1 |
-  // | card1 | card2 | ... card3 ... | card2 | card1 |
-  //
-  [...openCards].reverse().forEach((card, i) => {
-    const first = i === 0;
-    div = (
-      <div
-        css={{
-          ...Css.bgColor(card.bgColor).pxPx(card.pxPx).$,
-          // Only the 1st div needs border left/right radius + border top/bottom.
-          ...(first &&
-            Css.add({
-              [`border${place}RightRadius`]: `${card.brPx}px`,
-              [`border${place}LeftRadius`]: `${card.brPx}px`,
-            }).hPx(card.brPx).$),
-          ...(card.bColor && Css.bc(card.bColor).bl.br.if(first)[btOrBb].$),
-        }}
-      >
-        {div}
-      </div>
-    );
-  });
-  return div;
+export function makeOpenOrCloseCard(openCards: NestedCardStyle[], kind: "open" | "close"): Chrome {
+  return () => {
+    let div: any = <div />;
+    const place = kind === "open" ? "Top" : "Bottom";
+    const btOrBb = kind === "open" ? "bt" : "bb";
+    // Create nesting for the all open cards, i.e.:
+    //
+    // | card1 | card2  --------------   card2 | card1 |
+    // | card1 | card2 / ... card3 ... \ card2 | card1 |
+    // | card1 | card2 | ... card3 ... | card2 | card1 |
+    //
+    [...openCards].reverse().forEach((card, i) => {
+      const first = i === 0;
+      div = (
+        <div
+          css={{
+            ...Css.bgColor(card.bgColor).pxPx(card.pxPx).$,
+            // Only the 1st div needs border left/right radius + border top/bottom.
+            ...(first &&
+              Css.add({
+                [`border${place}RightRadius`]: `${card.brPx}px`,
+                [`border${place}LeftRadius`]: `${card.brPx}px`,
+              }).hPx(card.brPx).$),
+            ...(card.bColor && Css.bc(card.bColor).bl.br.if(first)[btOrBb].$),
+          }}
+        >
+          {div}
+        </div>
+      );
+    });
+    return div;
+  };
 }
 
 /**
@@ -142,14 +148,16 @@ export function maybeAddCardPadding(openCards: NestedCardStyle[], column: "first
  * Our height is not based on `openCards`, b/c for the top-most level, we won't
  * have any open cards, but still want a space between top-level cards.
  */
-export function makeSpacer(height: number, openCards: NestedCardStyle[]) {
-  let div = <div css={Css.hPx(height).$} />;
-  // Start at the current/inside card, and wrap outward padding + borders.
-  // | card1 | card2 | ... card3 ... | card2 | card1 |
-  [...openCards].reverse().forEach((card) => {
-    div = <div css={Css.bgColor(card.bgColor).pxPx(card.pxPx).if(!!card.bColor).bc(card.bColor).bl.br.$}>{div}</div>;
-  });
-  return div;
+export function makeSpacer(height: number, openCards: NestedCardStyle[]): Chrome {
+  return () => {
+    let div = <div css={Css.hPx(height).$} />;
+    // Start at the current/inside card, and wrap outward padding + borders.
+    // | card1 | card2 | ... card3 ... | card2 | card1 |
+    [...openCards].reverse().forEach((card) => {
+      div = <div css={Css.bgColor(card.bgColor).pxPx(card.pxPx).if(!!card.bColor).bc(card.bColor).bl.br.$}>{div}</div>;
+    });
+    return div;
+  };
 }
 
 /**
@@ -167,21 +175,38 @@ export function makeSpacer(height: number, openCards: NestedCardStyle[]) {
 export function maybeCreateChromeRow(
   columns: GridColumn<any>[],
   filteredRows: RowTuple<any>[],
-  chromeBuffer: JSX.Element[],
+  chromeBuffer: ChromeBuffer,
 ): void {
   if (chromeBuffer.length > 0) {
     filteredRows.push([
       undefined,
       // We add 2 to account for our dedicated open/close columns
-      <div css={Css.gc(`span ${columns.length + 2}`).$} data-chrome="true">
-        {chromeBuffer.map((c, i) => (
-          <Fragment key={i}>{c}</Fragment>
-        ))}
-      </div>,
+      <ChromeRow chromeBuffer={[...chromeBuffer]} columns={columns.length} />,
+      // () => (
+      //   <div css={Css.gc(`span ${columns.length + 2}`).$} data-chrome="true">
+      //     {chromeBuffer.map((c, i) => (
+      //       <Fragment key={i}>{c()}</Fragment>
+      //     ))}
+      //   </div>
+      // ),
     ]);
     // clear the buffer
     chromeBuffer.splice(0, chromeBuffer.length);
   }
+}
+
+interface ChromeRowProps {
+  chromeBuffer: ChromeBuffer;
+  columns: number;
+}
+export function ChromeRow({ chromeBuffer, columns }: ChromeRowProps) {
+  return (
+    <div css={Css.gc(`span ${columns + 2}`).$} data-chrome="true">
+      {chromeBuffer.map((c, i) => (
+        <Fragment key={i}>{c()}</Fragment>
+      ))}
+    </div>
+  );
 }
 
 export function dropChromeRows<R extends Kinded>(filteredRows: RowTuple<R>[]): [GridDataRow<R>, ReactElement][] {


### PR DESCRIPTION
TLDR - GridTable is performing expensive JSX computations in 2 places which it shouldn't be (at-least/especially for virtualized lists):

1. vistRows
2. sortRows - NOTE: Not addressing this, since we aren't using sorting at the moment

Here is a Profile from main for a virtualized list with 1500 rows (2.1 seconds to visitRows):
![image](https://user-images.githubusercontent.com/24765506/145004349-cf306b21-0b01-4dcd-bc64-2d4a7b825898.png)

Here is that same virtualized list on this branch (24 milliseconds to visitRows):
![image](https://user-images.githubusercontent.com/24765506/145004591-689c103d-f0ce-451b-8339-733918417521.png)

~~NOTE: Still working on getting the styling to be correct with this approach.~~ All good now 👍  🍣 