### PR TITLE
feat: Add selected row support to GridTable.

### DIFF
--- a/src/components/Table/CollapseToggle.test.tsx
+++ b/src/components/Table/CollapseToggle.test.tsx
@@ -25,7 +25,7 @@ describe("CollapseToggle", () => {
     }
     const r = await render(
       <RowStateContext.Provider value={{ rowState }}>
-        <CollapseToggle row={{ id: "r:1", kind, children: [{}] }} />
+        <CollapseToggle row={{ id: "r:1", kind, children: [{} as any] }} />
       </RowStateContext.Provider>,
     );
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual(expectedIcon);

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1,4 +1,5 @@
 import React, { MutableRefObject, useContext } from "react";
+import { selectColumn } from "src/components/Table/columns";
 import { GridRowLookup } from "src/components/Table/GridRowLookup";
 import {
   calcColumnSizes,
@@ -8,6 +9,7 @@ import {
   GridRowStyles,
   GridStyle,
   GridTable,
+  GridTableApi,
   matchesFilter,
   setRunningInJest,
 } from "src/components/Table/GridTable";
@@ -21,6 +23,7 @@ import {
 } from "src/components/Table/simpleHelpers";
 import { Css, Palette } from "src/Css";
 import { useComputed } from "src/hooks";
+import { Checkbox } from "src/inputs";
 import { cell, cellAnd, cellOf, click, render, row, rowAnd } from "src/utils/rtl";
 
 // Most of our tests use this simple Row and 2 columns
@@ -58,6 +61,12 @@ const nestedColumns: GridColumn<NestedRow>[] = [
     child: (row) => <Collapse id={row.id} />,
     grandChild: () => "",
   },
+  selectColumn<NestedRow>({
+    header: (row) => ({ content: <Select id={row.id} /> }),
+    parent: (row) => ({ content: <Select id={row.id} /> }),
+    child: (row) => ({ content: <Select id={row.id} /> }),
+    grandChild: (row) => ({ content: <Select id={row.id} /> }),
+  }),
   {
     header: () => "Name",
     parent: (row) => ({
@@ -913,9 +922,9 @@ describe("GridTable", () => {
     // When we filter by 'foo'
     const r = await render(<GridTable filter="foo" columns={nestedColumns} rows={rows} />);
     // Then we show the header
-    expect(cell(r, 0, 1)).toHaveTextContent("Name");
+    expect(cell(r, 0, 2)).toHaveTextContent("Name");
     // And the child that matched
-    expect(cell(r, 1, 1)).toHaveTextContent("foo");
+    expect(cell(r, 1, 2)).toHaveTextContent("foo");
     // And that's it
     expect(row(r, 2)).toBeUndefined();
   });
@@ -935,13 +944,13 @@ describe("GridTable", () => {
     ];
     const r = await render(<GridTable<NestedRow> columns={nestedColumns} rows={rows} />);
     // And all three rows are initially rendered
-    expect(cell(r, 0, 1)).toHaveTextContent("parent 1");
-    expect(cell(r, 1, 1)).toHaveTextContent("child p1c1");
-    expect(cell(r, 2, 1)).toHaveTextContent("grandchild p1c1g1");
+    expect(cell(r, 0, 2)).toHaveTextContent("parent 1");
+    expect(cell(r, 1, 2)).toHaveTextContent("child p1c1");
+    expect(cell(r, 2, 2)).toHaveTextContent("grandchild p1c1g1");
     // When the parent is collapsed
     click(cell(r, 0, 0).children[0] as any);
     // Then only the parent row is still shown
-    expect(cell(r, 0, 1)).toHaveTextContent("parent 1");
+    expect(cell(r, 0, 2)).toHaveTextContent("parent 1");
     expect(row(r, 1)).toBeUndefined();
   });
 
@@ -960,15 +969,15 @@ describe("GridTable", () => {
     ];
     const r = await render(<GridTable<NestedRow> columns={nestedColumns} rows={rows} />);
     // And all three rows are initially rendered
-    expect(cell(r, 0, 1)).toHaveTextContent("parent 1");
-    expect(cell(r, 1, 1)).toHaveTextContent("child p1c1");
-    expect(cell(r, 2, 1)).toHaveTextContent("grandchild p1c1g1");
+    expect(cell(r, 0, 2)).toHaveTextContent("parent 1");
+    expect(cell(r, 1, 2)).toHaveTextContent("child p1c1");
+    expect(cell(r, 2, 2)).toHaveTextContent("grandchild p1c1g1");
     expectRenderedRows("p1", "p1c1", "p1c1g1");
     // When the child is collapsed
     click(cell(r, 1, 0).children[0] as any);
     // Then the parent and child rows are still shown
-    expect(cell(r, 0, 1)).toHaveTextContent("parent 1");
-    expect(cell(r, 1, 1)).toHaveTextContent("child p1c1");
+    expect(cell(r, 0, 2)).toHaveTextContent("parent 1");
+    expect(cell(r, 1, 2)).toHaveTextContent("child p1c1");
     // But not the grandchild
     expect(row(r, 2)).toBeUndefined();
     // And nothing needed to re-render
@@ -991,9 +1000,9 @@ describe("GridTable", () => {
     ];
     const r = await render(<GridTable<NestedRow> columns={nestedColumns} rows={rows} />);
     // And all three rows are initially rendered
-    expect(cell(r, 1, 1)).toHaveTextContent("parent 1");
-    expect(cell(r, 2, 1)).toHaveTextContent("child p1c1");
-    expect(cell(r, 3, 1)).toHaveTextContent("grandchild p1c1g1");
+    expect(cell(r, 1, 2)).toHaveTextContent("parent 1");
+    expect(cell(r, 2, 2)).toHaveTextContent("child p1c1");
+    expect(cell(r, 3, 2)).toHaveTextContent("grandchild p1c1g1");
 
     // When we collapse all
     click(cell(r, 0, 0).children[0] as any);
@@ -1005,9 +1014,9 @@ describe("GridTable", () => {
     // And when we re-open all
     click(cell(r, 0, 0).children[0] as any);
     // Then all rows are shown
-    expect(cell(r, 1, 1)).toHaveTextContent("parent 1");
-    expect(cell(r, 2, 1)).toHaveTextContent("child p1c1");
-    expect(cell(r, 3, 1)).toHaveTextContent("grandchild p1c1g1");
+    expect(cell(r, 1, 2)).toHaveTextContent("parent 1");
+    expect(cell(r, 2, 2)).toHaveTextContent("child p1c1");
+    expect(cell(r, 3, 2)).toHaveTextContent("grandchild p1c1g1");
   });
 
   it("persists collapse", async () => {
@@ -1034,6 +1043,48 @@ describe("GridTable", () => {
 
     // Unset local storage
     localStorage.setItem(tableIdentifier, "");
+  });
+
+  it("can select all", async () => {
+    // Given a parent with a child and grandchild
+    const rows: GridDataRow<NestedRow>[] = [
+      { kind: "header", id: "header" },
+      {
+        ...{ kind: "parent", id: "p1", name: "parent 1" },
+        children: [
+          {
+            ...{ kind: "child", id: "p1c1", name: "child p1c1" },
+            children: [{ kind: "grandChild", id: "p1c1g1", name: "grandchild p1c1g1" }],
+          },
+        ],
+      },
+    ];
+    const api: MutableRefObject<GridTableApi | undefined> = { current: undefined };
+    const r = await render(<GridTable<NestedRow> api={api} columns={nestedColumns} rows={rows} />);
+    // And all three rows are initially rendered
+    expect(cell(r, 1, 2)).toHaveTextContent("parent 1");
+    expect(cell(r, 2, 2)).toHaveTextContent("child p1c1");
+    expect(cell(r, 3, 2)).toHaveTextContent("grandchild p1c1g1");
+
+    // When we select all
+    click(cell(r, 0, 1).children[0] as any);
+    // Then all rows are shown as selected
+    expect(cellAnd(r, 0, 1, "select")).toBeChecked();
+    expect(cellAnd(r, 1, 1, "select")).toBeChecked();
+    expect(cellAnd(r, 2, 1, "select")).toBeChecked();
+    expect(cellAnd(r, 3, 1, "select")).toBeChecked();
+    // And the api can fetch them
+    expect(api.current!.getSelectedRowIds()).toEqual(["p1", "p1c1", "p1c1g1"]);
+
+    // And when we unselect all
+    click(cell(r, 0, 1).children[0] as any);
+    // Then all rows are shown as unselected
+    expect(cellAnd(r, 0, 1, "select")).not.toBeChecked();
+    expect(cellAnd(r, 1, 1, "select")).not.toBeChecked();
+    expect(cellAnd(r, 2, 1, "select")).not.toBeChecked();
+    expect(cellAnd(r, 3, 1, "select")).not.toBeChecked();
+    // And they are no longer selected
+    expect(api.current!.getSelectedRowIds()).toEqual([]);
   });
 
   describe("matchesFilter", () => {
@@ -1300,13 +1351,13 @@ describe("GridTable", () => {
     // When using the various gridtable test helpers (cell, cellAnd, cellOf, row, rowAnd)
     // Then chrome rows, and padding columns are ignored
     expect(cellAnd(r, 0, 0, "collapse")).toBeTruthy();
-    expect(cell(r, 0, 1).textContent).toBe("Name");
+    expect(cell(r, 0, 2).textContent).toBe("Name");
     expect(cellAnd(r, 1, 0, "collapse")).toBeTruthy();
-    expect(cell(r, 1, 1).textContent).toBe("parent 1");
+    expect(cell(r, 1, 2).textContent).toBe("parent 1");
     expect(rowAnd(r, 2, "collapse")).toBeTruthy();
-    expect(cellOf(r, "gridTable", 2, 1).textContent).toBe("child p1c1");
+    expect(cellOf(r, "gridTable", 2, 2).textContent).toBe("child p1c1");
     expect(row(r, 3).querySelector("[data-testid='collapse']")).toBeFalsy();
-    expect(cell(r, 3, 1).textContent).toBe("grandchild p1c1g1");
+    expect(cell(r, 3, 2).textContent).toBe("grandchild p1c1g1");
   });
 
   it("can use custom table test ids on cell helpers that support it", async () => {
@@ -1323,6 +1374,22 @@ function Collapse({ id }: { id: string }) {
     <div onClick={() => rowState.toggleCollapsed(id)} data-testid="collapse">
       {icon}
     </div>
+  );
+}
+
+function Select({ id }: { id: string }) {
+  const { rowState } = useContext(RowStateContext);
+  const state = useComputed(() => rowState.getSelected(id), [rowState]);
+  const selected = state === "checked" ? true : state === "unchecked" ? false : "indeterminate";
+  return (
+    <Checkbox
+      label="Select"
+      checkboxOnly={true}
+      selected={selected}
+      onChange={(selected) => {
+        rowState.selectRow(id, selected);
+      }}
+    />
   );
 }
 

--- a/src/components/Table/SchedulesV2.stories.tsx
+++ b/src/components/Table/SchedulesV2.stories.tsx
@@ -80,10 +80,10 @@ const arrowColumn = actionColumn<Row>({
   w: "36px",
 });
 const selectColumn = actionColumn<Row>({
-  header: (row) => <Checkbox label="" onChange={action("Select All")} />,
+  header: (row) => <Checkbox label="" selected={false} onChange={action("Select All")} />,
   milestone: (row) => ({ colspan: 3, content: <div css={Css.smEm.gray900.$}>{row.name}</div>, alignment: "left" }),
   subgroup: (row) => ({ colspan: 3, content: <div css={Css.smEm.gray900.$}>{row.name}</div>, alignment: "left" }),
-  task: (task) => <Checkbox label="" onChange={action(`Select ${task.name}`)} />,
+  task: (task) => <Checkbox label="" selected={false} onChange={action(`Select ${task.name}`)} />,
   add: "",
   w: "32px",
 });

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -1,10 +1,11 @@
 import { Meta } from "@storybook/react";
-import { ReactNode } from "react";
+import React, { ReactNode, useContext } from "react";
 import { Chips } from "src/components/Chips";
 import { Icon } from "src/components/Icon";
 import { CollapseToggle } from "src/components/Table/CollapseToggle";
 import { collapseColumn, column, dateColumn, numericColumn, selectColumn } from "src/components/Table/columns";
 import { emptyCell, GridColumn, GridDataRow, GridTable } from "src/components/Table/GridTable";
+import { RowStateContext } from "src/components/Table/RowState";
 import { SimpleHeaderAndDataWith } from "src/components/Table/simpleHelpers";
 import {
   beamFixedStyle,
@@ -16,6 +17,7 @@ import {
 } from "src/components/Table/styles";
 import { Tag } from "src/components/Tag";
 import { Css, Palette } from "src/Css";
+import { useComputed } from "src/hooks";
 import { Checkbox, NumberField, SelectField } from "src/inputs";
 import { HasIdAndName } from "src/types";
 import { noop } from "src/utils";
@@ -220,6 +222,12 @@ const beamNestedColumns: GridColumn<BeamNestedRow>[] = [
     parent: (row) => <CollapseToggle row={row} />,
     child: emptyCell,
   }),
+  selectColumn<BeamNestedRow>({
+    totals: emptyCell,
+    header: (row) => ({ content: <Select id={row.id} /> }),
+    parent: (row) => ({ content: <Select id={row.id} /> }),
+    child: (row) => ({ content: <Select id={row.id} /> }),
+  }),
   column<BeamNestedRow>({
     totals: "Totals",
     header: "Cost Code",
@@ -293,8 +301,8 @@ function beamStyleColumns() {
   ];
 
   const selectCol = selectColumn<BeamRow>({
-    header: () => ({ content: <Checkbox label="Label" onChange={noop} checkboxOnly /> }),
-    data: () => ({ content: <Checkbox label="Label" onChange={noop} checkboxOnly /> }),
+    header: (row) => ({ content: <Select id={row.id} /> }),
+    data: (row) => ({ content: <Select id={row.id} /> }),
   });
   const favCol = column<BeamRow>({
     header: () => ({ content: "" }),
@@ -346,4 +354,20 @@ function beamStyleColumns() {
   });
 
   return [selectCol, favCol, statusCol, nameCol, tradeCol, locationCol, dateCol, priceCol, readOnlyPriceCol];
+}
+
+function Select({ id }: { id: string }) {
+  const { rowState } = useContext(RowStateContext);
+  const state = useComputed(() => rowState.getSelected(id), [rowState]);
+  const selected = state === "checked" ? true : state === "unchecked" ? false : "indeterminate";
+  return (
+    <Checkbox
+      label="Select"
+      checkboxOnly={true}
+      selected={selected}
+      onChange={(selected) => {
+        rowState.selectRow(id, selected);
+      }}
+    />
+  );
 }

--- a/src/forms/BoundCheckboxField.tsx
+++ b/src/forms/BoundCheckboxField.tsx
@@ -4,7 +4,7 @@ import { Checkbox, CheckboxProps } from "src/inputs";
 import { maybeCall, useTestIds } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
 
-export type BoundCheckboxFieldProps = Omit<CheckboxProps, "values" | "onChange" | "label"> & {
+export type BoundCheckboxFieldProps = Omit<CheckboxProps, "selected" | "onChange" | "label"> & {
   field: FieldState<any, boolean | null | undefined>;
   /** Make optional so that callers can override if they want to. */
   onChange?: (values: boolean) => void;

--- a/src/inputs/Checkbox.stories.tsx
+++ b/src/inputs/Checkbox.stories.tsx
@@ -16,14 +16,16 @@ export function Checkboxes() {
         <h2 css={Css.mb1.$}>Basic Checkboxes</h2>
         <div css={Css.dg.gap1.$}>
           <Checkbox
+            selected={false}
             onChange={action("onChange")}
             onFocus={action("onFocus")}
             onBlur={action("onBlur")}
             label="Default"
           />
-          <Checkbox onChange={action("onChange")} selected label="Selected" />
-          <Checkbox onChange={action("onChange")} indeterminate label="Indeterminate" />
-          <Checkbox onChange={action("onChange")} disabled label="Disabled" />
+          <Checkbox onChange={action("onChange")} selected={false} label="Selected" />
+          <Checkbox onChange={action("onChange")} selected="indeterminate" label="Indeterminate" />
+          <Checkbox onChange={action("onChange")} selected={false} disabled label="Disabled while unselected" />
+          <Checkbox onChange={action("onChange")} selected={true} disabled label="Disabled while selected" />
         </div>
       </div>
       <div>
@@ -33,6 +35,7 @@ export function Checkboxes() {
             onChange={action("onChange")}
             description="Get notified when someone posts a comment on a posting"
             label="Comments"
+            selected={false}
           />
         </div>
       </div>
@@ -40,6 +43,7 @@ export function Checkboxes() {
         <h2 css={Css.mb1.$}>Checkbox with error message and helper text</h2>
         <div>
           <Checkbox
+            selected={false}
             onChange={action("onChange")}
             description="Get notified when someone posts a comment on a posting"
             label="Comments"

--- a/src/inputs/Checkbox.test.tsx
+++ b/src/inputs/Checkbox.test.tsx
@@ -4,12 +4,12 @@ import { render } from "src/utils/rtl";
 
 describe("Checkbox", () => {
   it("can set default test ids", async () => {
-    const r = await render(<Checkbox label="Test Label" onChange={noop} />);
+    const r = await render(<Checkbox label="Test Label" selected={false} onChange={noop} />);
     expect(r.testLabel()).toBeTruthy();
   });
 
   it("can set explicit test ids", async () => {
-    const r = await render(<Checkbox label="Test Label" onChange={noop} data-testid="customId" />);
+    const r = await render(<Checkbox label="Test Label" selected={false} onChange={noop} data-testid="customId" />);
     expect(r.customId()).toBeTruthy();
   });
 });

--- a/src/inputs/Checkbox.test.tsx
+++ b/src/inputs/Checkbox.test.tsx
@@ -1,6 +1,6 @@
 import { Checkbox } from "src/inputs/Checkbox";
 import { noop } from "src/utils";
-import { render } from "src/utils/rtl";
+import { click, render } from "src/utils/rtl";
 
 describe("Checkbox", () => {
   it("can set default test ids", async () => {
@@ -11,5 +11,15 @@ describe("Checkbox", () => {
   it("can set explicit test ids", async () => {
     const r = await render(<Checkbox label="Test Label" selected={false} onChange={noop} data-testid="customId" />);
     expect(r.customId()).toBeTruthy();
+  });
+
+  it("treats indeterminate as false", async () => {
+    // Given an indeterminate checkbox
+    const onChange = jest.fn();
+    const r = await render(<Checkbox label="Test" selected="indeterminate" onChange={onChange} />);
+    // When the user clicks it
+    click(r.test);
+    // Then it becomes true
+    expect(onChange).toHaveBeenCalledWith(true);
   });
 });

--- a/src/inputs/Checkbox.tsx
+++ b/src/inputs/Checkbox.tsx
@@ -23,7 +23,7 @@ export interface CheckboxProps {
 export function Checkbox(props: CheckboxProps) {
   const { label, disabled: isDisabled = false, selected, ...otherProps } = props;
   // Treat indeterminate as false so that clicking on indeterminate always goes --> true.
-  const isSelected = selected === "indeterminate" ? false : selected;
+  const isSelected = selected === true;
   const isIndeterminate = selected === "indeterminate";
   const ariaProps = { isSelected, isDisabled, isIndeterminate, ...otherProps };
   const checkboxProps = { ...ariaProps, "aria-label": label };

--- a/src/inputs/Checkbox.tsx
+++ b/src/inputs/Checkbox.tsx
@@ -6,17 +6,12 @@ import { CheckboxBase } from "src/inputs/CheckboxBase";
 export interface CheckboxProps {
   label: string;
   checkboxOnly?: boolean;
+  selected: boolean | "indeterminate";
   /** Handler that is called when the element's selection state changes. */
   onChange: (selected: boolean) => void;
   /** Additional text displayed below label */
   description?: string;
   disabled?: boolean;
-  /**
-   * Indeterminism is presentational only.
-   * The indeterminate visual representation remains regardless of user interaction.
-   */
-  indeterminate?: boolean;
-  selected?: boolean;
   errorMsg?: string;
   helperText?: string | ReactNode;
   /** Callback fired when focus removes from the component */
@@ -26,18 +21,14 @@ export interface CheckboxProps {
 }
 
 export function Checkbox(props: CheckboxProps) {
-  const {
-    label,
-    indeterminate: isIndeterminate = false,
-    disabled: isDisabled = false,
-    selected,
-    ...otherProps
-  } = props;
-  const ariaProps = { isSelected: selected, isDisabled, isIndeterminate, ...otherProps };
+  const { label, disabled: isDisabled = false, selected, ...otherProps } = props;
+  // Treat indeterminate as false so that clicking on indeterminate always goes --> true.
+  const isSelected = selected === "indeterminate" ? false : selected;
+  const isIndeterminate = selected === "indeterminate";
+  const ariaProps = { isSelected, isDisabled, isIndeterminate, ...otherProps };
   const checkboxProps = { ...ariaProps, "aria-label": label };
   const ref = useRef(null);
   const toggleState = useToggleState(ariaProps);
-  const isSelected = toggleState.isSelected;
   const { inputProps } = useCheckbox(checkboxProps, toggleState, ref);
 
   return (


### PR DESCRIPTION
Leverages the new mobx-based `RowState` to add a map of `rowId` --> `checked | unchecked | partial`.

Uses the `Checkbox` `indeterminate` support to show partially-selected parents as indeterminate.

Handles clicking a parent --> make all children equally selected/unselected.

Handles clicking a child --> recalc it's parents "are you all/none/partially selected", recursively.

