### PR TITLE
fix: Prevent chips from stretching to fill container

### DIFF
--- a/src/components/Chips.stories.tsx
+++ b/src/components/Chips.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta } from "@storybook/react";
 import { Chips } from "src/components/Chips";
+import { PresentationProvider } from "src/components/PresentationContext";
 import { Css } from "src/Css";
 
 export default {
@@ -9,8 +10,23 @@ export default {
 
 export function DefaultChips() {
   return (
-    <div css={Css.wPx(300).ba.$}>
-      <Chips values={["First Last", "Second Last", "Third Last", "Fourth Last"]} />
-    </div>
+    <>
+      <h1>Chips wrap</h1>
+      <div css={Css.wPx(300).ba.$}>
+        <Chips values={["First Last", "Second Last", "Third Last", "Fourth Last"]} />
+      </div>
+
+      <h1 css={Css.mt3.$}>Chips truncate</h1>
+      <div css={Css.wPx(300).ba.$}>
+        <PresentationProvider wrap={false}>
+          <Chips values={["First Last", "Second Last", "Third Last", "Fourth Last"]} />
+        </PresentationProvider>
+      </div>
+
+      <h1 css={Css.mt3.$}>Chips do not stretch to fill container</h1>
+      <div css={Css.df.wPx(500).hPx(100).ba.$}>
+        <Chips values={["First Last", "Second Last", "Third Last", "Fourth Last"]} />
+      </div>
+    </>
   );
 }

--- a/src/components/Chips.tsx
+++ b/src/components/Chips.tsx
@@ -17,7 +17,7 @@ export function Chips<X extends Only<ChipsXss, X>>(props: ChipsProps<X>) {
   return (
     <div
       css={{
-        ...Css.df.gap1.whiteSpace("normal").$,
+        ...Css.df.aifs.gap1.whiteSpace("normal").$,
         ...(wrap !== false ? Css.add({ flexWrap: "wrap" }).$ : {}),
         ...xss,
       }}


### PR DESCRIPTION
Adds `align-items: flex-start` to the Chips container to prevent them from stretching to fill the full height. (by default align-items value is `stretch`)