### PR TITLE
fix: `firstNonHeaderRowCss` for Virtual GridTable

### DIFF
--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -301,7 +301,6 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
           value={row.kind === "header" ? collapseAllContext : collapseRowContext}
         >
           <RowComponent
-            key={`${row.kind}-${row.id}`}
             {...{
               as,
               columns,
@@ -368,7 +367,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
 
     // If nestedCards is set, we assume the top-level kind is a card, and so should add spacers between them
     visitRows(maybeSorted, !!nestedCards);
-    nestedCards && nestedCards.done(filteredRows);
+    nestedCards && nestedCards.done(maybeSorted[maybeSorted.length - 1], filteredRows);
 
     return [headerRows, filteredRows];
   }, [

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -683,9 +683,9 @@ const VirtualRoot = memoizeOne<
   return React.forwardRef(function VirtualRoot({ style, children }, ref) {
     // This VirtualRoot list represent the header when no styles are given. The
     // table list generally has styles to scroll the page for windowing.
-    const isList = Object.keys(style || {}).length !== 0;
+    const isHeader = Object.keys(style || {}).length === 0;
 
-    // This re-renders each time we have new children in the view port
+    // This re-renders each time we have new children in the viewport
     return (
       <div
         ref={ref}
@@ -694,11 +694,11 @@ const VirtualRoot = memoizeOne<
           // Add an extra `> div` due to Item + itemContent both having divs
           ...Css.addIn("& > div + div > div > *", gs.betweenRowsCss || {}).$,
           // Table list styles only
-          ...(isList
-            ? {
+          ...(isHeader
+            ? {}
+            : {
                 ...Css.addIn("& > div:first-of-type > *", gs.firstNonHeaderRowCss).$,
-              }
-            : {}),
+              }),
           ...gs.rootCss,
           ...xss,
         }}

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -354,10 +354,15 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
       const length = rows.length;
       rows.forEach((row, i) => {
         if (row.kind === "header") {
-          nestedCards && nestedCards.maybeOpenCard(row, headerRows);
+          // Flag to determine if the header has nested card styles.
+          // This will determine if we should include opening and closing
+          // Chrome rows.
+          const isHeaderNested = !!style.nestedCards?.kinds["header"];
+
+          isHeaderNested && nestedCards.maybeOpenCard(row, headerRows);
           headerRows.push([row, makeRowComponent(row)]);
-          nestedCards && nestedCards.closeCard();
-          nestedCards && nestedCards.done(headerRows);
+          isHeaderNested && nestedCards.closeCard();
+          isHeaderNested && nestedCards.done(row, headerRows);
           return;
         }
         visit(row);

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -359,10 +359,10 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
           // Chrome rows.
           const isHeaderNested = !!style.nestedCards?.kinds["header"];
 
-          isHeaderNested && nestedCards.maybeOpenCard(row, headerRows);
+          isHeaderNested && nestedCards && nestedCards.maybeOpenCard(row, headerRows);
           headerRows.push([row, makeRowComponent(row)]);
-          isHeaderNested && nestedCards.closeCard();
-          isHeaderNested && nestedCards.done(row, headerRows);
+          isHeaderNested && nestedCards && nestedCards.closeCard();
+          isHeaderNested && nestedCards && nestedCards.done(row, headerRows);
           return;
         }
         visit(row);

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -693,8 +693,6 @@ const VirtualRoot = memoizeOne<
         css={{
           // Add an extra `> div` due to Item + itemContent both having divs
           ...Css.addIn("& > div + div > div > *", gs.betweenRowsCss || {}).$,
-          // Add `display:contents` to Item to flatten it like we do GridRow
-          ...Css.addIn("& > div", Css.display("contents").$).$,
           // Table list styles only
           ...(isList
             ? {

--- a/src/components/Table/SchedulesV2.stories.tsx
+++ b/src/components/Table/SchedulesV2.stories.tsx
@@ -55,7 +55,7 @@ type Row = HeaderRow | MilestoneRow | SubGroupRow | TaskRow | AddRow;
 
 /** Rows */
 // TODO: Handle all 4 situations
-const rows: GridDataRow<Row>[] = [{ kind: "header", id: "header" }, ...createMilestones(1, 3, 2)];
+const rows: GridDataRow<Row>[] = [{ kind: "header", id: "header" }, ...createMilestones(2, 3, 2)];
 
 /** Columns */
 // FIXME: This column is not vertically aligned
@@ -182,13 +182,13 @@ const spacing = { brPx: 8, pxPx: 16 };
 const style: GridStyle = {
   headerCellCss: Css.sm.gray700.py1.df.aic.$,
   firstNonHeaderRowCss: Css.mt2.$,
-  cellCss: Css.gray700.sm.aic.pxPx(4).$,
+  cellCss: Css.h100.gray700.sm.aic.pxPx(4).$,
   rootCss: Css.pb(2).$,
   nestedCards: {
     spacerPx: 8,
     firstLastColumnWidth: 33, // 32px + 1px border
     kinds: {
-      header: { bgColor: Palette.Gray100, brPx: 1, pxPx: 0 },
+      header: { bgColor: Palette.Gray100, brPx: 4, pxPx: 0 },
       // TODO: It would be nice if this used CSS Properties so that we can use TRUSS
       milestone: { bgColor: Palette.Gray100, ...spacing },
       subgroup: { bgColor: Palette.White, ...spacing },
@@ -225,9 +225,6 @@ export function SchedulesV2() {
               cellCss: Css.py1.$,
             },
           }}
-          // FIXME: `firstNonHeaderRowCss` does not work when virtual is enabled
-          // Possible fix is to use an ref/class/id for this row
-          // as="virtual"
           stickyHeader
         />
       </PresentationProvider>

--- a/src/components/Table/SchedulesV2.stories.tsx
+++ b/src/components/Table/SchedulesV2.stories.tsx
@@ -103,7 +103,7 @@ const nameColumn = column<Row>({
   subgroup: (row) => ({ value: row.name, content: "" }),
   task: (row) => <TaskNameField value={row.name} />,
   add: "Add",
-  w: 1,
+  w: "200px",
 });
 const startColumn = dateColumn<Row>({
   header: "Start",
@@ -127,7 +127,7 @@ const durationColumn = column<Row>({
   subgroup: (row) => <div css={Css.smEm.gray900.$}>{row.duration} days</div>,
   task: (row) => <TaskDurationField value={row.duration} />,
   add: "",
-  w: 1,
+  w: "100px",
 });
 const milestoneColumn = column<Row>({
   header: "Milestone",
@@ -136,7 +136,7 @@ const milestoneColumn = column<Row>({
   subgroup: "",
   task: (row) => row.milestone,
   add: "",
-  w: 1,
+  w: "100px",
 });
 const subCategoryColumn = column<Row>({
   header: "SubCategory",
@@ -145,21 +145,13 @@ const subCategoryColumn = column<Row>({
   subgroup: "",
   task: (row) => row.subGroup,
   add: "",
-  w: 1,
+  w: "100px",
 });
 const statusColumn = column<Row>({
   header: "Status",
   milestone: "",
   subgroup: "",
   task: (row) => <TaskStatusField value={row.status} />,
-  add: "",
-  w: "150px",
-});
-const progressColumn = actionColumn<Row>({
-  header: "",
-  milestone: "",
-  subgroup: "",
-  task: "",
   add: "",
   w: "150px",
 });
@@ -174,7 +166,7 @@ const buttonColumns = actionColumn<Row>({
     </div>
   ),
   add: "",
-  w: 1,
+  w: "100px",
 });
 
 // TODO: Potentially add 8px spacer between each row
@@ -182,7 +174,7 @@ const spacing = { brPx: 8, pxPx: 16 };
 const style: GridStyle = {
   headerCellCss: Css.sm.gray700.py1.df.aic.$,
   firstNonHeaderRowCss: Css.mt2.$,
-  cellCss: Css.h100.gray700.sm.aic.pxPx(4).$,
+  cellCss: Css.gray700.sm.aic.pxPx(4).$,
   rootCss: Css.pb(2).$,
   nestedCards: {
     spacerPx: 8,
@@ -201,7 +193,7 @@ const style: GridStyle = {
 
 export function SchedulesV2() {
   return (
-    <div css={Css.h("100vh").$}>
+    <div css={Css.h("100vh").w("fit-content").mx("auto").$}>
       <PresentationProvider fieldProps={{ borderless: true, typeScale: "xs" }}>
         <GridTable<Row>
           rows={rows}
@@ -216,7 +208,6 @@ export function SchedulesV2() {
             milestoneColumn,
             subCategoryColumn,
             statusColumn,
-            progressColumn,
             buttonColumns,
           ]}
           style={style}
@@ -244,7 +235,7 @@ export function SchedulesV2Virtualized() {
   });
 
   return (
-    <div css={Css.h("100vh").$}>
+    <div css={Css.h("100vh").w("fit-content").mx("auto").$}>
       <PresentationProvider fieldProps={{ borderless: true, typeScale: "xs" }}>
         <GridTable<Row>
           id="virtual-schedules-grid-table"
@@ -260,7 +251,6 @@ export function SchedulesV2Virtualized() {
             milestoneColumn,
             subCategoryColumn,
             statusColumn,
-            progressColumn,
             buttonColumns,
           ]}
           style={{ ...style, rootCss: Css.pb4.$ }}

--- a/src/components/Table/SchedulesV2.stories.tsx
+++ b/src/components/Table/SchedulesV2.stories.tsx
@@ -55,7 +55,7 @@ type Row = HeaderRow | MilestoneRow | SubGroupRow | TaskRow | AddRow;
 
 /** Rows */
 // TODO: Handle all 4 situations
-const rows: GridDataRow<Row>[] = [{ kind: "header", id: "header" }, ...createMilestones(2, 3, 2)];
+const rows: GridDataRow<Row>[] = [{ kind: "header", id: "header" }, ...createMilestones(1, 3, 2)];
 
 /** Columns */
 // FIXME: This column is not vertically aligned

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactElement } from "react";
+import { Fragment, Key, ReactElement } from "react";
 import {
   GridColumn,
   GridDataRow,
@@ -57,7 +57,12 @@ export class NestedCards {
       this.chromeBuffer.push(makeOpenOrCloseCard(this.openCards, this.styles.kinds, "open"));
     }
     // But always close previous cards if needed
-    maybeCreateChromeRow(this.columns, buffer, this.chromeBuffer);
+    maybeCreateChromeRow({
+      key: `chrome-open-${row.kind}-${row.id}`,
+      columns: this.columns,
+      buffer,
+      chromeBuffer: this.chromeBuffer,
+    });
     return !!card;
   }
 
@@ -73,12 +78,18 @@ export class NestedCards {
   /**
    * Close the remaining open rows with a close Chrome row.
    *
+   * @param row The row that is completing/closing nested open Chrome rows.
    * @param buffer The buffer, array of rows, to close the opened Chrome rows so
    * far. Currently there are two buffers, one for header rows (`headerRows`) and a
    * second for filtered rows (`filteredRows`).
    */
-  done(buffer: RowTuple<any>[]) {
-    maybeCreateChromeRow(this.columns, buffer, this.chromeBuffer);
+  done(row: GridDataRow<any>, buffer: RowTuple<any>[]) {
+    maybeCreateChromeRow({
+      key: `chrome-close-${row.kind}-${row.id}`,
+      columns: this.columns,
+      buffer,
+      chromeBuffer: this.chromeBuffer,
+    });
   }
 
   /** Return a stable copy of the cards, so it won't change as we keep going. */
@@ -212,13 +223,19 @@ export function makeSpacer(height: number, openCards: string[], styles: NestedCa
  * @param buffer The buffer to store the Chrome row created.
  * @param chromeBuffer The Chrome row buffer to flush.
  */
-export function maybeCreateChromeRow(
-  columns: GridColumn<any>[],
-  buffer: RowTuple<any>[],
-  chromeBuffer: ChromeBuffer,
-): void {
+export function maybeCreateChromeRow({
+  key,
+  columns,
+  buffer,
+  chromeBuffer,
+}: {
+  key: Key;
+  columns: GridColumn<any>[];
+  buffer: RowTuple<any>[];
+  chromeBuffer: ChromeBuffer;
+}): void {
   if (chromeBuffer.length > 0) {
-    buffer.push([undefined, <ChromeRow chromeBuffer={[...chromeBuffer]} columns={columns.length} />]);
+    buffer.push([undefined, <ChromeRow key={key} chromeBuffer={[...chromeBuffer]} columns={columns.length} />]);
     // clear the Chrome buffer
     chromeBuffer.splice(0, chromeBuffer.length);
   }


### PR DESCRIPTION
This PR fixed the `firstNonHeaderRowCss` style for GridTables using the `as="virtual"` rendering engine. 

**Important Changes**:

- When using a `virtual` GridTable with `nestedCards` styles, we noticed that there was an extra Chrome row included at the start of the table list. This was due to the `VirtualRoot` not compensating for Chrome rows in this scenario. Resolved the Chrome rows to be pushed to both the `headerRows` and `filteredRows` arrays.

**Before**
<img width="380" alt="CleanShot 2021-12-14 at 15 01 56@2x" src="https://user-images.githubusercontent.com/3606121/146100500-9acf50ca-14a0-4226-a141-cf8c64459934.png">

**After**
<img width="315" alt="CleanShot 2021-12-14 at 19 27 09@2x" src="https://user-images.githubusercontent.com/3606121/146100619-80f917d2-7d2a-41a7-9b2f-95cab7d068ad.png">

- Conditionally add the `firstNonHeaderRowCss` for nestedCard styles situation to not add these styles to the header.
- Refactored nestedCard.tsx to more clearly expose the row buffer being updated.
- Fixed console.error from React regarding missing `key` props

# Performance

This was tested using the Storybook Performance addon using _1 copy and 10 samples_.

## Before

<table>
<tr>
	<th>Non-Virtual</th>
	<th>Virtual</th>
<tr>
	<td>
<img width="461" alt="CleanShot 2022-01-19 at 13 28 48@2x" src="https://user-images.githubusercontent.com/3606121/150183097-6252900f-3009-441c-a795-c58bfe7f69bf.png">
</td>
	<td> 
<img width="455" alt="CleanShot 2022-01-19 at 13 30 15@2x" src="https://user-images.githubusercontent.com/3606121/150183294-83d2ffd1-ed60-40e8-9118-ebd6374e97e6.png">
</td>

</table>

## After

<table>
<tr>
	<th>Non-Virtual</th>
	<th>Virtual</th>
<tr>
	<td>
<img width="465" alt="CleanShot 2022-01-19 at 13 19 46@2x" src="https://user-images.githubusercontent.com/3606121/150181693-18ff2963-dca1-4315-9122-8e266cec0c69.png">
</td>
	<td>
<img width="455" alt="CleanShot 2022-01-19 at 13 20 15@2x" src="https://user-images.githubusercontent.com/3606121/150181731-39549127-6e9d-41a1-b956-9b7f27fb2000.png">
</td>
</table>

## Conclusion

There is a performance boost on the virtual tables since we are no longer rendering un-needed chrome rows but the total number of chrome rows are the same! Maybe the cleanup of the NestedCard component helped with this too.

There is a performance hit on the non-virtual table could be due to the extra few lines of computation that was added to the renderer?
