### PR TITLE
fix: Support adding typeScale to a specific kind's column cells

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -719,6 +719,40 @@ describe("GridTable", () => {
     });
   });
 
+  it("throws error if column min-width definition is set with a non-px/percentage value", async () => {
+    // Given a column with an invalid `mw` value, then the render will fail
+    await expect(
+      render(
+        <GridTable
+          columns={[{ header: () => "Name", data: "Test", mw: "fit-content" }]}
+          rows={[simpleHeader, { kind: "data", id: "1", name: "a", value: 3 }]}
+        />,
+      ),
+    ).rejects.toThrow("Beam Table column min-width definition only supports px or percentage values");
+  });
+
+  it("accepts pixel values for column min-width definition", async () => {
+    // Given a column with an valid `mw` percentage value, then the render will succeed.
+    const r = await render(
+      <GridTable
+        columns={[{ header: () => "Name", data: "Test", mw: "100px" }]}
+        rows={[simpleHeader, { kind: "data", id: "1", name: "a", value: 3 }]}
+      />,
+    );
+    expect(r.gridTable()).toBeTruthy();
+  });
+
+  it("accepts percentage values for column min-width definition", async () => {
+    // Given a column with an valid `mw` percentage value, then the render will succeed.
+    const r = await render(
+      <GridTable
+        columns={[{ header: () => "Name", data: "Test", mw: "100%" }]}
+        rows={[simpleHeader, { kind: "data", id: "1", name: "a", value: 3 }]}
+      />,
+    );
+    expect(r.gridTable()).toBeTruthy();
+  });
+
   it("can handle onClick for rows", async () => {
     const onClick = jest.fn();
     const rowStyles: GridRowStyles<Row> = { header: {}, data: { onClick } };

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -778,6 +778,8 @@ export type GridColumn<R extends Kinded, S = {}> = {
    * - The default value is `1fr`
    */
   w?: number | string;
+  /** The minimum width the column can shrink to */
+  mw?: string;
   /** The column's default alignment for each cell. */
   align?: GridCellAlignment;
   /** Whether the column can be sorted (if client-side sorting). Defaults to true if sorting client-side. */
@@ -1002,6 +1004,7 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
             width: `calc(${columnSizes
               .slice(maybeNestedCardColumnIndex, maybeNestedCardColumnIndex + currentColspan)
               .join(" + ")})`,
+            ...(column.mw ? Css.mw(column.mw).$ : {}),
           }),
         };
 

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -24,7 +24,7 @@ import { getNestedCardStyles, isLeafRow, NestedCards, wrapCard } from "src/compo
 import { SortHeader } from "src/components/Table/SortHeader";
 import { ensureClientSideSortValueIsSortable, sortRows } from "src/components/Table/sortRows";
 import { SortState, useSortState } from "src/components/Table/useSortState";
-import { Css, Margin, Only, Properties, Xss } from "src/Css";
+import { Css, Margin, Only, Properties, Typography, Xss } from "src/Css";
 import tinycolor from "tinycolor2";
 import { defaultStyle } from ".";
 
@@ -856,7 +856,7 @@ export type GridCellContent = {
   /** Whether to indent the cell. */
   indent?: 1 | 2;
   colspan?: number;
-  css?: Properties;
+  typeScale?: Typography;
 };
 
 type MaybeFn<T> = T | (() => T);
