### PR TITLE
fix: Allow Tooltip children to be ReactNode, which includes strings

### DIFF
--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -1,4 +1,5 @@
-import { resolveTooltip } from "src/components/Tooltip";
+import { resolveTooltip, Tooltip } from "src/components/Tooltip";
+import { render } from "src/utils/rtl";
 
 describe("Tooltip", () => {
   it("can resolve tooltip text", () => {
@@ -25,5 +26,10 @@ describe("Tooltip", () => {
     expect(resolveTooltip(undefined, "Test 2")).toBe("Test 2");
     expect(resolveTooltip(undefined, "Test 2", true)).toBe("Test 2");
     expect(resolveTooltip(undefined, "Test 2", "")).toBe("Test 2");
+  });
+
+  it("renders with title prop", async () => {
+    const r = await render(<Tooltip title="Test tooltip">Text</Tooltip>);
+    expect(r.tooltip()).toHaveAttribute("title", "Test tooltip");
   });
 });

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom";
 import { usePopper } from "react-popper";
 import { useTooltipTriggerState } from "react-stately";
 import { Css } from "src/Css";
+import { useTestIds } from "src/utils";
 
 // We combine react-popper and aria-tooltip to makeup the tooltip component for the following reasons:
 // Aria can handle all aspects of the tooltip accessibility and rendering it except handling the dynamic positioning aspect
@@ -12,7 +13,7 @@ import { Css } from "src/Css";
 interface TooltipProps {
   /** The content that shows up when hovered */
   title: ReactNode;
-  children: ReactElement;
+  children: ReactNode;
   placement?: Placement;
   delay?: number;
   disabled?: boolean;
@@ -25,10 +26,16 @@ export function Tooltip(props: TooltipProps) {
   const triggerRef = React.useRef(null);
   const { triggerProps, tooltipProps: _tooltipProps } = useTooltipTrigger({ isDisabled: disabled }, state, triggerRef);
   const { tooltipProps } = useTooltip(_tooltipProps, state);
+  const tid = useTestIds(props, "tooltip");
 
   return (
     <>
-      <span ref={triggerRef} {...triggerProps}>
+      <span
+        ref={triggerRef}
+        {...triggerProps}
+        {...(!state.isOpen && typeof title === "string" ? { title } : {})}
+        {...tid}
+      >
         {children}
       </span>
       {state.isOpen && (
@@ -80,7 +87,8 @@ function Popper({ triggerRef, content, placement = "auto" }: PopperProps) {
 }
 
 // Helper function to conditionally wrap component with Tooltip if necessary.
-export function maybeTooltip(props: TooltipProps) {
+// `maybeTooltip` requires that the `children` prop be a ReactElement, even though <Tooltip /> allows for ReactNode.
+export function maybeTooltip(props: Omit<TooltipProps, "children"> & { children: ReactElement }) {
   return props.title ? <Tooltip {...props} /> : props.children;
 }
 


### PR DESCRIPTION
The `children` prop was previously ReactElement was was require because we used 'cloneElement'. We no longer clone the element and can now allow for more types to be passed along such as strings.

Additionally adds the 'title' prop to the wrapping element when the tooltip is not showing and only if the title is of type string. This is to help with testing purposes and follows a similar pattern found from MUI.