### PR TITLE
chore: SC-13496 update NPM contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  node: circleci/node@5.0.0
+
 node-image: &node-image
   image: cimg/node:16.4.0
   auth:
@@ -12,12 +15,24 @@ workflows:
     jobs:
       - build:
           context:
-            - npm
+            - npm-readonly
             - github
+            - dockerhub
+      - publish:
+          context:
+            - npm-publish
+            - github
+            - dockerhub
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - main
       - chromatic:
           context:
+            - npm-readonly
             - dockerhub
-            - npm
 
 jobs:
   build:
@@ -26,15 +41,21 @@ jobs:
       - <<: *node-image
     steps:
       - checkout
-      - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc'
-      - run: yarn install
+      - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc'
+      - node/install-packages:
+          pkg-manager: yarn
       - run: yarn build
       - run: yarn test
-      - when:
-          condition:
-            equal: [main, <<pipeline.git.branch>>]
-          steps:
-            - run: yarn semantic-release
+
+  publish:
+    resource_class: "xlarge"
+    docker:
+      - <<: *node-image
+    steps:
+      - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc'
+      - node/install-packages:
+          pkg-manager: yarn
+      - run: yarn semantic-release
 
   chromatic:
     resource_class: "xlarge"
@@ -47,8 +68,9 @@ jobs:
     working_directory: ~/project
     steps:
       - checkout
-      - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc'
-      - run: yarn install
+      - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc'
+      - node/install-packages:
+          pkg-manager: yarn
       - when:
           condition:
             equal: [main, <<pipeline.git.branch>>]

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@homebound/rtl-react-router-utils": "^1.0.3",
     "@homebound/rtl-utils": "^2.51.0",
     "@homebound/tsconfig": "^1.0.3",
+    "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^9.0.0",
     "@storybook/addon-essentials": "^6.4.9",
     "@storybook/addon-interactions": "^6.4.9",

--- a/release.config.js
+++ b/release.config.js
@@ -3,6 +3,12 @@ module.exports = {
   plugins: [
     ["@semantic-release/commit-analyzer", { preset: "conventionalcommits" }],
     ["@semantic-release/release-notes-generator", { preset: "conventionalcommits" }],
+    [
+      "@semantic-release/exec",
+      {
+        prepareCmd: "yarn build",
+      },
+    ],
     "@semantic-release/npm",
     "@semantic-release/github",
     "@semantic-release/git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3933,6 +3933,23 @@
   resolved "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz"
   integrity sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg==
 
+"@semantic-release/error@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-3.0.0.tgz#30a3b97bbb5844d695eb22f9d3aa40f6a92770c2"
+  integrity sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==
+
+"@semantic-release/exec@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@semantic-release/exec/-/exec-6.0.3.tgz#d212fdf19633bdfb553de6cb6c7f8781933224db"
+  integrity sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==
+  dependencies:
+    "@semantic-release/error" "^3.0.0"
+    aggregate-error "^3.0.0"
+    debug "^4.0.0"
+    execa "^5.0.0"
+    lodash "^4.17.4"
+    parse-json "^5.0.0"
+
 "@semantic-release/git@^9.0.0":
   version "9.0.0"
   resolved "https://registry.npmjs.org/@semantic-release/git/-/git-9.0.0.tgz"


### PR DESCRIPTION
https://app.shortcut.com/homebound-team/story/13496/regenerate-ci-npm-tokens

Our previous NPM token was quite old (2 years) and likely widely exposed before https://github.com/homebound-team/graphql-service/pull/2101 was merged.

This PR updates the CircleCI config to use two distinct `npm` contexts (read-only and publish). This reduces the risk of accidentally publishing in a step that should not. Additionally, it uses a new automation-type token that allows us to enable 2-Factor Auth for login but not for the publishing token.

Once I transition our projects, I will delete the old `npm` context.