### PR TITLE
fix: Remove 'omitExternalIcon' prop in favor of 'download' prop

### DIFF
--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -189,7 +189,7 @@ export function ButtonLink() {
           <Button onClick="/fakePath" label="Relative URL link" />
           <Button onClick="/" label="Relative URL - Open in New Tab" openInNew />
           <Button onClick="https://www.homebound.com" label="Absolute URL link" />
-          <Button onClick="https://www.homebound.com" label="External Download link" icon="download" omitExternalIcon />
+          <Button onClick="tony-stark.jpg" label="Download link" download />
           <Button icon="plus" onClick="/fakePath" label="Disabled link" disabled />
         </div>
 
@@ -198,13 +198,7 @@ export function ButtonLink() {
           <Button variant="secondary" onClick="/fakePath" label="Relative URL link" />
           <Button variant="secondary" onClick="/" label="Relative URL - Open in New Tab" openInNew />
           <Button variant="secondary" onClick="https://www.homebound.com" label="Absolute URL link" />
-          <Button
-            variant="secondary"
-            onClick="https://www.homebound.com"
-            label="External Download link"
-            icon="download"
-            omitExternalIcon
-          />
+          <Button variant="secondary" onClick="tony-stark.jpg" label="Download link" download />
           <Button variant="secondary" icon="plus" onClick="/fakePath" label="Disabled link" disabled />
         </div>
 
@@ -213,13 +207,7 @@ export function ButtonLink() {
           <Button variant="tertiary" onClick="/fakePath" label="Relative URL link" />
           <Button variant="tertiary" onClick="/" label="Relative URL - Open in New Tab" openInNew />
           <Button variant="tertiary" onClick="https://www.homebound.com" label="Absolute URL link" />
-          <Button
-            variant="tertiary"
-            onClick="https://www.homebound.com"
-            label="External Download link"
-            icon="download"
-            omitExternalIcon
-          />
+          <Button variant="tertiary" onClick="tony-stark.jpg" label="Download link" download />
           <Button variant="tertiary" icon="plus" onClick="/fakePath" label="Disabled link" disabled />
         </div>
 
@@ -228,13 +216,7 @@ export function ButtonLink() {
           <Button variant="danger" onClick="/fakePath" label="Relative URL link" />
           <Button variant="danger" onClick="/" label="Relative URL - Open in New Tab" openInNew />
           <Button variant="danger" onClick="https://www.homebound.com" label="Absolute URL link" />
-          <Button
-            variant="danger"
-            onClick="https://www.homebound.com"
-            label="External Download link"
-            icon="download"
-            omitExternalIcon
-          />
+          <Button variant="danger" onClick="tony-stark.jpg" label="Download link" download />
           <Button variant="danger" icon="plus" onClick="/fakePath" label="Disabled link" disabled />
         </div>
       </div>

--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -39,13 +39,18 @@ describe("Button", () => {
     expect(r.button())
       .toHaveAttribute("href", "https://www.homebound.com")
       .toHaveAttribute("target", "_blank")
-      .toHaveAttribute("rel", "noreferrer noopener");
+      .toHaveAttribute("rel", "noreferrer noopener")
+      .not.toHaveAttribute("download");
   });
 
   it("applies expected properties when rendering a link with a relative url", async () => {
     const r = await render(<Button label="Button" onClick="/testPath" />, withRouter());
     expect(r.button().tagName).toBe("A");
-    expect(r.button()).toHaveAttribute("href", "/testPath").not.toHaveAttribute("target").not.toHaveAttribute("rel");
+    expect(r.button())
+      .toHaveAttribute("href", "/testPath")
+      .not.toHaveAttribute("target")
+      .not.toHaveAttribute("rel")
+      .not.toHaveAttribute("download");
   });
 
   it("applies expected properties when rendering a link with a relative url to open in new tab", async () => {
@@ -54,6 +59,17 @@ describe("Button", () => {
     expect(r.button())
       .toHaveAttribute("href", "/testPath")
       .toHaveAttribute("target", "_blank")
-      .toHaveAttribute("rel", "noreferrer noopener");
+      .toHaveAttribute("rel", "noreferrer noopener")
+      .not.toHaveAttribute("download");
+  });
+
+  it("applies expected properties when adding the 'download' prop", async () => {
+    const r = await render(<Button label="Button" onClick="/testPath" download />, withRouter());
+    expect(r.button().tagName).toBe("A");
+    expect(r.button())
+      .toHaveAttribute("href", "/testPath")
+      .toHaveAttribute("download")
+      .not.toHaveAttribute("target", "_blank")
+      .not.toHaveAttribute("rel", "noreferrer noopener");
   });
 });

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -12,7 +12,7 @@ export interface ButtonProps extends BeamButtonProps, BeamFocusableProps {
   label: string;
   variant?: ButtonVariant;
   size?: ButtonSize;
-  icon?: IconProps["icon"];
+  icon?: IconProps["icon"] | null;
   /** Displays contents after the Button's label. Will be ignored for Buttons rendered as a link with an absolute URL */
   endAdornment?: ReactNode;
   /** HTML attributes to apply to the button element when it is being used to trigger a menu. */
@@ -20,8 +20,8 @@ export interface ButtonProps extends BeamButtonProps, BeamFocusableProps {
   buttonRef?: RefObject<HTMLElement>;
   /** Allow for setting "submit" | "button" | "reset" on button element */
   type?: ButtonHTMLAttributes<HTMLButtonElement>["type"];
-  /** Allows for omitting the external icon automatically applied when the button links to an external site. */
-  omitExternalIcon?: boolean;
+  /** Denotes if this button is used to download a resource. Uses the anchor tag with the `download` attribute */
+  download?: boolean;
 }
 
 export function Button(props: ButtonProps) {
@@ -32,12 +32,12 @@ export function Button(props: ButtonProps) {
     menuTriggerProps,
     tooltip,
     openInNew,
-    omitExternalIcon,
+    download,
     ...otherProps
   } = props;
   const isDisabled = !!disabled;
   const ariaProps = { onPress, isDisabled, ...otherProps, ...menuTriggerProps };
-  const { label, icon, variant = "primary", size = "sm", buttonRef } = ariaProps;
+  const { label, icon = download ? "download" : undefined, variant = "primary", size = "sm", buttonRef } = ariaProps;
   const ref = buttonRef || useRef(null);
   const tid = useTestIds(props, label);
   const { buttonProps, isPressed } = useButton(
@@ -84,10 +84,15 @@ export function Button(props: ButtonProps) {
 
   const button =
     typeof onPress === "string" ? (
-      isAbsoluteUrl(onPress) || openInNew ? (
-        <a {...buttonAttrs} href={onPress} className={navLink} target="_blank" rel="noreferrer noopener">
+      isAbsoluteUrl(onPress) || openInNew || download ? (
+        <a
+          {...buttonAttrs}
+          href={onPress}
+          className={navLink}
+          {...(download ? { download: "" } : { target: "_blank", rel: "noreferrer noopener" })}
+        >
           {buttonContent}
-          {!omitExternalIcon && (
+          {!download && (
             <span css={Css.ml1.$}>
               <Icon icon="linkExternal" />
             </span>


### PR DESCRIPTION
Adding the 'download' prop will:
1. Default to the 'download' icon
2. Use an anchor tag with the 'download' prop
3. Omit the 'linkExternal' icon that is typically supplied with absolute URLs

The 'omitExternalIcon' prop was meant to give the option for remove this default behavior for a download sort of link. Though, this resulted in opening a new tab to trigger a download. Since there are multiple behaviors we want changed when we have a 'download' type of link, the we are creating a single prop to signal those modifications.