### PR TITLE
feat: Export SelectToggle, make selectColumn provide by default.

### DIFF
--- a/src/components/Table/CollapseToggle.tsx
+++ b/src/components/Table/CollapseToggle.tsx
@@ -6,6 +6,7 @@ export interface GridTableCollapseToggleProps {
   row: GridDataRow<any>;
 }
 
+/** Provides a chevron icons to collapse/un-collapse for parent/child tables. */
 export function CollapseToggle(props: GridTableCollapseToggleProps) {
   const { row } = props;
   const { rowState } = useContext(RowStateContext);

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1059,7 +1059,7 @@ describe("GridTable", () => {
         ],
       },
     ];
-    const api: MutableRefObject<GridTableApi | undefined> = { current: undefined };
+    const api: MutableRefObject<GridTableApi<NestedRow> | undefined> = { current: undefined };
     const r = await render(<GridTable<NestedRow> api={api} columns={nestedColumns} rows={rows} />);
     // And all three rows are initially rendered
     expect(cell(r, 1, 2)).toHaveTextContent("parent 1");
@@ -1075,6 +1075,7 @@ describe("GridTable", () => {
     expect(cellAnd(r, 3, 1, "select")).toBeChecked();
     // And the api can fetch them
     expect(api.current!.getSelectedRowIds()).toEqual(["p1", "p1c1", "p1c1g1"]);
+    expect(api.current!.getSelectedRows()).toEqual([rows[1], rows[1].children![0], rows[1].children![0].children![0]]);
 
     // And when we unselect all
     click(cell(r, 0, 1).children[0] as any);

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -17,6 +17,7 @@ import { RowState, RowStateContext } from "src/components/Table/RowState";
 import { SortHeader } from "src/components/Table/SortHeader";
 import { ensureClientSideSortValueIsSortable, sortRows } from "src/components/Table/sortRows";
 import { SortState, useSortState } from "src/components/Table/useSortState";
+import { visit } from "src/components/Table/visitor";
 import { Css, Margin, Only, Properties, Typography, Xss } from "src/Css";
 import { useComputed } from "src/hooks";
 import tinycolor from "tinycolor2";
@@ -214,17 +215,20 @@ export interface GridTableProps<R extends Kinded, S, X> {
   persistCollapse?: string;
   xss?: X;
   /** Experimental API allowing one to scroll to a table index. Primarily intended for stories at the moment */
-  api?: MutableRefObject<GridTableApi | undefined>;
+  api?: MutableRefObject<GridTableApi<R> | undefined>;
   /** Experimental, expecting to be removed - Specify the element in which the table should resize its columns against. If not set, the table will resize columns based on its owns container's width */
   resizeTarget?: MutableRefObject<HTMLElement | null>;
 }
 
 /** NOTE: This API is experimental and primarily intended for story and testing purposes */
-export type GridTableApi = {
+export type GridTableApi<R extends Kinded> = {
   scrollToIndex: (index: number) => void;
 
   /** Returns the ids of currently-selected rows. */
   getSelectedRowIds(): string[];
+
+  /** Returns the currently-selected rows. */
+  getSelectedRows(): GridDataRow<R>[];
 };
 
 /**
@@ -281,6 +285,16 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
     api.current = {
       scrollToIndex: (index) => virtuosoRef.current && virtuosoRef.current.scrollToIndex(index),
       getSelectedRowIds: () => rowState.selectedIds,
+      getSelectedRows(): GridDataRow<R>[] {
+        const ids = rowState.selectedIds;
+        const selected: GridDataRow<R>[] = [];
+        visit(rows, (row) => {
+          if (ids.includes(row.id)) {
+            selected.push(row as any);
+          }
+        });
+        return selected;
+      },
     };
   }
 

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -817,6 +817,8 @@ export type GridColumn<R extends Kinded, S = {}> = {
   serverSideSortKey?: S;
 };
 
+export const nonKindGridColumnKeys = ["w", "mw", "align", "clientSideSort", "serverSideSortKey"];
+
 /** Allows rendering a specific cell. */
 type RenderCellFn<R extends Kinded> = (
   idx: number,

--- a/src/components/Table/RowState.ts
+++ b/src/components/Table/RowState.ts
@@ -1,6 +1,7 @@
 import { makeAutoObservable, ObservableMap, ObservableSet } from "mobx";
 import React, { MutableRefObject } from "react";
 import { GridDataRow } from "src/components/Table/GridTable";
+import { visit } from "src/components/Table/visitor";
 
 // A parent row can be partially selected when some children are selected/some aren't.
 export type SelectedState = "checked" | "unchecked" | "partial";
@@ -184,15 +185,4 @@ function deriveParentSelected(children: SelectedState[]): SelectedState {
   const allChecked = children.every((child) => child === "checked");
   const allUnchecked = children.every((child) => child === "unchecked");
   return allChecked ? "checked" : allUnchecked ? "unchecked" : "partial";
-}
-
-function visit(rows: GridDataRow<any>[], fn: (row: GridDataRow<any>) => void): void {
-  const todo = [...rows];
-  while (todo.length > 0) {
-    const row = todo.pop()!;
-    fn(row);
-    if (row.children) {
-      todo.push(...row.children);
-    }
-  }
 }

--- a/src/components/Table/SchedulesV2.stories.tsx
+++ b/src/components/Table/SchedulesV2.stories.tsx
@@ -225,7 +225,7 @@ export function SchedulesV2() {
 SchedulesV2.storyName = "SchedulesV2";
 
 export function SchedulesV2Virtualized() {
-  const api = useRef<GridTableApi>();
+  const api = useRef<GridTableApi<Row>>();
 
   // Scroll to the bottom of the page before taking snapshot
   useEffect(() => {

--- a/src/components/Table/SelectToggle.tsx
+++ b/src/components/Table/SelectToggle.tsx
@@ -1,0 +1,21 @@
+import React, { useContext } from "react";
+import { RowStateContext } from "src/components/Table/RowState";
+import { useComputed } from "src/hooks/index";
+import { Checkbox } from "src/inputs/index";
+
+/** Provides a checkbox to show/drive this row's selected state. */
+export function SelectToggle({ id }: { id: string }) {
+  const { rowState } = useContext(RowStateContext);
+  const state = useComputed(() => rowState.getSelected(id), [rowState]);
+  const selected = state === "checked" ? true : state === "unchecked" ? false : "indeterminate";
+  return (
+    <Checkbox
+      label="Select"
+      checkboxOnly={true}
+      selected={selected}
+      onChange={(selected) => {
+        rowState.selectRow(id, selected);
+      }}
+    />
+  );
+}

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -1,11 +1,10 @@
 import { Meta } from "@storybook/react";
-import React, { ReactNode, useContext } from "react";
+import React, { ReactNode } from "react";
 import { Chips } from "src/components/Chips";
 import { Icon } from "src/components/Icon";
 import { CollapseToggle } from "src/components/Table/CollapseToggle";
 import { collapseColumn, column, dateColumn, numericColumn, selectColumn } from "src/components/Table/columns";
 import { emptyCell, GridColumn, GridDataRow, GridTable } from "src/components/Table/GridTable";
-import { RowStateContext } from "src/components/Table/RowState";
 import { SimpleHeaderAndDataWith } from "src/components/Table/simpleHelpers";
 import {
   beamFixedStyle,
@@ -17,8 +16,7 @@ import {
 } from "src/components/Table/styles";
 import { Tag } from "src/components/Tag";
 import { Css, Palette } from "src/Css";
-import { useComputed } from "src/hooks";
-import { Checkbox, NumberField, SelectField } from "src/inputs";
+import { NumberField, SelectField } from "src/inputs";
 import { HasIdAndName } from "src/types";
 import { noop } from "src/utils";
 import { zeroTo } from "src/utils/sb";
@@ -222,12 +220,7 @@ const beamNestedColumns: GridColumn<BeamNestedRow>[] = [
     parent: (row) => <CollapseToggle row={row} />,
     child: emptyCell,
   }),
-  selectColumn<BeamNestedRow>({
-    totals: emptyCell,
-    header: (row) => ({ content: <Select id={row.id} /> }),
-    parent: (row) => ({ content: <Select id={row.id} /> }),
-    child: (row) => ({ content: <Select id={row.id} /> }),
-  }),
+  selectColumn<BeamNestedRow>({ totals: emptyCell }),
   column<BeamNestedRow>({
     totals: "Totals",
     header: "Cost Code",
@@ -300,10 +293,7 @@ function beamStyleColumns() {
     { id: "l:2", name: "Great Room" },
   ];
 
-  const selectCol = selectColumn<BeamRow>({
-    header: (row) => ({ content: <Select id={row.id} /> }),
-    data: (row) => ({ content: <Select id={row.id} /> }),
-  });
+  const selectCol = selectColumn<BeamRow>();
   const favCol = column<BeamRow>({
     header: () => ({ content: "" }),
     data: ({ favorite }) => ({
@@ -354,20 +344,4 @@ function beamStyleColumns() {
   });
 
   return [selectCol, favCol, statusCol, nameCol, tradeCol, locationCol, dateCol, priceCol, readOnlyPriceCol];
-}
-
-function Select({ id }: { id: string }) {
-  const { rowState } = useContext(RowStateContext);
-  const state = useComputed(() => rowState.getSelected(id), [rowState]);
-  const selected = state === "checked" ? true : state === "unchecked" ? false : "indeterminate";
-  return (
-    <Checkbox
-      label="Select"
-      checkboxOnly={true}
-      selected={selected}
-      onChange={(selected) => {
-        rowState.selectRow(id, selected);
-      }}
-    />
-  );
 }

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -2,7 +2,6 @@ import { Meta } from "@storybook/react";
 import React, { ReactNode } from "react";
 import { Chips } from "src/components/Chips";
 import { Icon } from "src/components/Icon";
-import { CollapseToggle } from "src/components/Table/CollapseToggle";
 import { collapseColumn, column, dateColumn, numericColumn, selectColumn } from "src/components/Table/columns";
 import { emptyCell, GridColumn, GridDataRow, GridTable } from "src/components/Table/GridTable";
 import { SimpleHeaderAndDataWith } from "src/components/Table/simpleHelpers";
@@ -214,12 +213,7 @@ function RollUpTotal({ num }: { num?: number }) {
 }
 
 const beamNestedColumns: GridColumn<BeamNestedRow>[] = [
-  collapseColumn<BeamNestedRow>({
-    totals: emptyCell,
-    header: (row) => <CollapseToggle row={row} />,
-    parent: (row) => <CollapseToggle row={row} />,
-    child: emptyCell,
-  }),
+  collapseColumn<BeamNestedRow>({ totals: emptyCell }),
   selectColumn<BeamNestedRow>({ totals: emptyCell }),
   column<BeamNestedRow>({
     totals: "Totals",

--- a/src/components/Table/columns.tsx
+++ b/src/components/Table/columns.tsx
@@ -1,3 +1,4 @@
+import { CollapseToggle } from "src/components/Table/CollapseToggle";
 import { GridColumn, Kinded, nonKindGridColumnKeys } from "src/components/Table/GridTable";
 import { SelectToggle } from "src/components/Table/SelectToggle";
 import { newMethodMissingProxy } from "src/utils/index";
@@ -24,14 +25,15 @@ export function actionColumn<T extends Kinded, S = {}>(columnDef: GridColumn<T, 
 }
 
 /**
- *  Provides default styling for a GridColumn containing a checkbox.
+ * Provides default styling for a GridColumn containing a checkbox.
  *
  * We allow either no `columnDef` at all, or a partial column def (i.e. to say a Totals row should
- * not have a `SelectToggle`, b/c we can provide the default behavior a SelectToggle for basically
+ * not have a `SelectToggle`, b/c we can provide the default behavior a `SelectToggle` for basically
  * all rows.
  */
 export function selectColumn<T extends Kinded, S = {}>(columnDef?: Partial<GridColumn<T, S>>): GridColumn<T, S> {
   const base = {
+    ...nonKindDefaults(),
     clientSideSort: false,
     align: "center",
     // Defining `w: 48px` to accommodate for the `16px` wide checkbox and `16px` of padding on either side.
@@ -40,16 +42,32 @@ export function selectColumn<T extends Kinded, S = {}>(columnDef?: Partial<GridC
     ...columnDef,
   };
   return newMethodMissingProxy(base, (key) => {
-    // Look for things like mw
-    if (nonKindGridColumnKeys.includes(key)) {
-      return undefined;
-    }
     return (row: any) => ({ content: <SelectToggle id={row.id} /> });
   }) as any;
 }
 
-/** Provides default styling for a GridColumn containing the CollapseToggle component. */
-export function collapseColumn<T extends Kinded, S = {}>(columnDef: GridColumn<T, S>): GridColumn<T, S> {
-  // Defining `w: 38px` based on the designs
-  return { ...columnDef, clientSideSort: false, align: "center", w: "38px" };
+/**
+ * Provides default styling for a GridColumn containing a collapse icon.
+ *
+ * We allow either no `columnDef` at all, or a partial column def (i.e. to say a Totals row should
+ * not have a `CollapseToggle`, b/c we can provide the default behavior a `CollapseToggle` for basically
+ * all rows.
+ */
+export function collapseColumn<T extends Kinded, S = {}>(columnDef?: Partial<GridColumn<T, S>>): GridColumn<T, S> {
+  const base = {
+    ...nonKindDefaults(),
+    clientSideSort: false,
+    align: "center",
+    // Defining `w: 38px` based on the designs
+    w: "38px",
+    ...columnDef,
+  };
+  return newMethodMissingProxy(base, (key) => {
+    return (row: any) => ({ content: <CollapseToggle row={row} /> });
+  }) as any;
+}
+
+// Keep keys like `w` and `mw` from hitting the method missing proxy
+function nonKindDefaults() {
+  return Object.fromEntries(nonKindGridColumnKeys.map((key) => [key, undefined]));
 }

--- a/src/components/Table/columns.tsx
+++ b/src/components/Table/columns.tsx
@@ -1,4 +1,6 @@
-import { GridColumn, Kinded } from "src/components/Table/GridTable";
+import { GridColumn, Kinded, nonKindGridColumnKeys } from "src/components/Table/GridTable";
+import { SelectToggle } from "src/components/Table/SelectToggle";
+import { newMethodMissingProxy } from "src/utils/index";
 
 /** Provides default styling for a GridColumn representing a Date. */
 export function column<T extends Kinded, S = {}>(columnDef: GridColumn<T, S>): GridColumn<T, S> {
@@ -21,10 +23,29 @@ export function actionColumn<T extends Kinded, S = {}>(columnDef: GridColumn<T, 
   return { clientSideSort: false, ...columnDef, align: "center" };
 }
 
-/** Provides default styling for a GridColumn containing a checkbox. */
-export function selectColumn<T extends Kinded, S = {}>(columnDef: GridColumn<T, S>): GridColumn<T, S> {
-  // Defining `w: 48px` to accommodate for the `16px` wide checkbox and `16px` of padding on either side.
-  return { clientSideSort: false, ...columnDef, align: "center", w: "48px" };
+/**
+ *  Provides default styling for a GridColumn containing a checkbox.
+ *
+ * We allow either no `columnDef` at all, or a partial column def (i.e. to say a Totals row should
+ * not have a `SelectToggle`, b/c we can provide the default behavior a SelectToggle for basically
+ * all rows.
+ */
+export function selectColumn<T extends Kinded, S = {}>(columnDef?: Partial<GridColumn<T, S>>): GridColumn<T, S> {
+  const base = {
+    clientSideSort: false,
+    align: "center",
+    // Defining `w: 48px` to accommodate for the `16px` wide checkbox and `16px` of padding on either side.
+    w: "48px",
+    // Use any of the user's per-row kind methods if they have them.
+    ...columnDef,
+  };
+  return newMethodMissingProxy(base, (key) => {
+    // Look for things like mw
+    if (nonKindGridColumnKeys.includes(key)) {
+      return undefined;
+    }
+    return (row: any) => ({ content: <SelectToggle id={row.id} /> });
+  }) as any;
 }
 
 /** Provides default styling for a GridColumn containing the CollapseToggle component. */

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -20,6 +20,7 @@ export type {
   setRunningInJest,
 } from "./GridTable";
 export { RowState, RowStateContext } from "./RowState";
+export * from "./SelectToggle";
 export { simpleDataRows, simpleHeader, simpleRows } from "./simpleHelpers";
 export type { SimpleHeaderAndDataOf, SimpleHeaderAndDataWith } from "./simpleHelpers";
 export { SortHeader } from "./SortHeader";

--- a/src/components/Table/visitor.ts
+++ b/src/components/Table/visitor.ts
@@ -1,0 +1,12 @@
+import { GridDataRow } from "src/components/Table/GridTable";
+
+export function visit(rows: GridDataRow<any>[], fn: (row: GridDataRow<any>) => void): void {
+  const todo = [...rows];
+  while (todo.length > 0) {
+    const row = todo.pop()!;
+    fn(row);
+    if (row.children) {
+      todo.push(...row.children);
+    }
+  }
+}

--- a/src/utils/useTestIds.tsx
+++ b/src/utils/useTestIds.tsx
@@ -45,7 +45,7 @@ export function useTestIds(props: object, defaultPrefix?: string): Record<string
 }
 
 /** Uses `object` for any keys that exist on it, otherwise calls `methodMissing` fn. */
-function newMethodMissingProxy<T extends object, Y>(
+export function newMethodMissingProxy<T extends object, Y>(
   object: T,
   methodMissing: (key: string) => Y,
 ): T & Record<string, Y> {


### PR DESCRIPTION
Export `SelectToggle` so that it can be used directly downstream in Blueprint.

Also make the `selectColumn` smarter such that, unless users need to override specific row kinds (i.e. for a totals row that is not selectable), then merely `selectColumn()` will do the right thing and provide a `SelectToggle` for each of the table's row kinds.

...

I also did the same thing for `collapseColumn`.

And also added a `GridTableApi.getSelectedRows` (in addition to the current `GridTableApi.getSelectedRowIds`).