### PR TITLE
feat: Add optional footer padding for virtual tables; add optional scrolling for tables

### DIFF
--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -200,6 +200,8 @@ export interface GridTableProps<R extends Kinded, S, X> {
    */
   persistCollapse?: string;
   xss?: X;
+  /** Adds padding to a footer at the bottom of a GridTable that's rendered `as=virtual` */
+  virtualFooterPadding?: number;
 }
 
 /**
@@ -239,6 +241,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
     setRowCount,
     observeRows,
     persistCollapse,
+    virtualFooterPadding,
   } = props;
 
   const [collapsedIds, toggleCollapsedId] = useToggleIds(rows, persistCollapse);
@@ -399,6 +402,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
         style.nestedCards?.firstLastColumnWidth,
         xss,
         virtuosoRef,
+        virtualFooterPadding,
       )}
     </PresentationProvider>
   );
@@ -423,6 +427,7 @@ function renderCssGrid<R extends Kinded>(
   firstLastColumnWidth: number | undefined,
   xss: any,
   virtuosoRef: MutableRefObject<VirtuosoHandle | null>,
+  _virtuosoFooterPadding?: number,
 ): ReactElement {
   return (
     <div
@@ -463,6 +468,7 @@ function renderTable<R extends Kinded>(
   _firstLastColumnWidth: number | undefined,
   xss: any,
   _virtuosoRef: MutableRefObject<VirtuosoHandle | null>,
+  _virtuosoFooterPadding?: number,
 ): ReactElement {
   return (
     <table
@@ -523,11 +529,15 @@ function renderVirtual<R extends Kinded>(
   firstLastColumnWidth: number | undefined,
   xss: any,
   virtuosoRef: MutableRefObject<VirtuosoHandle | null>,
+  footerPadding?: number,
 ): ReactElement {
   return (
     <Virtuoso
       ref={virtuosoRef}
-      components={{ List: VirtualRoot(style, columns, id, firstLastColumnWidth, xss) }}
+      components={{
+        List: VirtualRoot(style, columns, id, firstLastColumnWidth, xss),
+        Footer: () => <div css={Css.pb(footerPadding ?? 0).$}></div>,
+      }}
       // Pin/sticky both the header row(s) + firstRowMessage to the top
       topItemCount={(stickyHeader ? headerRows.length : 0) + (firstRowMessage ? 1 : 0)}
       itemSize={(el) => {

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -200,9 +200,14 @@ export interface GridTableProps<R extends Kinded, S, X> {
    */
   persistCollapse?: string;
   xss?: X;
-  /** Adds padding to a footer at the bottom of a GridTable that's rendered `as=virtual` */
-  virtualFooterPadding?: number;
+  /** Experimental API allowing one to scroll to a table index. Primarily intended for stories at the moment */
+  api?: MutableRefObject<GridTableApi | undefined>;
 }