@@ -948,6 +948,13 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
   const rowNode = (
     <Row css={rowCss} {...others} data-gridrow>
       {columns.map((column, columnIndex) => {
+        if (column.mw) {
+          // Validate the column's minWidth definition if set.
+          if (!column.mw.endsWith("px") && !column.mw.endsWith("%")) {
+            throw new Error("Beam Table column min-width definition only supports px or percentage values");
+          }
+        }
+
         // Decrement colspan count and skip if greater than 1.
         if (currentColspan > 1) {
           currentColspan -= 1;
@@ -997,8 +1004,8 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
           ...(isHeader && style.headerCellCss),
           // The specific cell's css (if any from GridCellContent)
           ...rowStyleCellCss,
-          // Cell Css from the specific cell/row kind
-          ...(isGridCellContent(maybeContent) ? maybeContent.css : {}),
+          // Add any cell specific style overrides
+          ...(isGridCellContent(maybeContent) && maybeContent.typeScale ? Css[maybeContent.typeScale].$ : {}),
           // Define the width of the column on each cell. Supports col spans.
           ...(columnSizes && {
             width: `calc(${columnSizes

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -854,6 +854,7 @@ export type GridCellContent = {
   /** Whether to indent the cell. */
   indent?: 1 | 2;
   colspan?: number;
+  css?: Properties;
 };
 
 type MaybeFn<T> = T | (() => T);
@@ -992,8 +993,10 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
           ...getIndentationCss(style, rowStyle, columnIndex, maybeContent),
           // Then apply any header-specific override
           ...(isHeader && style.headerCellCss),
-          // And finally the specific cell's css (if any from GridCellContent)
+          // The specific cell's css (if any from GridCellContent)
           ...rowStyleCellCss,
+          // Cell Css from the specific cell/row kind
+          ...(isGridCellContent(maybeContent) ? maybeContent.css : {}),
           // Define the width of the column on each cell. Supports col spans.
           ...(columnSizes && {
             width: `calc(${columnSizes

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -245,6 +245,8 @@ const beamNestedColumns: GridColumn<BeamNestedRow>[] = [
     header: "Original",
     parent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
     child: (row) => ({ content: () => numberFormatter(row.original) }),
+    w: "200px",
+    mw: "150px",
   }),
   numericColumn<BeamNestedRow>({
     totals: (row) => numberFormatter(row.changeOrders),

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -234,8 +234,7 @@ const beamNestedColumns: GridColumn<BeamNestedRow>[] = [
     header: "Cost Code",
     parent: (row) => ({
       content: () => `${row.name} (${row.children.length})`,
-      value: row.name,
-      css: Css.smEm.$,
+      typeScale: "smEm",
     }),
     child: (row) => row.name,
     w: "200px",
@@ -245,8 +244,6 @@ const beamNestedColumns: GridColumn<BeamNestedRow>[] = [
     header: "Original",
     parent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
     child: (row) => ({ content: () => numberFormatter(row.original) }),
-    w: "200px",
-    mw: "150px",
   }),
   numericColumn<BeamNestedRow>({
     totals: (row) => numberFormatter(row.changeOrders),

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -232,7 +232,11 @@ const beamNestedColumns: GridColumn<BeamNestedRow>[] = [
   column<BeamNestedRow>({
     totals: "Totals",
     header: "Cost Code",
-    parent: (row) => `${row.name ?? ""} (${row.children.length})`,
+    parent: (row) => ({
+      content: () => `${row.name} (${row.children.length})`,
+      value: row.name,
+      css: Css.smEm.$,
+    }),
     child: (row) => row.name,
     w: "200px",
   }),

--- a/src/components/Table/styles.tsx
+++ b/src/components/Table/styles.tsx
@@ -56,7 +56,7 @@ export const beamFlexibleStyle: GridStyle = {
   presentationSettings: { borderless: false, typeScale: "xs", wrap: true },
 };
 
-export const beamGroupRowStyle: Properties = Css.smEm
+export const beamGroupRowStyle: Properties = Css.xsEm
   .mhPx(56)
   .gray700.bgGray100.boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$;
 


### PR DESCRIPTION
Also updates group styles typography to be xsEm instead of smEm. Updates Storybook example to use `typeScale` prop for setting a specific row kind's column typography. This allowed for changing the font size on a single cell without having to nest it with additional elements. The nesting can circumvent the `PresentationContext.wrap`/truncation styles applied.

Also adds support for min-width definition on GridColumn