### PR TITLE
fix: MultiFilter does not show chips if number of options is zero

### DIFF
--- a/src/components/Filters/MultiFilter.stories.tsx
+++ b/src/components/Filters/MultiFilter.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from "@storybook/react";
 import { stageFilter } from "src/components/Filters/testDomain";
-import { Filters } from "src/components/index";
+import { Filters, multiFilter } from "src/components/index";
+import { HasIdAndName } from "src/types";
 
 export default {
   component: Filters,
@@ -21,4 +22,14 @@ export function MultiFilterInModal() {
 export function MultiFilterVertical() {
   const filter = stageFilter("stage");
   return filter.render(undefined, () => {}, {}, false, true);
+}
+
+export function ZeroOptions() {
+  const filter = multiFilter({
+    options: [] as HasIdAndName[],
+    getOptionValue: (s) => s.id,
+    getOptionLabel: (s) => s.name,
+    disabled: "Filter is disabled because there are no options",
+  })("key");
+  return filter.render(undefined, () => {}, {}, true, false);
 }

--- a/src/components/Filters/MultiFilter.tsx
+++ b/src/components/Filters/MultiFilter.tsx
@@ -27,7 +27,7 @@ class MultiFilter<O, V extends Value> extends BaseFilter<V[], MultiFilterProps<O
     inModal: boolean,
     vertical: boolean,
   ): JSX.Element {
-    if (inModal && this.props.options.length <= 8) {
+    if (inModal && this.props.options.length > 0 && this.props.options.length <= 8) {
       return (
         <ToggleChipGroup
           label={this.label}


### PR DESCRIPTION
By rendering the MultiSelectField for the MultiFilter when the options.length is zero, then we allow users to provide additional UX such as disabling with a tooltip or helper text to communicate why the filter is currently disabled