+
+/** NOTE: This API is experimental and primarily intended for story and testing purposes */
+export type GridTableApi = {
+  scrollToIndex: (index: number) => void;
+};
 
 /**
  * Renders data in our table layout.
@@ -241,12 +246,18 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
     setRowCount,
     observeRows,
     persistCollapse,
-    virtualFooterPadding,
+    api,
   } = props;
 
   const [collapsedIds, toggleCollapsedId] = useToggleIds(rows, persistCollapse);
   // We only use this in as=virtual mode, but keep this here for rowLookup to use
   const virtuosoRef = useRef<VirtuosoHandle | null>(null);
+
+  if (api) {
+    api.current = {
+      scrollToIndex: (index) => virtuosoRef.current && virtuosoRef.current.scrollToIndex(index),
+    };
+  }
 
   const [sortState, setSortKey] = useSortState<R, S>(columns, sorting);
   // Disclaimer that technically even though this is a useMemo, sortRows is mutating `rows` directly
@@ -402,7 +413,6 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
         style.nestedCards?.firstLastColumnWidth,
         xss,
         virtuosoRef,
-        virtualFooterPadding,
       )}
     </PresentationProvider>
   );
@@ -427,7 +437,6 @@ function renderCssGrid<R extends Kinded>(
   firstLastColumnWidth: number | undefined,
   xss: any,
   virtuosoRef: MutableRefObject<VirtuosoHandle | null>,
-  _virtuosoFooterPadding?: number,
 ): ReactElement {
   return (
     <div
@@ -468,7 +477,6 @@ function renderTable<R extends Kinded>(
   _firstLastColumnWidth: number | undefined,
   xss: any,
   _virtuosoRef: MutableRefObject<VirtuosoHandle | null>,
-  _virtuosoFooterPadding?: number,
 ): ReactElement {
   return (
     <table
@@ -529,14 +537,14 @@ function renderVirtual<R extends Kinded>(
   firstLastColumnWidth: number | undefined,
   xss: any,
   virtuosoRef: MutableRefObject<VirtuosoHandle | null>,
-  footerPadding?: number,
 ): ReactElement {
+  const { paddingBottom } = style.rootCss ?? {};
   return (
     <Virtuoso
       ref={virtuosoRef}
       components={{
         List: VirtualRoot(style, columns, id, firstLastColumnWidth, xss),
-        Footer: () => <div css={Css.pb(footerPadding ?? 0).$}></div>,
+        Footer: () => <div css={{ paddingBottom }}></div>,
       }}
       // Pin/sticky both the header row(s) + firstRowMessage to the top
       topItemCount={(stickyHeader ? headerRows.length : 0) + (firstRowMessage ? 1 : 0)}

--- a/src/components/Table/SchedulesV2.stories.tsx
+++ b/src/components/Table/SchedulesV2.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
 import { arrayMoveImmutable } from "array-move";
-import { DragEventHandler, useLayoutEffect, useRef, useState } from "react";
+import { DragEventHandler, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { DragDropContext, DragDropContextProps, Draggable, Droppable } from "react-beautiful-dnd";
 import { TaskStatus } from "src/components/Filters/testDomain";
 import { PresentationProvider } from "src/components/PresentationContext";
@@ -11,7 +11,7 @@ import { Checkbox, DateField, NumberField, SelectField, TextAreaField } from "sr
 import { zeroTo } from "src/utils/sb";
 import { Icon } from "../Icon";
 import { actionColumn, column, dateColumn } from "./columns";
-import { GridDataRow } from "./GridTable";
+import { GridDataRow, GridTableApi } from "./GridTable";
 
 export default {
   title: "Pages / SchedulesV2",
@@ -183,11 +183,12 @@ const style: GridStyle = {
   headerCellCss: Css.sm.gray700.py1.df.aic.$,
   firstNonHeaderRowCss: Css.mt2.$,
   cellCss: Css.h100.gray700.sm.aic.pxPx(4).$,
+  rootCss: Css.pb(2).$,
   nestedCards: {
     spacerPx: 8,
     firstLastColumnWidth: 33, // 32px + 1px border
     kinds: {
-      header: { bgColor: Palette.Gray100, brPx: 0, pxPx: 0 },
+      header: { bgColor: Palette.Gray100, brPx: 1, pxPx: 0 },
       // TODO: It would be nice if this used CSS Properties so that we can use TRUSS
       milestone: { bgColor: Palette.Gray100, ...spacing },
       subgroup: { bgColor: Palette.White, ...spacing },
@@ -235,6 +236,51 @@ export function SchedulesV2() {
 }
 SchedulesV2.storyName = "SchedulesV2";
 
+export function SchedulesV2Virtualized() {
+  const api = useRef<GridTableApi>();
+
+  // Scroll to the bottom of the page before taking snapshot
+  useEffect(() => {
+    if (api.current) {
+      api.current.scrollToIndex(50);
+    }
+  });
+
+  return (
+    <div css={Css.h("100vh").$}>
+      <PresentationProvider fieldProps={{ borderless: true, typeScale: "xs" }}>
+        <GridTable<Row>
+          id="virtual-schedules-grid-table"
+          rows={rows}
+          columns={[
+            arrowColumn,
+            selectColumn,
+            idColumn,
+            nameColumn,
+            startColumn,
+            endColumn,
+            durationColumn,
+            milestoneColumn,
+            subCategoryColumn,
+            statusColumn,
+            progressColumn,
+            buttonColumns,
+          ]}
+          style={{ ...style, rootCss: Css.pb4.$ }}
+          rowStyles={{
+            task: {
+              cellCss: Css.py1.$,
+            },
+          }}
+          stickyHeader
+          as="virtual"
+          api={api}
+        />
+      </PresentationProvider>
+    </div>
+  );
+}
+SchedulesV2Virtualized.storyName = "Virtualized Schedules V2";
 /**
  * Example table using the same approach as GridTable to test out drag libraries
  *


### PR DESCRIPTION
This PR adds an additional GridTable prop to provide virtual tables with a footer. 

This uses the [Footer component](https://virtuoso.dev/footer/) from virtuoso.