### PR TITLE
feat: Reset to initial sort state for GridTable

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -10,7 +10,7 @@ export interface IconProps extends AriaAttributes, DOMProps {
   /** The size of the icon in increments, i.e. 1 == 8px, default is 3 == 24px. */
   inc?: number;
   /** Styles overrides */
-  xss?: Xss<Margin>;
+  xss?: Xss<Margin | "visibility">;
 }
 
 export const Icon = React.memo((props: IconProps) => {

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -648,7 +648,7 @@ export function WrappedHeaders() {
   return (
     <GridTable<Row2>
       columns={[leftAlignedColumn, rightAlignedColumn, centerAlignedColumn]}
-      sorting={{ on: "client", initial: [rightAlignedColumn, "ASC"] }}
+      sorting={{ on: "client", initial: undefined }}
       style={condensedStyle}
       rows={[
         { kind: "header", id: "header" },

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -386,6 +386,87 @@ describe("GridTable", () => {
       expect(cell(r, 2, 0)).toHaveTextContent("b");
     });
 
+    it("reverts to initial sorted column", async () => {
+      // Given a table
+      const r = await render(
+        <GridTable
+          columns={[nameColumn, valueColumn]}
+          // And there is an initial sort defined
+          sorting={{ on: "client", initial: [nameColumn, "ASC"] }}
+          rows={[
+            simpleHeader,
+            { kind: "data", id: "1", name: "a", value: 2 },
+            { kind: "data", id: "2", name: "b", value: 3 },
+            { kind: "data", id: "3", name: "c", value: 1 },
+          ]}
+        />,
+      );
+      // When initializing sort on the "value" column
+      click(r.sortHeader_1);
+      // Then expect ASC order
+      expect(cell(r, 1, 1)).toHaveTextContent("1");
+      // And when clicking a 2nd time
+      click(r.sortHeader_1);
+      // Then expect DESC order
+      expect(cell(r, 1, 1)).toHaveTextContent("3");
+      // And when clicking a 3rd time
+      click(r.sortHeader_1);
+      // Then expect the order to have been reset
+      expect(cell(r, 1, 1)).toHaveTextContent("2");
+    });
+
+    it("initializes with undefined sort", async () => {
+      // Given a table
+      const r = await render(
+        <GridTable
+          columns={[nameColumn, valueColumn]}
+          // And the initial sort is explicitly set to `undefined`
+          sorting={{ on: "client", initial: undefined }}
+          rows={[
+            simpleHeader,
+            // And the data is initially unsorted
+            { kind: "data", id: "2", name: "b", value: 2 },
+            { kind: "data", id: "1", name: "a", value: 3 },
+            { kind: "data", id: "3", name: "c", value: 1 },
+          ]}
+        />,
+      );
+      // Then the data remains unsorted
+      expect(cell(r, 1, 0)).toHaveTextContent("b");
+      expect(cell(r, 2, 0)).toHaveTextContent("a");
+      expect(cell(r, 3, 0)).toHaveTextContent("c");
+    });
+
+    it("reverts to initially undefined sort", async () => {
+      // Given a table
+      const r = await render(
+        <GridTable
+          columns={[nameColumn, valueColumn]}
+          // And the initial sort is explicitly set to `undefined`
+          sorting={{ on: "client", initial: undefined }}
+          rows={[
+            simpleHeader,
+            // And the data is initially unsorted
+            { kind: "data", id: "2", name: "b", value: 2 },
+            { kind: "data", id: "1", name: "a", value: 3 },
+            { kind: "data", id: "3", name: "c", value: 1 },
+          ]}
+        />,
+      );
+      // When initializing sort on the "name" column
+      click(r.sortHeader_0);
+      // Then expect ASC order
+      expect(cell(r, 1, 0)).toHaveTextContent("a");
+      // And when clicking a 2nd time
+      click(r.sortHeader_0);
+      // Then expect DESC order
+      expect(cell(r, 1, 0)).toHaveTextContent("c");
+      // And when clicking a 3rd time
+      click(r.sortHeader_0);
+      // Then expect the order to have been reset
+      expect(cell(r, 1, 0)).toHaveTextContent("b");
+    });
+
     it("can sort nested rows", async () => {
       // Given a table with nested rows
       const r = await render(
@@ -465,14 +546,14 @@ describe("GridTable", () => {
       );
       const { sortHeader_0, sortHeader_icon_0 } = r;
       // It is initially not sorted
-      expect(() => sortHeader_icon_0()).toThrow("Unable to find");
+      expect(sortHeader_icon_0()).not.toBeVisible();
 
       // Then when sorted by the 1st column
       click(sortHeader_0);
       // Then the callback was called
       expect(onSort).toHaveBeenCalledWith("name", "ASC");
       // And we show the sort toggle
-      expect(sortHeader_icon_0()).toHaveAttribute("data-icon", "sortUp");
+      expect(sortHeader_icon_0()).toHaveAttribute("data-icon", "sortUp").toBeVisible();
       // And the data was not reordered (we defer to the server-side)
       expect(cell(r, 1, 0)).toHaveTextContent("foo");
 
@@ -481,7 +562,14 @@ describe("GridTable", () => {
       // Then it was called again but desc
       expect(onSort).toHaveBeenCalledWith("name", "DESC");
       // And we flip the sort toggle
-      expect(sortHeader_icon_0()).toHaveAttribute("data-icon", "sortDown");
+      expect(sortHeader_icon_0()).toHaveAttribute("data-icon", "sortDown").toBeVisible();
+
+      // And when we sort again
+      click(sortHeader_0);
+      // Then it was called again with undefined
+      expect(onSort).toHaveBeenCalledWith(undefined, undefined);
+      // And we hide the sort toggle (back to the initial sort)
+      expect(sortHeader_icon_0()).not.toBeVisible();
     });
 
     it("doesn't sort columns w/o onSort", async () => {
@@ -521,7 +609,7 @@ describe("GridTable", () => {
         />,
       );
       // Then it is shown as initially sorted asc
-      expect(sortHeader_icon_0()).toHaveAttribute("data-icon", "sortUp");
+      expect(sortHeader_icon_0()).toHaveAttribute("data-icon", "sortUp").toBeVisible();
     });
 
     it("initializes with desc sorting", async () => {
@@ -541,7 +629,7 @@ describe("GridTable", () => {
         />,
       );
       // Then it is shown as initially sorted desc
-      expect(sortHeader_icon_0()).toHaveAttribute("data-icon", "sortDown");
+      expect(sortHeader_icon_0()).toHaveAttribute("data-icon", "sortDown").toBeVisible();
     });
 
     it("can pin rows first", async () => {

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -157,7 +157,7 @@ export type GridSortConfig<S> =
       /** The current sort by value + direction (if server-side sorting). */
       value?: [S, Direction];
       /** Callback for when the column is sorted (if server-side sorting). */
-      onSort: (orderBy: S, direction: Direction) => void;
+      onSort: (orderBy: S | undefined, direction: Direction | undefined) => void;
     };
 
 export interface GridTableProps<R extends Kinded, S, X> {

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -150,13 +150,13 @@ export type GridSortConfig<S> =
   | {
       on: "client";
       /** The optional initial column (index in columns) and direction to sort. */
-      initial?: [S | GridColumn<any>, Direction];
+      initial?: [S | GridColumn<any>, Direction] | undefined;
     }
   | {
       on: "server";
       /** The current sort by value + direction (if server-side sorting). */
       value?: [S, Direction];
-      /** Callback for when the column is sorted (if server-side sorting). */
+      /** Callback for when the column is sorted (if server-side sorting). Parameters set to `undefined` is a signal to return to the initial sort state */
       onSort: (orderBy: S | undefined, direction: Direction | undefined) => void;
     };
 
@@ -269,12 +269,11 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
   }
 
   const [sortState, setSortKey] = useSortState<R, S>(columns, sorting);
-  // Disclaimer that technically even though this is a useMemo, sortRows is mutating `rows` directly
+
   const maybeSorted = useMemo(() => {
     if (sorting?.on === "client" && sortState) {
       // If using client-side sort, the sortState use S = number
-      sortRows(columns, rows, sortState as any as SortState<number>);
-      return rows;
+      return sortRows(columns, rows, sortState as any as SortState<number>);
     }
     return rows;
   }, [columns, rows, sorting, sortState]);

--- a/src/components/Table/SortHeader.tsx
+++ b/src/components/Table/SortHeader.tsx
@@ -1,7 +1,8 @@
 import React, { useContext } from "react";
 import { Icon } from "src/components/Icon";
 import { GridSortContext } from "src/components/Table/GridSortContext";
-import { Css, Properties } from "src/Css";
+import { Css, Palette, Properties } from "src/Css";
+import { useHover } from "src/hooks";
 import { useTestIds } from "src/utils/useTestIds";
 
 /**
@@ -17,13 +18,26 @@ import { useTestIds } from "src/utils/useTestIds";
  */
 export function SortHeader(props: { content: string; xss?: Properties }) {
   const { content, xss } = props;
+  const { isHovered, hoverProps } = useHover({});
   const { sorted, toggleSort } = useContext(GridSortContext);
   const tid = useTestIds(props, "sortHeader");
   return (
-    <div {...tid} css={{ ...Css.df.aic.cursorPointer.selectNone.$, ...xss }} onClick={toggleSort}>
+    <div {...tid} css={{ ...Css.df.aic.h100.cursorPointer.selectNone.$, ...xss }} {...hoverProps} onClick={toggleSort}>
       {content}
-      {sorted === "ASC" && <Icon icon="sortUp" inc={2} {...tid.icon} xss={Css.mlPx(4).$} />}
-      {sorted === "DESC" && <Icon icon="sortDown" inc={2} {...tid.icon} xss={Css.mlPx(4).$} />}
+      <span css={Css.fs0.$}>
+        <Icon
+          icon={sorted === "DESC" ? "sortDown" : "sortUp"}
+          color={sorted !== undefined ? Palette.LightBlue700 : Palette.Gray400}
+          xss={
+            Css.ml1
+              .visibility("hidden")
+              .if(isHovered || sorted !== undefined)
+              .visibility("visible").$
+          }
+          inc={2}
+          {...tid.icon}
+        />
+      </span>
     </div>
   );
 }

--- a/src/components/Table/sortRows.test.ts
+++ b/src/components/Table/sortRows.test.ts
@@ -1,0 +1,66 @@
+import { GridColumn, GridDataRow } from "src/components/Table/GridTable";
+import { simpleHeader } from "src/components/Table/simpleHelpers";
+import { sortRows } from "src/components/Table/sortRows";
+
+describe("sortRows", () => {
+  it("can return a sorted copy of nested rows in ascending order", () => {
+    // Given a set of unsorted nested rows
+    const rows: GridDataRow<Row>[] = [
+      simpleHeader,
+      // And the data is initially unsorted
+      {
+        kind: "parent",
+        id: "2",
+        name: "b",
+        children: [
+          { kind: "child", id: "2.1", name: "b1" },
+          { kind: "child", id: "2.3", name: "b3" },
+          { kind: "child", id: "2.2", name: "b2" },
+        ],
+      },
+      { kind: "parent", id: "1", name: "a" },
+      { kind: "parent", id: "3", name: "c" },
+    ];
+    // When sorting them in ascending order based on the name property
+    const sorted = sortRows([nameColumn], rows, [0, "ASC"]);
+    // Then expected sorted to be in ascending correct order
+    expect(rowsToIdArray(sorted)).toEqual(["header", "1", "2", "2.1", "2.2", "2.3", "3"]);
+    // And `rows` to maintain original order
+    expect(rowsToIdArray(rows)).toEqual(["header", "2", "2.1", "2.3", "2.2", "1", "3"]);
+  });
+  it("can return a sorted copy of nested rows in descending order", () => {
+    // Given a set of unsorted nested rows
+    const rows: GridDataRow<Row>[] = [
+      simpleHeader,
+      // And the data is initially unsorted
+      {
+        kind: "parent",
+        id: "2",
+        name: "b",
+        children: [
+          { kind: "child", id: "2.1", name: "b1" },
+          { kind: "child", id: "2.3", name: "b3" },
+          { kind: "child", id: "2.2", name: "b2" },
+        ],
+      },
+      { kind: "parent", id: "1", name: "a" },
+      { kind: "parent", id: "3", name: "c" },
+    ];
+    // When sorting them in descending order based on the name property
+    const sorted = sortRows([nameColumn], rows, [0, "DESC"]);
+    // Then expected sorted to be in descending correct order
+    expect(rowsToIdArray(sorted)).toEqual(["3", "2", "2.3", "2.2", "2.1", "1", "header"]);
+    // And `rows` to maintain original order
+    expect(rowsToIdArray(rows)).toEqual(["header", "2", "2.1", "2.3", "2.2", "1", "3"]);
+  });
+});
+
+type HeaderRow = { kind: "header" };
+type ParentRow = { kind: "parent"; id: string; name: string | undefined };
+type ChildRow = { kind: "child"; id: string; name: string | undefined };
+type Row = HeaderRow | ParentRow | ChildRow;
+const nameColumn: GridColumn<Row> = { header: "Name", parent: ({ name }) => name, child: ({ name }) => name };
+
+function rowsToIdArray(rows: GridDataRow<Row>[]): string[] {
+  return rows.flatMap((r) => (r.children ? [r.id, ...r.children.map((c) => c.id)] : r.id));
+}

--- a/src/components/Table/sortRows.ts
+++ b/src/components/Table/sortRows.ts
@@ -17,12 +17,12 @@ export function sortRows<R extends Kinded>(
 ): GridDataRow<R>[] {
   const sorted = sortBatch(columns, rows, sortState);
   // Recursively sort child rows
-  for (const row of sorted) {
+  sorted.forEach((row, i) => {
     if (row.children) {
-      // Replace the existing `children` prop with a sorted shallow copy
-      Object.assign(row, { children: sortRows(columns, row.children, sortState) });
+      sorted[i] = { ...sorted[i], children: sortRows(columns, row.children, sortState) };
     }
-  }
+  });
+
   return sorted;
 }
 

--- a/src/components/Table/useSortState.test.ts
+++ b/src/components/Table/useSortState.test.ts
@@ -1,0 +1,20 @@
+import { ASC, DESC } from "src/components/Table/GridTable";
+import { deriveSortState } from "src/components/Table/useSortState";
+
+describe("useSortState", () => {
+  it("can derive the next sort state when current state is undefined", () => {
+    expect(deriveSortState(undefined, 2, undefined)).toEqual([2, ASC]);
+  });
+  it("can derive the next sort state when clicking on a new column", () => {
+    expect(deriveSortState([1, ASC], 2, undefined)).toEqual([2, ASC]);
+  });
+  it("can derive the next sort state when clicking on a currently ascending column", () => {
+    expect(deriveSortState([1, ASC], 1, undefined)).toEqual([1, DESC]);
+  });
+  it("can derive the next sort state when clicking on a currently descending column", () => {
+    // With `initialSortState` defined
+    expect(deriveSortState([1, DESC], 1, [2, ASC])).toEqual([2, ASC]);
+    // Without `initialSortState` defined
+    expect(deriveSortState([1, DESC], 1, undefined)).toEqual(undefined);
+  });
+});

--- a/src/components/Table/useSortState.ts
+++ b/src/components/Table/useSortState.ts
@@ -46,8 +46,8 @@ export function useSortState<R extends Kinded, S>(
       setSortState(newState);
 
       if (sorting?.on === "server") {
-        const [initialKey, initialDirection] = newState ? newState : [undefined, undefined];
-        sorting.onSort(initialKey, initialDirection);
+        const [newKey, newDirection] = newState ?? [undefined, undefined];
+        sorting.onSort(newKey, newDirection);
       }
     },
     // Note that sorting.onSort is not listed here, so we bind to whatever the 1st sorting.onSort was
@@ -76,6 +76,6 @@ export function deriveSortState<S>(
     return [clickedKey, DESC];
   }
 
-  // Else, direction is already DESC, so revert to original sort value or undefined.
-  return initialSortState ? [...initialSortState] : undefined;
+  // Else, direction is already DESC, so revert to original sort value.
+  return initialSortState;
 }


### PR DESCRIPTION
### [SC-11548](https://app.shortcut.com/homebound-team/story/11548/gridtable-to-reset-back-to-initial-sort-when-clicking-on-a-column-that-is-currently-in-descending-order)

GridTable sorting state now toggle between ASC -> DESC -> Initial Sort State. For client side sorting, the initial sort is defined either by the specified initial sort, or as the first sortable column.
For server side sorting we do not define an initially sorted column if it was not specified, (i.e. we do not look for a "first sortable column"). This gives the ability for server side sorting implementations to handle an `undefined` sort state. For use cases like Blueprint's Schedule V2, this allows the table to handle it's sorting reset via: 

```
<GridTable sorting={{ on: "server", value: undefined, onSort: (sortState) => { 
  if (sortState[0] === undefined) { 
    // reset to original list
  } else {
    // sort tasks locally
  }
}} />
```

Granted, this now requires Blueprint's Schedule V2 table to do their sorting locally (as it is currently client-side sorted), but this seemed like kind of a one-off. I did not think it worth maintaining a list of the initial order (especially when it comes to nested structures) for a "reset" look up. Happy to revisit if we find it a more common pattern.