### PR TITLE
fix: Avoid stack errors with cyclic rows.

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1314,6 +1314,14 @@ describe("GridTable", () => {
     expect(cellOf(r, "customTestId", 0, 0).textContent).toBe("Name");
     expect(row(r, 0, "customTestId").textContent).toBe("NameValue");
   });
+
+  it("does not blow up when rows have circular references", async () => {
+    // Given rows that have a circular reference, i.e. from our GraphQL fragment factories
+    const row1 = rows[1];
+    (row1 as any).parent = row1;
+    // Then we can still render
+    await render(<GridTable rows={[row1]} columns={columns} />);
+  });
 });
 
 function Collapse({ id }: { id: string }) {

--- a/src/components/Table/RowState.ts
+++ b/src/components/Table/RowState.ts
@@ -34,7 +34,7 @@ export class RowState {
     this.collapsedRows = new ObservableSet(persistCollapse ? readLocalCollapseState(persistCollapse) : []);
     // Make ourselves an observable so that mobx will do caching of .collapseIds so
     // that it'll be a stable identity for GridTable to useMemo against.
-    makeAutoObservable(this);
+    makeAutoObservable(this, { rows: false } as any); // as any b/c rows is private, so the mapped type doesn't see it
   }
 
   get collapsedIds(): string[] {


### PR DESCRIPTION
We were unintentionally observing the RowState.rows field, which
was a ref to the rows themselves.

So when `RowState.rows.current` became "list of 100s of rows", we
were observizing them.

Which a) we should not do b/c it'd be a perf hint, but b) only blew
up if the rows had circular references which typically only happens
when our factories create dummy GraphQL fragment data.

So I reproduced that setup here, and then told mobx to not observe
the rows field.