### PR TITLE
fix: Expose an onEnter callback for TextField

### DIFF
--- a/src/forms/BoundTextField.test.tsx
+++ b/src/forms/BoundTextField.test.tsx
@@ -1,5 +1,6 @@
 import { createObjectState, ObjectConfig, required } from "@homebound/form-state";
 import { render } from "@homebound/rtl-utils";
+import { fireEvent } from "@testing-library/react";
 import { BoundTextField } from "src/forms/BoundTextField";
 import { AuthorInput } from "src/forms/formStateDomain";
 
@@ -15,6 +16,30 @@ describe("BoundTextField", () => {
     author.touched = true;
     const { firstName_errorMsg } = await render(<BoundTextField field={author.firstName} />);
     expect(firstName_errorMsg()).toHaveTextContent("Required");
+  });
+
+  it("shows an error message", async () => {
+    const author = createObjectState(formConfig, {});
+    author.touched = true;
+    const { firstName_errorMsg } = await render(<BoundTextField field={author.firstName} />);
+    expect(firstName_errorMsg()).toHaveTextContent("Required");
+  });
+
+  it("can blur on Enter and call onEnter callback", async () => {
+    const onBlur = jest.fn();
+    const onEnter = jest.fn();
+    const author = createObjectState(formConfig, {}, { onBlur });
+    // Given a textfield
+    const r = await render(<BoundTextField field={author.firstName} onEnter={onEnter} />);
+    // With focus
+    r.firstName().focus();
+    expect(r.firstName()).toHaveFocus();
+    // When hitting the Enter key
+    fireEvent.keyDown(r.firstName(), { key: "Enter" });
+    // Then onEnter should be called
+    expect(onEnter).toHaveBeenCalledTimes(1);
+    // And the Field State's onBlur should have been called.
+    expect(onBlur).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/forms/BoundTextField.tsx
+++ b/src/forms/BoundTextField.tsx
@@ -3,7 +3,7 @@ import { Observer } from "mobx-react";
 import { Only } from "src/Css";
 import { TextField, TextFieldProps } from "src/inputs";
 import { TextFieldXss } from "src/interfaces";
-import { useTestIds } from "src/utils";
+import { maybeCall, useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
 
 export type BoundTextFieldProps<X> = Omit<TextFieldProps<X>, "value" | "onChange" | "onBlur" | "onFocus" | "label"> & {
@@ -16,7 +16,14 @@ export type BoundTextFieldProps<X> = Omit<TextFieldProps<X>, "value" | "onChange
 
 /** Wraps `TextField` and binds it to a form field. */
 export function BoundTextField<X extends Only<TextFieldXss, X>>(props: BoundTextFieldProps<X>) {
-  const { field, readOnly, onChange = (value) => field.set(value), label = defaultLabel(field.key), ...others } = props;
+  const {
+    field,
+    readOnly,
+    onChange = (value) => field.set(value),
+    label = defaultLabel(field.key),
+    onEnter,
+    ...others
+  } = props;
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
@@ -30,6 +37,11 @@ export function BoundTextField<X extends Only<TextFieldXss, X>>(props: BoundText
           required={field.required}
           onBlur={() => field.blur()}
           onFocus={() => field.focus()}
+          onEnter={() => {
+            maybeCall(onEnter);
+            // Blur the field when the user hits the enter key - as if they are "committing" the value and done with the field
+            field.blur();
+          }}
           {...testId}
           {...others}
         />

--- a/src/inputs/TextField.test.tsx
+++ b/src/inputs/TextField.test.tsx
@@ -83,10 +83,11 @@ describe("TextFieldTest", () => {
     expect(onFocus).toHaveBeenCalledTimes(1);
   });
 
-  it("can blur on Enter", async () => {
+  it("can blur on Enter and call onEnter callback", async () => {
     const onBlur = jest.fn();
+    const onEnter = jest.fn();
     // Given a textfield
-    const r = await render(<TestTextField value="foo" onBlur={onBlur} />);
+    const r = await render(<TestTextField value="foo" onBlur={onBlur} onEnter={onEnter} />);
     // With focus
     r.name().focus();
     expect(r.name()).toHaveFocus();
@@ -96,6 +97,7 @@ describe("TextFieldTest", () => {
     expect(r.name()).not.toHaveFocus();
     // And onBlur should be called
     expect(onBlur).toHaveBeenCalledTimes(1);
+    expect(onEnter).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/inputs/TextField.test.tsx
+++ b/src/inputs/TextField.test.tsx
@@ -83,20 +83,16 @@ describe("TextFieldTest", () => {
     expect(onFocus).toHaveBeenCalledTimes(1);
   });
 
-  it("can blur on Enter and call onEnter callback", async () => {
-    const onBlur = jest.fn();
+  it("can trigger onEnter callback", async () => {
     const onEnter = jest.fn();
-    // Given a textfield
-    const r = await render(<TestTextField value="foo" onBlur={onBlur} onEnter={onEnter} />);
+    // Given a Textfield
+    const r = await render(<TestTextField value="foo" onEnter={onEnter} />);
     // With focus
     r.name().focus();
     expect(r.name()).toHaveFocus();
     // When hitting the Enter key
     fireEvent.keyDown(r.name(), { key: "Enter" });
-    // Then the field should no longer have focus
-    expect(r.name()).not.toHaveFocus();
-    // And onBlur should be called
-    expect(onBlur).toHaveBeenCalledTimes(1);
+    // Then onEnter should be called
     expect(onEnter).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/inputs/TextField.tsx
+++ b/src/inputs/TextField.tsx
@@ -4,6 +4,7 @@ import { Only } from "src/Css";
 import { TextFieldBase } from "src/inputs/TextFieldBase";
 import { BeamTextFieldProps, TextFieldXss } from "src/interfaces";
 import { Callback } from "src/types";
+import { maybeCall } from "src/utils";
 
 // exported for testing purposes
 export interface TextFieldProps<X> extends BeamTextFieldProps<X> {
@@ -11,6 +12,7 @@ export interface TextFieldProps<X> extends BeamTextFieldProps<X> {
   inlineLabel?: boolean;
   clearable?: boolean;
   api?: MutableRefObject<TextFieldApi | undefined>;
+  onEnter?: Callback;
 }
 
 export function TextField<X extends Only<TextFieldXss, X>>(props: TextFieldProps<X>) {
@@ -23,6 +25,7 @@ export function TextField<X extends Only<TextFieldXss, X>>(props: TextFieldProps
     onBlur,
     onFocus,
     api,
+    onEnter,
     ...otherProps
   } = props;
   const textFieldProps = {
@@ -41,6 +44,7 @@ export function TextField<X extends Only<TextFieldXss, X>>(props: TextFieldProps
         if (e.key === "Enter") {
           // Blur the field when the user hits the enter key - as if they are "committing" the value and done with the field
           inputRef.current?.blur();
+          maybeCall(onEnter);
         }
       },
     },

--- a/src/inputs/TextField.tsx
+++ b/src/inputs/TextField.tsx
@@ -42,8 +42,6 @@ export function TextField<X extends Only<TextFieldXss, X>>(props: TextFieldProps
       ...textFieldProps,
       onKeyDown: (e) => {
         if (e.key === "Enter") {
-          // Blur the field when the user hits the enter key - as if they are "committing" the value and done with the field
-          inputRef.current?.blur();
           maybeCall(onEnter);
         }
       },


### PR DESCRIPTION
We recently introduced that hitting the "Enter" on a TextField would immediately blur the field. Because we blur out of the field, then we no longer trigger default form submission behavior when a user hits the "Enter" key when the `<input />` element is wrapped in a `<form />`. It is unfortunate to have this be the default behavior in my opinion, but perhaps we can change this in the future? For now, providing an `onEnter` as another way to support submitting a form via the Enter key when within a TextField.