### PR TITLE
chore(grid-table): fallback message styling

### DIFF
--- a/src/components/Table/styles.tsx
+++ b/src/components/Table/styles.tsx
@@ -12,7 +12,7 @@ export const defaultStyle: GridStyle = {
   indentOneCss: Css.pl4.$,
   indentTwoCss: Css.pl7.$,
   headerCellCss: Css.nowrap.py1.bgGray100.aife.$,
-  firstRowMessageCss: Css.px1.py2.$,
+  firstRowMessageCss: Css.tc.p3.$,
 };
 
 /** Tightens up the padding of rows, great for rows that have form elements in them. */


### PR DESCRIPTION
Updates fallback message styling 

<details><summary>From...</summary>
<img width="773" alt="image" src="https://user-images.githubusercontent.com/20718430/160187461-c69c9ff7-c79c-4070-b1c8-3b212c87912b.png">

</details>

To this:

<img width="775" alt="image" src="https://user-images.githubusercontent.com/20718430/160186224-ae26ef0f-2a6a-4362-8bda-73551ddf340b.png">

I also wanted to update the Fallback message from `string` to `ReactNode` but that started to cascade and I didn't feel it was worth the trouble right now.