### PR TITLE
fix: Ensure chrome rows always fit to GridRows

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-stately": "^3.9.0",
-    "react-virtuoso": "^2.3.1",
+    "react-virtuoso": "^2.4.0",
     "tinycolor2": "^1.4.2",
     "tributejs": "^5.1.3",
     "trix": "^1.3.1",

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -27,7 +27,7 @@ import {
 import { Css, Palette } from "src/Css";
 import { NumberField } from "src/inputs/NumberField";
 import { noop } from "src/utils";
-import { newStory, withRouter, zeroTo } from "src/utils/sb";
+import { newStory, withDimensions, withRouter, zeroTo } from "src/utils/sb";
 
 export default {
   component: GridTable,
@@ -293,6 +293,52 @@ function NestedCards({ rows, as, sorting, style }: NestedCardsProps) {
     />
   );
 }
+
+export const NestedCardsOverflowX = newStory(
+  () => {
+    const nameColumn: GridColumn<NestedRow> = {
+      header: () => "Name",
+      parent: (row) => ({
+        content: () => <div css={Css.base.$}>{row.name}</div>,
+        value: row.name,
+      }),
+      child: (row) => ({
+        content: () => <div css={Css.sm.$}>{row.name}</div>,
+        value: row.name,
+      }),
+      grandChild: (row) => ({
+        content: () => <div css={Css.xs.$}>{row.name}</div>,
+        value: row.name,
+      }),
+      add: () => "Add",
+      w: "300px",
+    };
+    const actionColumn: GridColumn<NestedRow> = {
+      header: () => "Action",
+      parent: () => "",
+      child: () => "",
+      grandChild: () => <div css={Css.xs.$}>Delete</div>,
+      add: () => "",
+      clientSideSort: false,
+      w: "300px",
+    };
+    const spacing = { brPx: 4, pxPx: 4 };
+    const nestedStyle: GridStyle = {
+      nestedCards: {
+        firstLastColumnWidth: 24,
+        spacerPx: 8,
+        kinds: {
+          parent: { bgColor: Palette.Gray500, ...spacing },
+          child: { bgColor: Palette.Gray200, bColor: Palette.Gray600, ...spacing },
+          grandChild: { bgColor: Palette.Green200, bColor: Palette.Green400, ...spacing },
+        },
+      },
+    };
+
+    return <GridTable as="virtual" columns={[nameColumn, nameColumn, actionColumn]} rows={rows} style={nestedStyle} />;
+  },
+  { decorators: [withDimensions("800px")] },
+);
 
 export function OneOffInlineTable() {
   const items: { code: string; name: string; quantity: number }[] = [

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -614,7 +614,7 @@ const VirtualRoot = memoizeOne<
     return (
       <div
         ref={ref}
-        style={style}
+        style={{ ...style, ...(gs.nestedCards ? { minWidth: "fit-content" } : {}) }}
         css={{
           // Add an extra `> div` due to Item + itemContent both having divs
           ...Css.addIn("& > div + div > div > *", gs.betweenRowsCss || {}).$,


### PR DESCRIPTION
Use `minWidth: fit-content` on the virtual table's wrapping element. This allows for the table to dictate its size based on the width of the GridRows, and ensures the chrome rows always adjust to the GridRows size.