### PR TITLE
fix: Update for the collapse icon to correctly reflect the state of the row

### DIFF
--- a/src/components/Table/CollapseToggle.test.tsx
+++ b/src/components/Table/CollapseToggle.test.tsx
@@ -1,0 +1,38 @@
+import { CollapseToggle } from "src/components/Table/CollapseToggle";
+import { GridCollapseContext } from "src/components/Table/GridTable";
+import { noop } from "src/utils";
+import { render } from "src/utils/rtl";
+
+describe("CollapseToggle", () => {
+  it("defaults to uncollapsed", async () => {
+    const r = await render(<CollapseToggle row={{ id: "r:1", kind: "header" }} />);
+    expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("chevronsDown");
+  });
+
+  it.each([
+    [true, "header", "chevronsRight"],
+    [false, "header", "chevronsDown"],
+    [true, "otherKind", "chevronRight"],
+    [false, "otherKind", "chevronDown"],
+  ])("displays the correct chevron based on context and kind", async (isCollapsed, kind, expectedIcon) => {
+    const r = await render(
+      <GridCollapseContext.Provider
+        value={{ headerCollapsed: false, isCollapsed: () => isCollapsed, toggleCollapsed: noop }}
+      >
+        <CollapseToggle row={{ id: "r:1", kind, children: [{}] }} />
+      </GridCollapseContext.Provider>,
+    );
+    expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual(expectedIcon);
+  });
+
+  it("only renders for non-header rows when there are children", async () => {
+    const r = await render(<CollapseToggle row={{ id: "r:1", kind: "otherKind", children: [] }} />);
+
+    expect(r.firstElement).toMatchInlineSnapshot(`
+      <div
+        data-overlay-container="true"
+      />
+    `);
+    expect(r.firstElement.firstElementChild).toBeNull();
+  });
+});

