### PR TITLE
feat: GridTable improvements

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -25,6 +25,7 @@ import {
   SimpleHeaderAndDataOf,
 } from "src/components/index";
 import { Css, Palette } from "src/Css";
+import { TextField } from "src/inputs";
 import { NumberField } from "src/inputs/NumberField";
 import { noop } from "src/utils";
 import { newStory, withDimensions, withRouter, zeroTo } from "src/utils/sb";
@@ -269,6 +270,7 @@ function NestedCards({ rows, as, sorting, style }: NestedCardsProps) {
     add: () => "",
     clientSideSort: false,
   };
+
   const spacing = { brPx: 4, pxPx: 4 };
   const nestedStyle: GridStyle = {
     nestedCards: {
@@ -282,15 +284,28 @@ function NestedCards({ rows, as, sorting, style }: NestedCardsProps) {
       },
     },
   };
+  const [filter, setFilter] = useState<string>();
 
   return (
-    <GridTable
-      as={as}
-      columns={[nameColumn, nameColumn, actionColumn]}
-      rows={rows}
-      style={style ?? nestedStyle}
-      sorting={sorting}
-    />
+    <>
+      <TextField
+        label="Filter"
+        hideLabel
+        placeholder="Search"
+        value={filter}
+        onChange={setFilter}
+        startAdornment={<Icon icon="search" />}
+        clearable
+      />
+      <GridTable
+        as={as}
+        columns={[nameColumn, nameColumn, actionColumn]}
+        rows={rows}
+        style={style ?? nestedStyle}
+        sorting={sorting}
+        filter={filter}
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
Updates include:
- Selected state for parent rows is rederived when child rows change (either by filter or adding new)
- Selecting a parent element only selects visible child rows
- When filtering, parent rows remain in the filtered list if any of their children match the filter. This keeps the nested structure intact.