### PR TITLE
fix: Remove 'overflow: overlay' as it can sit on top of padding/content

### DIFF
--- a/src/components/Layout/ScrollableParent.tsx
+++ b/src/components/Layout/ScrollableParent.tsx
@@ -63,21 +63,9 @@ export function ScrollableParent(props: PropsWithChildren<ScrollableParentContex
       <Tag css={{ ...Css.mh0.mw0.fg1.df.fdc.$, ...otherXss }}>
         {/* Use `overflow: overlay` to prevent scrollbar from pushing content in when rendered. This is only supported in Webkit browsers, so we also keep `overflow: auto` as a fallback for other browsers.*/}
         {/* `overlay` needs to be applied using `addIn` otherwise the two `overflow` properties will be merged. */}
-        <div
-          css={
-            Css.pl(context.pl)
-              .pr(context.pr)
-              .if(!hasScrollableContent)
-              .h100.overflowAuto.addIn("&", Css.if(!hasScrollableContent).add("overflow", "overlay").$).$
-          }
-        >
-          {children}
-        </div>
+        <div css={Css.pl(context.pl).pr(context.pr).if(!hasScrollableContent).h100.overflowAuto.$}>{children}</div>
         {/* Set fg1 to take up the remaining space in the viewport.*/}
-        <div
-          css={Css.fg1.overflowAuto.pl(context.pl).pr(context.pr).addIn("&", Css.add("overflow", "overlay").$).$}
-          ref={scrollableRef}
-        />
+        <div css={Css.fg1.overflowAuto.pl(context.pl).pr(context.pr).$} ref={scrollableRef} />
       </Tag>
     </ScrollableParentContext.Provider>
   );


### PR DESCRIPTION
This seemed like it was doing more harm than good. 

## Before
<img width="510" alt="Screen Shot 2022-02-18 at 1 35 42 PM" src="https://user-images.githubusercontent.com/1143861/154743053-c54ab309-3660-4e0c-9910-e572f5342e45.png">

## After
<img width="362" alt="Screen Shot 2022-02-18 at 1 36 19 PM" src="https://user-images.githubusercontent.com/1143861/154743073-43b8f46f-bdb5-4a94-80a8-ca8ae9c08a30.png">

