### PR TITLE
fix: Use CSS only solution to style focus state for CompoundField

### DIFF
--- a/src/components/internal/CompoundField.tsx
+++ b/src/components/internal/CompoundField.tsx
@@ -1,55 +1,44 @@
-import { cloneElement, useState } from "react";
+import { cloneElement } from "react";
 import { Css } from "src/Css";
 import { TextFieldInternalProps } from "src/interfaces";
-import { maybeCall } from "src/utils";
 
 /** Internal component to help create compound fields */
 export function CompoundField({ children }: { children: JSX.Element[] }) {
   if (children?.length !== 2) {
     throw global.Error("CompoundField requires two children components");
   }
-  const [focusedEl, setFocusedEl] = useState<"left" | "right" | undefined>();
   const commonStyles = Css.df.aic.fs1.maxwPx(550).bt.bb.bGray300.$;
   const internalProps: TextFieldInternalProps = { compound: true };
 
   return (
-    <div css={Css.df.$}>
+    <div
+      css={{
+        ...Css.df.$,
+        "&:focus-within > div:nth-of-type(2)": Css.bgLightBlue700.$, // Separation line when inputs are focused
+      }}
+    >
       <div
         css={{
           ...commonStyles,
-          ...Css.bl.borderRadius("4px 0 0 4px").if(focusedEl === "left").bLightBlue700.$,
+          ...Css.bl.borderRadius("4px 0 0 4px").$,
+          "&:focus-within": Css.bLightBlue700.$,
         }}
       >
         {cloneElement(children[0], {
-          onFocus: () => {
-            maybeCall(children[0].props.onFocus);
-            setFocusedEl("left");
-          },
-          onBlur: () => {
-            maybeCall(children[0].props.onBlur);
-            setFocusedEl(undefined);
-          },
           internalProps,
         })}
       </div>
       {/* Separation line */}
-      <div css={Css.wPx(1).flexNone.bgGray300.if(focusedEl !== undefined).bgLightBlue700.$} />
+      <div css={Css.wPx(1).flexNone.bgGray300.$} />
 
       <div
         css={{
           ...commonStyles,
-          ...Css.fg1.br.borderRadius("0 4px 4px 0").if(focusedEl === "right").bLightBlue700.$,
+          ...Css.fg1.br.borderRadius("0 4px 4px 0").$,
+          "&:focus-within": Css.bLightBlue700.$,
         }}
       >
         {cloneElement(children[1], {
-          onFocus: () => {
-            maybeCall(children[1].props.onFocus);
-            setFocusedEl("right");
-          },
-          onBlur: () => {
-            maybeCall(children[1].props.onBlur);
-            setFocusedEl(undefined);
-          },
           internalProps,
         })}
       </div>


### PR DESCRIPTION
Fixes an issue where `onFocus` and `onBlur` are getting overwritten (a problem for `Bound` type fields that never expect `onFocus` or `onBlur` to be passed in externally, but due to using `...others` prop spread below, the existing logic gets clobbered).