### PR TITLE
feat: Add useGridTableApi hook as a better ref

### DIFF
--- a/src/components/Table/CollapseToggle.test.tsx
+++ b/src/components/Table/CollapseToggle.test.tsx
@@ -4,7 +4,7 @@ import { render } from "src/utils/rtl";
 
 describe("CollapseToggle", () => {
   it("defaults to uncollapsed", async () => {
-    const rowState = new RowState(null!, undefined, undefined);
+    const rowState = new RowState();
     const r = await render(
       <RowStateContext.Provider value={{ rowState }}>
         <CollapseToggle row={{ id: "r:1", kind: "header" }} />
@@ -19,7 +19,7 @@ describe("CollapseToggle", () => {
     [true, "otherKind", "chevronRight"],
     [false, "otherKind", "chevronDown"],
   ])("displays the correct chevron based on context and kind", async (isCollapsed, kind, expectedIcon) => {
-    const rowState = new RowState(null!, undefined, undefined);
+    const rowState = new RowState();
     if (isCollapsed) {
       rowState.toggleCollapsed("r:1");
     }
@@ -32,7 +32,7 @@ describe("CollapseToggle", () => {
   });
 
   it("only renders for non-header rows when there are children", async () => {
-    const rowState = new RowState(null!, undefined, undefined);
+    const rowState = new RowState();
     const r = await render(
       <RowStateContext.Provider value={{ rowState }}>
         <CollapseToggle row={{ id: "r:1", kind: "otherKind", children: [] }} />

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -9,10 +9,10 @@ import {
   GridRowStyles,
   GridStyle,
   GridTable,
-  GridTableApi,
   matchesFilter,
   setRunningInJest,
 } from "src/components/Table/GridTable";
+import { GridTableApi, useGridTableApi } from "src/components/Table/GridTableApi";
 import { RowStateContext } from "src/components/Table/RowState";
 import {
   simpleDataRows,
@@ -1136,7 +1136,12 @@ describe("GridTable", () => {
       },
     ];
     const api: MutableRefObject<GridTableApi<NestedRow> | undefined> = { current: undefined };
-    const r = await render(<GridTable<NestedRow> api={api} columns={nestedColumns} rows={rows} />);
+    function Test() {
+      const _api = useGridTableApi<NestedRow>();
+      api.current = _api;
+      return <GridTable<NestedRow> api={_api} columns={nestedColumns} rows={rows} />;
+    }
+    const r = await render(<Test />);
     // And all three rows are initially rendered
     expect(cell(r, 1, 2)).toHaveTextContent("parent 1");
     expect(cell(r, 2, 2)).toHaveTextContent("child p1c1");
@@ -1626,7 +1631,9 @@ function TestFilterAndSelect(props: {
   api: MutableRefObject<GridTableApi<NestedRow> | undefined>;
   rows: GridDataRow<NestedRow>[];
 }) {
-  const { api, rows } = props;
+  const { api: apiRef, rows } = props;
+  const api = useGridTableApi<NestedRow>();
+  apiRef.current = api;
   const [filter, setFilter] = useState<string | undefined>("");
   return (
     <div>

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -1,0 +1,84 @@
+import { MutableRefObject, useMemo } from "react";
+import { VirtuosoHandle } from "react-virtuoso";
+import { DiscriminateUnion, GridDataRow, Kinded } from "src/components/Table/GridTable";
+import { RowState } from "src/components/Table/RowState";
+import { visit } from "src/components/Table/visitor";
+
+/**
+ * Creates an `api` handle to drive a `GridTable`.
+ *
+ * ```
+ * const api = useGridTableApi<Row>();
+ * const count = useComputed(() => api.getSelectedRows().length, [api]);
+ * ...
+ * return <GridTable api={api} />
+ * ```
+ *
+ * This is very similar to a `useRef`, except that the parent function has
+ * immediate access to `api` and can use it for `useComputed`, instead of
+ * having to wait for `ref.current` to be set after the child `GridTable`
+ * has ran.
+ */
+export function useGridTableApi<R extends Kinded>(): GridTableApi<R> {
+  return useMemo(() => new GridTableApiImpl<R>(), []);
+}
+
+/** Provides an imperative API for an application page to interact with the table. */
+export type GridTableApi<R extends Kinded> = {
+  /** Scrolls row `index` into view; only supported with `as=virtual` and after a `useEffect`. */
+  scrollToIndex: (index: number) => void;
+
+  /** Returns the ids of currently-selected rows. */
+  getSelectedRowIds(): string[];
+  getSelectedRowIds<K extends R["kind"]>(kind: K): string[];
+
+  /** Returns the currently-selected rows. */
+  getSelectedRows(): GridDataRow<R>[];
+  getSelectedRows<K extends R["kind"]>(kind: K): GridDataRow<DiscriminateUnion<R, "kind", K>>[];
+
+  /** Sets the internal state of 'activeRowId' */
+  setActiveRowId: (id: string | undefined) => void;
+};
+
+// Using `FooImpl`to keep the public GridTableApi definition separate.
+export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
+  // This is public to GridTable but not exported outside of Beam
+  readonly rowState: RowState = new RowState();
+  virtuosoRef: MutableRefObject<VirtuosoHandle | null> = { current: null };
+
+  /** Called once by the GridTable when it takes ownership of this api instance. */
+  init(persistCollapse: string | undefined, virtuosoRef: MutableRefObject<VirtuosoHandle | null>) {
+    if (persistCollapse) {
+      this.rowState.loadPersistedCollapse(persistCollapse);
+    }
+    this.virtuosoRef = virtuosoRef;
+  }
+
+  public scrollToIndex(index: number): void {
+    this.virtuosoRef.current && this.virtuosoRef.current.scrollToIndex(index);
+  }
+
+  public getSelectedRowIds(kind?: string): string[] {
+    if (kind === undefined) {
+      return this.rowState.selectedIds;
+    } else {
+      return this.getSelectedRows(kind).map((row: any) => row.id);
+    }
+  }
+
+  // The any is not great, but getting the overload to handle the optional kind is annoying
+  public getSelectedRows(kind?: string): any {
+    const ids = this.rowState.selectedIds;
+    const selected: GridDataRow<R>[] = [];
+    visit(this.rowState.rows, (row) => {
+      if (ids.includes(row.id) && (!kind || row.kind === kind)) {
+        selected.push(row as any);
+      }
+    });
+    return selected;
+  }
+
+  public setActiveRowId(id: string | undefined) {
+    this.rowState.activeRowId = id;
+  }
+}

--- a/src/components/Table/SchedulesV2.stories.tsx
+++ b/src/components/Table/SchedulesV2.stories.tsx
@@ -6,12 +6,13 @@ import { DragDropContext, DragDropContextProps, Draggable, Droppable } from "rea
 import { TaskStatus } from "src/components/Filters/testDomain";
 import { PresentationProvider } from "src/components/PresentationContext";
 import { CollapseToggle, GridStyle, GridTable } from "src/components/Table";
+import { useGridTableApi } from "src/components/Table/GridTableApi";
 import { Css, Palette } from "src/Css";
 import { Checkbox, DateField, NumberField, SelectField, TextAreaField } from "src/inputs";
 import { zeroTo } from "src/utils/sb";
 import { Icon } from "../Icon";
 import { actionColumn, column, dateColumn } from "./columns";
-import { GridDataRow, GridTableApi } from "./GridTable";
+import { GridDataRow } from "./GridTable";
 
 export default {
   title: "Pages / SchedulesV2",
@@ -225,13 +226,11 @@ export function SchedulesV2() {
 SchedulesV2.storyName = "SchedulesV2";
 
 export function SchedulesV2Virtualized() {
-  const api = useRef<GridTableApi<Row>>();
+  const api = useGridTableApi<Row>();
 
   // Scroll to the bottom of the page before taking snapshot
   useEffect(() => {
-    if (api.current) {
-      api.current.scrollToIndex(50);
-    }
+    api.scrollToIndex(50);
   });
 
   return (

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -3,14 +3,8 @@ import { default as React, ReactNode, useMemo, useState } from "react";
 import { Chips } from "src/components/Chips";
 import { Icon } from "src/components/Icon";
 import { collapseColumn, column, dateColumn, numericColumn, selectColumn } from "src/components/Table/columns";
-import {
-  emptyCell,
-  GridColumn,
-  GridDataRow,
-  GridSortConfig,
-  GridTable,
-  GridTableApi,
-} from "src/components/Table/GridTable";
+import { emptyCell, GridColumn, GridDataRow, GridSortConfig, GridTable } from "src/components/Table/GridTable";
+import { useGridTableApi } from "src/components/Table/GridTableApi";
 import { SimpleHeaderAndDataWith } from "src/components/Table/simpleHelpers";
 import {
   beamFixedStyle,
@@ -122,9 +116,8 @@ export function NestedFlexible() {
 // 2. Select individual "Project Items". Note parent is "checked"
 // 3. Remove filter, additional project items under parent are "unchecked", though parent still shows "checked" instead of what it should show as "indeterminate".
 export function Filterable() {
-  // Using a useState so that useComputed works
-  const [api, setApi] = useState<GridTableApi<BeamNestedRow> | null>();
-  const selectedIds = useComputed(() => api?.getSelectedRows().map((r) => r.id) || [], [api]);
+  const api = useGridTableApi<BeamNestedRow>();
+  const selectedIds = useComputed(() => api.getSelectedRows().map((r) => r.id), [api]);
 
   // This is useful to debug if doing `visibleRows.replace` in `RowState`
   // spams the page component to re-render in a not-infinite-but-still-unhelpful loop.
@@ -157,13 +150,7 @@ export function Filterable() {
         rows={beamNestedRows}
         stickyHeader
         filter={filter}
-        api={{
-          set current(newApi: GridTableApi<any>) {
-            if (api !== newApi) {
-              setApi(newApi);
-            }
-          },
-        }}
+        api={api}
       />
     </div>
   );

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -19,6 +19,8 @@ export type {
   RowStyle,
   setRunningInJest,
 } from "./GridTable";
+export { useGridTableApi } from "./GridTableApi";
+export type { GridTableApi } from "./GridTableApi";
 export { RowState, RowStateContext } from "./RowState";
 export * from "./SelectToggle";
 export { simpleDataRows, simpleHeader, simpleRows } from "./simpleHelpers";


### PR DESCRIPTION
We have a chicken-vs-egg condition with our current GridTable ref-based approach:

```
const api = useRef();
// can't actually use the api yet...
const count = useComputed(() => ..., [api]);
// now api will be set, but we'll only know about it after either
// a useEffect or a re-render.
return <GridTable api={api} />;
```

The "refs are only set after DOM elements are available" makes a lot of sense for DOM elements.

But we want the function to have immediate access to the GridTable API, to set up reactivity on things like which rows are selected.

To provide this, we just let the caller instantiate the api directly:

```
const api = useGridTableApi();
// Can immediately use it
const count = useComputed(() => api.selectedRows.length, [api]);
// Pass it to GridTable
return <GridTable api={api} />
```

And have GridTable internally realize, before it goes off and makes "an api" or "a row state", to check to see if the caller passed one in, and use that instead.