--- a/src/components/Table/CollapseToggle.tsx
+++ b/src/components/Table/CollapseToggle.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from "react";
+import { useCallback, useContext, useState } from "react";
 import { GridCollapseContext, GridDataRow, IconButton } from "src/components";
 
 export interface GridTableCollapseToggleProps {
@@ -8,9 +8,15 @@ export interface GridTableCollapseToggleProps {
 export function CollapseToggle(props: GridTableCollapseToggleProps) {
   const { row } = props;
   const { isCollapsed, toggleCollapsed } = useContext(GridCollapseContext);
-  const toggleOnClick = useCallback(() => toggleCollapsed(row.id), [row.id, toggleCollapsed]);
-  const iconKey = isCollapsed(row.id) ? "chevronRight" : "chevronDown";
-  const headerIconKey = isCollapsed(row.id) ? "chevronsRight" : "chevronsDown";
+  const [, setTick] = useState(0);
+  const currentlyCollapsed = isCollapsed(row.id);
+  const toggleOnClick = useCallback(() => {
+    toggleCollapsed(row.id);
+    setTick(Date.now());
+  }, [row.id, currentlyCollapsed, toggleCollapsed]);
+  console.log({ id: row.id, currentlyCollapsed });
+  const iconKey = currentlyCollapsed ? "chevronRight" : "chevronDown";
+  const headerIconKey = currentlyCollapsed ? "chevronsRight" : "chevronsDown";
   const isHeader = row.kind === "header";
   if (!isHeader && (!props.row.children || props.row.children.length === 0)) {
     return null;

--- a/src/components/Table/CollapseToggle.tsx
+++ b/src/components/Table/CollapseToggle.tsx
@@ -14,7 +14,6 @@ export function CollapseToggle(props: GridTableCollapseToggleProps) {
     toggleCollapsed(row.id);
     setTick(Date.now());
   }, [row.id, currentlyCollapsed, toggleCollapsed]);
-  console.log({ id: row.id, currentlyCollapsed });
   const iconKey = currentlyCollapsed ? "chevronRight" : "chevronDown";
   const headerIconKey = currentlyCollapsed ? "chevronsRight" : "chevronsDown";
   const isHeader = row.kind === "header";

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -1052,15 +1052,23 @@ const defaultRenderFn: (as: RenderAs) => RenderCellFn<any> = (as: RenderAs) => (
 };
 
 /**
- * Provides each row access to its `collapsed` current state and toggle.
+ * Provides each row access to a method to check if it is collapsed and toggle it's collapsed state.
  *
  * Calling `toggleCollapse` will keep the row itself showing, but will hide any
  * children rows (specifically those that have this row's `id` in their `parentIds`
  * prop).
+ *
+ * headerCollapsed is used to trigger rows at the root level to rerender their chevron when all are
+ * collapsed/expanded.
  */
-type GridCollapseContextProps = { isCollapsed: (id: string) => boolean; toggleCollapsed(id: string): void };
+type GridCollapseContextProps = {
+  headerCollapsed: boolean;
+  isCollapsed: (id: string) => boolean;
+  toggleCollapsed(id: string): void;
+};
 
 export const GridCollapseContext = React.createContext<GridCollapseContextProps>({
+  headerCollapsed: false,
   isCollapsed: (id: string) => false,
   toggleCollapsed: (id: string) => {},
 });
@@ -1242,7 +1250,7 @@ function useToggleIds(rows: GridDataRow<Kinded>[], persistCollapse: string | und
         // Trigger a re-render
         setTick(collapsedIds.join(","));
       };
-      return { isCollapsed, toggleCollapsed: toggleAll };
+      return { allCollapsed: isCollapsed("header"), isCollapsed, toggleCollapsed: toggleAll };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [rows],
@@ -1266,10 +1274,10 @@ function useToggleIds(rows: GridDataRow<Kinded>[], persistCollapse: string | und
         // Trigger a re-render
         setTick(collapsedIds.join(","));
       };
-      return { isCollapsed, toggleCollapsed: toggleRow };
+      return { allCollapsed: isCollapsed("header"), isCollapsed, toggleCollapsed: toggleRow };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+    [collapseAllContext.isCollapsed("header")],
   );
 
   // Return a copy of the list, b/c we want external useMemos that do explicitly use the

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -1204,7 +1204,10 @@ function getCollapsedRows(persistCollapse: string | undefined): string[] {
  * function should see/update the latest list of values, which is not possible with a
  * traditional `useState` hook because it captures the original/stale list identity.
  */
-function useToggleIds(rows: GridDataRow<Kinded>[], persistCollapse: string | undefined) {
+function useToggleIds(
+  rows: GridDataRow<Kinded>[],
+  persistCollapse: string | undefined,
+): readonly [string[], GridCollapseContextProps, GridCollapseContextProps] {
   // Make a list that we will only mutate, so that our callbacks have a stable identity.
   const [collapsedIds] = useState<string[]>(getCollapsedRows(persistCollapse));
   // Use this to trigger the component to re-render even though we're not calling `setList`
@@ -1250,7 +1253,7 @@ function useToggleIds(rows: GridDataRow<Kinded>[], persistCollapse: string | und
         // Trigger a re-render
         setTick(collapsedIds.join(","));
       };
-      return { allCollapsed: isCollapsed("header"), isCollapsed, toggleCollapsed: toggleAll };
+      return { headerCollapsed: isCollapsed("header"), isCollapsed, toggleCollapsed: toggleAll };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [rows],
@@ -1274,7 +1277,7 @@ function useToggleIds(rows: GridDataRow<Kinded>[], persistCollapse: string | und
         // Trigger a re-render
         setTick(collapsedIds.join(","));
       };
-      return { allCollapsed: isCollapsed("header"), isCollapsed, toggleCollapsed: toggleRow };
+      return { headerCollapsed: isCollapsed("header"), isCollapsed, toggleCollapsed: toggleRow };
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [collapseAllContext.isCollapsed("header")],

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -535,12 +535,12 @@ function renderVirtual<R extends Kinded>(
   xss: any,
   virtuosoRef: MutableRefObject<VirtuosoHandle | null>,
 ): ReactElement {
-  const { paddingBottom } = style.rootCss ?? {};
+  const { paddingBottom, ...otherRootStyles } = style.rootCss ?? {};
   return (
     <Virtuoso
       ref={virtuosoRef}
       components={{
-        List: VirtualRoot(style, columns, id, firstLastColumnWidth, xss),
+        List: VirtualRoot({ ...style, rootCss: otherRootStyles }, columns, id, firstLastColumnWidth, xss),
         Footer: () => <div css={{ paddingBottom }}></div>,
       }}
       // Pin/sticky both the header row(s) + firstRowMessage to the top


### PR DESCRIPTION
I accidentally broke the collapse chevron behaviour with my perf fix the other day.

Before:
https://share.getcloudapp.com/DOumRXBZ

After:
https://share.getcloudapp.com/E0uoG2lq