### PR TITLE
fix: Nested GridTable leaf cards draw their own borders

### DIFF
--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -16,7 +16,7 @@ import { navLink } from "src/components/CssReset";
 import { PresentationProvider } from "src/components/PresentationContext";
 import { createRowLookup, GridRowLookup } from "src/components/Table/GridRowLookup";
 import { GridSortContext, GridSortContextProps } from "src/components/Table/GridSortContext";
-import { maybeAddCardPadding, NestedCards } from "src/components/Table/nestedCards";
+import { isLeafRow, maybeWrapCard, NestedCards } from "src/components/Table/nestedCards";
 import { SortHeader } from "src/components/Table/SortHeader";
 import { ensureClientSideSortValueIsSortable, sortRows } from "src/components/Table/sortRows";
 import { SortState, useSortState } from "src/components/Table/useSortState";
@@ -291,8 +291,6 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
       const sortProps = row.kind === "header" ? { sorting, sortState, setSortKey } : { sorting };
       const RowComponent = observeRows ? ObservedGridRow : MemoizedGridRow;
 
-      const openCards = row.kind === "header" ? headerCards : rowCards;
-
       return (
         <GridCollapseContext.Provider
           key={`${row.kind}-${row.id}`}
@@ -307,7 +305,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
               rowStyles,
               stickyHeader,
               stickyOffset,
-              openCards: openCards ? openCards.currentOpenCards() : undefined,
+              openCards: nestedCards ? nestedCards.currentOpenCards() : undefined,
               columnSizes,
               ...sortProps,
             }}
@@ -321,9 +319,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
     const filteredRows: RowTuple<R>[] = [];
 
     // Misc state to track our nested card-ification, i.e. interleaved actual rows + chrome rows
-    // for the header and row (non-header rows) cards.
-    const headerCards = !!style.nestedCards && new NestedCards(columns, headerRows, style.nestedCards);
-    const rowCards = !!style.nestedCards && new NestedCards(columns, filteredRows, style.nestedCards);
+    const nestedCards = !!style.nestedCards && new NestedCards(columns, filteredRows, style.nestedCards);
 
     // Depth-first to filter
     function visit(row: GridDataRow<R>): void {
@@ -337,46 +333,36 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
       let isCard = false;
 
       if (matches) {
-        isCard = rowCards && rowCards.maybeOpenCard(row);
+        isCard = nestedCards && nestedCards.maybeOpenCard(row);
         filteredRows.push([row, makeRowComponent(row)]);
       }
 
       const isCollapsed = collapsedIds.includes(row.id);
       if (!isCollapsed && !!row.children?.length) {
-        rowCards && matches && rowCards.addSpacer();
+        nestedCards && matches && nestedCards.addSpacer();
         visitRows(row.children, isCard);
       }
 
-      isCard && rowCards && rowCards.closeCard();
+      !isLeafRow(row) && isCard && nestedCards && nestedCards.closeCard();
     }
 
     function visitRows(rows: GridDataRow<R>[], addSpacer: boolean): void {
       const length = rows.length;
       rows.forEach((row, i) => {
         if (row.kind === "header") {
-          // Flag to determine if the header has nested card styles.
-          // This will determine if we should include opening and closing
-          // Chrome rows.
-          const isHeaderNested = !!style.nestedCards?.kinds["header"];
-
-          isHeaderNested && headerCards && headerCards.maybeOpenCard(row);
           headerRows.push([row, makeRowComponent(row)]);
-          isHeaderNested && headerCards && headerCards.closeCard();
-
-          isHeaderNested && headerCards && headerCards.done();
-
           return;
         }
 
         visit(row);
 
-        addSpacer && rowCards && i !== length - 1 && rowCards.addSpacer();
+        addSpacer && nestedCards && i !== length - 1 && nestedCards.addSpacer();
       });
     }
 
     // If nestedCards is set, we assume the top-level kind is a card, and so should add spacers between them
