### PR TITLE
feat: Support Tooltip on readOnly TextFieldBase

### DIFF
--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -12,6 +12,7 @@ describe("Tooltip", () => {
     expect(resolveTooltip("Test")).toBe("Test");
     expect(resolveTooltip("Test", "Test 2")).toBe("Test");
     expect(resolveTooltip(disabledNode, "Test 2")).toBe(disabledNode);
+    expect(resolveTooltip("Test", "Test 2", "Test 3")).toBe("Test");
 
     // `readOnly` param should always trump `tooltip` param
     expect(resolveTooltip(false, undefined, "read only")).toBe("read only");

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -8,14 +8,21 @@ describe("Tooltip", () => {
     expect(resolveTooltip(false)).toBe(undefined);
     expect(resolveTooltip(true, null)).toBe(undefined);
 
-    // `disabled` param should always trump `tooltip` param
+    // `disabled` param should always trump `tooltip` and `readOnly` params
     expect(resolveTooltip("Test")).toBe("Test");
     expect(resolveTooltip("Test", "Test 2")).toBe("Test");
     expect(resolveTooltip(disabledNode, "Test 2")).toBe(disabledNode);
+
+    // `readOnly` param should always trump `tooltip` param
+    expect(resolveTooltip(false, undefined, "read only")).toBe("read only");
+    expect(resolveTooltip(true, "test", "read only")).toBe("read only");
+    expect(resolveTooltip(undefined, "test", "read only")).toBe("read only");
 
     // Can show tooltip text if `disabled` is not set
     expect(resolveTooltip(false, "Test 2")).toBe("Test 2");
     expect(resolveTooltip(true, "Test 2")).toBe("Test 2");
     expect(resolveTooltip(undefined, "Test 2")).toBe("Test 2");
+    expect(resolveTooltip(undefined, "Test 2", true)).toBe("Test 2");
+    expect(resolveTooltip(undefined, "Test 2", "")).toBe("Test 2");
   });
 });

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -85,7 +85,15 @@ export function maybeTooltip(props: TooltipProps) {
 }
 
 // Helper function for resolving showing the Tooltip text via a 'disabled' prop, or the 'tooltip' prop.
-export function resolveTooltip(disabled?: boolean | ReactNode, tooltip?: ReactNode): ReactNode | undefined {
+export function resolveTooltip(
+  disabled?: boolean | ReactNode,
+  tooltip?: ReactNode,
+  readOnly?: boolean | ReactNode,
+): ReactNode | undefined {
   // If `disabled` is a ReactNode, then return that. Otherwise, return `tooltip`
-  return typeof disabled !== "boolean" && disabled ? disabled : tooltip ?? undefined;
+  return typeof disabled !== "boolean" && disabled
+    ? disabled
+    : typeof readOnly !== "boolean" && readOnly
+    ? readOnly
+    : tooltip ?? undefined;
 }

--- a/src/inputs/MultiSelectField.mock.tsx
+++ b/src/inputs/MultiSelectField.mock.tsx
@@ -13,6 +13,7 @@ export function MultiSelectField<T, V extends Value>(props: MultiSelectFieldProp
     errorMsg,
     onFocus,
     onBlur,
+    disabled,
   } = props;
   const tid = useTestIds(props, "multiSelect");
 
@@ -49,7 +50,7 @@ export function MultiSelectField<T, V extends Value>(props: MultiSelectFieldProp
         if (!readOnly && onBlur) onBlur();
       }}
       // Read Only does not apply to `select` fields, instead we'll add in disabled for tests to verify.
-      disabled={readOnly}
+      disabled={!!(readOnly || disabled)}
       data-error={!!errorMsg}
       data-errormsg={errorMsg}
       data-readonly={readOnly}

--- a/src/inputs/SelectField.mock.tsx
+++ b/src/inputs/SelectField.mock.tsx
@@ -38,7 +38,7 @@ export function SelectField<T extends object, V extends Key>(props: SelectFieldP
         if (!readOnly && onBlur) onBlur();
       }}
       // Read Only does not apply to `select` fields, instead we'll add in disabled for tests to verify.
