### PR TITLE
fix: Update input field styles in tables

### DIFF
--- a/src/components/PresentationContext.tsx
+++ b/src/components/PresentationContext.tsx
@@ -15,6 +15,8 @@ export interface PresentationFieldProps {
   typeScale?: Typography;
   // If set to `false` then fields will not appear disabled, but will still be disabled.
   visuallyDisabled?: false;
+  // If set error messages will be rendered as tooltips rather than below the field
+  errorInTooltip?: true;
 }
 
 export type PresentationContextProps = {

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -474,6 +474,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
       hideLabel: true,
       numberAlignment: "right",
       compact: true,
+      errorInTooltip: true,
       // Avoid passing `undefined` as it will unset existing PresentationContext settings
       ...(borderless !== undefined ? { borderless } : {}),
       ...(typeScale !== undefined ? { typeScale } : {}),

--- a/src/components/Table/styles.tsx
+++ b/src/components/Table/styles.tsx
@@ -73,7 +73,7 @@ export const beamTotalsFixedStyle: GridStyle = {
 export const beamFlexibleStyle: GridStyle = {
   ...beamFixedStyle,
   cellCss: Css.xs.bgWhite.aic.p2.boxShadow(`inset 0 -1px 0 ${Palette.Gray100}`).$,
-  presentationSettings: { borderless: false, typeScale: "xs", wrap: true },
+  presentationSettings: { borderless: true, typeScale: "xs", wrap: true },
 };
 
 export const beamNestedFlexibleStyle: GridStyle = {

--- a/src/forms/formStateDomain.ts
+++ b/src/forms/formStateDomain.ts
@@ -5,6 +5,7 @@
 export const jan1 = new Date(2020, 0, 1);
 export const jan2 = new Date(2020, 0, 2);
 export const jan10 = new Date(2020, 0, 10);
+export const jan29 = new Date(2020, 0, 29);
 export const dd100: DeweyDecimalClassification = { number: "100", category: "Philosophy" };
 export const dd200: DeweyDecimalClassification = { number: "200", category: "Religion" };
 
@@ -23,6 +24,7 @@ export interface AuthorInput {
   favoriteShapes?: string[] | null;
   isAvailable?: boolean | null;
   animals?: string[] | null;
+  bio?: string | null;
 }
 
 export interface AuthorAddress {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -57,4 +57,8 @@ export interface TextFieldInternalProps {
    * This is explicitly an internal property that is not exposed to any field's API.
    */
   compound?: boolean;
+  /** Forces focus styles for storybook purposes */
+  forceFocus?: true;
+  /** Forces hover styles for storybook purposes */
+  forceHover?: boolean;
 }


### PR DESCRIPTION
Changes include:
- Input fields no longer use box-shadow for focus state when 'borderless'
- New presentation prop for fields: 'errorInTooltip'. Allows the error message to display in a tooltip instead of beneath the field.
- 'borderless' presentation prop is defined for Flexible table styles as well.
- Adds 'internalProps' for TextField to allow for forcing hover and focus states for snapshot purposes.

Adds story for fields in a table in their various states.