### PR TITLE
fix: update disabledOptions logic

### DIFF
--- a/src/inputs/SelectField.mock.test.tsx
+++ b/src/inputs/SelectField.mock.test.tsx
@@ -74,5 +74,8 @@ describe("MockSelectField", () => {
     // Then matching options are disabled
     expect(r.getByText("two")).toBeDisabled();
     expect(r.getByText("thr")).toBeDisabled();
+    // and unmatching options are not disabled
+    expect(r.getByText("one")).not.toBeDisabled();
+    expect(r.getByText("four")).not.toBeDisabled();
   });
 });

--- a/src/inputs/SelectField.mock.tsx
+++ b/src/inputs/SelectField.mock.tsx
@@ -50,7 +50,7 @@ export function SelectField<T extends object, V extends Key>(props: SelectFieldP
           <option
             key={i}
             value={`${getOptionValue(option)}`}
-            disabled={disabledOptions.includes(getOptionValue(option).toString())}
+            disabled={disabledOptions.includes(getOptionValue(option))}
           >
             {getOptionLabel(option)}
           </option>


### PR DESCRIPTION
- update disabledOptions logic since no need to `toString()` which was failing when `getOptionValue(option)` was `undefined`
- update test to confirm forked case