### PR TITLE
fix: 'Bound' fields to use maybeAutoSave

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "format": "prettier --loglevel warn --write \"**/*.{ts,tsx,css,md}\""
   },
   "dependencies": {
-    "@homebound/form-state": "^2.2.13",
+    "@homebound/form-state": "2.4.1",
     "@internationalized/number": "^3.0.3",
     "@react-aria/utils": "^3.9.0",
     "@react-hook/resize-observer": "^1.2.2",

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { Button, ModalBody, ModalFooter, ModalHeader, ModalProps, OpenModal, useModal } from "src/components/index";
 import { Modal } from "src/components/Modal/Modal";
 import { TestModalContent, TestModalContentProps, TestModalFilterTable } from "src/components/Modal/TestModalContent";
+import { FormStateApp } from "src/forms/FormStateApp";
 import { noop } from "src/utils/index";
 import { withBeamDecorator, withDimensions } from "src/utils/sb";
 
@@ -69,6 +70,22 @@ export const OpenModalKeepOpen = () => {
     </OpenModal>
   );
 };
+
+export function ModalForm() {
+  return (
+    <OpenModal size="xl">
+      <>
+        <ModalHeader>Form Example</ModalHeader>
+        <ModalBody>
+          <FormStateApp />
+        </ModalBody>
+        <ModalFooter>
+          <Button label="Submit" />
+        </ModalFooter>
+      </>
+    </OpenModal>
+  );
+}
 
 interface ModalExampleProps extends Pick<ModalProps, "size" | "forceScrolling">, TestModalContentProps {}
 

--- a/src/forms/BoundCheckboxField.test.tsx
+++ b/src/forms/BoundCheckboxField.test.tsx
@@ -1,4 +1,4 @@
-import { createObjectState, ObjectConfig, required } from "@homebound/form-state";
+import { createObjectState, ObjectConfig, ObjectState, required } from "@homebound/form-state";
 import { click, render } from "@homebound/rtl-utils";
 import { BoundCheckboxField } from "src/forms";
 import { AuthorInput } from "src/forms/formStateDomain";
@@ -13,22 +13,56 @@ describe("BoundCheckboxField", () => {
     const formState = createObjectState(formConfig, { isAvailable: true });
 
     // When rendered
-    const { isAvailable } = await render(<BoundCheckboxField field={formState.isAvailable} />);
+    const r = await render(<BoundCheckboxField field={formState.isAvailable} />);
 
     // Expect the BoundCheckboxField to be checked
-    expect(isAvailable()).toBeChecked();
+    expect(r.isAvailable()).toBeChecked();
   });
 
   it("should uncheck when clicked", async () => {
     // Given a rendered checked BoundCheckboxField
     const formState = createObjectState(formConfig, { isAvailable: true });
-    const { isAvailable } = await render(<BoundCheckboxField field={formState.isAvailable} />);
+    const r = await render(<BoundCheckboxField field={formState.isAvailable} />);
 
     // When interacting with a BoundCheckboxField
-    click(isAvailable());
+    click(r.isAvailable);
 
     // Then expect the checkbox to be unchecked and the formState to reflect that state
-    expect(isAvailable()).not.toBeChecked();
+    expect(r.isAvailable()).not.toBeChecked();
     expect(formState.isAvailable.value).toBeFalsy();
+  });
+
+  it("trigger onFocus and onBlur callbacks", async () => {
+    const onBlur = jest.fn();
+    const onFocus = jest.fn();
+    // Given a BoundCheckboxField with onFocus and onBlur methods
+    const formState = createObjectState(formConfig, { isAvailable: true });
+    const r = await render(<BoundCheckboxField field={formState.isAvailable} onBlur={onBlur} onFocus={onFocus} />);
+
+    // When focus is triggered
+    r.isAvailable().focus();
+    // Then the callback should be triggered
+    expect(onFocus).toBeCalledTimes(1);
+
+    // When blur is triggered
+    r.isAvailable().blur();
+    // Then the callback should be triggered
+    expect(onBlur).toBeCalledTimes(1);
+  });
+
+  it("triggers 'maybeAutoSave' on change", async () => {
+    const autoSave = jest.fn();
+    // Given a BoundCheckboxField with auto save
+    const formState: ObjectState<AuthorInput> = createObjectState(
+      formConfig,
+      { isAvailable: true },
+      { maybeAutoSave: () => autoSave(formState.isAvailable.value) },
+    );
+    const r = await render(<BoundCheckboxField field={formState.isAvailable} />);
+
+    // When toggling the checkbox off
+    click(r.isAvailable());
+    // Then the callback should be triggered with the current value
+    expect(autoSave).toBeCalledWith(false);
   });
 });

