### PR TITLE
fix(rich-text-field): async init had issues

### DIFF
--- a/src/inputs/RichTextField.test.tsx
+++ b/src/inputs/RichTextField.test.tsx
@@ -1,0 +1,16 @@
+import { render } from "@homebound/rtl-utils";
+import { noop } from "src/utils";
+import { RichTextField } from "./RichTextField";
+
+describe(RichTextField, () => {
+  it("renders", async () => {
+    const r = await render(<RichTextField value="<div>test</div>" onChange={noop} />);
+    expect(r.getByText("test")).toBeInTheDocument();
+  });
+
+  it("rehydrates if data populates", async () => {
+    const r = await render(<RichTextField value={""} onChange={noop} />);
+    r.rerender(<RichTextField value="<div><!--block-->test</div>" onChange={noop} />);
+    expect(r.getByText("test")).toBeInTheDocument();
+  });
+});

--- a/src/inputs/RichTextField.tsx
+++ b/src/inputs/RichTextField.tsx
@@ -1,6 +1,6 @@
 import { Global } from "@emotion/react";
 import DOMPurify from "dompurify";
-import { ChangeEvent, createElement, useEffect, useMemo, useRef } from "react";
+import { ChangeEvent, createElement, useEffect, useMemo, useRef, useState } from "react";
 import { Label } from "src/components/Label";
 import { Css, Palette } from "src/Css";
 import { maybeCall, noop } from "src/utils";
@@ -41,7 +41,7 @@ export function RichTextField(props: RichTextFieldProps) {
   const { mergeTags, label, value = "", onChange, onBlur = noop, onFocus = noop, readOnly } = props;
 
   // We get a reference to the Editor instance after trix-init fires
-  const editor = useRef<Editor | undefined>(undefined);
+  const [editor, setEditor] = useState<Editor>();
   const editorElement = useRef<HTMLElement>();
 
   // Keep track of what we pass to onChange, so that we can make ourselves keep looking
@@ -68,13 +68,14 @@ export function RichTextField(props: RichTextFieldProps) {
       const targetEl = e.target as HTMLElement;
       if (targetEl.id === id) {
         editorElement.current = targetEl;
-        editor.current = (editorElement.current as any).editor;
+        const editor = (editorElement.current as any).editor;
+        setEditor(editor);
         if (mergeTags !== undefined) {
           attachTributeJs(mergeTags, editorElement.current!);
         }
 
         currentHtml.current = value;
-        editor.current!.loadHTML(value || "");
+        editor.loadHTML(value || "");
         // Remove listener once we've initialized
         window.removeEventListener("trix-initialize", onEditorInit);
 
@@ -114,10 +115,10 @@ export function RichTextField(props: RichTextFieldProps) {
 
   useEffect(() => {
     // If our value prop changes (without the change coming from us), reload it
-    if (!readOnly && editor.current && value !== currentHtml.current) {
-      editor.current.loadHTML(value || "");
+    if (!readOnly && editor && value !== currentHtml.current) {
+      editor.loadHTML(value || "");
     }
-  }, [value, readOnly]);
+  }, [value, readOnly, editor]);
 
   const { placeholder, autoFocus } = props;
 


### PR DESCRIPTION
## Live Bug
Working example of the issue:

* Spam refresh on this page and the text will nondeterministically pop in and out of the textboxes https://blueprint.dev-homebound.com/development-commitments/dc:197?filter=%7B%7D&tab=scheduleAndScope

## Context/Issue
Some combination of Async Initialization and stale closures were leading to cases where, more often than not, either `editor.current` was undefined, or `value` was undefined.

* The useEffect would bail due to an undefined `editor.current` (After triggering from an external `value` update)
* And `value` would be `undefined` during the onEditorInit block

## The Chosen Fix
This change switches `editor` from a Ref to State so that **onEditorInit can trigger a rerender**, at which point the useEffect can do its job and re-sync the `value`

## Other Possible Fixes
We're abusing useMemo, which is intended to calculate a value, not induce side-effects. `onEditorInit` should be broken out into its own slice of code, potentially with a [useEventListener](https://usehooks.com/useEventListener/) hook or a useEffect. 