### PR TITLE
feat: Expand support of tooltips via disabled and readOnly

### DIFF
--- a/src/inputs/DateField.mock.tsx
+++ b/src/inputs/DateField.mock.tsx
@@ -21,7 +21,7 @@ export function DateField(props: DateFieldProps) {
       onBlur={() => maybeCall(onBlur)}
       onFocus={() => maybeCall(onFocus)}
       disabled={!!props.disabled}
-      readOnly={props.readOnly}
+      readOnly={!!props.readOnly}
       data-disabled-days={JSON.stringify(props.disabledDays)}
     />
   );

--- a/src/inputs/DateField.stories.tsx
+++ b/src/inputs/DateField.stories.tsx
@@ -20,7 +20,7 @@ export function DateFields() {
     ["With Label", <TestDateField label="Projected Client Presentation Date" />],
     ["Disabled", <TestDateField label="Start Date" disabled="Disabled Reason" />],
     ["Inline Label", <TestDateField label="Start Date" inlineLabel />],
-    ["Read Only", <TestDateField label="Start Date" readOnly />],
+    ["Read Only", <TestDateField label="Start Date" readOnly="Read only reason tooltip" />],
     ["Read Only Long", <TestDateField label="Start Date" readOnly format="long" />],
     ["Error Message", <TestDateField label="Start Date" errorMsg="Required" />],
     [

--- a/src/inputs/NumberField.stories.tsx
+++ b/src/inputs/NumberField.stories.tsx
@@ -17,8 +17,8 @@ export function NumberFieldStyles() {
         <h1 css={Css.lg.$}>Regular</h1>
         <TestNumberField value={0} label="Age" hideLabel />
         <TestNumberField label="Age" value={1000} />
-        <TestNumberField label="Age Disabled" value={1000} disabled />
-        <TestNumberField label="Age Read Only" value={1000} readOnly />
+        <TestNumberField label="Age Disabled" value={1000} disabled="Disabled reason tooltip" />
+        <TestNumberField label="Age Read Only" value={1000} readOnly="Read only reason tooltip" />
         <TestNumberField
           label="Age Read Helper Text"
           value={1000}

--- a/src/inputs/TextAreaField.stories.tsx
+++ b/src/inputs/TextAreaField.stories.tsx
@@ -18,7 +18,11 @@ export function TextAreaStyles() {
         <TestTextArea value="" label="Description" hideLabel />
         <TestTextArea label="Description" value="" />
         <TestTextArea label="Description" value="An example description text." autoFocus />
-        <TestTextArea label="Description" value="This is a description that can no longer be edited." disabled />
+        <TestTextArea
+          label="Description"
+          value="This is a description that can no longer be edited."
+          disabled="Disabled reason tooltip"
+        />
         <TestTextArea
           label="Description"
           value="See helper text."
@@ -40,7 +44,7 @@ export function TextAreaReadOnly() {
       <div css={Css.df.fdc.childGap3.$}>
         <b>Read Only</b>
         <TestTextArea label="Name" value="first" readOnly={true} />
-        <TestTextArea label="Name" value="first" hideLabel readOnly={true} />
+        <TestTextArea label="Name" value="first - with a tooltip" hideLabel readOnly="Read only with a tooltip" />
         <TestTextArea label="Name" value={("first ".repeat(40) + "last.\n\n").repeat(4)} readOnly={true} />
         <TestTextArea label="Name" value={"this is a sentence\n".repeat(4)} readOnly={true} />
       </div>

--- a/src/inputs/TextAreaField.tsx
+++ b/src/inputs/TextAreaField.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect } from "@react-aria/utils";
 import { useCallback, useRef } from "react";
 import { mergeProps, useTextField } from "react-aria";
+import { resolveTooltip } from "src/components";
 import { Only } from "src/Css";
 import { TextFieldBase } from "src/inputs/TextFieldBase";
 import { BeamTextFieldProps, TextFieldXss } from "src/interfaces";
@@ -27,7 +28,9 @@ export function TextAreaField<X extends Only<TextFieldXss, X>>(props: TextAreaFi
     onEnter,
     ...otherProps
   } = props;
-  const textFieldProps = { ...otherProps, value, isDisabled: disabled, isReadOnly: readOnly };
+  const isDisabled = !!disabled;
+  const isReadOnly = !!readOnly;
+  const textFieldProps = { ...otherProps, value, isDisabled, isReadOnly };
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const inputWrapRef = useRef<HTMLDivElement | null>(null);
 
@@ -90,9 +93,9 @@ export function TextAreaField<X extends Only<TextFieldXss, X>>(props: TextAreaFi
       labelProps={labelProps}
       inputProps={inputProps}
       inputRef={inputRef}
-      readOnly={readOnly}
       inputWrapRef={inputWrapRef}
       textAreaMinHeight={preventNewLines ? 0 : undefined}
+      tooltip={resolveTooltip(disabled, undefined, readOnly)}
     />
   );
 }

--- a/src/inputs/TextField.stories.tsx
+++ b/src/inputs/TextField.stories.tsx
@@ -21,7 +21,7 @@ export function TextFieldStyles() {
         <TestTextField label="Name" value="" />
         <TestTextField label="Name" required value="" />
         <TestTextField label="Name Focused" value="Brandon" autoFocus />
-        <TestTextField label="Name Disabled" value="Brandon" disabled />
+        <TestTextField label="Name Disabled" value="Brandon" disabled="Disabled reason tooltip" />
         <TestTextField
           label="Name Helper Text"
           value="Brandon"
@@ -78,7 +78,7 @@ export function TextFieldReadOnly() {
       <div css={Css.df.fdc.childGap3.$}>
         <b>Read Only</b>
         <TestTextField label="Name" value="first" readOnly={true} />
-        <TestTextField label="Name" value="first" inlineLabel readOnly={true} />
+        <TestTextField label="Name" value="first - with tooltip" inlineLabel readOnly="Read only reason tooltip" />
         <TestTextField label="Name" value="first" hideLabel readOnly={true} />
         <TestTextField label="Name" value={"first ".repeat(20) + "last"} readOnly={true} />
       </div>

--- a/src/inputs/TextField.tsx
+++ b/src/inputs/TextField.tsx
@@ -1,5 +1,6 @@
 import { MutableRefObject, ReactNode, useRef } from "react";
 import { mergeProps, useTextField } from "react-aria";
+import { resolveTooltip } from "src/components";
 import { Only } from "src/Css";
 import { TextFieldBase } from "src/inputs/TextFieldBase";
 import { BeamTextFieldProps, TextFieldXss } from "src/interfaces";
@@ -19,7 +20,7 @@ export interface TextFieldProps<X> extends BeamTextFieldProps<X> {
 
 export function TextField<X extends Only<TextFieldXss, X>>(props: TextFieldProps<X>) {
   const {
-    disabled: isDisabled = false,
+    disabled = false,
     readOnly = false,
     required,
     errorMsg,
@@ -30,10 +31,13 @@ export function TextField<X extends Only<TextFieldXss, X>>(props: TextFieldProps
     onEnter,
     ...otherProps
   } = props;
+
+  const isDisabled = !!disabled;
+  const isReadOnly = !!readOnly;
   const textFieldProps = {
     ...otherProps,
     isDisabled,
-    isReadOnly: readOnly,
+    isReadOnly,
     isRequired: required,
     validationState: errorMsg ? ("invalid" as const) : ("valid" as const),
     value,
@@ -62,12 +66,12 @@ export function TextField<X extends Only<TextFieldXss, X>>(props: TextFieldProps
   return (
     <TextFieldBase
       {...mergeProps(textFieldProps, { onBlur, onFocus })}
-      readOnly={readOnly}
       errorMsg={errorMsg}
       required={required}
       labelProps={labelProps}
       inputProps={inputProps}
       inputRef={inputRef}
+      tooltip={resolveTooltip(disabled, undefined, readOnly)}
     />
   );
 }

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -27,7 +27,6 @@ export interface TextFieldBaseProps<X>
       BeamTextFieldProps<X>,
       | "label"
       | "required"
-      | "readOnly"
       | "errorMsg"
       | "onBlur"
       | "onFocus"
@@ -72,7 +71,6 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
     errorMsg,
     helperText,
     multiline = false,
-    readOnly,
     onChange,
     onBlur,
     onFocus,
@@ -87,6 +85,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
     tooltip,
     visuallyDisabled = fieldProps?.visuallyDisabled ?? true,
   } = props;
+
   const typeScale = fieldProps?.typeScale ?? "sm";
   const internalProps: TextFieldInternalProps = (props as any).internalProps || {};
   const { compound = false } = internalProps;
@@ -165,7 +164,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
       {maybeTooltip({
         title: tooltip,
         placement: "top",
-        children: readOnly ? (
+        children: inputProps.readOnly ? (
           <div
             css={{
               // Use input wrapper to get common styles, but then we need to override some
@@ -197,8 +196,8 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
             css={{
               ...fieldStyles.inputWrapper,
               ...(inputProps.disabled ? fieldStyles.disabled : {}),
-              ...(isFocused && !readOnly ? fieldStyles.focus : {}),
-              ...(isHovered && !inputProps.disabled && !readOnly && !isFocused ? fieldStyles.hover : {}),
+              ...(isFocused && !inputProps.readOnly ? fieldStyles.focus : {}),
+              ...(isHovered && !inputProps.disabled && !inputProps.readOnly && !isFocused ? fieldStyles.hover : {}),
               ...(errorMsg ? fieldStyles.error : {}),
               ...Css.if(multiline).aifs.px0.mhPx(textAreaMinHeight).$,
             }}
@@ -221,7 +220,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
               css={{
                 ...fieldStyles.input,
                 ...(inputProps.disabled ? fieldStyles.disabled : {}),
-                ...(isHovered && !inputProps.disabled && !readOnly && !isFocused ? fieldStyles.hover : {}),
+                ...(isHovered && !inputProps.disabled && !inputProps.readOnly && !isFocused ? fieldStyles.hover : {}),
                 ...(multiline ? Css.h100.p1.add("resize", "none").if(borderless).pPx(4).$ : Css.truncate.$),
                 ...xss,
               }}

--- a/src/inputs/internal/SelectFieldInput.tsx
+++ b/src/inputs/internal/SelectFieldInput.tsx
@@ -66,7 +66,6 @@ export function SelectFieldInput<O, V extends Value>(props: SelectFieldInputProp
   return (
     <TextFieldBase
       {...otherProps}
-      readOnly={inputProps.readOnly}
       inlineLabel={inlineLabel}
       errorMsg={errorMsg}
       contrast={contrast}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,8 +28,8 @@ export interface BeamButtonProps {
 export type TextFieldXss = Xss<"textAlign" | "justifyContent" | "fontWeight" | "fontSize" | "lineHeight">;
 
 export interface BeamTextFieldProps<X> extends BeamFocusableProps, PresentationFieldProps {
-  /** Whether the interactive element is disabled. */
-  disabled?: boolean;
+  /** Whether the field is disabled. If a ReactNode, it's treated as a "disabled reason" that's shown in a tooltip. */
+  disabled?: boolean | ReactNode;
   errorMsg?: string;
   helperText?: string | ReactNode;
   /** Input label */
@@ -43,7 +43,8 @@ export interface BeamTextFieldProps<X> extends BeamFocusableProps, PresentationF
   onBlur?: Callback;
   onFocus?: Callback;
   onEnter?: Callback;
-  readOnly?: boolean;
+  /** Whether the field is readOnly. If a ReactNode, it's treated as a "readOnly reason" that's shown in a tooltip. */
+  readOnly?: boolean | ReactNode;
   placeholder?: string;
   /** Styles overrides */
   xss?: X;


### PR DESCRIPTION
Adds support for displaying tooltips via the 'disabled' or 'readOnly' props for:
- TextField
- TextAreaField
- NumberField
- DateField

These follow the pattern already in place by SelectField and MultiSelectField.
With this PR, all components that utilize TextFieldBase now support tooltips via the readOnly and disabled properties