-      disabled={disabled || readOnly}
+      disabled={!!(disabled || readOnly)}
       data-error={!!errorMsg}
       data-errormsg={errorMsg}
       data-readonly={readOnly}

--- a/src/inputs/SelectField.stories.tsx
+++ b/src/inputs/SelectField.stories.tsx
@@ -92,9 +92,15 @@ function Template(args: SelectFieldProps<any, any>) {
           label="Favorite Icon - Disabled"
           value={undefined}
           options={options}
-          disabled
+          disabled="Disabled reason"
         />
-        <TestSelectField {...args} label="Favorite Icon - Read Only" options={options} value={options[2].id} readOnly />
+        <TestSelectField
+          {...args}
+          label="Favorite Icon - Read Only"
+          options={options}
+          value={options[2].id}
+          readOnly="Read only reason"
+        />
         <TestSelectField<TestOption, string>
           {...args}
           label="Favorite Icon - Invalid"

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -162,88 +162,86 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
           {...tid.label}
         />
       )}
-      {readOnly && (
-        <div
-          css={{
-            // Use input wrapper to get common styles, but then we need to override some
-            ...fieldStyles.inputWrapperReadOnly,
-            ...(multiline ? Css.fdc.aifs.childGap2.$ : Css.truncate.$),
-            ...xss,
-          }}
-          data-readonly="true"
-          {...tid}
-        >
-          {!multiline && inlineLabel && label && !hideLabel && (
-            <InlineLabel labelProps={labelProps} label={label} {...tid.label} />
-          )}
-          {multiline
-            ? (inputProps.value as string | undefined)?.split("\n\n").map((p, i) => (
-                <p key={i} css={Css.my1.$}>
-                  {p.split("\n").map((sentence, j) => (
-                    <span key={j}>
-                      {sentence}
-                      <br />
-                    </span>
-                  ))}
-                </p>
-              ))
-            : inputProps.value}
-        </div>
-      )}
-      {!readOnly &&
-        maybeTooltip({
-          title: tooltip,
-          placement: "top",
-          children: (
-            <div
+      {maybeTooltip({
+        title: tooltip,
+        placement: "top",
+        children: readOnly ? (
+          <div
+            css={{
+              // Use input wrapper to get common styles, but then we need to override some
+              ...fieldStyles.inputWrapperReadOnly,
+              ...(multiline ? Css.fdc.aifs.childGap2.$ : Css.truncate.$),
+              ...xss,
+            }}
+            data-readonly="true"
+            {...tid}
+          >
+            {!multiline && inlineLabel && label && !hideLabel && (
+              <InlineLabel labelProps={labelProps} label={label} {...tid.label} />
+            )}
+            {multiline
+              ? (inputProps.value as string | undefined)?.split("\n\n").map((p, i) => (
+                  <p key={i} css={Css.my1.$}>
+                    {p.split("\n").map((sentence, j) => (
+                      <span key={j}>
+                        {sentence}
+                        <br />
+                      </span>
+                    ))}
+                  </p>
+                ))
+              : inputProps.value}
+          </div>
+        ) : (
+          <div
+            css={{
+              ...fieldStyles.inputWrapper,
+              ...(inputProps.disabled ? fieldStyles.disabled : {}),
+              ...(isFocused && !readOnly ? fieldStyles.focus : {}),
+              ...(isHovered && !inputProps.disabled && !readOnly && !isFocused ? fieldStyles.hover : {}),
+              ...(errorMsg ? fieldStyles.error : {}),
+              ...Css.if(multiline).aifs.px0.mhPx(textAreaMinHeight).$,
+            }}
+            {...hoverProps}
+            ref={inputWrapRef as any}
+          >
+            {!multiline && inlineLabel && label && !hideLabel && (
+              <InlineLabel labelProps={labelProps} label={label} {...tid.label} />
+            )}
+            {!multiline && startAdornment && <span css={Css.df.aic.fs0.br4.pr1.$}>{startAdornment}</span>}
+            <ElementType
+              {...mergeProps(
+                inputProps,
+                { onBlur, onFocus: onFocusChained, onChange: onDomChange },
+                { "aria-invalid": Boolean(errorMsg), ...(hideLabel ? { "aria-label": label } : {}) },
+              )}
+              {...(errorMsg ? { "aria-errormessage": errorMessageId } : {})}
+              ref={fieldRef as any}
+              rows={multiline ? 1 : undefined}
               css={{
-                ...fieldStyles.inputWrapper,
+                ...fieldStyles.input,
                 ...(inputProps.disabled ? fieldStyles.disabled : {}),
-                ...(isFocused && !readOnly ? fieldStyles.focus : {}),
                 ...(isHovered && !inputProps.disabled && !readOnly && !isFocused ? fieldStyles.hover : {}),
-                ...(errorMsg ? fieldStyles.error : {}),
-                ...Css.if(multiline).aifs.px0.mhPx(textAreaMinHeight).$,
+                ...(multiline ? Css.h100.p1.add("resize", "none").if(borderless).pPx(4).$ : Css.truncate.$),
+                ...xss,
               }}
-              {...hoverProps}
-              ref={inputWrapRef as any}
-            >
-              {!multiline && inlineLabel && label && !hideLabel && (
-                <InlineLabel labelProps={labelProps} label={label} {...tid.label} />
-              )}
-              {!multiline && startAdornment && <span css={Css.df.aic.fs0.br4.pr1.$}>{startAdornment}</span>}
-              <ElementType
-                {...mergeProps(
-                  inputProps,
-                  { onBlur, onFocus: onFocusChained, onChange: onDomChange },
-                  { "aria-invalid": Boolean(errorMsg), ...(hideLabel ? { "aria-label": label } : {}) },
-                )}
-                {...(errorMsg ? { "aria-errormessage": errorMessageId } : {})}
-                ref={fieldRef as any}
-                rows={multiline ? 1 : undefined}
-                css={{
-                  ...fieldStyles.input,
-                  ...(inputProps.disabled ? fieldStyles.disabled : {}),
-                  ...(isHovered && !inputProps.disabled && !readOnly && !isFocused ? fieldStyles.hover : {}),
-                  ...(multiline ? Css.h100.p1.add("resize", "none").if(borderless).pPx(4).$ : Css.truncate.$),
-                  ...xss,
+              {...tid}
+            />
+            {isFocused && clearable && onChange && inputProps.value && (
+              <IconButton
+                icon="xCircle"
+                color={Palette.Gray700}
+                onClick={() => {
+                  onChange(undefined);
+                  // Reset focus to input element
+                  fieldRef.current?.focus();
                 }}
-                {...tid}
               />
-              {isFocused && clearable && onChange && inputProps.value && (
-                <IconButton
-                  icon="xCircle"
-                  color={Palette.Gray700}
-                  onClick={() => {
-                    onChange(undefined);
-                    // Reset focus to input element
-                    fieldRef.current?.focus();
-                  }}
-                />
-              )}
-              {!multiline && endAdornment && <span css={Css.df.aic.pl1.fs0.$}>{endAdornment}</span>}
-            </div>
-          ),
-        })}
+            )}
+            {!multiline && endAdornment && <span css={Css.df.aic.pl1.fs0.$}>{endAdornment}</span>}
+          </div>
+        ),
+      })}
 
       {/* Compound fields will handle their own error and helper text */}
       {errorMsg && !compound && <ErrorMessage id={errorMessageId} errorMsg={errorMsg} {...tid.errorMsg} />}

--- a/src/inputs/internal/SelectFieldBase.tsx
+++ b/src/inputs/internal/SelectFieldBase.tsx
@@ -2,6 +2,7 @@ import { Selection } from "@react-types/shared";
 import { Key, ReactNode, useEffect, useRef, useState } from "react";
 import { useButton, useComboBox, useFilter, useOverlayPosition } from "react-aria";
 import { Item, useComboBoxState, useMultipleSelectionState } from "react-stately";
+import { resolveTooltip } from "src/components";
 import { Popover } from "src/components/internal";
 import { PresentationFieldProps } from "src/components/PresentationContext";
 import { Css, px } from "src/Css";
@@ -42,14 +43,14 @@ export interface SelectFieldBaseProps<O, V extends Value> extends BeamSelectFiel
 export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<O, V>): JSX.Element {
   const {
     compact,
-    disabled: isDisabled = false,
+    disabled,
     errorMsg,
     helperText,
     label,
     hideLabel,
     required,
     inlineLabel,
-    readOnly: isReadOnly = false,
+    readOnly,
     onSelect,
     fieldDecoration,
     options,
@@ -69,6 +70,8 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
   } = props;
 
   const { contains } = useFilter({ sensitivity: "base" });
+  const isDisabled = !!disabled;
+  const isReadOnly = !!readOnly;
 
   function onSelectionChange(keys: Selection): void {
     // Close menu upon selection change only for Single selection mode
@@ -293,6 +296,7 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
         contrast={contrast}
         nothingSelectedText={nothingSelectedText}
         borderless={borderless}
+        tooltip={resolveTooltip(disabled, undefined, readOnly)}
       />
       {state.isOpen && (
         <Popover
@@ -321,7 +325,8 @@ export function SelectFieldBase<O, V extends Value>(props: SelectFieldBaseProps<
 
 export interface BeamSelectFieldBaseProps<T, V extends Value> extends BeamFocusableProps, PresentationFieldProps {
   disabledOptions?: V[];
-  disabled?: boolean;
+  // Whether the field is disabled. If a ReactNode, it's treated as a "disabled reason" that's shown in a tooltip.
+  disabled?: boolean | ReactNode;
   required?: boolean;
   errorMsg?: string;
   helperText?: string | ReactNode;
@@ -331,7 +336,8 @@ export interface BeamSelectFieldBaseProps<T, V extends Value> extends BeamFocusa
   label: string;
   /** Renders the label inside the input field, i.e. for filters. */
   inlineLabel?: boolean;
-  readOnly?: boolean;
+  // Whether the field is readOnly. If a ReactNode, it's treated as a "readOnly reason" that's shown in a tooltip.
+  readOnly?: boolean | ReactNode;
   onBlur?: () => void;
   onFocus?: () => void;
   sizeToContent?: boolean;

--- a/src/inputs/internal/SelectFieldInput.tsx
+++ b/src/inputs/internal/SelectFieldInput.tsx
@@ -32,6 +32,7 @@ interface SelectFieldInputProps<O, V extends Value> extends PresentationFieldPro
   sizeToContent: boolean;
   contrast?: boolean;
   nothingSelectedText: string;
+  tooltip?: ReactNode;
 }
 
 export function SelectFieldInput<O, V extends Value>(props: SelectFieldInputProps<O, V>) {

--- a/src/inputs/internal/SelectFieldInput.tsx
+++ b/src/inputs/internal/SelectFieldInput.tsx
@@ -87,7 +87,7 @@ export function SelectFieldInput<O, V extends Value>(props: SelectFieldInputProp
       errorMsg={errorMsg}
       helperText={helperText}
       contrast={contrast}
-      xss={!inlineLabel ? Css.fw5.$ : {}}
+      xss={!inlineLabel && !isReadOnly ? Css.fw5.$ : {}}
       startAdornment={
         (showNumSelection && (
           <span css={Css.wPx(16).hPx(16).fs0.br100.bgLightBlue700.white.tinyEm.df.aic.jcc.$}>


### PR DESCRIPTION
SelectField to support tooltip text as part of the `readOnly` prop, similar to `disabled`.