### PR TITLE
feat: Beam Table Styles

### DIFF
--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { usePresentationContext } from "src/components/PresentationContext";
 import { Css, Margin, Only, Xss } from "src/Css";
 import { useTestIds } from "src/utils/useTestIds";
 
@@ -10,11 +11,13 @@ export interface ChipProps<X> {
 /** Kinda like a chip, but read-only, so no `onClick` or `hover`. */
 export function Chip<X extends Only<Xss<Margin>, X>>(props: ChipProps<X>) {
   const { text, xss = {} } = props;
+  const { fieldProps } = usePresentationContext();
+  const typeScale = fieldProps?.typeScale ?? "sm";
   const tid = useTestIds(props, "chip");
   return (
     <span
       css={{
-        ...Css.dif.aic.br16.sm.pl1.px1.pyPx(2).gray900.bgGray200.$,
+        ...Css[typeScale].dif.aic.br16.pl1.px1.pyPx(2).gray900.bgGray200.$,
         ...xss,
       }}
       {...tid}

--- a/src/components/Chips.tsx
+++ b/src/components/Chips.tsx
@@ -12,12 +12,16 @@ export interface ChipsProps<X> {
 
 /** Renders a list of `Chip`s, with wrapping & appropriate margin between each `Chip`. */
 export function Chips<X extends Only<ChipsXss, X>>(props: ChipsProps<X>) {
-  const { tableStyle } = usePresentationContext();
+  const { wrap } = usePresentationContext();
   const { values, xss = {} } = props;
-  // Do not allow Chips to wrap if within a `fixed` style table
-  const wrap = tableStyle !== "fixed";
   return (
-    <div css={{ ...Css.df.gap1.whiteSpace("normal").$, ...(wrap ? Css.add({ flexWrap: "wrap" }).$ : {}), ...xss }}>
+    <div
+      css={{
+        ...Css.df.gap1.whiteSpace("normal").$,
+        ...(wrap !== false ? Css.add({ flexWrap: "wrap" }).$ : {}),
+        ...xss,
+      }}
+    >
       {values.map((value, i) => (
         <Chip key={i} text={value} />
       ))}

--- a/src/components/Chips.tsx
+++ b/src/components/Chips.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Chip } from "src/components/Chip";
+import { usePresentationContext } from "src/components/PresentationContext";
 import { Css, Margin, Only, Xss } from "src/Css";
 
 type ChipsXss = Xss<Margin>;
@@ -11,11 +12,14 @@ export interface ChipsProps<X> {
 
 /** Renders a list of `Chip`s, with wrapping & appropriate margin between each `Chip`. */
 export function Chips<X extends Only<ChipsXss, X>>(props: ChipsProps<X>) {
+  const { tableStyle } = usePresentationContext();
   const { values, xss = {} } = props;
+  // Do not allow Chips to wrap if within a `fixed` style table
+  const wrap = tableStyle !== "fixed";
   return (
-    <div css={{ ...Css.df.add({ flexWrap: "wrap" }).my1.$, ...xss }}>
+    <div css={{ ...Css.df.gap1.whiteSpace("normal").$, ...(wrap ? Css.add({ flexWrap: "wrap" }).$ : {}), ...xss }}>
       {values.map((value, i) => (
-        <Chip key={i} text={value} xss={Css.mr1.mb1.$} />
+        <Chip key={i} text={value} />
       ))}
     </div>
   );

--- a/src/components/PresentationContext.tsx
+++ b/src/components/PresentationContext.tsx
@@ -11,7 +11,7 @@ export interface PresentationFieldProps {
   borderless?: boolean;
   // Defines height of the field
   compact?: boolean;
-  // Changes default font styles for input fields
+  // Changes default font styles for input fields and Chips
   typeScale?: Typography;
   // If set to `false` then fields will not appear disabled, but will still be disabled.
   visuallyDisabled?: false;
@@ -19,6 +19,8 @@ export interface PresentationFieldProps {
 
 export type PresentationContextProps = {
   fieldProps?: PresentationFieldProps;
+  // Defines if the table styles, allowing components to render accordingly.
+  tableStyle?: "fixed" | "flexible";
   gridTableStyle?: GridStyle;
 };
 

--- a/src/components/PresentationContext.tsx
+++ b/src/components/PresentationContext.tsx
@@ -19,9 +19,9 @@ export interface PresentationFieldProps {
 
 export type PresentationContextProps = {
   fieldProps?: PresentationFieldProps;
-  // Defines if the table styles, allowing components to render accordingly.
-  tableStyle?: "fixed" | "flexible";
   gridTableStyle?: GridStyle;
+  // Defines whether content should be allowed to wrap or not. `undefined` is treated as true.
+  wrap?: boolean;
 };
 
 export const PresentationContext = createContext<PresentationContextProps>({});

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -5,7 +5,6 @@ import {
   actionColumn,
   Button,
   cardStyle,
-  Chip,
   CollapseToggle,
   column,
   condensedStyle,
@@ -22,16 +21,11 @@ import {
   Icon,
   IconButton,
   numericColumn,
-  selectColumn,
   simpleHeader,
   SimpleHeaderAndDataOf,
-  Tag,
 } from "src/components/index";
-import { beamFixedStyle } from "src/components/Table/styles";
 import { Css, Palette } from "src/Css";
-import { Checkbox, SelectField } from "src/inputs";
 import { NumberField } from "src/inputs/NumberField";
-import { HasIdAndName } from "src/types";
 import { noop } from "src/utils";
 import { newStory, withDimensions, withRouter, zeroTo } from "src/utils/sb";
 
@@ -725,99 +719,6 @@ export function CustomEmptyCell() {
         { kind: "data", id: "1", name: "c", value: 1 },
         { kind: "data", id: "2", name: "b", value: undefined },
         { kind: "data", id: "3", name: "", value: 3 },
-      ]}
-    />
-  );
-}
-
-type BeamData = {
-  id: string;
-  favorite: boolean;
-  status: string;
-  commitmentName: string;
-  tradeCategories: string[];
-  location: string;
-  date: string;
-  priceInCents: number;
-};
-type BeamRow = SimpleHeaderAndDataOf<BeamData>;
-export function StyleBeam() {
-  const locations: HasIdAndName<string>[] = [
-    { id: "l:1", name: "Living Room" },
-    { id: "l:2", name: "Great Room" },
-  ];
-
-  const selectCol = selectColumn<BeamRow>({
-    header: () => ({ content: <Checkbox label="Label" onChange={noop} checkboxOnly /> }),
-    data: () => ({ content: <Checkbox label="Label" onChange={noop} checkboxOnly /> }),
-  });
-  const favCol = column<BeamRow>({
-    header: () => ({ content: "" }),
-    data: ({ favorite }) => ({
-      content: <Icon icon="star" color={favorite ? Palette.Gray700 : Palette.Gray300} />,
-      sortValue: favorite ? 0 : 1,
-    }),
-    // Defining `w: 56px` to accommodate for the `27px` wide checkbox and `16px` of padding on either side.
-    w: "56px",
-  });
-  const statusCol = column<BeamRow>({
-    header: "Status",
-    data: ({ status }) => ({ content: <Tag text={status} type="success" />, sortValue: status }),
-  });
-  const nameCol = column<BeamRow>({ header: "Commitment Name", data: ({ commitmentName }) => commitmentName });
-  const tradeCol = column<BeamRow>({
-    header: "Trade Categories",
-    data: ({ tradeCategories }) => ({
-      content: () => (
-        <div css={Css.df.gap1.$}>
-          {tradeCategories.sort().map((tc) => (
-            <Chip text={tc} />
-          ))}
-        </div>
-      ),
-      sortValue: tradeCategories.sort().join(" "),
-    }),
-  });
-  const dateCol = dateColumn<BeamRow>({ header: "Date", data: ({ date }) => date });
-  const locationCol = column<BeamRow>({
-    header: "Location",
-    data: (row) => ({
-      content: <SelectField value={row.location} onSelect={noop} options={locations} label="Location" />,
-      sortValue: row.location,
-    }),
-  });
-  const priceCol = numericColumn<BeamRow>({
-    header: "Price",
-    data: ({ priceInCents }) => ({
-      content: () => <NumberField label="Price" value={priceInCents} onChange={noop} type="cents" />,
-      sortValue: priceInCents,
-    }),
-  });
-  const readOnlyPriceCol = numericColumn<BeamRow>({
-    header: "Read only Price",
-    data: ({ priceInCents }) => ({
-      content: () => <NumberField label="Price" value={priceInCents} onChange={noop} type="cents" readOnly />,
-      sortValue: priceInCents,
-    }),
-  });
-  return (
-    <GridTable<BeamRow>
-      style={beamFixedStyle}
-      sorting={{ on: "client", initial: [3, "DESC"] }}
-      columns={[selectCol, favCol, statusCol, nameCol, tradeCol, locationCol, dateCol, priceCol, readOnlyPriceCol]}
-      rows={[
-        { kind: "header", id: "header" },
-        ...zeroTo(20).map((idx) => ({
-          kind: "data" as const,
-          id: `r:${idx + 1}`,
-          favorite: idx < 5,
-          commitmentName: `Commitment ${idx + 1}`,
-          date: `01/${idx + 1 > 9 ? idx + 1 : `0${idx + 1}`}/2020`,
-          status: "Success",
-          tradeCategories: ["Roofing", "Architecture", "Plumbing"],
-          priceInCents: 1234_56 + idx,
-          location: idx % 2 ? "l:1" : "l:2",
-        })),
       ]}
     />
   );

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -13,12 +13,13 @@ import React, {
 import { Link } from "react-router-dom";
 import { Components, Virtuoso, VirtuosoHandle } from "react-virtuoso";
 import { navLink } from "src/components/CssReset";
-import { PresentationProvider } from "src/components/PresentationContext";
+import { PresentationFieldProps, PresentationProvider } from "src/components/PresentationContext";
 import { createRowLookup, GridRowLookup } from "src/components/Table/GridRowLookup";
 import { GridSortContext, GridSortContextProps } from "src/components/Table/GridSortContext";
 import { getNestedCardStyles, isLeafRow, NestedCards, wrapCard } from "src/components/Table/nestedCards";
 import { SortHeader } from "src/components/Table/SortHeader";
 import { ensureClientSideSortValueIsSortable, sortRows } from "src/components/Table/sortRows";
+import { beamFixedStyle, beamFlexibleStyle } from "src/components/Table/styles";
 import { SortState, useSortState } from "src/components/Table/useSortState";
 import { Css, Margin, Only, Properties, Xss } from "src/Css";
 import tinycolor from "tinycolor2";
@@ -278,12 +279,15 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
     return rows;
   }, [columns, rows, sorting, sortState]);
 
+  const columnSizes = useMemo(
+    () => calcColumnSizes(columns, style.nestedCards?.firstLastColumnWidth),
+    [columns, style.nestedCards?.firstLastColumnWidth],
+  );
+
   // Filter + flatten + component-ize the sorted rows.
   let [headerRows, filteredRows]: [RowTuple<R>[], RowTuple<R>[]] = useMemo(() => {
     // Break up "foo bar" into `[foo, bar]` and a row must match both `foo` and `bar`
     const filters = (filter && filter.split(/ +/)) || [];
-
-    const columnSizes = calcColumnSizes(columns, style.nestedCards?.firstLastColumnWidth);
 
     function makeRowComponent(row: GridDataRow<R>): JSX.Element {
       // We only pass sortState to header rows, b/c non-headers rows shouldn't have to re-render on sorting
@@ -404,13 +408,25 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
   const firstRowMessage =
     (noData && fallbackMessage) || (tooManyClientSideRows && "Hiding some rows, use filter...") || infoMessage;
 
+  const borderless = style === beamFixedStyle;
+  const tableStyle = style === beamFixedStyle ? "fixed" : style === beamFlexibleStyle ? "flexible" : undefined;
+  const fieldProps: PresentationFieldProps = useMemo(
+    () => ({
+      hideLabel: true,
+      numberAlignment: "right",
+      compact: true,
+      ...(borderless ? { borderless, typeScale: "xs" } : {}),
+    }),
+    [borderless],
+  );
+
   // If we're running in Jest, force using `as=div` b/c jsdom doesn't support react-virtuoso.
   // This enables still putting the application's business/rendering logic under test, and letting it
   // just trust the GridTable impl that, at runtime, `as=virtual` will (other than being virtualized)
   // behave semantically the same as `as=div` did for its tests.
   const _as = as === "virtual" && runningInJest ? "div" : as;
   return (
-    <PresentationProvider fieldProps={{ hideLabel: true, numberAlignment: "right", compact: true }}>
+    <PresentationProvider fieldProps={fieldProps} tableStyle={tableStyle}>
       {renders[_as](
         style,
         id,
@@ -1044,6 +1060,12 @@ function toContent(
   }
   if (content && typeof content === "string" && isHeader && canSortColumn) {
     return <SortHeader content={content} iconOnLeft={alignment === "right"} />;
+  } else if (content && typeof content === "string" && style === beamFixedStyle) {
+    return (
+      <span css={Css.mw0.truncate.$} title={content}>
+        {content}
+      </span>
+    );
   } else if (style.emptyCell && isContentEmpty(content)) {
     // If the content is empty and the user specified an `emptyCell` node, return that.
     return style.emptyCell;

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -1,0 +1,332 @@
+import { Meta } from "@storybook/react";
+import { ReactNode, useMemo } from "react";
+import { Chips } from "src/components/Chips";
+import { Icon } from "src/components/Icon";
+import { CollapseToggle } from "src/components/Table/CollapseToggle";
+import { collapseColumn, column, dateColumn, numericColumn, selectColumn } from "src/components/Table/columns";
+import { emptyCell, GridColumn, GridDataRow, GridTable } from "src/components/Table/GridTable";
+import { SimpleHeaderAndDataWith } from "src/components/Table/simpleHelpers";
+import { beamFixedStyle, beamFlexibleStyle, beamGroupRowStyle, beamTotalsRowStyle } from "src/components/Table/styles";
+import { Tag } from "src/components/Tag";
+import { Css, Palette } from "src/Css";
+import { Checkbox, NumberField, SelectField } from "src/inputs";
+import { HasIdAndName } from "src/types";
+import { noop } from "src/utils";
+import { zeroTo } from "src/utils/sb";
+
+export default {
+  component: GridTable,
+  title: "Design QA/Table",
+  parameters: { layout: "fullscreen", backgrounds: { default: "white" } },
+} as Meta;
+
+type BeamData = {
+  id: string;
+  favorite: boolean;
+  status: string;
+  commitmentName: string;
+  tradeCategories: string[];
+  location: string;
+  date: string;
+  priceInCents: number;
+};
+type BeamRow = SimpleHeaderAndDataWith<BeamData>;
+
+export function Fixed() {
+  return (
+    <GridTable<BeamRow>
+      style={beamFixedStyle}
+      sorting={{ on: "client", initial: [1, "ASC"] }}
+      columns={beamStyleColumns()}
+      rows={[
+        { kind: "header", id: "header" },
+        ...zeroTo(20).map((idx) => ({
+          kind: "data" as const,
+          id: `r:${idx + 1}`,
+          data: {
+            id: `r:${idx + 1}`,
+            favorite: idx < 5,
+            commitmentName: idx === 9 ? "A longer name that will truncate with an ellipsis" : `Commitment ${idx + 1}`,
+            date: `01/${idx + 1 > 9 ? idx + 1 : `0${idx + 1}`}/2020`,
+            status: "Success",
+            tradeCategories: ["Roofing", "Architecture", "Plumbing"],
+            priceInCents: 1234_56 + idx,
+            location: idx % 2 ? "l:1" : "l:2",
+          },
+        })),
+      ]}
+    />
+  );
+}
+
+export function Flexible() {
+  return (
+    <GridTable<BeamRow>
+      style={beamFlexibleStyle}
+      sorting={{ on: "client", initial: [1, "ASC"] }}
+      columns={beamStyleColumns()}
+      rows={[
+        { kind: "header", id: "header" },
+        ...zeroTo(20).map((idx) => ({
+          kind: "data" as const,
+          id: `r:${idx + 1}`,
+          data: {
+            id: `r:${idx + 1}`,
+            favorite: idx < 5,
+            commitmentName: idx === 9 ? "A longer name that will truncate with an ellipsis" : `Commitment ${idx + 1}`,
+            date: `01/${idx + 1 > 9 ? idx + 1 : `0${idx + 1}`}/2020`,
+            status: "Success",
+            tradeCategories: ["Roofing", "Architecture", "Plumbing"],
+            priceInCents: 1234_56 + idx,
+            location: idx % 2 ? "l:1" : "l:2",
+          },
+        })),
+      ]}
+    />
+  );
+}
+
+type BeamBudgetData = {
+  name?: ReactNode;
+  original?: number;
+  changeOrders?: number;
+  reallocations?: number;
+  revised?: number;
+  committed?: number;
+  difference?: number;
+  actuals?: number;
+  projected?: number;
+  costToComplete?: number;
+  children?: BeamChildRow[];
+};
+type HeaderRow = { kind: "header" };
+type BeamTotalsRow = { kind: "totals"; id: string } & BeamBudgetData;
+type BeamParentRow = { kind: "parent"; id: string } & BeamBudgetData;
+type BeamChildRow = { kind: "child"; id: string } & BeamBudgetData;
+type BeamNestedRow = BeamTotalsRow | HeaderRow | BeamParentRow | BeamChildRow;
+
+export function Nested() {
+  const totalsRowStyles = useMemo(() => ({ totals: { cellCss: beamTotalsRowStyle } }), []);
+  const rowStyles = useMemo(() => ({ parent: { cellCss: beamGroupRowStyle } }), []);
+  return (
+    <div css={Css.mw("fit-content").$}>
+      <GridTable<BeamNestedRow>
+        style={beamFixedStyle}
+        columns={beamNestedColumns}
+        rows={beamTotalsRows}
+        rowStyles={totalsRowStyles}
+      />
+      <GridTable<BeamNestedRow>
+        style={beamFixedStyle}
+        sorting={{ on: "client" }}
+        columns={beamNestedColumns}
+        rows={beamNestedRows}
+        rowStyles={rowStyles}
+        stickyHeader
+      />
+    </div>
+  );
+}
+
+const beamNestedRows: GridDataRow<BeamNestedRow>[] = [
+  { kind: "header", id: "header" },
+  ...zeroTo(5).map((pIdx) => {
+    // Get a semi-random, but repeatable number of children
+    const numChildren = (pIdx % 3) + pIdx + 1;
+    const children = zeroTo(numChildren).map((cIdx) => ({
+      kind: "child" as const,
+      id: `p${pIdx + 1}_c${cIdx + 1}`,
+      name: `10${pIdx + 1}0.${cIdx + 1} - Project Item`,
+      original: 1234_56,
+      changeOrders: 543_21,
+      reallocations: 568_56,
+      revised: undefined,
+      committed: 129_86,
+      difference: 1025_23,
+      actuals: 1108_18,
+      projected: 421_21,
+      costToComplete: 1129_85,
+    }));
+
+    return {
+      kind: "parent" as const,
+      id: `p:${pIdx + 1}`,
+      name: `10${pIdx + 1}0 - Cost Code`,
+      original: children.map((c) => c.original ?? 0).reduce((acc, n) => acc + n, 0),
+      changeOrders: children.map((c) => c.changeOrders ?? 0).reduce((acc, n) => acc + n, 0),
+      reallocations: children.map((c) => c.reallocations ?? 0).reduce((acc, n) => acc + n, 0),
+      revised: children.map((c) => c.revised ?? 0).reduce((acc, n) => acc + n, 0),
+      committed: children.map((c) => c.committed ?? 0).reduce((acc, n) => acc + n, 0),
+      difference: children.map((c) => c.difference ?? 0).reduce((acc, n) => acc + n, 0),
+      actuals: children.map((c) => c.actuals ?? 0).reduce((acc, n) => acc + n, 0),
+      projected: children.map((c) => c.projected ?? 0).reduce((acc, n) => acc + n, 0),
+      costToComplete: children.map((c) => c.costToComplete ?? 0).reduce((acc, n) => acc + n, 0),
+      children,
+    };
+  }),
+];
+
+const beamTotalsRows: GridDataRow<BeamNestedRow>[] = [
+  {
+    kind: "totals",
+    id: "totals",
+    name: "Totals",
+    original: 1234_56,
+    changeOrders: 1234_56,
+    reallocations: 1234_56,
+    revised: undefined,
+    committed: 1234_56,
+    difference: 1234_56,
+    actuals: 1234_56,
+    projected: 1234_56,
+    costToComplete: 1234_56,
+  },
+];
+
+function numberFormatter(numInCents: number | undefined) {
+  return typeof numInCents !== "number"
+    ? undefined
+    : new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", minimumFractionDigits: 2 }).format(
+        numInCents / 100,
+      );
+}
+
+function maybeFormatNumber(num?: number) {
+  return typeof num !== "number" || num === 0 ? null : <RollUpTotal num={num} />;
+}
+
+function RollUpTotal({ num }: { num?: number }) {
+  return typeof num !== "number" || num === 0 ? null : <span css={Css.xs.$}>{numberFormatter(num)}</span>;
+}
+
+const beamNestedColumns: GridColumn<BeamNestedRow>[] = [
+  collapseColumn<BeamNestedRow>({
+    totals: emptyCell,
+    header: (row) => <CollapseToggle row={row} />,
+    parent: (row) => <CollapseToggle row={row} />,
+    child: emptyCell,
+  }),
+  column<BeamNestedRow>({
+    totals: "Totals",
+    header: "Cost Code",
+    parent: (row) => `${row.name ?? ""} (${row.children.length})`,
+    child: (row) => row.name,
+    w: "200px",
+  }),
+  numericColumn<BeamNestedRow>({
+    totals: (row) => numberFormatter(row.original),
+    header: "Original",
+    parent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
+    child: (row) => ({ content: () => numberFormatter(row.original) }),
+  }),
+  numericColumn<BeamNestedRow>({
+    totals: (row) => numberFormatter(row.changeOrders),
+    header: "Change Orders",
+    parent: (row) => ({ content: () => maybeFormatNumber(row.changeOrders), value: row.changeOrders }),
+    child: (row) => ({ content: () => numberFormatter(row.changeOrders) }),
+  }),
+  numericColumn<BeamNestedRow>({
+    totals: (row) => numberFormatter(row.reallocations),
+    header: "Reallocations",
+    parent: (row) => ({ content: () => maybeFormatNumber(row.reallocations), value: row.reallocations }),
+    child: (row) => ({ content: () => numberFormatter(row.reallocations) }),
+  }),
+  numericColumn<BeamNestedRow>({
+    totals: (row) => numberFormatter(row.revised),
+    header: "Revised",
+    parent: (row) => ({ content: () => maybeFormatNumber(row.revised), value: row.revised }),
+    child: (row) => ({ content: () => numberFormatter(row.revised) }),
+  }),
+  numericColumn<BeamNestedRow>({
+    totals: (row) => numberFormatter(row.committed),
+    header: "Committed",
+    parent: (row) => ({ content: () => maybeFormatNumber(row.committed), value: row.committed }),
+    child: (row) => ({ content: () => numberFormatter(row.committed) }),
+  }),
+  numericColumn<BeamNestedRow>({
+    totals: (row) => numberFormatter(row.difference),
+    header: "Difference",
+    parent: (row) => ({ content: () => maybeFormatNumber(row.difference), value: row.difference }),
+    child: (row) => ({ content: () => numberFormatter(row.difference) }),
+  }),
+  numericColumn<BeamNestedRow>({
+    totals: (row) => numberFormatter(row.actuals),
+    header: "Actuals",
+    parent: (row) => ({ content: () => maybeFormatNumber(row.actuals), value: row.actuals }),
+    child: (row) => ({ content: () => numberFormatter(row.actuals) }),
+  }),
+  numericColumn<BeamNestedRow>({
+    totals: (row) => numberFormatter(row.projected),
+    header: "Projected",
+    parent: (row) => ({ content: () => maybeFormatNumber(row.projected), value: row.projected }),
+    child: (row) => ({ content: () => numberFormatter(row.projected) }),
+  }),
+  numericColumn<BeamNestedRow>({
+    totals: (row) => numberFormatter(row.costToComplete),
+    header: "Cost To Complete",
+    parent: (row) => ({ content: () => maybeFormatNumber(row.costToComplete), value: row.costToComplete }),
+    child: (row) => ({ content: () => numberFormatter(row.costToComplete) }),
+  }),
+];
+
+function beamStyleColumns() {
+  const locations: HasIdAndName<string>[] = [
+    { id: "l:1", name: "Living Room" },
+    { id: "l:2", name: "Great Room" },
+  ];
+
+  const selectCol = selectColumn<BeamRow>({
+    header: () => ({ content: <Checkbox label="Label" onChange={noop} checkboxOnly /> }),
+    data: () => ({ content: <Checkbox label="Label" onChange={noop} checkboxOnly /> }),
+  });
+  const favCol = column<BeamRow>({
+    header: () => ({ content: "" }),
+    data: ({ favorite }) => ({
+      content: <Icon icon="star" color={favorite ? Palette.Gray700 : Palette.Gray300} />,
+      sortValue: favorite ? 0 : 1,
+    }),
+    // Defining `w: 56px` to accommodate for the `27px` wide checkbox and `16px` of padding on either side.
+    w: "56px",
+  });
+  const statusCol = column<BeamRow>({
+    header: "Status",
+    data: ({ status }) => ({ content: <Tag text={status} type="success" />, sortValue: status }),
+    w: "125px",
+  });
+  const nameCol = column<BeamRow>({
+    header: "Commitment Name",
+    data: ({ commitmentName }) => commitmentName,
+    w: "220px",
+  });
+  const tradeCol = column<BeamRow>({
+    header: "Trade Categories",
+    data: ({ tradeCategories }) => ({
+      content: () => <Chips values={tradeCategories.sort()} />,
+      sortValue: tradeCategories.sort().join(" "),
+    }),
+  });
+  const dateCol = dateColumn<BeamRow>({ header: "Date", data: ({ date }) => date });
+  const locationCol = column<BeamRow>({
+    header: "Location",
+    data: (row) => ({
+      content: <SelectField value={row.location} onSelect={noop} options={locations} label="Location" />,
+      sortValue: row.location,
+    }),
+  });
+  const priceCol = numericColumn<BeamRow>({
+    header: "Price",
+    data: ({ priceInCents }) => ({
+      content: () => <NumberField label="Price" value={priceInCents} onChange={noop} type="cents" />,
+      sortValue: priceInCents,
+    }),
+  });
+  const readOnlyPriceCol = numericColumn<BeamRow>({
+    header: "Read only Price",
+    data: ({ priceInCents }) => ({
+      content: () => <NumberField label="Price" value={priceInCents} onChange={noop} type="cents" readOnly />,
+      sortValue: priceInCents,
+    }),
+  });
+
+  return [selectCol, favCol, statusCol, nameCol, tradeCol, locationCol, dateCol, priceCol, readOnlyPriceCol];
+}

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -46,7 +46,7 @@ export function Fixed() {
           data: {
             id: `r:${idx + 1}`,
             favorite: idx < 5,
-            commitmentName: idx === 9 ? "A longer name that will truncate with an ellipsis" : `Commitment ${idx + 1}`,
+            commitmentName: idx === 2 ? "A longer name that will truncate with an ellipsis" : `Commitment ${idx + 1}`,
             date: `01/${idx + 1 > 9 ? idx + 1 : `0${idx + 1}`}/2020`,
             status: "Success",
             tradeCategories: ["Roofing", "Architecture", "Plumbing"],
@@ -73,7 +73,7 @@ export function Flexible() {
           data: {
             id: `r:${idx + 1}`,
             favorite: idx < 5,
-            commitmentName: idx === 9 ? "A longer name that will truncate with an ellipsis" : `Commitment ${idx + 1}`,
+            commitmentName: idx === 2 ? "A longer name that will truncate with an ellipsis" : `Commitment ${idx + 1}`,
             date: `01/${idx + 1 > 9 ? idx + 1 : `0${idx + 1}`}/2020`,
             status: "Success",
             tradeCategories: ["Roofing", "Architecture", "Plumbing"],
@@ -105,7 +105,7 @@ type BeamParentRow = { kind: "parent"; id: string } & BeamBudgetData;
 type BeamChildRow = { kind: "child"; id: string } & BeamBudgetData;
 type BeamNestedRow = BeamTotalsRow | HeaderRow | BeamParentRow | BeamChildRow;
 
-export function Nested() {
+export function NestedFixed() {
   const totalsRowStyles = useMemo(() => ({ totals: { cellCss: beamTotalsRowStyle } }), []);
   const rowStyles = useMemo(() => ({ parent: { cellCss: beamGroupRowStyle } }), []);
   return (
@@ -128,6 +128,29 @@ export function Nested() {
   );
 }
 
+export function NestedFlexible() {
+  const totalsRowStyles = useMemo(() => ({ totals: { cellCss: beamTotalsRowStyle } }), []);
+  const rowStyles = useMemo(() => ({ parent: { cellCss: beamGroupRowStyle } }), []);
+  return (
+    <div css={Css.mw("fit-content").$}>
+      <GridTable<BeamNestedRow>
+        style={beamFlexibleStyle}
+        columns={beamNestedColumns}
+        rows={beamTotalsRows}
+        rowStyles={totalsRowStyles}
+      />
+      <GridTable<BeamNestedRow>
+        style={beamFlexibleStyle}
+        sorting={{ on: "client" }}
+        columns={beamNestedColumns}
+        rows={beamNestedRows}
+        rowStyles={rowStyles}
+        stickyHeader
+      />
+    </div>
+  );
+}
+
 const beamNestedRows: GridDataRow<BeamNestedRow>[] = [
   { kind: "header", id: "header" },
   ...zeroTo(5).map((pIdx) => {
@@ -136,7 +159,7 @@ const beamNestedRows: GridDataRow<BeamNestedRow>[] = [
     const children = zeroTo(numChildren).map((cIdx) => ({
       kind: "child" as const,
       id: `p${pIdx + 1}_c${cIdx + 1}`,
-      name: `10${pIdx + 1}0.${cIdx + 1} - Project Item`,
+      name: `10${pIdx + 1}0.${cIdx + 1} - Project Item${pIdx === 0 ? " with a longer name that will wrap" : ""}`,
       original: 1234_56,
       changeOrders: 543_21,
       reallocations: 568_56,
@@ -151,7 +174,7 @@ const beamNestedRows: GridDataRow<BeamNestedRow>[] = [
     return {
       kind: "parent" as const,
       id: `p:${pIdx + 1}`,
-      name: `10${pIdx + 1}0 - Cost Code`,
+      name: `10${pIdx + 1}0 - Cost Code${pIdx === 1 ? " with a longer name that will wrap" : ""}`,
       original: children.map((c) => c.original ?? 0).reduce((acc, n) => acc + n, 0),
       changeOrders: children.map((c) => c.changeOrders ?? 0).reduce((acc, n) => acc + n, 0),
       reallocations: children.map((c) => c.reallocations ?? 0).reduce((acc, n) => acc + n, 0),

--- a/src/components/Table/columns.tsx
+++ b/src/components/Table/columns.tsx
@@ -26,3 +26,9 @@ export function selectColumn<T extends Kinded, S = {}>(columnDef: GridColumn<T, 
   // Defining `w: 48px` to accommodate for the `16px` wide checkbox and `16px` of padding on either side.
   return { clientSideSort: false, ...columnDef, align: "center", w: "48px" };
 }
+
+/** Provides default styling for a GridColumn containing the CollapseToggle component. */
+export function collapseColumn<T extends Kinded, S = {}>(columnDef: GridColumn<T, S>): GridColumn<T, S> {
+  // Defining `w: 38px` based on the designs
+  return { ...columnDef, clientSideSort: false, align: "center", w: "38px" };
+}

--- a/src/components/Table/styles.tsx
+++ b/src/components/Table/styles.tsx
@@ -47,6 +47,7 @@ export const beamFixedStyle: GridStyle = {
   cellCss: Css.gray900.xs.bgWhite.aic.nowrap.pxPx(12).hPx(36).boxShadow(`inset 0 -1px 0 ${Palette.Gray100}`).$,
   emptyCell: "-",
   presentationSettings: { borderless: true, typeScale: "xs", wrap: false },
+  rowHoverColor: Palette.Gray200,
 };
 
 export const beamFlexibleStyle: GridStyle = {

--- a/src/components/Table/styles.tsx
+++ b/src/components/Table/styles.tsx
@@ -46,15 +46,17 @@ export const beamFixedStyle: GridStyle = {
   headerCellCss: Css.gray700.xsEm.bgGray200.aic.nowrap.pxPx(12).hPx(40).$,
   cellCss: Css.gray900.xs.bgWhite.aic.nowrap.pxPx(12).hPx(36).boxShadow(`inset 0 -1px 0 ${Palette.Gray100}`).$,
   emptyCell: "-",
+  presentationSettings: { borderless: true, typeScale: "xs", wrap: false },
 };
 
 export const beamFlexibleStyle: GridStyle = {
   ...beamFixedStyle,
   cellCss: Css.xs.bgWhite.aic.p2.boxShadow(`inset 0 -1px 0 ${Palette.Gray100}`).$,
+  presentationSettings: { borderless: false, typeScale: "xs", wrap: true },
 };
 
 export const beamGroupRowStyle: Properties = Css.smEm
-  .hPx(56)
+  .mhPx(56)
   .gray700.bgGray100.boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$;
 
 export const beamTotalsRowStyle: Properties = Css.gray700.smEm.hPx(40).mb1.bgWhite.boxShadow("none").$;

--- a/src/components/Table/styles.tsx
+++ b/src/components/Table/styles.tsx
@@ -1,4 +1,4 @@
-import { Css, Palette } from "src/Css";
+import { Css, Palette, Properties } from "src/Css";
 import { GridStyle } from ".";
 
 /** Our original table look & feel/style. */
@@ -43,12 +43,18 @@ export const cardStyle: GridStyle = {
 
 // Once completely rolled out across all tables in Blueprint, this will change to be the `defaultStyle`.
 export const beamFixedStyle: GridStyle = {
-  rootCss: Css.gray700.$,
-  // Doing a mix of `min` and `max` height of 40 as each cell is currently defining `h100`.
-  headerCellCss: Css.xsEm.bgGray200.aic.nowrap.px2.mhPx(40).maxhPx(40).$,
-  // TODO: `cellCss` has incomplete styling at the moment. Will be done as part of SC-8145
-  cellCss: Css.xs.bgWhite.aic.nowrap.px2.hPx(40).boxShadow(`inset 0 -1px 0 ${Palette.Gray100}`).$,
+  headerCellCss: Css.gray700.xsEm.bgGray200.aic.nowrap.pxPx(12).hPx(40).$,
+  cellCss: Css.gray900.xs.bgWhite.aic.nowrap.pxPx(12).hPx(36).boxShadow(`inset 0 -1px 0 ${Palette.Gray100}`).$,
+  emptyCell: "-",
 };
 
-// TODO: `cellCss` has incomplete styling at the moment. Will be done as part of SC-8145
-export const beamFlexibleStyle: GridStyle = { ...beamFixedStyle, cellCss: Css.p2.$ };
+export const beamFlexibleStyle: GridStyle = {
+  ...beamFixedStyle,
+  cellCss: Css.xs.bgWhite.aic.p2.boxShadow(`inset 0 -1px 0 ${Palette.Gray100}`).$,
+};
+
+export const beamGroupRowStyle: Properties = Css.smEm
+  .hPx(56)
+  .gray700.bgGray100.boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$;
+
+export const beamTotalsRowStyle: Properties = Css.gray700.smEm.hPx(40).mb1.bgWhite.boxShadow("none").$;

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -127,7 +127,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
       ...(!contrast ? Css.bgWhite.$ : Css.bgGray700.addIn("&::selection", Css.bgGray800.$).$),
     },
     hover: Css.bgGray100.if(contrast).bgGray600.bGray600.$,
-    focus: borderless ? Css.bshFocus.$ : Css.bLightBlue700.if(contrast).bLightBlue500.$,
+    focus: borderless ? Css.bshFocus.z1.$ : Css.bLightBlue700.if(contrast).bLightBlue500.$,
     disabled: visuallyDisabled
       ? Css.cursorNotAllowed.gray400.bgGray100.if(contrast).gray500.bgGray700.$
       : Css.cursorNotAllowed.$,


### PR DESCRIPTION
Includes a first pass at the following styles:
- Fixed: All rows have a fixed height and content will overflow with an ellipsis if the column is not wide enough to contain it. Provides a 'title' attribute on cells that only contain a string so the browser can provide the built in 'tooltip'.
- Flexible: Content within cells can wrap and will have 16px of padding on top and bottom.

- Nested: Provides a 'groupRowStyle' for providing parent when there is for a nesting depth of 2. Working off of the Budget table example. This can be used along side the Fixed or Flexible row styles.