### PR TITLE
feat: Remove use of CSS grid from GridTable

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -159,7 +159,7 @@ export function NestedRows() {
     child: (row) => <CollapseToggle row={row} />,
     grandChild: () => "",
     add: () => "",
-    w: 0,
+    w: "60px",
   });
   const nameColumn: GridColumn<NestedRow> = {
     header: () => "Name",

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1,8 +1,7 @@
 import React, { MutableRefObject, useContext } from "react";
 import { GridRowLookup } from "src/components/Table/GridRowLookup";
 import {
-  calcDivGridColumns,
-  calcVirtualGridColumns,
+  calcColumnSizes,
   emptyCell,
   GridCollapseContext,
   GridColumn,
@@ -685,42 +684,34 @@ describe("GridTable", () => {
     });
   });
 
-  describe("gtc", () => {
-    it("as=div defaults to auto", () => {
-      expect(calcDivGridColumns([{}, {}], undefined)).toEqual("auto auto");
-    });
-
+  describe("column sizes", () => {
     it("as=virtual defaults to fr widths", () => {
-      expect(calcVirtualGridColumns([{}, {}], undefined).join(" ")).toEqual(
+      expect(calcColumnSizes([{}, {}], undefined).join(" ")).toEqual(
         "((100% - 0% - 0px) * (1 / 2)) ((100% - 0% - 0px) * (1 / 2))",
       );
     });
 
-    it("as=div treats numbers as fr", () => {
-      expect(calcDivGridColumns([{ w: 1 }, { w: 2 }] as any, undefined)).toEqual("1fr 2fr");
-    });
-
     it("as=virtual treats numbers as fr", () => {
-      expect(calcVirtualGridColumns([{ w: 1 }, { w: 2 }] as any, undefined).join(" ")).toEqual(
+      expect(calcColumnSizes([{ w: 1 }, { w: 2 }] as any, undefined).join(" ")).toEqual(
         "((100% - 0% - 0px) * (1 / 3)) ((100% - 0% - 0px) * (2 / 3))",
       );
     });
 
     it("as=virtual accepts percentages ", () => {
-      expect(calcVirtualGridColumns([{ w: "10%" }, { w: 2 }] as any, undefined).join(" ")).toEqual(
+      expect(calcColumnSizes([{ w: "10%" }, { w: 2 }] as any, undefined).join(" ")).toEqual(
         "10% ((100% - 10% - 0px) * (2 / 2))",
       );
     });
 
     it("as=virtual rejects relative units", () => {
-      expect(() => calcVirtualGridColumns([{ w: "auto" }] as any, undefined).join(" ")).toThrow(
+      expect(() => calcColumnSizes([{ w: "auto" }] as any, undefined).join(" ")).toThrow(
         "as=virtual only supports px, percentage, or fr units",
       );
     });
 
     it("as=virtual with both px and default", () => {
       expect(
-        calcVirtualGridColumns(
+        calcColumnSizes(
           [{ w: "200px" }, { w: "100px" }, { w: "10%" }, { w: "20%" }, { w: 2 }, {}] as any,
           undefined,
         ).join(" "),

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -705,7 +705,7 @@ describe("GridTable", () => {
 
     it("as=virtual rejects relative units", () => {
       expect(() => calcColumnSizes([{ w: "auto" }] as any, undefined).join(" ")).toThrow(
-        "as=virtual only supports px, percentage, or fr units",
+        "Beam Table column width definition only supports px, percentage, or fr units",
       );
     });
 

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -729,7 +729,7 @@ export function calcColumnSizes(columns: GridColumn<any>[], firstLastColumnWidth
       } else if (w.endsWith("%")) {
         return { ...acc, claimedPercentages: acc.claimedPercentages + Number(w.replace("%", "")) };
       } else {
-        throw new Error("as=virtual only supports px, percentage, or fr units");
+        throw new Error("Beam Table column width definition only supports px, percentage, or fr units");
       }
     },
     { claimedPercentages: 0, claimedPixels: firstLastColumnWidth ? firstLastColumnWidth * 2 : 0, totalFr: 0 },


### PR DESCRIPTION
[SC-11802](https://app.shortcut.com/homebound-team/story/11802/remove-use-of-css-grid-in-gridtable)