--- a/src/forms/BoundCheckboxField.tsx
+++ b/src/forms/BoundCheckboxField.tsx
@@ -31,7 +31,7 @@ export function BoundCheckboxField(props: BoundCheckboxFieldProps) {
           onChange={(selected) => {
             // We are triggering blur manually for checkbox fields due to its transactional nature
             onChange(selected);
-            field.blur();
+            field.maybeAutoSave();
           }}
           errorMsg={field.touched ? field.errors.join(" ") : undefined}
           onFocus={() => {

--- a/src/forms/BoundCheckboxGroupField.test.tsx
+++ b/src/forms/BoundCheckboxGroupField.test.tsx
@@ -1,8 +1,9 @@
-import { createObjectState, ObjectConfig, required } from "@homebound/form-state";
+import { createObjectState, ObjectConfig, ObjectState, required } from "@homebound/form-state";
 import { render } from "@homebound/rtl-utils";
 import { BoundCheckboxGroupField } from "src/forms";
 import { AuthorInput } from "src/forms/formStateDomain";
 import { CheckboxGroupItemOption } from "src/inputs";
+import { click } from "src/utils/rtl";
 
 const colors: CheckboxGroupItemOption[] = [
   { value: "c:1", label: "Blue" },
@@ -13,10 +14,44 @@ const colors: CheckboxGroupItemOption[] = [
 describe("BoundCheckboxGroupField", () => {
   it("shows the label", async () => {
     const author = createObjectState(formConfig, {});
-    const { favoriteColors_label } = await render(
-      <BoundCheckboxGroupField field={author.favoriteColors} options={colors} />,
+    const r = await render(<BoundCheckboxGroupField field={author.favoriteColors} options={colors} />);
+    expect(r.favoriteColors_label()).toHaveTextContent("Favorite Colors");
+  });
+
+  it("trigger onFocus and onBlur callbacks", async () => {
+    const onBlur = jest.fn();
+    const onFocus = jest.fn();
+    // Given a BoundCheckboxGroupField with onFocus and onBlur methods
+    const author = createObjectState(formConfig, {});
+    const r = await render(
+      <BoundCheckboxGroupField field={author.favoriteColors} options={colors} onBlur={onBlur} onFocus={onFocus} />,
     );
-    expect(favoriteColors_label()).toHaveTextContent("Favorite Colors");
+
+    // When focus is triggered on a checkbox
+    r.blue().focus();
+    // Then the callback should be triggered
+    expect(onFocus).toBeCalledTimes(1);
+
+    // When blur is triggered on a checkbox
+    r.blue().blur();
+    // Then the callback should be triggered
+    expect(onBlur).toBeCalledTimes(1);
+  });
+
+  it("triggers 'maybeAutoSave' on change", async () => {
+    const autoSave = jest.fn();
+    // Given a BoundCheckboxField with auto save
+    const author: ObjectState<AuthorInput> = createObjectState(
+      formConfig,
+      {},
+      { maybeAutoSave: () => autoSave(author.favoriteColors.value) },
+    );
+    const r = await render(<BoundCheckboxGroupField field={author.favoriteColors} options={colors} />);
+
+    // When toggling the checkbox off
+    click(r.blue());
+    // Then the callback should be triggered with the current value
+    expect(autoSave).toBeCalledWith(["c:1"]);
   });
 });
 

--- a/src/forms/BoundChipSelectField.tsx
+++ b/src/forms/BoundChipSelectField.tsx
@@ -39,7 +39,10 @@ export function BoundChipSelectField<O, V extends Value>(
         <ChipSelectField
           label={label}
           value={field.value ?? undefined}
-          onSelect={onSelect}
+          onSelect={(value) => {
+            onSelect(value);
+            field.maybeAutoSave();
+          }}
           getOptionLabel={getOptionLabel}
           getOptionValue={getOptionValue}
           onBlur={() => {

--- a/src/forms/BoundChipSelectField.tsx
+++ b/src/forms/BoundChipSelectField.tsx
@@ -29,6 +29,7 @@ export function BoundChipSelectField<O, V extends Value>(
     label = defaultLabel(field.key),
     onBlur,
     onFocus,
+    onCreateNew,
     ...others
   } = props;
   const testId = useTestIds(props, field.key);
@@ -53,6 +54,14 @@ export function BoundChipSelectField<O, V extends Value>(
             field.focus();
             maybeCall(onFocus);
           }}
+          onCreateNew={
+            onCreateNew
+              ? async (v) => {
+                  await onCreateNew(v);
+                  field.maybeAutoSave();
+                }
+              : undefined
+          }
           {...others}
           {...testId}
         />

--- a/src/forms/BoundDateField.test.tsx
+++ b/src/forms/BoundDateField.test.tsx
@@ -1,0 +1,68 @@
+import { createObjectState, ObjectConfig, ObjectState } from "@homebound/form-state";
+import { render } from "@homebound/rtl-utils";
+import { fireEvent } from "@testing-library/react";
+import { BoundDateField } from "src/forms/BoundDateField";
+import { AuthorInput, jan1, jan2 } from "src/forms/formStateDomain";
+import { click } from "src/utils/rtl";
+
+describe("BoundDateField", () => {
+  it("trigger onFocus and onBlur callbacks", async () => {
+    const onBlur = jest.fn();
+    const onFocus = jest.fn();
+    // Given a BoundDateField with onFocus and onBlur methods
+    const author = createObjectState(formConfig, {});
+    const r = await render(<BoundDateField field={author.birthday} onBlur={onBlur} onFocus={onFocus} />);
+
+    // When focus is triggered on a checkbox
+    r.birthday().focus();
+    // Then the callback should be triggered
+    expect(onFocus).toBeCalledTimes(1);
+
+    // When blur is triggered on a checkbox
+    r.birthday().blur();
+    // Then the callback should be triggered
+    expect(onBlur).toBeCalledTimes(1);
+  });
+
+  it("triggers 'maybeAutoSave' on change", async () => {
+    const autoSave = jest.fn();
+    // Given a BoundDateField with auto save
+    const author: ObjectState<AuthorInput> = createObjectState(
+      formConfig,
+      { birthday: jan2 },
+      // Using toDateString to remove timezone info to prevent flaky test runs.
+      { maybeAutoSave: () => autoSave(author.birthday.value?.toDateString()) },
+    );
+    const r = await render(<BoundDateField field={author.birthday} />);
+
+    // When triggering the Date Picker
+    r.birthday().focus();
+    // And when selecting a date - React-Day-Picker uses role="gridcell" for all dates. Choose the first of these, which should be `jan1`
+    click(r.queryAllByRole("gridcell")[0]);
+
+    // Then the callback should be triggered with the current value
+    expect(autoSave).toBeCalledWith(jan1.toDateString());
+  });
+
+  it("triggers 'maybeAutoSave' on enter", async () => {
+    const autoSave = jest.fn();
+    // Given a BoundDateField with auto save
+    const author: ObjectState<AuthorInput> = createObjectState(
+      formConfig,
+      { birthday: jan2 },
+      // Using toDateString to remove timezone info to prevent flaky test runs.
+      { maybeAutoSave: () => autoSave(author.birthday.value?.toDateString()) },
+    );
+    const r = await render(<BoundDateField field={author.birthday} />);
+
+    // When hitting the enter key
+    fireEvent.keyDown(r.birthday(), { key: "Enter" });
+
+    // Then the callback should be triggered with the current value
+    expect(autoSave).toBeCalledWith(jan2.toDateString());
+  });
+});
+
+const formConfig: ObjectConfig<AuthorInput> = {
+  birthday: { type: "value" },
+};

--- a/src/forms/BoundMultiSelectField.test.tsx
+++ b/src/forms/BoundMultiSelectField.test.tsx
@@ -1,7 +1,8 @@
-import { createObjectState, ObjectConfig, required } from "@homebound/form-state";
+import { createObjectState, ObjectConfig, ObjectState, required } from "@homebound/form-state";
 import { render } from "@homebound/rtl-utils";
 import { BoundMultiSelectField } from "src/forms/BoundMultiSelectField";
 import { AuthorInput } from "src/forms/formStateDomain";
+import { click } from "src/utils/rtl";
 
 const shapes = [
   { id: "sh:1", name: "Triangle" },
@@ -10,27 +11,55 @@ const shapes = [
 ];
 
 describe("BoundMultiSelectField", () => {
-  it("shows the current value", async () => {
+  it("shows the current value and label", async () => {
     const author = createObjectState(formConfig, { favoriteShapes: ["sh:1"] });
-    const { favoriteShapes } = await render(<BoundMultiSelectField field={author.favoriteShapes} options={shapes} />);
-    expect(favoriteShapes()).toHaveValue("Triangle");
+    const r = await render(<BoundMultiSelectField field={author.favoriteShapes} options={shapes} />);
+    expect(r.favoriteShapes()).toHaveValue("Triangle");
+    expect(r.favoriteShapes_label()).toHaveTextContent("Favorite Shape");
   });
 
   it("shows the error message", async () => {
     const author = createObjectState(formConfig, {});
     author.favoriteShapes.touched = true;
-    const { favoriteShapes_errorMsg } = await render(
-      <BoundMultiSelectField field={author.favoriteShapes} options={shapes} />,
-    );
-    expect(favoriteShapes_errorMsg()).toHaveTextContent("Required");
+    const r = await render(<BoundMultiSelectField field={author.favoriteShapes} options={shapes} />);
+    expect(r.favoriteShapes_errorMsg()).toHaveTextContent("Required");
   });
 
-  it("shows the label", async () => {
+  it("trigger onFocus and onBlur callbacks", async () => {
+    const onBlur = jest.fn();
+    const onFocus = jest.fn();
+    // Given a BoundMultiSelectField with onFocus and onBlur methods
     const author = createObjectState(formConfig, { favoriteShapes: ["sh:1"] });
-    const { favoriteShapes_label } = await render(
-      <BoundMultiSelectField field={author.favoriteShapes} options={shapes} />,
+    const r = await render(
+      <BoundMultiSelectField field={author.favoriteShapes} options={shapes} onBlur={onBlur} onFocus={onFocus} />,
     );
-    expect(favoriteShapes_label()).toHaveTextContent("Favorite Shape");
+
+    // When focus is triggered on a checkbox
+    r.favoriteShapes().focus();
+    // Then the callback should be triggered
+    expect(onFocus).toBeCalledTimes(1);
+
+    // When blur is triggered on a checkbox
+    r.favoriteShapes().blur();
+    // Then the callback should be triggered
+    expect(onBlur).toBeCalledTimes(1);
+  });
+
+  it("triggers 'maybeAutoSave' on change", async () => {
+    const autoSave = jest.fn();
+    // Given a BoundMultiSelectField with auto save
+    const author: ObjectState<AuthorInput> = createObjectState(
+      formConfig,
+      { favoriteShapes: ["sh:1"] },
+      { maybeAutoSave: () => autoSave(author.favoriteShapes.value) },
+    );
+    const r = await render(<BoundMultiSelectField field={author.favoriteShapes} options={shapes} />);
+
+    r.favoriteShapes().focus();
+    click(r.getByRole("option", { name: "Square" }));
+
+    // Then the callback should be triggered with the current value
+    expect(autoSave).toBeCalledWith(["sh:1", "sh:2"]);
   });
 });
 

--- a/src/forms/BoundNumberField.test.tsx
+++ b/src/forms/BoundNumberField.test.tsx
@@ -1,28 +1,29 @@
-import { createObjectState, ObjectConfig, required } from "@homebound/form-state";
+import { createObjectState, ObjectConfig, ObjectState, required } from "@homebound/form-state";
 import { render } from "@homebound/rtl-utils";
 import { act, fireEvent } from "@testing-library/react";
 import { Observer } from "mobx-react";
 import { BoundNumberField } from "src/forms/BoundNumberField";
 import { AuthorInput } from "src/forms/formStateDomain";
+import { type } from "src/utils/rtl";
 
 describe("BoundNumberField", () => {
   it("shows the current value", async () => {
     const author = createObjectState(formConfig, { heightInInches: 10 });
-    const { heightInInches } = await render(<BoundNumberField field={author.heightInInches} />);
-    expect(heightInInches()).toHaveValue("10");
+    const r = await render(<BoundNumberField field={author.heightInInches} />);
+    expect(r.heightInInches()).toHaveValue("10");
   });
 
   it("can change the current value", async () => {
     const author = createObjectState(formConfig, { heightInInches: 10 });
-    const { heightInInches } = await render(<BoundNumberField field={author.heightInInches} />);
+    const r = await render(<BoundNumberField field={author.heightInInches} />);
     // Given the user types a valid WIP value
-    fireEvent.input(heightInInches(), { target: { value: "11" } });
+    fireEvent.input(r.heightInInches(), { target: { value: "11" } });
     // Then that value is in the DOM (as controlled by react-aria)
-    expect(heightInInches()).toHaveValue("11");
+    expect(r.heightInInches()).toHaveValue("11");
     // And also pushed immediately into the FieldState (i.e. w/o waiting for blur)
     expect(author.heightInInches.value).toEqual(11);
     // And when blur finally does happen
-    fireEvent.blur(heightInInches());
+    fireEvent.blur(r.heightInInches());
     // Then the value is still 11
     expect(author.heightInInches.value).toEqual(11);
   });
@@ -30,19 +31,19 @@ describe("BoundNumberField", () => {
   it("doesn't blow up when changing to an invalid value", async () => {
     // Given an initial value of 10
     const author = createObjectState(formConfig, { heightInInches: 10 });
-    const { heightInInches } = await render(<BoundNumberField field={author.heightInInches} />);
+    const r = await render(<BoundNumberField field={author.heightInInches} />);
     // When the user focuses
-    fireEvent.focus(heightInInches());
+    fireEvent.focus(r.heightInInches());
     // And types an invalid, WIP value
-    fireEvent.input(heightInInches(), { target: { value: "11," } });
+    fireEvent.input(r.heightInInches(), { target: { value: "11," } });
     // Then that value is technically in the DOM
-    expect(heightInInches()).toHaveValue("11,");
+    expect(r.heightInInches()).toHaveValue("11,");
     // And we pass a sanitized value into the field state for rules to see
     expect(author.heightInInches.value).toEqual(11);
     // And when the user blurs out
-    fireEvent.blur(heightInInches());
+    fireEvent.blur(r.heightInInches());
     // Then the DOM value is sanitized as well
-    expect(heightInInches()).toHaveValue("11");
+    expect(r.heightInInches()).toHaveValue("11");
   });
 
   it("shows an error message", async () => {
@@ -77,6 +78,43 @@ describe("BoundNumberField", () => {
     });
     expect(author.royaltiesInCents.value).toBeNull();
     expect(r.royalties()).toHaveValue("");
+  });
+
+  it("trigger onFocus and onBlur callbacks", async () => {
+    const onBlur = jest.fn();
+    const onFocus = jest.fn();
+    // Given a BoundNumberField with onFocus and onBlur methods
+    const author = createObjectState(formConfig, { heightInInches: 10 });
+    const r = await render(<BoundNumberField field={author.heightInInches} onBlur={onBlur} onFocus={onFocus} />);
+
+    // When focus is triggered on a checkbox
+    r.heightInInches().focus();
+    // Then the callback should be triggered
+    expect(onFocus).toBeCalledTimes(1);
+
+    // When blur is triggered on a checkbox
+    r.heightInInches().blur();
+    // Then the callback should be triggered
+    expect(onBlur).toBeCalledTimes(1);
+  });
+
+  it("triggers 'maybeAutoSave' on enter", async () => {
+    const autoSave = jest.fn();
+    // Given a BoundNumberField with auto save
+    const author: ObjectState<AuthorInput> = createObjectState(
+      formConfig,
+      { heightInInches: 10 },
+      { maybeAutoSave: () => autoSave(author.heightInInches.value) },
+    );
+    const r = await render(<BoundNumberField field={author.heightInInches} />);
+
+    // When typing in a new value
+    type(r.heightInInches, "73");
+    // And hitting the Enter key
+    fireEvent.keyDown(r.heightInInches(), { key: "Enter" });
+
+    // Then the callback should be triggered with the current value
+    expect(autoSave).toBeCalledWith(73);
   });
 });
 

--- a/src/forms/BoundNumberField.tsx
+++ b/src/forms/BoundNumberField.tsx
@@ -1,10 +1,10 @@
 import { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
 import { NumberField, NumberFieldProps } from "src/inputs/NumberField";
-import { useTestIds } from "src/utils";
+import { maybeCall, useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
 
-export type BoundNumberFieldProps = Omit<NumberFieldProps, "value" | "onChange" | "onBlur" | "onFocus" | "label"> & {
+export type BoundNumberFieldProps = Omit<NumberFieldProps, "value" | "onChange" | "label"> & {
   // Make optional as it'll create a label from the field's key if not present
   label?: string;
   field: FieldState<any, number | null | undefined>;
@@ -20,6 +20,9 @@ export function BoundNumberField(props: BoundNumberFieldProps) {
     onChange = (value) => field.set(value),
     label = defaultLabel(field.key.replace(/InCents$/, "")),
     type = field.key.endsWith("InCents") ? "cents" : undefined,
+    onFocus,
+    onBlur,
+    onEnter,
     ...others
   } = props;
   const testId = useTestIds(props, label || field.key);
@@ -34,8 +37,18 @@ export function BoundNumberField(props: BoundNumberFieldProps) {
           readOnly={readOnly ?? field.readOnly}
           errorMsg={field.touched ? field.errors.join(" ") : undefined}
           required={field.required}
-          onFocus={() => field.focus()}
-          onBlur={() => field.blur()}
+          onFocus={() => {
+            field.focus();
+            maybeCall(onFocus);
+          }}
+          onBlur={() => {
+            field.blur();
+            maybeCall(onBlur);
+          }}
+          onEnter={() => {
+            maybeCall(onEnter);
+            field.maybeAutoSave();
+          }}
           {...testId}
           {...others}
         />

--- a/src/forms/BoundRadioGroupField.test.tsx
+++ b/src/forms/BoundRadioGroupField.test.tsx
@@ -1,22 +1,56 @@
-import { createObjectState, ObjectConfig, required } from "@homebound/form-state";
+import { createObjectState, ObjectConfig, ObjectState, required } from "@homebound/form-state";
 import { render } from "@homebound/rtl-utils";
 import { BoundRadioGroupField } from "src/forms/BoundRadioGroupField";
 import { AuthorInput } from "src/forms/formStateDomain";
-import { RadioFieldOption } from "src/inputs";
+import { click } from "src/utils/rtl";
 
-const colors: RadioFieldOption<string>[] = [
-  { value: "c:1", label: "Blue" },
-  { value: "c:2", label: "Red" },
-  { value: "c:3", label: "Green" },
+const sports = [
+  { value: "s:1", label: "Football" },
+  { value: "s:2", label: "Soccer" },
+  { value: "s:3", label: "Basketball" },
 ];
 
 describe("BoundRadioGroupField", () => {
   it("shows the label", async () => {
     const author = createObjectState(formConfig, {});
-    const { favoriteSport_label } = await render(
-      <BoundRadioGroupField field={author.favoriteSport} options={colors} />,
+    const r = await render(<BoundRadioGroupField field={author.favoriteSport} options={sports} />);
+    expect(r.favoriteSport_label()).toHaveTextContent("Favorite Sport");
+  });
+
+  it("trigger onFocus and onBlur callbacks", async () => {
+    const onBlur = jest.fn();
+    const onFocus = jest.fn();
+    // Given a BoundRadioGroupField with onFocus and onBlur methods
+    const author = createObjectState(formConfig, {});
+    const r = await render(
+      <BoundRadioGroupField field={author.favoriteSport} options={sports} onBlur={onBlur} onFocus={onFocus} />,
     );
-    expect(favoriteSport_label()).toHaveTextContent("Favorite Sport");
+
+    // When focus is triggered on a checkbox
+    r.favoriteSport_s1().focus();
+    // Then the callback should be triggered
+    expect(onFocus).toBeCalledTimes(1);
+
+    // When blur is triggered on a checkbox
+    r.favoriteSport_s1().blur();
+    // Then the callback should be triggered
+    expect(onBlur).toBeCalledTimes(1);
+  });
+
+  it("triggers 'maybeAutoSave' on change", async () => {
+    const autoSave = jest.fn();
+    // Given a BoundRadioGroupField with auto save
+    const author: ObjectState<AuthorInput> = createObjectState(
+      formConfig,
+      { favoriteSport: "s:2" },
+      { maybeAutoSave: () => autoSave(author.favoriteSport.value) },
+    );
+    const r = await render(<BoundRadioGroupField field={author.favoriteSport} options={sports} />);
+
+    click(r.favoriteSport_s3());
+
+    // Then the callback should be triggered with the current value
+    expect(autoSave).toBeCalledWith("s:3");
   });
 });
 

--- a/src/forms/BoundRadioGroupField.tsx
+++ b/src/forms/BoundRadioGroupField.tsx
@@ -1,12 +1,12 @@
 import { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
 import { RadioGroupField, RadioGroupFieldProps } from "src/inputs";
-import { useTestIds } from "src/utils";
+import { maybeCall, useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
 
 export type BoundRadioGroupFieldProps<K extends string> = Omit<
   RadioGroupFieldProps<K>,
-  "value" | "onChange" | "label" | "onBlur" | "onFocus"
+  "value" | "onChange" | "label"
 > & {
   field: FieldState<any, K | null | undefined>;
   /** Make optional so that callers can override if they want to. */
@@ -16,7 +16,14 @@ export type BoundRadioGroupFieldProps<K extends string> = Omit<
 
 /** Wraps `TextField` and binds it to a form field. */
 export function BoundRadioGroupField<K extends string>(props: BoundRadioGroupFieldProps<K>) {
-  const { field, onChange = (value) => field.set(value), label = defaultLabel(field.key), ...others } = props;
+  const {
+    field,
+    onChange = (value) => field.set(value),
+    label = defaultLabel(field.key),
+    onBlur,
+    onFocus,
+    ...others
+  } = props;
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
@@ -24,10 +31,19 @@ export function BoundRadioGroupField<K extends string>(props: BoundRadioGroupFie
         <RadioGroupField<K>
           label={label}
           value={field.value || undefined}
-          onChange={onChange}
+          onChange={(value) => {
+            onChange(value);
+            field.maybeAutoSave();
+          }}
           errorMsg={field.touched ? field.errors.join(" ") : undefined}
-          onBlur={() => field.blur()}
-          onFocus={() => field.focus()}
+          onBlur={() => {
+            field.blur();
+            maybeCall(onBlur);
+          }}
+          onFocus={() => {
+            field.focus();
+            maybeCall(onFocus);
+          }}
           {...testId}
           {...others}
         />

--- a/src/forms/BoundRichTextField.tsx
+++ b/src/forms/BoundRichTextField.tsx
@@ -1,10 +1,10 @@
 import { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
 import { RichTextField, RichTextFieldProps } from "src/inputs/RichTextField";
-import { useTestIds } from "src/utils";
+import { maybeCall, useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
 
-export type BoundRichTextFieldProps = Omit<RichTextFieldProps, "value" | "onChange" | "onBlur" | "onFocus"> & {
+export type BoundRichTextFieldProps = Omit<RichTextFieldProps, "value" | "onChange"> & {
   field: FieldState<any, string | null | undefined>;
   // Optional in case the page wants extra behavior
   onChange?: (value: string | undefined) => void;
@@ -12,7 +12,15 @@ export type BoundRichTextFieldProps = Omit<RichTextFieldProps, "value" | "onChan
 
 /** Wraps `RichTextField` and binds it to a form field. */
 export function BoundRichTextField(props: BoundRichTextFieldProps) {
-  const { field, onChange = (value) => field.set(value), label = defaultLabel(field.key), readOnly, ...others } = props;
+  const {
+    field,
+    onChange = (value) => field.set(value),
+    label = defaultLabel(field.key),
+    readOnly,
+    onFocus,
+    onBlur,
+    ...others
+  } = props;
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
@@ -23,8 +31,14 @@ export function BoundRichTextField(props: BoundRichTextFieldProps) {
           onChange={onChange}
           // TODO: Potentially support this in the future?
           // errorMsg={field.touched ? field.errors.join(" ") : undefined}
-          onBlur={() => field.blur()}
-          onFocus={() => field.focus()}
+          onBlur={() => {
+            field.blur();
+            maybeCall(onBlur);
+          }}
+          onFocus={() => {
+            field.focus();
+            maybeCall(onFocus);
+          }}
           readOnly={readOnly ?? field.readOnly}
           {...testId}
           {...others}

--- a/src/forms/BoundSelectField.test.tsx
+++ b/src/forms/BoundSelectField.test.tsx
@@ -46,13 +46,13 @@ describe("BoundSelectField", () => {
     expect(r.isAvailable()).toHaveValue("");
   });
 
-  it("has the latest value when onBlur is triggered", async () => {
+  it("has the latest value when onChange is triggered", async () => {
     // Given a FormState/ObjectState with an onBlur callback
-    const onBlur = jest.fn();
+    const autoSave = jest.fn();
     const author: ObjectState<AuthorInput> = createObjectState(
       formConfig,
       { favoriteSport: "s:1" },
-      { onBlur: () => onBlur(author.favoriteSport.value) },
+      { maybeAutoSave: () => autoSave(author.favoriteSport.value) },
     );
     const r = await render(<BoundSelectField field={author.favoriteSport} options={sports} />);
     // When changing the value
@@ -60,7 +60,7 @@ describe("BoundSelectField", () => {
     click(r.getByRole("option", { name: "Soccer" }));
 
     // Then formState has the latest value when onBlur is called
-    expect(onBlur).toBeCalledWith("s:2");
+    expect(autoSave).toBeCalledWith("s:2");
   });
 });
 

--- a/src/forms/BoundSwitchField.test.tsx
+++ b/src/forms/BoundSwitchField.test.tsx
@@ -1,4 +1,4 @@
-import { createObjectState, ObjectConfig, required } from "@homebound/form-state";
+import { createObjectState, ObjectConfig, ObjectState, required } from "@homebound/form-state";
 import { click, render } from "@homebound/rtl-utils";
 import { BoundSwitchField } from "src/forms";
 import { AuthorInput } from "src/forms/formStateDomain";
@@ -14,8 +14,13 @@ describe("BoundSwitchField", () => {
   });
 
   it("should uncheck when clicked", async () => {
+    const autoSave = jest.fn();
     // Given a rendered checked BoundSwitchField
-    const formState = createObjectState(formConfig, { isAvailable: true });
+    const formState: ObjectState<AuthorInput> = createObjectState(
+      formConfig,
+      { isAvailable: true },
+      { maybeAutoSave: () => autoSave(formState.isAvailable.value) },
+    );
     const { isAvailable } = await render(<BoundSwitchField field={formState.isAvailable} />);
 
     // When interacting with a BoundSwitchField
@@ -24,6 +29,8 @@ describe("BoundSwitchField", () => {
     // Then expect the checkbox to be unchecked and the formState to reflect that state
     expect(isAvailable()).not.toBeChecked();
     expect(formState.isAvailable.value).toBeFalsy();
+    // And auto save was triggered with the correct value
+    expect(autoSave).toBeCalledWith(false);
   });
 });
 

--- a/src/forms/BoundSwitchField.tsx
+++ b/src/forms/BoundSwitchField.tsx
@@ -23,9 +23,8 @@ export function BoundSwitchField(props: BoundSwitchFieldProps) {
           labelStyle="form"
           selected={field.value ?? false}
           onChange={(selected) => {
-            // We are triggering blur manually for checkbox fields due to its transactional nature
             onChange(selected);
-            field.blur();
+            field.maybeAutoSave();
           }}
           // errorMsg={field.touched ? field.errors.join(" ") : undefined}
           {...testId}

--- a/src/forms/BoundTextField.test.tsx
+++ b/src/forms/BoundTextField.test.tsx
@@ -1,8 +1,9 @@
-import { createObjectState, ObjectConfig, required } from "@homebound/form-state";
+import { createObjectState, ObjectConfig, ObjectState, required } from "@homebound/form-state";
 import { render } from "@homebound/rtl-utils";
 import { fireEvent } from "@testing-library/react";
 import { BoundTextField } from "src/forms/BoundTextField";
 import { AuthorInput } from "src/forms/formStateDomain";
+import { type } from "src/utils/rtl";
 
 describe("BoundTextField", () => {
   it("shows the current value", async () => {
@@ -25,21 +26,24 @@ describe("BoundTextField", () => {
     expect(firstName_errorMsg()).toHaveTextContent("Required");
   });
 
-  it("can blur on Enter and call onEnter callback", async () => {
-    const onBlur = jest.fn();
+  it("can blur onEnter and call onEnter callback", async () => {
+    const autoSave = jest.fn();
     const onEnter = jest.fn();
-    const author = createObjectState(formConfig, {}, { onBlur });
+    const author: ObjectState<AuthorInput> = createObjectState(
+      formConfig,
+      {},
+      { maybeAutoSave: () => autoSave(author.firstName.value) },
+    );
     // Given a textfield
     const r = await render(<BoundTextField field={author.firstName} onEnter={onEnter} />);
-    // With focus
-    r.firstName().focus();
-    expect(r.firstName()).toHaveFocus();
-    // When hitting the Enter key
+    // When entering a name
+    type(r.firstName, "Brandon");
+    // And hitting the Enter key
     fireEvent.keyDown(r.firstName(), { key: "Enter" });
     // Then onEnter should be called
     expect(onEnter).toHaveBeenCalledTimes(1);
-    // And the Field State's onBlur should have been called.
-    expect(onBlur).toHaveBeenCalledTimes(1);
+    // And the Field State's autoSave should have been called.
+    expect(autoSave).toHaveBeenCalledWith("Brandon");
   });
 });
 

--- a/src/forms/BoundTextField.tsx
+++ b/src/forms/BoundTextField.tsx
@@ -39,8 +39,7 @@ export function BoundTextField<X extends Only<TextFieldXss, X>>(props: BoundText
           onFocus={() => field.focus()}
           onEnter={() => {
             maybeCall(onEnter);
-            // Blur the field when the user hits the enter key - as if they are "committing" the value and done with the field
-            field.blur();
+            field.maybeAutoSave();
           }}
           {...testId}
           {...others}

--- a/src/inputs/ChipSelectField.test.tsx
+++ b/src/inputs/ChipSelectField.test.tsx
@@ -50,8 +50,6 @@ describe("ChipSelectField", () => {
     expect(r.queryByTestId("chipSelectField_clearButton")).toBeFalsy();
     // And onSelect to be called
     expect(onSelect).toBeCalledWith([undefined, undefined]);
-    // And the `onBlur` callback is triggered
-    expect(onBlur).toBeCalledTimes(1);
   });
 
   it("can select options", async () => {
@@ -105,8 +103,6 @@ describe("ChipSelectField", () => {
     click(r.getByRole("option", { name: "Basketball" }));
     // Then the focus is returned to the field
     expect(onFocus).toBeCalledTimes(2);
-    // And immediately blurred.
-    expect(onBlur).toBeCalledTimes(1);
   });
 
   it("can disable field", async () => {
@@ -146,8 +142,6 @@ describe("ChipSelectField", () => {
     expect(r.queryByTestId("chipSelectField_createNewField")).toBeFalsy();
     // And onCreateNew to be called with text field value
     expect(onCreateNew).toBeCalledWith(newOpt.name);
-    // And triggers onBlur again
-    expect(onBlur).toBeCalledTimes(1);
   });
 
   it("can escape out of Add New field", async () => {

--- a/src/inputs/ChipSelectField.tsx
+++ b/src/inputs/ChipSelectField.tsx
@@ -1,5 +1,5 @@
 import { camelCase } from "change-case";
-import React, { Key, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { Key, ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { mergeProps, useButton, useFocus, useOverlayPosition, useSelect } from "react-aria";
 import { Item, Section, useListData, useSelectState } from "react-stately";
 import { Icon, maybeTooltip, resolveTooltip } from "src/components";
@@ -177,10 +177,8 @@ export function ChipSelectField<O, V extends Value>(
       if (selectedItem) {
         onSelect(key as V, selectedItem);
       }
-      // Per UX, when an option is selected then we want to call our `onBlur` callback and remove the focus styles. The field _is_ still in focus but that is only to retain tab position in the DOM.
-      // We cannot simply call `buttonRef.current.blur()` here because `state.isOpen === true` and we keep the visualFocus shown when the menu is open.
+      // Per UX, we do not want to show visual focus upon selection change.
       setVisualFocus(false);
-      maybeCall(onBlur);
     },
     onOpenChange: (isOpen) => {
       if (!isOpen) {
@@ -217,20 +215,15 @@ export function ChipSelectField<O, V extends Value>(
 
   // State management for the "Create new" flow with ChipTextField.
   const [showInput, setShowInput] = useState(false);
-  const removeCreateNewField = useCallback(() => {
-    setShowInput(false);
-    // Trigger onBlur to initiate any auto-saving behavior.
-    maybeCall(onBlur);
-  }, [setShowInput]);
 
   return (
     <>
       {showInput && onCreateNew && (
         <CreateNewField
-          onBlur={removeCreateNewField}
+          onBlur={() => setShowInput(false)}
           onEnter={async (value) => {
             await onCreateNew(value);
-            removeCreateNewField();
+            setShowInput(false);
           }}
           {...tid.createNewField}
         />
@@ -274,7 +267,6 @@ export function ChipSelectField<O, V extends Value>(
                 }}
                 onClick={() => {
                   onSelect(undefined as any, undefined as any);
-                  maybeCall(onBlur);
                   setIsClearFocused(false);
                 }}
                 aria-label="Remove"

--- a/src/inputs/DateField.test.tsx
+++ b/src/inputs/DateField.test.tsx
@@ -130,18 +130,20 @@ describe("DateField", () => {
     expect(onBlur).toBeCalledTimes(1);
   });
 
-  it("fires on blur when pressing Enter key", async () => {
+  it("fires onEnter and blurs field when pressing Enter key", async () => {
     // Given a DateField with `jan2` as our date
+    const onEnter = jest.fn();
     const onBlur = jest.fn();
-    const r = await render(<DateField value={jan2} label="Date" onChange={noop} onBlur={onBlur} />);
+    const r = await render(<DateField value={jan2} label="Date" onChange={noop} onEnter={onEnter} onBlur={onBlur} />);
     // When changing the input value to an valid date
     r.date().focus();
+    expect(r.date()).toHaveFocus();
     // And when hitting the Enter key
     fireEvent.keyDown(r.date(), { key: "Enter" });
-    // Then field should be no longer in focus
-    expect(r.date()).not.toHaveFocus();
-    // And the onBlur callback should be triggered
+    // And the onEnter and onBlur callbacks should be triggered
+    expect(onEnter).toBeCalledTimes(1);
     expect(onBlur).toBeCalledTimes(1);
+    expect(r.date()).not.toHaveFocus();
   });
 
   it("resets to previous date if user enters invalid value and does not fire onChange", async () => {

--- a/src/inputs/DateField.tsx
+++ b/src/inputs/DateField.tsx
@@ -8,6 +8,7 @@ import { Popover } from "src/components/internal";
 import { Css, Palette } from "src/Css";
 import { DatePickerOverlay } from "src/inputs/internal/DatePickerOverlay";
 import { TextFieldBase, TextFieldBaseProps } from "src/inputs/TextFieldBase";
+import { Callback } from "src/types";
 import { maybeCall, useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
 import "./DateField.css";
@@ -32,11 +33,12 @@ export interface DateFieldProps
   placeholder?: string;
   format?: keyof typeof dateFormats;
   iconLeft?: boolean;
-  /** 
+  /**
    * Set custom logic for individual dates or date ranges to be disabled in the picker
    * exposed from `react-day-picker`: https://react-day-picker.js.org/api/DayPicker#modifiers
-  */
+   */
   disabledDays?: Modifier;
+  onEnter?: Callback;
 }
 
 export function DateField(props: DateFieldProps) {
@@ -55,6 +57,7 @@ export function DateField(props: DateFieldProps) {
     format = "short",
     iconLeft = false,
     disabledDays,
+    onEnter,
     ...others
   } = props;
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -125,7 +128,7 @@ export function DateField(props: DateFieldProps) {
       },
       onKeyDown: (e) => {
         if (e.key === "Enter") {
-          // Blur the field when the user hits the enter key - as if they are "committing" the value and done with the field
+          maybeCall(onEnter);
           inputRef.current?.blur();
         }
       },

--- a/src/inputs/NumberField.test.tsx
+++ b/src/inputs/NumberField.test.tsx
@@ -121,19 +121,20 @@ describe("NumberFieldTest", () => {
     expect(r.zeroPercent()).toHaveValue("0%");
   });
 
-  it("can blur on Enter", async () => {
+  it("fires onEnter and blurs field", async () => {
     const onBlur = jest.fn();
+    const onEnter = jest.fn();
     // Given a numberfield
-    const r = await render(<TestNumberField label="Age" value={10} onBlur={onBlur} />);
+    const r = await render(<TestNumberField label="Age" value={10} onBlur={onBlur} onEnter={onEnter} />);
     // With focus
     r.age().focus();
     expect(r.age()).toHaveFocus();
     // When hitting the Enter key
     fireEvent.keyDown(r.age(), { key: "Enter" });
-    // Then the field should no longer have focus
-    expect(r.age()).not.toHaveFocus();
-    // And onBlur should be called
+    // And onEnter and onBlur should be called
     expect(onBlur).toHaveBeenCalledTimes(1);
+    expect(onEnter).toHaveBeenCalledTimes(1);
+    expect(r.age()).not.toHaveFocus();
   });
 
   it("respects numFractionDigits and truncate props", async () => {

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -5,6 +5,8 @@ import { useLocale, useNumberField } from "react-aria";
 import { useNumberFieldState } from "react-stately";
 import { usePresentationContext } from "src/components/PresentationContext";
 import { Css, Xss } from "src/Css";
+import { Callback } from "src/types";
+import { maybeCall } from "src/utils";
 import { TextFieldBase } from "./TextFieldBase";
 
 export type NumberFieldType = "cents" | "percent" | "basisPoints" | "days";
@@ -31,6 +33,7 @@ export interface NumberFieldProps {
   displayDirection?: boolean;
   numFractionDigits?: number;
   truncate?: boolean;
+  onEnter?: Callback;
 }
 
 export function NumberField(props: NumberFieldProps) {
@@ -53,6 +56,7 @@ export function NumberField(props: NumberFieldProps) {
     displayDirection = false,
     numFractionDigits,
     truncate = false,
+    onEnter,
     ...otherProps
   } = props;
 
@@ -110,7 +114,7 @@ export function NumberField(props: NumberFieldProps) {
     },
     onKeyDown: (e) => {
       if (e.key === "Enter") {
-        // Blur the field when the user hits the enter key - as if they are "committing" the value and done with the field
+        maybeCall(onEnter);
         inputRef.current?.blur();
       }
     },

--- a/src/inputs/SelectField.test.tsx
+++ b/src/inputs/SelectField.test.tsx
@@ -31,6 +31,9 @@ describe("SelectFieldTest", () => {
     click(r.getByRole("option", { name: "Three" }));
     // Then onSelect was called
     expect(onSelect).toHaveBeenCalledWith("3");
+    // And the field has not been blurred (regression test to prevent SelectField's list box from opening back up after selecting an option)
+    expect(r.age()).toHaveFocus();
+    expect(onBlur).not.toHaveBeenCalled();
   });
 
   it("does not fire focus/blur when readOnly", async () => {

--- a/src/inputs/SelectField.test.tsx
+++ b/src/inputs/SelectField.test.tsx
@@ -31,9 +31,6 @@ describe("SelectFieldTest", () => {
     click(r.getByRole("option", { name: "Three" }));
     // Then onSelect was called
     expect(onSelect).toHaveBeenCalledWith("3");
-    // And the field is no longer in focus
-    expect(r.age()).not.toHaveFocus();
-    expect(onBlur).toHaveBeenCalledTimes(1);
   });
 
   it("does not fire focus/blur when readOnly", async () => {

--- a/src/inputs/TextAreaField.test.tsx
+++ b/src/inputs/TextAreaField.test.tsx
@@ -33,14 +33,16 @@ describe("TextAreaFieldTest", () => {
     expect(onBlur).not.toHaveBeenCalled();
   });
 
-  it("fires blur when preventNewLines is set and hitting the Enter key", async () => {
+  it("fires onEnter when preventNewLines is set and hitting the Enter key and blurs field", async () => {
+    const onEnter = jest.fn();
     const onBlur = jest.fn();
-    const r = await render(<TestTextAreaField value="foo" onBlur={onBlur} preventNewLines />);
+    const r = await render(<TestTextAreaField value="foo" onEnter={onEnter} onBlur={onBlur} preventNewLines />);
     r.note().focus();
     expect(r.note()).toHaveFocus();
     fireEvent.keyDown(r.note(), { key: "Enter" });
-    expect(r.note()).not.toHaveFocus();
+    expect(onEnter).toBeCalledTimes(1);
     expect(onBlur).toBeCalledTimes(1);
+    expect(r.note()).not.toHaveFocus();
   });
 });
 

--- a/src/inputs/TextAreaField.tsx
+++ b/src/inputs/TextAreaField.tsx
@@ -4,16 +4,29 @@ import { mergeProps, useTextField } from "react-aria";
 import { Only } from "src/Css";
 import { TextFieldBase } from "src/inputs/TextFieldBase";
 import { BeamTextFieldProps, TextFieldXss } from "src/interfaces";
+import { Callback } from "src/types";
+import { maybeCall } from "src/utils";
 
 // Exported for test purposes
 export interface TextAreaFieldProps<X> extends BeamTextFieldProps<X> {
   // Does not allow the user to enter new line characters and removes minimum height for textarea.
   preventNewLines?: boolean;
+  // `onEnter` is only triggered when `preventNewLines` is set to `true`
+  onEnter?: Callback;
 }
 
 /** Returns a <textarea /> element that auto-adjusts height based on the field's value */
 export function TextAreaField<X extends Only<TextFieldXss, X>>(props: TextAreaFieldProps<X>) {
-  const { value = "", disabled = false, readOnly = false, onBlur, onFocus, preventNewLines, ...otherProps } = props;
+  const {
+    value = "",
+    disabled = false,
+    readOnly = false,
+    onBlur,
+    onFocus,
+    preventNewLines,
+    onEnter,
+    ...otherProps
+  } = props;
   const textFieldProps = { ...otherProps, value, isDisabled: disabled, isReadOnly: readOnly };
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const inputWrapRef = useRef<HTMLDivElement | null>(null);
@@ -55,7 +68,7 @@ export function TextAreaField<X extends Only<TextFieldXss, X>>(props: TextAreaFi
               // Prevent user from typing the new line character
               if (e.key === "Enter") {
                 e.preventDefault();
-                // And then leave the field
+                maybeCall(onEnter);
                 inputRef.current?.blur();
               }
             },

--- a/src/inputs/TextField.test.tsx
+++ b/src/inputs/TextField.test.tsx
@@ -85,15 +85,18 @@ describe("TextFieldTest", () => {
 
   it("can trigger onEnter callback", async () => {
     const onEnter = jest.fn();
+    const onBlur = jest.fn();
     // Given a Textfield
-    const r = await render(<TestTextField value="foo" onEnter={onEnter} />);
+    const r = await render(<TestTextField value="foo" onEnter={onEnter} onBlur={onBlur} />);
     // With focus
     r.name().focus();
     expect(r.name()).toHaveFocus();
     // When hitting the Enter key
     fireEvent.keyDown(r.name(), { key: "Enter" });
-    // Then onEnter should be called
+    // Then onEnter and onBlur callbacks should be called
     expect(onEnter).toHaveBeenCalledTimes(1);
+    expect(onBlur).toHaveBeenCalledTimes(1);
+    expect(r.name()).not.toHaveFocus();
   });
 });
 

--- a/src/inputs/TextField.tsx
+++ b/src/inputs/TextField.tsx
@@ -43,6 +43,7 @@ export function TextField<X extends Only<TextFieldXss, X>>(props: TextFieldProps
       onKeyDown: (e) => {
         if (e.key === "Enter") {
           maybeCall(onEnter);
+          inputRef.current?.blur();
         }
       },
     },

--- a/src/inputs/internal/SelectFieldBase.tsx
+++ b/src/inputs/internal/SelectFieldBase.tsx
@@ -82,7 +82,6 @@ export function SelectFieldBase<O, V extends Value>(props: BeamSelectFieldBasePr
     const initOptions = Array.isArray(maybeOptions) ? maybeOptions : maybeOptions.initial;
     const selectedOptions = initOptions.filter((o) => values.includes(getOptionValue(o)));
     return {
-      isOpen: false,
       selectedKeys: selectedOptions?.map((o) => valueToKey(getOptionValue(o))) ?? [],
       inputValue: getInputValue(
         initOptions.filter((o) => values?.includes(getOptionValue(o))),
@@ -109,7 +108,6 @@ export function SelectFieldBase<O, V extends Value>(props: BeamSelectFieldBasePr
     if (inputValue !== fieldState.inputValue || fieldState.filteredOptions.length !== fieldState.allOptions.length) {
       setFieldState((prevState) => ({
         ...prevState,
-        isOpen: false,
         inputValue,
         filteredOptions: prevState.allOptions,
       }));
@@ -133,7 +131,6 @@ export function SelectFieldBase<O, V extends Value>(props: BeamSelectFieldBasePr
     if (multiselect && keys.size === 0) {
       setFieldState({
         ...fieldState,
-        isOpen: true,
         inputValue: state.isOpen ? "" : nothingSelectedText,
         selectedKeys: [],
         selectedOptions: [],
@@ -148,8 +145,6 @@ export function SelectFieldBase<O, V extends Value>(props: BeamSelectFieldBasePr
 
     setFieldState((prevState) => ({
       ...prevState,
-      // Close menu upon selection change only for Single selection mode
-      isOpen: multiselect,
       // If menu is open then reset inputValue to "". Otherwise set inputValue depending on number of options selected.
       inputValue:
         multiselect && (state.isOpen || selectedKeys.length > 1)
@@ -165,8 +160,8 @@ export function SelectFieldBase<O, V extends Value>(props: BeamSelectFieldBasePr
     selectionChanged && onSelect(selectedKeys.map(keyToValue) as V[], selectedOptions);
 
     if (!multiselect) {
-      // When a single select menu item changes, then blur the field AFTER `onSelect` has been called
-      inputRef.current?.blur();
+      // Close menu upon selection change only for Single selection mode
+      state.close();
     }
   }
 
@@ -203,7 +198,6 @@ export function SelectFieldBase<O, V extends Value>(props: BeamSelectFieldBasePr
       ...prevState,
       // When using the multiselect field, always empty the input upon open.
       inputValue: multiselect && isOpen ? "" : prevState.inputValue,
-      isOpen,
     }));
   }
 
@@ -234,7 +228,6 @@ export function SelectFieldBase<O, V extends Value>(props: BeamSelectFieldBasePr
 
   const state = useComboBoxState<any>({
     ...comboBoxProps,
-
     allowsEmptyCollection: true,
     // useComboBoxState.onSelectionChange will be executed if a keyboard interaction (Enter key) is used to select an item
     onSelectionChange: (key) => {
@@ -387,7 +380,6 @@ export function SelectFieldBase<O, V extends Value>(props: BeamSelectFieldBasePr
 }
 
 type FieldState<O> = {
-  isOpen: boolean;
   selectedKeys: Key[];
   inputValue: string;
   filteredOptions: O[];

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,6 +2,7 @@ import type { PressEvent } from "@react-types/shared";
 import { ReactNode } from "react";
 import { PresentationFieldProps } from "src/components/PresentationContext";
 import { Xss } from "src/Css";
+import { Callback } from "src/types";
 
 /** Base Interfaced */
 export interface BeamFocusableProps {
@@ -39,8 +40,9 @@ export interface BeamTextFieldProps<X> extends BeamFocusableProps, PresentationF
   /** Handler called when the interactive element state changes. */
   onChange: (value: string | undefined) => void;
   /** Called when the component loses focus, mostly for BoundTextField to use. */
-  onBlur?: () => void;
-  onFocus?: () => void;
+  onBlur?: Callback;
+  onFocus?: Callback;
+  onEnter?: Callback;
   readOnly?: boolean;
   placeholder?: string;
   /** Styles overrides */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2422,10 +2422,10 @@
   dependencies:
     tslib "^2.1.0"
 
-"@homebound/form-state@^2.2.13":
-  version "2.2.13"
-  resolved "https://registry.yarnpkg.com/@homebound/form-state/-/form-state-2.2.13.tgz#1e8df19306ced4d07018e7a284cdeee72e10833e"
-  integrity sha512-pezynd1M3iWQ7h8DR86HgrRWEmsyTYeyMB/C+bJ+nx5RFIGV9lzJpEKRLNejv3COMQJqvm0haufpZXA0M46L6Q==
+"@homebound/form-state@2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@homebound/form-state/-/form-state-2.4.1.tgz#1526385916611b713dbe9b9b072cd46b5ab3ebef"
+  integrity sha512-8/xmpbKi0THL4iOfUHhxQCd0YwyI6JLm5fXOEGJx7WFPV4dlSMkP4whhS7pm2ZR4aZcPpcIyCk4NRkUmmUwhgA==
   dependencies:
     fast-deep-equal "^3.1.3"
     is-plain-object "^5.0.0"
@@ -2464,14 +2464,7 @@
     "@babel/runtime" "^7.6.2"
     intl-messageformat "^9.6.12"
 
-"@internationalized/number@^3.0.2":
-  version "3.0.3"
-  resolved "https://registry.npmjs.org/@internationalized/number/-/number-3.0.3.tgz"
-  integrity sha512-ewFoVvsxSyd9QZnknvOWPjirYqdMQhXTeDhJg3hM6C/FeZt0banpGH1nZ0SGMZXHz8NK9uAa2KVIq+jqAIOg4w==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-
-"@internationalized/number@^3.0.3":
+"@internationalized/number@^3.0.2", "@internationalized/number@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@internationalized/number/-/number-3.0.3.tgz#d29003dffdff54ca6f2287ec0cb77ff3d045478f"
   integrity sha512-ewFoVvsxSyd9QZnknvOWPjirYqdMQhXTeDhJg3hM6C/FeZt0banpGH1nZ0SGMZXHz8NK9uAa2KVIq+jqAIOg4w==


### PR DESCRIPTION
Removes hacky use of blurring field just to trigger FormState's auto save.
For text input fields (DateField, TextField, TextAreaField, NumberField), we introduce an 'onEnter' callback used by each field's corresponding "Bound" version to explicitly call 'maybeAutoSave'. These fields will still 'blur' the field on "Enter" press, as that continues to give us the UX feedback we want (when hitting Enter, blurring the field makes it feel like it was committed).

For fields with menu selection  (DateField, SelectField, MultiSelectField, ChipSelectField), or transaction fields (RadioGroup, Checkbox), their corresponding "Bound" versions trigger 'maybeAutoSave' on change.