### PR TITLE
feat: Add beamNestedFixedStyle.

### DIFF
--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -1,12 +1,19 @@
 import { Meta } from "@storybook/react";
-import { ReactNode, useMemo } from "react";
+import { ReactNode } from "react";
 import { Chips } from "src/components/Chips";
 import { Icon } from "src/components/Icon";
 import { CollapseToggle } from "src/components/Table/CollapseToggle";
 import { collapseColumn, column, dateColumn, numericColumn, selectColumn } from "src/components/Table/columns";
 import { emptyCell, GridColumn, GridDataRow, GridTable } from "src/components/Table/GridTable";
 import { SimpleHeaderAndDataWith } from "src/components/Table/simpleHelpers";
-import { beamFixedStyle, beamFlexibleStyle, beamGroupRowStyle, beamTotalsRowStyle } from "src/components/Table/styles";
+import {
+  beamFixedStyle,
+  beamFlexibleStyle,
+  beamNestedFixedStyle,
+  beamNestedFlexibleStyle,
+  beamTotalsFixedStyle,
+  beamTotalsFlexibleStyle,
+} from "src/components/Table/styles";
 import { Tag } from "src/components/Tag";
 import { Css, Palette } from "src/Css";
 import { Checkbox, NumberField, SelectField } from "src/inputs";
@@ -106,22 +113,14 @@ type BeamChildRow = { kind: "child"; id: string } & BeamBudgetData;
 type BeamNestedRow = BeamTotalsRow | HeaderRow | BeamParentRow | BeamChildRow;
 
 export function NestedFixed() {
-  const totalsRowStyles = useMemo(() => ({ totals: { cellCss: beamTotalsRowStyle } }), []);
-  const rowStyles = useMemo(() => ({ parent: { cellCss: beamGroupRowStyle } }), []);
   return (
     <div css={Css.mw("fit-content").$}>
+      <GridTable<BeamNestedRow> style={beamTotalsFixedStyle} columns={beamNestedColumns} rows={beamTotalsRows} />
       <GridTable<BeamNestedRow>
-        style={beamFixedStyle}
-        columns={beamNestedColumns}
-        rows={beamTotalsRows}
-        rowStyles={totalsRowStyles}
-      />
-      <GridTable<BeamNestedRow>
-        style={beamFixedStyle}
+        style={beamNestedFixedStyle}
         sorting={{ on: "client" }}
         columns={beamNestedColumns}
         rows={beamNestedRows}
-        rowStyles={rowStyles}
         stickyHeader
       />
     </div>
@@ -129,22 +128,14 @@ export function NestedFixed() {
 }
 
 export function NestedFlexible() {
-  const totalsRowStyles = useMemo(() => ({ totals: { cellCss: beamTotalsRowStyle } }), []);
-  const rowStyles = useMemo(() => ({ parent: { cellCss: beamGroupRowStyle } }), []);
   return (
     <div css={Css.mw("fit-content").$}>
+      <GridTable<BeamNestedRow> style={beamTotalsFlexibleStyle} columns={beamNestedColumns} rows={beamTotalsRows} />
       <GridTable<BeamNestedRow>
-        style={beamFlexibleStyle}
-        columns={beamNestedColumns}
-        rows={beamTotalsRows}
-        rowStyles={totalsRowStyles}
-      />
-      <GridTable<BeamNestedRow>
-        style={beamFlexibleStyle}
+        style={beamNestedFlexibleStyle}
         sorting={{ on: "client" }}
         columns={beamNestedColumns}
         rows={beamNestedRows}
-        rowStyles={rowStyles}
         stickyHeader
       />
     </div>

--- a/src/components/Table/styles.tsx
+++ b/src/components/Table/styles.tsx
@@ -48,6 +48,26 @@ export const beamFixedStyle: GridStyle = {
   emptyCell: "-",
   presentationSettings: { borderless: true, typeScale: "xs", wrap: false },
   rowHoverColor: Palette.Gray200,
+  // Included as a hacky "treat indent as deprecated for this table" hint to GridTable
+  levels: {},
+};
+
+// The look & feel for parent rows' cells in a nested parent/child table.
+export const beamGroupRowStyle: Properties = Css.xsEm
+  .mhPx(56)
+  .gray700.bgGray100.boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$;
+
+// The look & feel for a totals row's cells.
+export const beamTotalsRowStyle: Properties = Css.gray700.smEm.hPx(40).mb1.bgWhite.boxShadow("none").$;
+
+export const beamNestedFixedStyle: GridStyle = {
+  ...beamFixedStyle,
+  levels: { 0: { cellCss: beamGroupRowStyle } },
+};
+
+export const beamTotalsFixedStyle: GridStyle = {
+  ...beamFixedStyle,
+  cellCss: { ...beamFixedStyle.cellCss, ...beamTotalsRowStyle },
 };
 
 export const beamFlexibleStyle: GridStyle = {
@@ -56,8 +76,12 @@ export const beamFlexibleStyle: GridStyle = {
   presentationSettings: { borderless: false, typeScale: "xs", wrap: true },
 };
 
-export const beamGroupRowStyle: Properties = Css.xsEm
-  .mhPx(56)
-  .gray700.bgGray100.boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$;
+export const beamNestedFlexibleStyle: GridStyle = {
+  ...beamFlexibleStyle,
+  levels: { 0: { cellCss: beamGroupRowStyle } },
+};
 
-export const beamTotalsRowStyle: Properties = Css.gray700.smEm.hPx(40).mb1.bgWhite.boxShadow("none").$;
+export const beamTotalsFlexibleStyle: GridStyle = {
+  ...beamFlexibleStyle,
+  cellCss: { ...beamFlexibleStyle.cellCss, ...beamTotalsRowStyle },
+};


### PR DESCRIPTION
The new `beamFixedStyle` didn't work with our old `indent: ...` way of applying "out-of-the-box" parent/child styling, and instead used manually applied row styles like:

```
const rowStyles = useMemo(() => ({ parent: { cellCss: beamGroupRowStyle } }), []);
<GridTable<BeamNestedRow>
  style={beamFlexibleStyle}
  sorting={{ on: "client" }}
  columns={beamNestedColumns}
  rows={beamNestedRows}
  rowStyles={rowStyles}
  stickyHeader
/>
```

This was fine, but I wanted something more out-of-the-box, so this adds a specific `beamNestedFixedStyle` that uses a new `GridStyle.levels` map of level to style, so the usage is now:

```
<GridTable<BeamNestedRow>
  style={beamNestedFlexibleStyle}
  sorting={{ on: "client" }}
  columns={beamNestedColumns}
  rows={beamNestedRows}
  stickyHeader
/>
```

I.e. the extra `rowStyles` prop and `useMemo` lines went away.

Granted, we only do two-levels of style at the moment, but I imagine that's what most of our use cases will be; use cases with three levels can define their own `GridStyle.levels` entries.

I did briefly consider having only a single `beamFixedStyle` with `levels` that were _conditionally_ used based on the presence of "does this table have parent/children rows in it? if so, use the levels, if not just ignore it".

I still kinda like the automatic-ness of that, but for now going with the more explicit option that isn't based on "are there parent/child rows being passed to us?" and instead requires an explicit `style=beamNestedFixedStyle`.

