### PR TITLE
feat: Add kind filters to selected rows.

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1108,7 +1108,9 @@ describe("GridTable", () => {
     expect(cellAnd(r, 3, 1, "select")).toBeChecked();
     // And the api can fetch them
     expect(api.current!.getSelectedRowIds()).toEqual(["p1", "p1c1", "p1c1g1"]);
+    expect(api.current!.getSelectedRowIds("child")).toEqual(["p1c1"]);
     expect(api.current!.getSelectedRows()).toEqual([rows[1], rows[1].children![0], rows[1].children![0].children![0]]);
+    expect(api.current!.getSelectedRows("child")).toEqual([rows[1].children![0]]);
 
     // And when we unselect all
     click(cell(r, 0, 1).children[0] as any);


### PR DESCRIPTION
To easily ask for e.g. only children and skip the header + group rows that are selected.

Existing methods to get all:

```typescript
    expect(api.current!.getSelectedRowIds()).toEqual(["p1", "p1c1", "p1c1g1"]);
    expect(api.current!.getSelectedRows()).toEqual([rows[1], rows[1].children![0], rows[1].children![0].children![0]]);
```

New methods to get by kind:

```typescript
    expect(api.current!.getSelectedRowIds("child")).toEqual(["p1c1"]);
    expect(api.current!.getSelectedRows("child")).toEqual([rows[1].children![0]]);
```

The return type of `getSelectedRows("child")` will also be narrowed to the specific ADT type, i.e. if it was `type Row = HeaderRow | ParentRow | ChildRow`, the return value will be `GridDataRow<ChildRow>`, so the caller can access any child-specific data.