### PR TITLE
feat: Update to nesting styles for Table component

### DIFF
--- a/src/components/Table/CollapseToggle.tsx
+++ b/src/components/Table/CollapseToggle.tsx
@@ -1,14 +1,14 @@
 import { useContext } from "react";
-import { GridDataRow, IconButton, RowStateContext } from "src/components";
+import { GridDataRow, IconButton, IconButtonProps, RowStateContext } from "src/components";
 import { useComputed } from "src/hooks";
 
-export interface GridTableCollapseToggleProps {
+export interface GridTableCollapseToggleProps extends Pick<IconButtonProps, "compact"> {
   row: GridDataRow<any>;
 }
 
 /** Provides a chevron icons to collapse/un-collapse for parent/child tables. */
 export function CollapseToggle(props: GridTableCollapseToggleProps) {
-  const { row } = props;
+  const { row, compact } = props;
   const { rowState } = useContext(RowStateContext);
 
   const isCollapsed = useComputed(() => rowState.isCollapsed(row.id), [rowState]);
@@ -17,9 +17,15 @@ export function CollapseToggle(props: GridTableCollapseToggleProps) {
 
   // If we're not a header, only render a toggle if we have child rows to actually collapse
   const isHeader = row.kind === "header";
-  if (!isHeader && (!props.row.children || props.row.children.length === 0)) {
+  if (!isHeader && (!row.children || row.children.length === 0)) {
     return null;
   }
 
-  return <IconButton onClick={() => rowState.toggleCollapsed(row.id)} icon={isHeader ? headerIconKey : iconKey} />;
+  return (
+    <IconButton
+      onClick={() => rowState.toggleCollapsed(row.id)}
+      icon={isHeader ? headerIconKey : iconKey}
+      compact={compact}
+    />
+  );
 }

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -148,9 +148,9 @@ const rowsWithHeader: GridDataRow<NestedRow>[] = [simpleHeader, ...rows];
 
 export function NestedRows() {
   const arrowColumn = actionColumn<NestedRow>({
-    header: (data, row) => <CollapseToggle row={row} />,
-    parent: (data, row) => <CollapseToggle row={row} />,
-    child: (data, row) => <CollapseToggle row={row} />,
+    header: (data, { row }) => <CollapseToggle row={row} />,
+    parent: (data, { row }) => <CollapseToggle row={row} />,
+    child: (data, { row }) => <CollapseToggle row={row} />,
     grandChild: () => "",
     add: () => "",
     w: "60px",
@@ -693,7 +693,7 @@ type ColspanRow = HeaderRow | DataRow | TotalsRow;
 export function ColSpan() {
   const idCol = column<ColspanRow>({
     header: "ID",
-    data: (data, { id }) => id,
+    data: (data, { row }) => row.id,
     // Not putting the colspan here just as a POC that we can colspan somewhere other than from the first column.
     // We should expect this to show the `emptyCell` fallback
     total: "",
@@ -1025,7 +1025,7 @@ export function ActiveRowNestedCard() {
     header: () => "Action",
     parent: () => "",
     child: () => "",
-    grandChild: (data, row, api) => (
+    grandChild: (data, { row, api }) => (
       <Button label="Activate Row" onClick={() => api.setActiveRowId(`grandChild_${row.id}`)} />
     ),
     add: () => "",

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -51,34 +51,34 @@ beforeEach(() => (renderedNameColumn = []));
 // TODO Move this to the bottom of the file in it's own PR
 const nestedColumns: GridColumn<NestedRow>[] = [
   {
-    header: (data, row) => <Collapse id={row.id} />,
-    parent: (data, row) => <Collapse id={row.id} />,
-    child: (data, row) => <Collapse id={row.id} />,
+    header: (data, { row }) => <Collapse id={row.id} />,
+    parent: (data, { row }) => <Collapse id={row.id} />,
+    child: (data, { row }) => <Collapse id={row.id} />,
     grandChild: () => "",
   },
   selectColumn<NestedRow>({
-    header: (data, row) => ({ content: <Select id={row.id} /> }),
-    parent: (data, row) => ({ content: <Select id={row.id} /> }),
-    child: (data, row) => ({ content: <Select id={row.id} /> }),
-    grandChild: (data, row) => ({ content: <Select id={row.id} /> }),
+    header: (data, { row }) => ({ content: <Select id={row.id} /> }),
+    parent: (data, { row }) => ({ content: <Select id={row.id} /> }),
+    child: (data, { row }) => ({ content: <Select id={row.id} /> }),
+    grandChild: (data, { row }) => ({ content: <Select id={row.id} /> }),
   }),
   {
     header: () => "Name",
-    parent: (data, row) => ({
+    parent: (data, { row }) => ({
       content() {
         renderedNameColumn.push(row.id);
         return <div>{data.name}</div>;
       },
       value: data.name,
     }),
-    child: (data, row) => ({
+    child: (data, { row }) => ({
       content() {
         renderedNameColumn.push(row.id);
         return <div css={Css.ml2.$}>{data.name}</div>;
       },
       value: data.name,
     }),
-    grandChild: (data, row) => ({
+    grandChild: (data, { row }) => ({
       content() {
         renderedNameColumn.push(row.id);
         return <div css={Css.ml4.$}>{data.name}</div>;
@@ -1452,7 +1452,7 @@ describe("GridTable", () => {
     const valueColumn: GridColumn<Row> = {
       header: "",
       // Then the column can accept both the value (not the GriDataRow) directly and the row id
-      data: (v, row) => `id=${row.id} value=${v.value}`,
+      data: (v, { row }) => `id=${row.id} value=${v.value}`,
     };
     const r = await render(<GridTable columns={[valueColumn]} rows={rows} />);
     expect(cell(r, 1, 0)).toHaveTextContent("id=a:1 value=1");

--- a/src/components/Table/SchedulesV2.stories.tsx
+++ b/src/components/Table/SchedulesV2.stories.tsx
@@ -67,17 +67,17 @@ const rows: GridDataRow<Row>[] = [simpleHeader, ...createMilestones(1, 3, 2)];
 /** Columns */
 // FIXME: This column is not vertically aligned
 const arrowColumn = actionColumn<Row>({
-  header: (data, row) => (
+  header: (data, { row }) => (
     <div css={Css.pr1.$}>
       <CollapseToggle row={row} />
     </div>
   ),
-  milestone: (data, row) => (
+  milestone: (data, { row }) => (
     <div css={Css.pr1.$}>
       <CollapseToggle row={row} />
     </div>
   ),
-  subgroup: (data, row) => (
+  subgroup: (data, { row }) => (
     <div css={Css.pr1.$}>
       <CollapseToggle row={row} />
     </div>
@@ -99,7 +99,7 @@ const idColumn = column<Row>({
   header: "",
   milestone: "",
   subgroup: "",
-  task: (data, row) => row.id,
+  task: (data, { row }) => row.id,
   add: "",
   w: "20px",
   align: "center",

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -4,14 +4,7 @@ import { default as React, ReactNode, useMemo, useState } from "react";
 import { Chips } from "src/components/Chips";
 import { Icon } from "src/components/Icon";
 import { collapseColumn, column, dateColumn, numericColumn, selectColumn } from "src/components/Table/columns";
-import {
-  emptyCell,
-  GridColumn,
-  GridDataRow,
-  GridRowStyles,
-  GridSortConfig,
-  GridTable,
-} from "src/components/Table/GridTable";
+import { emptyCell, GridColumn, GridDataRow, GridSortConfig, GridTable } from "src/components/Table/GridTable";
 import { useGridTableApi } from "src/components/Table/GridTableApi";
 import { simpleHeader, SimpleHeaderAndData } from "src/components/Table/simpleHelpers";
 import {
@@ -174,12 +167,6 @@ export function Filterable() {
   );
 }
 
-const indentedChildRowStyles: GridRowStyles<BeamNestedRow> = {
-  child: {
-    indent: 1,
-  },
-};
-
 export function NestedThreeLevels() {
   return (
     <GridTable<BeamNestedRow>
@@ -187,7 +174,6 @@ export function NestedThreeLevels() {
       sorting={{ on: "client" }}
       columns={nestedColumnsThreeLevels}
       rows={nestedRowsThreeLevels}
-      rowStyles={indentedChildRowStyles}
       stickyHeader
     />
   );
@@ -306,12 +292,12 @@ function beamNestedColumns(threeLevels: boolean = false): GridColumn<BeamNestedR
     column<BeamNestedRow>({
       totals: "Totals",
       header: "Cost Code",
-      grandparent: (data, row) => ({
+      grandparent: (data, { row }) => ({
         content: () => `${data.name} (${row.children.length})`,
         // Apply `smEm` typeScale if nesting three levels
         typeScale: threeLevels ? "smEm" : undefined,
       }),
-      parent: (data, row) => ({
+      parent: (data, { row }) => ({
         content: () => `${data.name} (${row.children.length})`,
         // Apply `smEm` typeScale if not nesting three levels
         typeScale: threeLevels ? undefined : "smEm",
@@ -502,7 +488,7 @@ function inputFieldColumns(getFormState: (author: AuthorInput) => ObjectState<Au
   return [
     column<InputFieldRows>({
       header: "Name",
-      data: (data, row) => ({
+      data: (data, { row }) => ({
         content: () => {
           const os = getFormState(data);
           return <BoundTextField field={os.firstName} {...applyStateProps(row.id)} />;
@@ -511,7 +497,7 @@ function inputFieldColumns(getFormState: (author: AuthorInput) => ObjectState<Au
     }),
     column<InputFieldRows>({
       header: "Biography",
-      data: (data, row) => ({
+      data: (data, { row }) => ({
         content: () => {
           const os = getFormState(data);
           return flexible ? (
@@ -525,7 +511,7 @@ function inputFieldColumns(getFormState: (author: AuthorInput) => ObjectState<Au
     }),
     column<InputFieldRows>({
       header: "Birthdate",
-      data: (data, row) => ({
+      data: (data, { row }) => ({
         content: () => {
           const os = getFormState(data);
           return <BoundDateField field={os.birthday} {...applyStateProps(row.id)} />;
@@ -535,7 +521,7 @@ function inputFieldColumns(getFormState: (author: AuthorInput) => ObjectState<Au
     }),
     numericColumn<InputFieldRows>({
       header: "Height",
-      data: (data, row) => ({
+      data: (data, { row }) => ({
         content: () => {
           const os = getFormState(data);
           return <BoundNumberField field={os.heightInInches} {...applyStateProps(row.id)} />;
@@ -545,7 +531,7 @@ function inputFieldColumns(getFormState: (author: AuthorInput) => ObjectState<Au
     }),
     column<InputFieldRows>({
       header: "Favorite Sport",
-      data: (data, row) => ({
+      data: (data, { row }) => ({
         content: () => {
           const os = getFormState(data);
           return <BoundSelectField field={os.favoriteSport} options={sports} {...applyStateProps(row.id)} />;
@@ -554,7 +540,7 @@ function inputFieldColumns(getFormState: (author: AuthorInput) => ObjectState<Au
     }),
     column<InputFieldRows>({
       header: "Favorite Shapes",
-      data: (data, row) => ({
+      data: (data, { row }) => ({
         content: () => {
           const os = getFormState(data);
           return <BoundMultiSelectField field={os.favoriteShapes} options={shapes} {...applyStateProps(row.id)} />;

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -4,7 +4,14 @@ import { default as React, ReactNode, useMemo, useState } from "react";
 import { Chips } from "src/components/Chips";
 import { Icon } from "src/components/Icon";
 import { collapseColumn, column, dateColumn, numericColumn, selectColumn } from "src/components/Table/columns";
-import { emptyCell, GridColumn, GridDataRow, GridSortConfig, GridTable } from "src/components/Table/GridTable";
+import {
+  emptyCell,
+  GridColumn,
+  GridDataRow,
+  GridRowStyles,
+  GridSortConfig,
+  GridTable,
+} from "src/components/Table/GridTable";
 import { useGridTableApi } from "src/components/Table/GridTableApi";
 import { simpleHeader, SimpleHeaderAndData } from "src/components/Table/simpleHelpers";
 import {
@@ -87,19 +94,20 @@ type BeamBudgetData = {
 };
 type HeaderRow = { kind: "header" };
 type BeamTotalsRow = { kind: "totals"; id: string; data: BeamBudgetData };
+type BeamGrandParentRow = { kind: "grandparent"; id: string; data: BeamBudgetData };
 type BeamParentRow = { kind: "parent"; id: string; data: BeamBudgetData };
 type BeamChildRow = { kind: "child"; id: string; data: BeamBudgetData };
-type BeamNestedRow = BeamTotalsRow | HeaderRow | BeamParentRow | BeamChildRow;
+type BeamNestedRow = BeamTotalsRow | HeaderRow | BeamGrandParentRow | BeamParentRow | BeamChildRow;
 
 export function NestedFixed() {
   return (
     <div css={Css.mw("fit-content").$}>
-      <GridTable<BeamNestedRow> style={beamTotalsFixedStyle} columns={beamNestedColumns} rows={beamTotalsRows} />
+      <GridTable<BeamNestedRow> style={beamTotalsFixedStyle} columns={nestedColumnsTwoLevels} rows={beamTotalsRows} />
       <GridTable<BeamNestedRow>
         style={beamNestedFixedStyle}
         sorting={{ on: "client" }}
-        columns={beamNestedColumns}
-        rows={beamNestedRows}
+        columns={nestedColumnsTwoLevels}
+        rows={nestedRowsTwoLevels}
         stickyHeader
       />
     </div>
@@ -109,22 +117,22 @@ export function NestedFixed() {
 export function NestedFlexible() {
   return (
     <div css={Css.mw("fit-content").$}>
-      <GridTable<BeamNestedRow> style={beamTotalsFlexibleStyle} columns={beamNestedColumns} rows={beamTotalsRows} />
+      <GridTable<BeamNestedRow>
+        style={beamTotalsFlexibleStyle}
+        columns={nestedColumnsTwoLevels}
+        rows={beamTotalsRows}
+      />
       <GridTable<BeamNestedRow>
         style={beamNestedFlexibleStyle}
         sorting={{ on: "client" }}
-        columns={beamNestedColumns}
-        rows={beamNestedRows}
+        columns={nestedColumnsTwoLevels}
+        rows={nestedRowsTwoLevels}
         stickyHeader
       />
     </div>
   );
 }
 
-// Reproducible issue to fix for re-deriving:
-// 1. filter on "Yo"
-// 2. Select individual "Project Items". Note parent is "checked"
-// 3. Remove filter, additional project items under parent are "unchecked", though parent still shows "checked" instead of what it should show as "indeterminate".
 export function Filterable() {
   const api = useGridTableApi<BeamNestedRow>();
   const selectedIds = useComputed(() => api.getSelectedRows().map((r) => r.id), [api]);
@@ -156,8 +164,8 @@ export function Filterable() {
       <GridTable<BeamNestedRow>
         style={beamNestedFixedStyle}
         sorting={sorting}
-        columns={beamNestedColumns}
-        rows={beamNestedRows}
+        columns={beamNestedColumns()}
+        rows={nestedRowsTwoLevels}
         stickyHeader
         filter={filter}
         api={api}
@@ -166,47 +174,92 @@ export function Filterable() {
   );
 }
 
-const beamNestedRows: GridDataRow<BeamNestedRow>[] = [
-  simpleHeader,
-  ...zeroTo(5).map((pIdx) => {
-    // Get a semi-random, but repeatable number of children
-    const numChildren = (pIdx % 3) + pIdx + 1;
-    const children = zeroTo(numChildren).map((cIdx) => ({
-      kind: "child" as const,
-      id: `p${pIdx + 1}_c${cIdx + 1}`,
-      data: {
-        name: `10${pIdx + 1}0.${cIdx + 1} - Project Item${pIdx === 0 ? " with a longer name that will wrap" : ""}`,
-        original: 1234_56,
-        changeOrders: 543_21,
-        reallocations: 568_56,
-        revised: undefined,
-        committed: 129_86,
-        difference: 1025_23,
-        actuals: 1108_18,
-        projected: 421_21,
-        costToComplete: 1129_85,
-      },
-    }));
+const indentedChildRowStyles: GridRowStyles<BeamNestedRow> = {
+  child: {
+    indent: 1,
+  },
+};
+
+export function NestedThreeLevels() {
+  return (
+    <GridTable<BeamNestedRow>
+      style={beamNestedFixedStyle}
+      sorting={{ on: "client" }}
+      columns={nestedColumnsThreeLevels}
+      rows={nestedRowsThreeLevels}
+      rowStyles={indentedChildRowStyles}
+      stickyHeader
+    />
+  );
+}
+
+const nestedRowsTwoLevels = beamNestedRows();
+const nestedRowsThreeLevels = beamNestedRows(true);
+
+function beamNestedRows(threeLevels: boolean = false): GridDataRow<BeamNestedRow>[] {
+  const grandParents: GridDataRow<BeamNestedRow>[] = zeroTo(2).map((idx) => {
+    const parents = zeroTo(2 + (idx % 2)).map((pIdx) => {
+      // Get a semi-random, but repeatable number of children
+      const numChildren = (pIdx % 3) + pIdx + idx + 1;
+      const children = zeroTo(numChildren).map((cIdx) => ({
+        kind: "child" as const,
+        id: `gp:${idx + 1}_p${pIdx + 1}_c${cIdx + 1}`,
+        data: {
+          name: `${idx + 1}0${pIdx + 1}0.${cIdx + 1} - Project Item${
+            pIdx === 0 ? " with a longer name that will wrap" : ""
+          }`,
+          original: 1234_56,
+          changeOrders: 543_21,
+          reallocations: 568_56,
+          revised: undefined,
+          committed: 129_86,
+          difference: 1025_23,
+          actuals: 1108_18,
+          projected: 421_21,
+          costToComplete: 1129_85,
+        },
+      }));
+
+      return {
+        kind: "parent" as const,
+        id: `gp:${idx + 1}_p:${pIdx + 1}`,
+        children,
+        data: {
+          name: `${idx + 1}0${pIdx + 1}0 - Cost Code${pIdx === 1 ? " with a longer name that will wrap" : ""}`,
+          original: children.map((c) => c.data.original ?? 0).reduce((acc, n) => acc + n, 0),
+          changeOrders: children.map((c) => c.data.changeOrders ?? 0).reduce((acc, n) => acc + n, 0),
+          reallocations: children.map((c) => c.data.reallocations ?? 0).reduce((acc, n) => acc + n, 0),
+          revised: children.map((c) => c.data.revised ?? 0).reduce((acc, n) => acc + n, 0),
+          committed: children.map((c) => c.data.committed ?? 0).reduce((acc, n) => acc + n, 0),
+          difference: children.map((c) => c.data.difference ?? 0).reduce((acc, n) => acc + n, 0),
+          actuals: children.map((c) => c.data.actuals ?? 0).reduce((acc, n) => acc + n, 0),
+          projected: children.map((c) => c.data.projected ?? 0).reduce((acc, n) => acc + n, 0),
+          costToComplete: children.map((c) => c.data.costToComplete ?? 0).reduce((acc, n) => acc + n, 0),
+        },
+      };
+    });
 
     return {
-      kind: "parent" as const,
-      id: `p:${pIdx + 1}`,
+      id: `gp:${idx + 1}`,
+      kind: "grandparent" as const,
+      children: parents,
       data: {
-        name: `10${pIdx + 1}0 - Cost Code${pIdx === 1 ? " with a longer name that will wrap" : ""}`,
-        original: children.map(({ data }) => data.original ?? 0).reduce((acc, n) => acc + n, 0),
-        changeOrders: children.map(({ data }) => data.changeOrders ?? 0).reduce((acc, n) => acc + n, 0),
-        reallocations: children.map(({ data }) => data.reallocations ?? 0).reduce((acc, n) => acc + n, 0),
-        revised: children.map(({ data }) => data.revised ?? 0).reduce((acc, n) => acc + n, 0),
-        committed: children.map(({ data }) => data.committed ?? 0).reduce((acc, n) => acc + n, 0),
-        difference: children.map(({ data }) => data.difference ?? 0).reduce((acc, n) => acc + n, 0),
-        actuals: children.map(({ data }) => data.actuals ?? 0).reduce((acc, n) => acc + n, 0),
-        projected: children.map(({ data }) => data.projected ?? 0).reduce((acc, n) => acc + n, 0),
-        costToComplete: children.map(({ data }) => data.costToComplete ?? 0).reduce((acc, n) => acc + n, 0),
+        name: `${idx + 1}000 - Division`,
+        original: parents.map((p) => p.data.original ?? 0).reduce((acc, n) => acc + n, 0),
+        changeOrders: parents.map((p) => p.data.changeOrders ?? 0).reduce((acc, n) => acc + n, 0),
+        reallocations: parents.map((p) => p.data.reallocations ?? 0).reduce((acc, n) => acc + n, 0),
+        revised: parents.map((p) => p.data.revised ?? 0).reduce((acc, n) => acc + n, 0),
+        committed: parents.map((p) => p.data.committed ?? 0).reduce((acc, n) => acc + n, 0),
+        difference: parents.map((p) => p.data.difference ?? 0).reduce((acc, n) => acc + n, 0),
+        actuals: parents.map((p) => p.data.actuals ?? 0).reduce((acc, n) => acc + n, 0),
+        projected: parents.map((p) => p.data.projected ?? 0).reduce((acc, n) => acc + n, 0),
+        costToComplete: parents.map((p) => p.data.costToComplete ?? 0).reduce((acc, n) => acc + n, 0),
       },
-      children,
     };
-  }),
-];
+  });
+
+  return [simpleHeader, ...(threeLevels ? grandParents : grandParents.flatMap((gp) => gp.children!))];
+}
 
 const beamTotalsRows: GridDataRow<BeamNestedRow>[] = [
   {
@@ -243,74 +296,94 @@ function RollUpTotal({ num }: { num?: number }) {
   return typeof num !== "number" || num === 0 ? null : <span css={Css.xs.$}>{numberFormatter(num)}</span>;
 }
 
-const beamNestedColumns: GridColumn<BeamNestedRow>[] = [
-  collapseColumn<BeamNestedRow>({ totals: emptyCell }),
-  selectColumn<BeamNestedRow>({ totals: emptyCell }),
-  column<BeamNestedRow>({
-    totals: "Totals",
-    header: "Cost Code",
-    parent: (data, row) => ({
-      content: () => `${data.name} (${row.children.length})`,
-      typeScale: "smEm",
+const nestedColumnsTwoLevels = beamNestedColumns();
+const nestedColumnsThreeLevels = beamNestedColumns(true);
+
+function beamNestedColumns(threeLevels: boolean = false): GridColumn<BeamNestedRow>[] {
+  return [
+    collapseColumn<BeamNestedRow>({ totals: emptyCell }),
+    selectColumn<BeamNestedRow>({ totals: emptyCell }),
+    column<BeamNestedRow>({
+      totals: "Totals",
+      header: "Cost Code",
+      grandparent: (data, row) => ({
+        content: () => `${data.name} (${row.children.length})`,
+        // Apply `smEm` typeScale if nesting three levels
+        typeScale: threeLevels ? "smEm" : undefined,
+      }),
+      parent: (data, row) => ({
+        content: () => `${data.name} (${row.children.length})`,
+        // Apply `smEm` typeScale if not nesting three levels
+        typeScale: threeLevels ? undefined : "smEm",
+      }),
+      child: (row) => row.name,
+      w: "200px",
     }),
-    child: (row) => row.name,
-    w: "200px",
-  }),
-  numericColumn<BeamNestedRow>({
-    totals: (row) => numberFormatter(row.original),
-    header: "Original",
-    parent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
-    child: (row) => ({ content: () => numberFormatter(row.original) }),
-  }),
-  numericColumn<BeamNestedRow>({
-    totals: (row) => numberFormatter(row.changeOrders),
-    header: "Change Orders",
-    parent: (row) => ({ content: () => maybeFormatNumber(row.changeOrders), value: row.changeOrders }),
-    child: (row) => ({ content: () => numberFormatter(row.changeOrders) }),
-  }),
-  numericColumn<BeamNestedRow>({
-    totals: (row) => numberFormatter(row.reallocations),
-    header: "Reallocations",
-    parent: (row) => ({ content: () => maybeFormatNumber(row.reallocations), value: row.reallocations }),
-    child: (row) => ({ content: () => numberFormatter(row.reallocations) }),
-  }),
-  numericColumn<BeamNestedRow>({
-    totals: (row) => numberFormatter(row.revised),
-    header: "Revised",
-    parent: (row) => ({ content: () => maybeFormatNumber(row.revised), value: row.revised }),
-    child: (row) => ({ content: () => numberFormatter(row.revised) }),
-  }),
-  numericColumn<BeamNestedRow>({
-    totals: (row) => numberFormatter(row.committed),
-    header: "Committed",
-    parent: (row) => ({ content: () => maybeFormatNumber(row.committed), value: row.committed }),
-    child: (row) => ({ content: () => numberFormatter(row.committed) }),
-  }),
-  numericColumn<BeamNestedRow>({
-    totals: (row) => numberFormatter(row.difference),
-    header: "Difference",
-    parent: (row) => ({ content: () => maybeFormatNumber(row.difference), value: row.difference }),
-    child: (row) => ({ content: () => numberFormatter(row.difference) }),
-  }),
-  numericColumn<BeamNestedRow>({
-    totals: (row) => numberFormatter(row.actuals),
-    header: "Actuals",
-    parent: (row) => ({ content: () => maybeFormatNumber(row.actuals), value: row.actuals }),
-    child: (row) => ({ content: () => numberFormatter(row.actuals) }),
-  }),
-  numericColumn<BeamNestedRow>({
-    totals: (row) => numberFormatter(row.projected),
-    header: "Projected",
-    parent: (row) => ({ content: () => maybeFormatNumber(row.projected), value: row.projected }),
-    child: (row) => ({ content: () => numberFormatter(row.projected) }),
-  }),
-  numericColumn<BeamNestedRow>({
-    totals: (row) => numberFormatter(row.costToComplete),
-    header: "Cost To Complete",
-    parent: (row) => ({ content: () => maybeFormatNumber(row.costToComplete), value: row.costToComplete }),
-    child: (row) => ({ content: () => numberFormatter(row.costToComplete) }),
-  }),
-];
+    numericColumn<BeamNestedRow>({
+      totals: (row) => numberFormatter(row.original),
+      header: "Original",
+      grandparent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
+      parent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
+      child: (row) => ({ content: () => numberFormatter(row.original) }),
+    }),
+    numericColumn<BeamNestedRow>({
+      totals: (row) => numberFormatter(row.changeOrders),
+      header: "Change Orders",
+      grandparent: (row) => ({ content: () => maybeFormatNumber(row.changeOrders), value: row.changeOrders }),
+      parent: (row) => ({ content: () => maybeFormatNumber(row.changeOrders), value: row.changeOrders }),
+      child: (row) => ({ content: () => numberFormatter(row.changeOrders) }),
+    }),
+    numericColumn<BeamNestedRow>({
+      totals: (row) => numberFormatter(row.reallocations),
+      header: "Reallocations",
+      grandparent: (row) => ({ content: () => maybeFormatNumber(row.reallocations), value: row.reallocations }),
+      parent: (row) => ({ content: () => maybeFormatNumber(row.reallocations), value: row.reallocations }),
+      child: (row) => ({ content: () => numberFormatter(row.reallocations) }),
+    }),
+    numericColumn<BeamNestedRow>({
+      totals: (row) => numberFormatter(row.revised),
+      header: "Revised",
+      grandparent: (row) => ({ content: () => maybeFormatNumber(row.revised), value: row.revised }),
+      parent: (row) => ({ content: () => maybeFormatNumber(row.revised), value: row.revised }),
+      child: (row) => ({ content: () => numberFormatter(row.revised) }),
+    }),
+    numericColumn<BeamNestedRow>({
+      totals: (row) => numberFormatter(row.committed),
+      header: "Committed",
+      grandparent: (row) => ({ content: () => maybeFormatNumber(row.committed), value: row.committed }),
+      parent: (row) => ({ content: () => maybeFormatNumber(row.committed), value: row.committed }),
+      child: (row) => ({ content: () => numberFormatter(row.committed) }),
+    }),
+    numericColumn<BeamNestedRow>({
+      totals: (row) => numberFormatter(row.difference),
+      header: "Difference",
+      grandparent: (row) => ({ content: () => maybeFormatNumber(row.difference), value: row.difference }),
+      parent: (row) => ({ content: () => maybeFormatNumber(row.difference), value: row.difference }),
+      child: (row) => ({ content: () => numberFormatter(row.difference) }),
+    }),
+    numericColumn<BeamNestedRow>({
+      totals: (row) => numberFormatter(row.actuals),
+      header: "Actuals",
+      grandparent: (row) => ({ content: () => maybeFormatNumber(row.actuals), value: row.actuals }),
+      parent: (row) => ({ content: () => maybeFormatNumber(row.actuals), value: row.actuals }),
+      child: (row) => ({ content: () => numberFormatter(row.actuals) }),
+    }),
+    numericColumn<BeamNestedRow>({
+      totals: (row) => numberFormatter(row.projected),
+      header: "Projected",
+      grandparent: (row) => ({ content: () => maybeFormatNumber(row.projected), value: row.projected }),
+      parent: (row) => ({ content: () => maybeFormatNumber(row.projected), value: row.projected }),
+      child: (row) => ({ content: () => numberFormatter(row.projected) }),
+    }),
+    numericColumn<BeamNestedRow>({
+      totals: (row) => numberFormatter(row.costToComplete),
+      header: "Cost To Complete",
+      grandparent: (row) => ({ content: () => maybeFormatNumber(row.costToComplete), value: row.costToComplete }),
+      parent: (row) => ({ content: () => maybeFormatNumber(row.costToComplete), value: row.costToComplete }),
+      child: (row) => ({ content: () => numberFormatter(row.costToComplete) }),
+    }),
+  ];
+}
 
 function beamStyleColumns() {
   const locations: HasIdAndName<string>[] = [

--- a/src/components/Table/columns.tsx
+++ b/src/components/Table/columns.tsx
@@ -1,5 +1,6 @@
 import { CollapseToggle } from "src/components/Table/CollapseToggle";
 import { GridColumn, Kinded, nonKindGridColumnKeys } from "src/components/Table/GridTable";
+import { GridTableApi } from "src/components/Table/GridTableApi";
 import { SelectToggle } from "src/components/Table/SelectToggle";
 import { newMethodMissingProxy } from "src/utils/index";
 
@@ -21,7 +22,7 @@ export function numericColumn<T extends Kinded, S = {}>(columnDef: GridColumn<T,
 
 /** Provides default styling for a GridColumn representing an Action. */
 export function actionColumn<T extends Kinded, S = {}>(columnDef: GridColumn<T, S>): GridColumn<T, S> {
-  return { clientSideSort: false, ...columnDef, align: "center" };
+  return { clientSideSort: false, ...columnDef, align: "center", isAction: true };
 }
 
 /**
@@ -39,6 +40,7 @@ export function selectColumn<T extends Kinded, S = {}>(columnDef?: Partial<GridC
     // Defining `w: 48px` to accommodate for the `16px` wide checkbox and `16px` of padding on either side.
     w: "48px",
     wrapAction: false,
+    isAction: true,
     // Use any of the user's per-row kind methods if they have them.
     ...columnDef,
   };
@@ -62,10 +64,13 @@ export function collapseColumn<T extends Kinded, S = {}>(columnDef?: Partial<Gri
     // Defining `w: 38px` based on the designs
     w: "38px",
     wrapAction: false,
+    isAction: true,
     ...columnDef,
   };
   return newMethodMissingProxy(base, (key) => {
-    return (data: any, row: any) => ({ content: <CollapseToggle row={row} /> });
+    return (data: any, row: any, api: GridTableApi<any>, level: number) => ({
+      content: <CollapseToggle row={row} compact={level > 0} />,
+    });
   }) as any;
 }
 

--- a/src/components/Table/columns.tsx
+++ b/src/components/Table/columns.tsx
@@ -1,6 +1,5 @@
 import { CollapseToggle } from "src/components/Table/CollapseToggle";
-import { GridColumn, Kinded, nonKindGridColumnKeys } from "src/components/Table/GridTable";
-import { GridTableApi } from "src/components/Table/GridTableApi";
+import { GridColumn, GridDataRow, Kinded, nonKindGridColumnKeys } from "src/components/Table/GridTable";
 import { SelectToggle } from "src/components/Table/SelectToggle";
 import { newMethodMissingProxy } from "src/utils/index";
 
@@ -45,7 +44,7 @@ export function selectColumn<T extends Kinded, S = {}>(columnDef?: Partial<GridC
     ...columnDef,
   };
   return newMethodMissingProxy(base, (key) => {
-    return (data: any, row: any) => ({ content: <SelectToggle id={row.id} /> });
+    return (data: any, { row }: { row: GridDataRow<any> }) => ({ content: <SelectToggle id={row.id} /> });
   }) as any;
 }
 
@@ -68,7 +67,7 @@ export function collapseColumn<T extends Kinded, S = {}>(columnDef?: Partial<Gri
     ...columnDef,
   };
   return newMethodMissingProxy(base, (key) => {
-    return (data: any, row: any, api: GridTableApi<any>, level: number) => ({
+    return (data: any, { row, level }: { row: GridDataRow<any>; level: number }) => ({
       content: <CollapseToggle row={row} compact={level > 0} />,
     });
   }) as any;

--- a/src/components/Table/sortRows.ts
+++ b/src/components/Table/sortRows.ts
@@ -31,8 +31,8 @@ function sortBatch<R extends Kinded>(
 
   // Make a shallow copy for sorting to avoid mutating the original list
   return [...batch].sort((a, b) => {
-    const v1 = sortValue(applyRowFn(column, a, {} as any));
-    const v2 = sortValue(applyRowFn(column, b, {} as any));
+    const v1 = sortValue(applyRowFn(column, a, {} as any, 0));
+    const v2 = sortValue(applyRowFn(column, b, {} as any, 0));
     const v1e = v1 === null || v1 === undefined;
     const v2e = v2 === null || v2 === undefined;
     if (a.pin || b.pin) {

--- a/src/components/Table/styles.tsx
+++ b/src/components/Table/styles.tsx
@@ -48,9 +48,6 @@ export const beamFixedStyle: GridStyle = {
   emptyCell: "-",
   presentationSettings: { borderless: true, typeScale: "xs", wrap: false },
   firstRowMessageCss: Css.tc.py3.$,
-  // Indent styles extends the existing padding-left defined in CellCss. The indentation should be +12px.
-  indentOneCss: Css.pl3.$,
-  indentTwoCss: Css.plPx(36).$,
   // Included as a hacky "treat indent as deprecated for this table" hint to GridTable
   levels: {},
 };
@@ -65,7 +62,7 @@ export const beamTotalsRowStyle: Properties = Css.gray700.smEm.hPx(40).mb1.bgWhi
 
 export const beamNestedFixedStyle: GridStyle = {
   ...beamFixedStyle,
-  levels: { 0: { cellCss: beamGroupRowStyle } },
+  levels: { 0: { cellCss: beamGroupRowStyle }, 2: { firstContentColumn: Css.tiny.pl3.$ } },
 };
 
 export const beamTotalsFixedStyle: GridStyle = {
@@ -81,7 +78,7 @@ export const beamFlexibleStyle: GridStyle = {
 
 export const beamNestedFlexibleStyle: GridStyle = {
   ...beamFlexibleStyle,
-  levels: { 0: { cellCss: beamGroupRowStyle } },
+  levels: { 0: { cellCss: beamGroupRowStyle }, 2: { firstContentColumn: Css.tiny.pl3.$ } },
 };
 
 export const beamTotalsFlexibleStyle: GridStyle = {

--- a/src/components/Table/styles.tsx
+++ b/src/components/Table/styles.tsx
@@ -44,10 +44,13 @@ export const cardStyle: GridStyle = {
 // Once completely rolled out across all tables in Blueprint, this will change to be the `defaultStyle`.
 export const beamFixedStyle: GridStyle = {
   headerCellCss: Css.gray700.xsEm.bgGray200.aic.nowrap.pxPx(12).hPx(40).$,
-  cellCss: Css.gray900.xs.bgWhite.aic.nowrap.pxPx(12).hPx(36).boxShadow(`inset 0 -1px 0 ${Palette.Gray100}`).$,
+  cellCss: Css.gray900.xs.bgWhite.aic.nowrap.pxPx(12).hPx(36).boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$,
   emptyCell: "-",
   presentationSettings: { borderless: true, typeScale: "xs", wrap: false },
   firstRowMessageCss: Css.tc.py3.$,
+  // Indent styles extends the existing padding-left defined in CellCss. The indentation should be +12px.
+  indentOneCss: Css.pl3.$,
+  indentTwoCss: Css.plPx(36).$,
   // Included as a hacky "treat indent as deprecated for this table" hint to GridTable
   levels: {},
 };


### PR DESCRIPTION
Includes UX for a third level of nesting in GridTable.
Changes include:
- Collapse Toggle to use 'compact' variant if already nested
- Apply 'tiny' type scale for first non-action column for further visual difference between 2nd and 3rd level of nesting.