### PR TITLE
feat: Expose SelectField and MultiSelectField `placeholder` prop

### DIFF
--- a/src/inputs/MultiSelectField.stories.tsx
+++ b/src/inputs/MultiSelectField.stories.tsx
@@ -74,6 +74,14 @@ export function MultiSelectFields() {
           fieldDecoration={(o) => o.icon && <Icon icon={o.icon} />}
           values={[] as Value[]}
         />
+
+        <TestMultiSelectField
+          label="With Placeholder"
+          options={options}
+          placeholder="Placeholder Content"
+          fieldDecoration={(o) => o.icon && <Icon icon={o.icon} />}
+          values={[] as Value[]}
+        />
       </div>
 
       <div css={Css.df.fdc.childGap2.$}>

--- a/src/inputs/SelectField.stories.tsx
+++ b/src/inputs/SelectField.stories.tsx
@@ -101,6 +101,24 @@ function Template(args: SelectFieldProps<any, any>) {
           value={options[2].id}
           readOnly="Read only reason"
         />
+        <TestSelectField
+          {...args}
+          label="With Placeholder"
+          value={undefined}
+          options={options}
+          placeholder="Placeholder Content"
+          getOptionMenuLabel={(o) => (
+            <div css={Css.df.aic.$}>
+              {o.icon && (
+                <span css={Css.fs0.mr2.$}>
+                  <Icon icon={o.icon} />
+                </span>
+              )}
+              {o.name}
+            </div>
+          )}
+        />
+        <TestSelectField {...args} label="Favorite Icon - Read Only" options={options} value={options[2].id} readOnly />
         <TestSelectField<TestOption, string>
           {...args}
           label="Favorite Icon - Invalid"

--- a/src/inputs/internal/SelectFieldBase.tsx
+++ b/src/inputs/internal/SelectFieldBase.tsx
@@ -345,4 +345,6 @@ export interface BeamSelectFieldBaseProps<T, V extends Value> extends BeamFocusa
   nothingSelectedText?: string;
   /** When set the SelectField is expected to be put on a darker background */
   contrast?: boolean;
+  /** Placeholder content */
+  placeholder?: string;
 }


### PR DESCRIPTION
Expose the `placeholder` props which already works in the background via prop spread but it was being lost when used with `BoundSelectFields`. 