-    visitRows(maybeSorted, !!rowCards);
-    rowCards && rowCards.done();
+    visitRows(maybeSorted, !!nestedCards);
+    nestedCards && nestedCards.done();
 
     return [headerRows, filteredRows];
   }, [
@@ -461,48 +447,18 @@ function renderDiv<R extends Kinded>(
   xss: any,
   _virtuosoRef: MutableRefObject<VirtuosoHandle | null>,
 ): ReactElement {
-  // We must determine if the header is using nested card styles to account for
-  // the opening and closing Chrome rows.
-  const isNestedCardStyleHeader = !!style.nestedCards?.kinds["header"];
-  /*
-    Determine at what CSS selector index is the first non header row. Note that
-    CSS selectors are not zero-based, unlike JavaScript, so we must add 1 to
-    what we'd normally expect.
-
-    Ex: When we don't have nestedCard styled headers, then we don't have opening
-    and closing Chrome rows. Therefore, the first non-header row is the second
-    row and since CSS selectors are not zero-based, we are aiming for a value
-    of 2 (1 + 1).
-
-    Ex: When we have nestedCard styled headers, then we have opening and closing
-    Chrome rows. Therefore, the first non-header row is the fourth row because:
-    - Row 1 is the opening Chrome Row
-    - Row 2 is the header
-    - Row 3 is the closing Chrome Row
-    - Row 4 is the first non-header row
-    And since CSS selectors are not zero-based, we are aiming for a value of 4
-    (3 + 1).
-  */
-  const firstNonHeaderRowIndex = (!isNestedCardStyleHeader ? 1 : 3) + 1;
-
   return (
     <div
       css={{
         // Ensure all rows extend the same width
         ...Css.mw("fit-content").$,
         /*
-          Using n + (firstNonHeaderRowIndex + 1) here to target all rows that
-          are after the first non-header row. Since n starts at 0, we can use
+          Using (n + 3) here to target all rows that are after the first non-header row. Since n starts at 0, we can use
           the + operator as an offset.
-
           Inspired by: https://stackoverflow.com/a/25005740/2551333
         */
-        ...(style.betweenRowsCss
-          ? Css.addIn(`& > div:nth-of-type(n + ${firstNonHeaderRowIndex + 1}) > *`, style.betweenRowsCss).$
-          : {}),
-        ...(style.firstNonHeaderRowCss
-          ? Css.addIn(`& > div:nth-of-type(${firstNonHeaderRowIndex}) > *`, style.firstNonHeaderRowCss).$
-          : {}),
+        ...(style.betweenRowsCss ? Css.addIn(`& > div:nth-of-type(n+3) > *`, style.betweenRowsCss).$ : {}),
+        ...(style.firstNonHeaderRowCss ? Css.addIn(`& > div:nth-of-type(2) > *`, style.firstNonHeaderRowCss).$ : {}),
         ...style.rootCss,
         ...xss,
       }}
@@ -607,18 +563,6 @@ function renderVirtual<R extends Kinded>(
       }}
       // Pin/sticky both the header row(s) + firstRowMessage to the top
       topItemCount={(stickyHeader ? headerRows.length : 0) + (firstRowMessage ? 1 : 0)}
-      itemSize={(el) => {
-        const maybeContentsDiv = el.firstElementChild! as HTMLElement;
-
-        // If it is a chrome row, then we are not using `display: contents;`, return the height of this element.
-        if ("chrome" in maybeContentsDiv.dataset) {
-          return maybeContentsDiv.getBoundingClientRect().height || 1;
-        }
-
-        // Both the `Item` and `itemContent` use `display: contents`, so their height is 0,
-        // so instead drill into the 1st real content cell.
-        return (maybeContentsDiv.firstElementChild! as HTMLElement).getBoundingClientRect().height;
-      }}
       itemContent={(index) => {
         // Since we have two arrays of rows: `headerRows` and `filteredRow` we
         // must determine which one to render.
@@ -736,7 +680,7 @@ export function calcColumnSizes(columns: GridColumn<any>[], firstLastColumnWidth
         throw new Error("Beam Table column width definition only supports px, percentage, or fr units");
       }
     },
-    { claimedPercentages: 0, claimedPixels: firstLastColumnWidth ? firstLastColumnWidth * 2 : 0, totalFr: 0 },
+    { claimedPercentages: 0, claimedPixels: 0, totalFr: 0 },
   );
 
   // This is our "fake but for some reason it lines up better" fr calc
@@ -944,20 +888,6 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
   // We treat the "header" kind as special for "good defaults" styling
   const isHeader = row.kind === "header";
   const rowStyle = rowStyles?.[row.kind];
-
-  const rowStyleCellCss = maybeApplyFunction(row, rowStyle?.cellCss);
-  const rowCss = {
-    // For virtual tables use `display: flex` to keep all cells on the same row, but use `flexNone` to ensure the cells stay their defined widths
-    ...(as === "table" ? {} : Css.df.addIn("&>*", Css.flexNone.$).$),
-    ...((rowStyle?.rowLink || rowStyle?.onClick) &&
-      style.rowHoverColor && {
-        // Even though backgroundColor is set on the cellCss (due to display: content), the hover target is the row.
-        "&:hover > *": Css.cursorPointer.bgColor(maybeDarken(rowStyleCellCss?.backgroundColor, style.rowHoverColor)).$,
-      }),
-    ...maybeApplyFunction(row, rowStyle?.rowCss),
-    ...(isHeader && stickyHeader ? Css.sticky.top(stickyOffset).z1.$ : undefined),
-  };
-
   const Row = as === "table" ? "tr" : "div";
 
   const openCardStyles =
@@ -967,17 +897,47 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
           .map((openCardKind) => style.nestedCards!.kinds[openCardKind])
           .filter((style) => style)
       : undefined;
-  const currentCard = openCardStyles && openCardStyles[openCardStyles.length - 1];
-  let currentColspan = 1;
-  const maybeStickyHeaderStyles = isHeader && stickyHeader ? Css.sticky.top(stickyOffset).z1.$ : undefined;
 
-  return (
-    <Row css={rowCss} {...others}>
-      {openCardStyles &&
-        maybeAddCardPadding(openCardStyles, "first", {
-          ...maybeStickyHeaderStyles,
-          ...(columnSizes ? Css.w(columnSizes[0]).$ : {}),
-        })}
+  const leafCardStyles = isLeafRow(row) ? style.nestedCards?.kinds[row.kind] : undefined;
+  // Calculate the horizontal space already allocated by the open cards (paddings and borders)
+  const openCardWidth = openCardStyles ? openCardStyles.reduce((acc, o) => acc + o.pxPx + (o.bColor ? 1 : 0), 0) : 0;
+  // Subtract the openCardWidth from the `firstLastColumnWidth` to determine the amount of padding to add to this card.
+  // Also if it is a leaf card, then we need to additionally subtract out the border width to have it properly line up with the chrome rows
+  const currentCardPaddingWidth =
+    (style.nestedCards?.firstLastColumnWidth ?? 0) - openCardWidth - (leafCardStyles?.bColor ? 1 : 0);
+
+  const rowStyleCellCss = maybeApplyFunction(row, rowStyle?.cellCss);
+  const rowCss = {
+    // For virtual tables use `display: flex` to keep all cells on the same row. For each cell in the row use `flexNone` to ensure they stay their defined widths
+    ...(as === "table" ? {} : Css.relative.df.fg1.fs1.addIn("&>*", Css.flexNone.$).$),
+    ...((rowStyle?.rowLink || rowStyle?.onClick) &&
+      style.rowHoverColor && {
+        // Even though backgroundColor is set on the cellCss (due to display: content), the hover target is the row.
+        "&:hover > *": Css.cursorPointer.bgColor(maybeDarken(rowStyleCellCss?.backgroundColor, style.rowHoverColor)).$,
+      }),
+    ...maybeApplyFunction(row, rowStyle?.rowCss),
+    // Maybe add the sticky header styles
+    ...(isHeader && stickyHeader ? Css.sticky.top(stickyOffset).z1.$ : undefined),
+    // Card styles apply a calculated padding to ensure the content lines up properly across all columns
+    ...(currentCardPaddingWidth ? Css.pxPx(currentCardPaddingWidth).$ : undefined),
+    // Leaf cards define their own borders + padding
+    ...(leafCardStyles
+      ? // We can have versions of the same card as a leaf and not as a leaf.
+        // When it is not a leaf then it has chrome rows that create the top and bottom "padding" based on border-radius size. (brPx = "chrome" row height)
+        // When it is a leaf, then we need to apply the brPx to the row to ensure consistent spacing between leaf & non-leaf renders
+        // Additionally, if the leaf card has a border, then subtract the 1px border width from the padding to keep consistent with the "chrome" row
+        Css.pyPx(leafCardStyles.brPx - (leafCardStyles.bColor ? 1 : 0))
+          .borderRadius(`${leafCardStyles.brPx}px`)
+          .bgColor(leafCardStyles.bgColor)
+          .if(!!leafCardStyles.bColor)
+          .bc(leafCardStyles.bColor).ba.$
+      : undefined),
+  };
+
+  let currentColspan = 1;
+
+  const rowNode = (
+    <Row css={rowCss} {...others} data-gridrow>
       {columns.map((column, columnIndex) => {
         // Decrement colspan count and skip if greater than 1.
         if (currentColspan > 1) {
@@ -1026,8 +986,6 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
           ...getIndentationCss(style, rowStyle, columnIndex, maybeContent),
           // Then apply any header-specific override
           ...(isHeader && style.headerCellCss),
-          // If we're within a card, use its background color
-          ...(currentCard && Css.bgColor(currentCard.bgColor).$),
           // And finally the specific cell's css (if any from GridCellContent)
           ...rowStyleCellCss,
           // Define the width of the column on each cell. Supports col spans.
@@ -1049,13 +1007,10 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
 
         return renderFn(columnIndex, cellCss, content, row, rowStyle);
       })}
-      {openCardStyles &&
-        maybeAddCardPadding(openCardStyles, "final", {
-          ...maybeStickyHeaderStyles,
-          ...(columnSizes ? Css.w(columnSizes[columnSizes.length - 1]).$ : {}),
-        })}
     </Row>
   );
+
+  return openCardStyles ? maybeWrapCard(openCardStyles, rowNode) : rowNode;
 }
 
 // Fix to work with generics, see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/37087#issuecomment-656596623

--- a/src/components/Table/SchedulesV2.stories.tsx
+++ b/src/components/Table/SchedulesV2.stories.tsx
@@ -184,7 +184,7 @@ const style: GridStyle = {
       // TODO: It would be nice if this used CSS Properties so that we can use TRUSS
       milestone: { bgColor: Palette.Gray100, ...spacing },
       subgroup: { bgColor: Palette.White, ...spacing },
-      // TODO: Validate with Dare regarding nested 3rd child.
+      // TODO: Validate with Dara regarding nested 3rd child.
       task: { bgColor: Palette.White, bColor: Palette.Gray200, ...spacing, pxPx: 0 },
       // Purposefully leave out the `add` kind
     },

--- a/src/components/Table/nestedCards.test.tsx
+++ b/src/components/Table/nestedCards.test.tsx
@@ -1,5 +1,5 @@
 import { NestedCardStyle, NestedCardStyleByKind } from "src/components/Table/GridTable";
-import { makeOpenOrCloseCard, maybeWrapCard } from "src/components/Table/nestedCards";
+import { makeOpenOrCloseCard, wrapCard } from "src/components/Table/nestedCards";
 import { Palette } from "src/Css";
 import { render } from "src/utils/rtl";
 
@@ -85,7 +85,7 @@ describe("NestedCards", () => {
   });
 
   it("can add padding w/two levels", async () => {
-    const r = await render(maybeWrapCard([parentCardStyle, childCardStyle], <div data-testid="grandchild" />));
+    const r = await render(wrapCard([parentCardStyle, childCardStyle], <div data-testid="grandchild" />));
     expect(r.firstElement).toMatchInlineSnapshot(`
       .emotion-0 {
         background-color: rgba(247,245,245,1);

--- a/src/components/Table/nestedCards.test.tsx
+++ b/src/components/Table/nestedCards.test.tsx
@@ -1,5 +1,5 @@
 import { NestedCardStyle, NestedCardStyleByKind } from "src/components/Table/GridTable";
-import { makeOpenOrCloseCard, maybeAddCardPadding } from "src/components/Table/nestedCards";
+import { makeOpenOrCloseCard, maybeWrapCard } from "src/components/Table/nestedCards";
 import { Palette } from "src/Css";
 import { render } from "src/utils/rtl";
 
@@ -84,57 +84,25 @@ describe("NestedCards", () => {
     `);
   });
 
-  it("can add left padding w/two levels", async () => {
-    const r = await render(maybeAddCardPadding([parentCardStyle, childCardStyle], "first"));
+  it("can add padding w/two levels", async () => {
+    const r = await render(maybeWrapCard([parentCardStyle, childCardStyle], <div data-testid="grandchild" />));
     expect(r.firstElement).toMatchInlineSnapshot(`
       .emotion-0 {
         background-color: rgba(247,245,245,1);
         height: 100%;
         padding-left: 8px;
-      }
-
-      .emotion-1 {
-        background-color: rgba(221,220,220,1);
-        border-color: rgba(236,235,235,1);
-        height: 100%;
-        border-left-style: solid;
-        border-left-width: 1px;
-        padding-left: 6px;
-      }
-
-      <div
-        data-overlay-container="true"
-      >
-        <div
-          data-cardpadding="true"
-        >
-          <div
-            class="emotion-0"
-          >
-            <div
-              class="emotion-1"
-            />
-          </div>
-        </div>
-      </div>
-    `);
-  });
-
-  it("can add right padding w/two levels", async () => {
-    const r = await render(maybeAddCardPadding([parentCardStyle, childCardStyle], "final"));
-    expect(r.firstElement).toMatchInlineSnapshot(`
-      .emotion-0 {
-        background-color: rgba(247,245,245,1);
-        height: 100%;
         padding-right: 8px;
       }
 
       .emotion-1 {
         background-color: rgba(221,220,220,1);
         border-color: rgba(236,235,235,1);
-        height: 100%;
+        border-left-style: solid;
+        border-left-width: 1px;
         border-right-style: solid;
         border-right-width: 1px;
+        height: 100%;
+        padding-left: 6px;
         padding-right: 6px;
       }
 
@@ -142,13 +110,13 @@ describe("NestedCards", () => {
         data-overlay-container="true"
       >
         <div
-          data-cardpadding="true"
+          class="emotion-0"
         >
           <div
-            class="emotion-0"
+            class="emotion-1"
           >
             <div
-              class="emotion-1"
+              data-testid="grandchild"
             />
           </div>
         </div>

--- a/src/components/Table/nestedCards.tsx
+++ b/src/components/Table/nestedCards.tsx
@@ -1,7 +1,8 @@
-import { Fragment, ReactElement, ReactNode } from "react";
+import { Fragment, ReactElement } from "react";
 import {
   GridColumn,
   GridDataRow,
+  GridStyle,
   Kinded,
   NestedCardsStyle,
   NestedCardStyle,
@@ -163,39 +164,13 @@ export function makeOpenOrCloseCard(
 }
 
 /**
- * For the first or last cell of actual content, wrap them in divs that re-create the
- * outer cards' padding + background.
- */
-export function maybeAddCardPadding(openCards: NestedCardStyle[], column: "first" | "final", styles?: {}): any {
-  let div: any = undefined;
-  [...openCards].reverse().forEach((card) => {
-    div = (
-      <div
-        css={{
-          ...Css.h100.bgColor(card.bgColor).if(!!card.bColor).bc(card.bColor).$,
-          ...(column === "first" && Css.plPx(card.pxPx).if(!!card.bColor).bl.$),
-          ...(column === "final" && Css.prPx(card.pxPx).if(!!card.bColor).br.$),
-        }}
-      >
-        {div}
-      </div>
-    );
-  });
-
-  return (
-    <div data-cardpadding="true" {...(styles ? { css: styles } : {})}>
-      {div}
-    </div>
-  );
-}
-
-/**
  * Wraps a row within its parent cards. Creates a wrapping div to add the card padding.
+ * Adds non-leaf card padding and borders, e.g. if the current row is a non-leaf then it will already be in `openCards`
  * Example:
  * <div parent> <div child> <div grandchild /> </div> </div>
  */
-export function maybeWrapCard(openCards: NestedCardStyle[], row: ReactNode): any {
-  let div: ReactNode = row;
+export function wrapCard(openCards: NestedCardStyle[], row: JSX.Element): JSX.Element {
+  let div: JSX.Element = row;
   [...openCards].reverse().forEach((card) => {
     div = (
       <div
@@ -209,6 +184,37 @@ export function maybeWrapCard(openCards: NestedCardStyle[], row: ReactNode): any
   });
 
   return div;
+}
+
+export function getNestedCardStyles(
+  row: GridDataRow<any>,
+  openCardStyles: NestedCardStyle[] | undefined,
+  style: GridStyle,
+) {
+  const leafCardStyles = isLeafRow(row) ? style.nestedCards?.kinds[row.kind] : undefined;
+  // Calculate the horizontal space already allocated by the open cards (paddings and borders)
+  const openCardWidth = openCardStyles ? openCardStyles.reduce((acc, o) => acc + o.pxPx + (o.bColor ? 1 : 0), 0) : 0;
+  // Subtract the openCardWidth from the `firstLastColumnWidth` to determine the amount of padding to add to this card.
+  // Also if it is a leaf card, then we need to additionally subtract out the border width to have it properly line up with the chrome rows
+  const currentCardPaddingWidth =
+    (style.nestedCards?.firstLastColumnWidth ?? 0) - openCardWidth - (leafCardStyles?.bColor ? 1 : 0);
+
+  return {
+    // Card styles apply a calculated padding to ensure the content lines up properly across all columns
+    ...(currentCardPaddingWidth ? Css.pxPx(currentCardPaddingWidth).$ : undefined),
+    // Leaf cards define their own borders + padding
+    ...(leafCardStyles
+      ? // We can have versions of the same card as a leaf and not as a leaf.
+        // When it is not a leaf then it has chrome rows that create the top and bottom "padding" based on border-radius size. (brPx = "chrome" row height)
+        // When it is a leaf, then we need to apply the brPx to the row to ensure consistent spacing between leaf & non-leaf renders
+        // Additionally, if the leaf card has a border, then subtract the 1px border width from the padding to keep consistent with the "chrome" row
+        Css.pyPx(leafCardStyles.brPx - (leafCardStyles.bColor ? 1 : 0))
+          .borderRadius(`${leafCardStyles.brPx}px`)
+          .bgColor(leafCardStyles.bgColor)
+          .if(!!leafCardStyles.bColor)
+          .bc(leafCardStyles.bColor).ba.$
+      : undefined),
+  };
 }
 
 /**

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,7 +1,6 @@
 export * from "src/components/Chip";
 export * from "src/components/Chips";
 export * from "src/components/Table/GridTable";
-export { makeOpenOrCloseCard, makeSpacer, maybeAddCardPadding } from "src/components/Table/nestedCards";
 export * from "src/components/ToggleChip";
 export * from "src/components/ToggleChips";
 export * from "./Alert";

--- a/src/utils/rtl.tsx
+++ b/src/utils/rtl.tsx
@@ -70,10 +70,7 @@ export function cell(r: RenderResult, row: number, column: number): HTMLElement 
 }
 
 export function cellOf(r: RenderResult, tableTestId: string, rowNum: number, column: number): HTMLElement {
-  const nonPaddingColumns = Array.from(row(r, rowNum, tableTestId).childNodes).filter(
-    (node) => !("cardpadding" in (node as HTMLElement).dataset),
-  );
-  return nonPaddingColumns[column] as HTMLElement;
+  return row(r, rowNum, tableTestId).childNodes[column] as HTMLElement;
 }
 
 export function cellAnd(r: RenderResult, row: number, column: number, testId: string): HTMLElement {
@@ -84,10 +81,8 @@ export function cellAnd(r: RenderResult, row: number, column: number, testId: st
 }
 
 export function row(r: RenderResult, row: number, tableTestId: string = "gridTable"): HTMLElement {
-  const nonChromeRows = Array.from(r.getByTestId(tableTestId).childNodes).filter(
-    (node) => !("chrome" in (node as HTMLElement).dataset),
-  );
-  return nonChromeRows[row] as HTMLElement;
+  const dataRows = Array.from(r.getByTestId(tableTestId).querySelectorAll("[data-gridrow]"));
+  return dataRows[row] as HTMLElement;
 }
 
 export function rowAnd(r: RenderResult, rowNum: number, testId: string): HTMLElement {


### PR DESCRIPTION
Perf Test results on the "Nested Cards Three Levels" story:
## Before
![Before](https://user-images.githubusercontent.com/1143861/153026127-eaf2524d-c19a-4db4-8692-0d8cfbe6a871.png)

## After
<img width="1040" alt="After" src="https://user-images.githubusercontent.com/1143861/153026091-549e0e26-9c41-4edc-876b-b1a0ef318bfe.png">
