### PR TITLE
fix: Memo on GridDataRow.data instead of the row itself.

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@emotion/jest": "^11.3.0",
     "@emotion/react": "^11.1.5",
     "@homebound/rtl-react-router-utils": "^1.0.3",
-    "@homebound/rtl-utils": "^2.51.0",
+    "@homebound/rtl-utils": "^2.59.3",
     "@homebound/truss": "^1.111.3",
     "@homebound/tsconfig": "^1.0.3",
     "@semantic-release/exec": "^6.0.3",

--- a/src/components/Layout/ScrollableContent.tsx
+++ b/src/components/Layout/ScrollableContent.tsx
@@ -4,14 +4,9 @@ import { FullBleed } from "src/components/Layout/FullBleed";
 import { useScrollableParent } from "src/components/Layout/ScrollableParent";
 import { Css } from "src/Css";
 
-/** Helper component for placing scrollable content within a `NestedScrollProvider`. */
-export function ScrollableContent({
-  children,
-  virtualized = false,
-}: {
-  children: ReactNode;
-  virtualized?: boolean;
-}): ReactPortal | JSX.Element {
+/** Helper component for placing scrollable content within a `ScrollableParent`. */
+export function ScrollableContent(props: { children: ReactNode; virtualized?: boolean }): ReactPortal | JSX.Element {
+  const { children, virtualized = false } = props;
   const { scrollableEl, setPortalTick, pl } = useScrollableParent();
 
   useEffect(() => {

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1588,6 +1588,18 @@ describe("GridTable", () => {
     expect(row(r, 2).getAttribute("data-render")).toEqual("1");
   });
 
+  it("memoizes rows based on the data attribute", async () => {
+    const [header, row1, row2] = rows;
+    const columns = [nameColumn];
+    // Given a table is initially rendered with 2 rows
+    const r = await render(<GridTable key="a" columns={columns} rows={[header, row1, row2]} />);
+    // When we render with new rows but unchanged data prows
+    r.rerender(<GridTable key="a" columns={columns} rows={[header, { ...row1 }, row2]} />);
+    // Then neither row was re-rendered
+    expect(row(r, 1).getAttribute("data-render")).toEqual("1");
+    expect(row(r, 2).getAttribute("data-render")).toEqual("1");
+  });
+
   it("reacts to setting activeRowId", async () => {
     const activeRowIdRowStyles: GridRowStyles<Row> = {
       data: {

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1593,8 +1593,8 @@ describe("GridTable", () => {
     const columns = [nameColumn];
     // Given a table is initially rendered with 2 rows
     const r = await render(<GridTable key="a" columns={columns} rows={[header, row1, row2]} />);
-    // When we render with new rows but unchanged data prows
-    r.rerender(<GridTable key="a" columns={columns} rows={[header, { ...row1 }, row2]} />);
+    // When we render with new rows but unchanged data values
+    r.rerender(<GridTable key="a" columns={columns} rows={[header, { ...row1 }, { ...row2 }]} />);
     // Then neither row was re-rendered
     expect(row(r, 1).getAttribute("data-render")).toEqual("1");
     expect(row(r, 2).getAttribute("data-render")).toEqual("1");

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -1187,7 +1187,7 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
  * We use a custom `propsAreEqual` for the `GridRowProps.row` property, which we memoize
  * based on the `GridDataRow.data` prop, such that if a table re-renders (i.e. for a cache
  * updated) and technically creates new row instances, but a row's `row.data` points to the
- * same/unchanged Apollo cache fragment, then we won't re-render that row).
+ * same/unchanged Apollo cache fragment, then we won't re-render that row.
  *
  * Note that if you're using virtualization, it can be surprising how unnoticeable broken row
  * memoization is.
@@ -1196,7 +1196,7 @@ function GridRow<R extends Kinded, S>(props: GridRowProps<R, S>): ReactElement {
 const MemoizedGridRow = React.memo(GridRow, (one, two) => {
   const { row: row1, ...others1 } = one;
   const { row: row2, ...others2 } = two;
-  return shallowEqual(row1.data, row2.data) && shallowEqual(others1, others2);
+  return shallowEqual(row1, row2) && shallowEqual(others1, others2);
 }) as typeof GridRow;
 
 /** Wraps a mobx Observer around the row's rendering/evaluation, so that it will be reactive. */

--- a/src/utils/rtl.tsx
+++ b/src/utils/rtl.tsx
@@ -46,23 +46,22 @@ export function render(
   wrapperOrOpts: RenderOpts | Wrapper | undefined,
   ...otherWrappers: Wrapper[]
 ): Promise<RenderResult & Record<string, HTMLElement & Function>> {
+  let wrappers: Wrapper[];
   if (wrapperOrOpts && "wrap" in wrapperOrOpts) {
     // They passed at least single wrapper + maybe more.
     // We put `withBeamRTL` first so that any `withApollo`s wrap outside of beam, so in-drawer/in-modal content has apollo
-    return rtlRender(component, ...[withBeamRTL, wrapperOrOpts as Wrapper, ...otherWrappers]);
+    wrappers = [withBeamRTL, wrapperOrOpts as Wrapper, ...otherWrappers];
   } else if (wrapperOrOpts) {
     const { omitBeamContext, at } = wrapperOrOpts;
-    return rtlRender(
-      component,
-      ...[
-        ...otherWrappers,
-        ...(!omitBeamContext ? [withBeamRTL] : []),
-        ...(at ? [_withRouter(at.url, at.route)] : [_withRouter()]),
-      ],
-    );
+    wrappers = [
+      ...otherWrappers,
+      ...(!omitBeamContext ? [withBeamRTL] : []),
+      ...(at ? [_withRouter(at.url, at.route)] : [_withRouter()]),
+    ];
+  } else {
+    wrappers = [withBeamRTL];
   }
-
-  return rtlRender(component, withBeamRTL);
+  return rtlRender(component, { wrappers, wait: true });
 }
 
 export function cell(r: RenderResult, row: number, column: number): HTMLElement {

--- a/src/utils/shallowEqual.ts
+++ b/src/utils/shallowEqual.ts
@@ -1,0 +1,29 @@
+/**
+ * An inlined version of shallowEach, see https://github.com/facebook/react/issues/16919
+ */
+export function shallowEqual(objA: any, objB: any): boolean {
+  if (Object.is(objA, objB)) {
+    return true;
+  }
+
+  if (typeof objA !== "object" || objA === null || typeof objB !== "object" || objB === null) {
+    return false;
+  }
+
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  // Test for A's keys different from B.
+  for (let i = 0; i < keysA.length; i++) {
+    const currentKey = keysA[i];
+    if (!objB.hasOwnProperty(currentKey) || !Object.is(objA[currentKey], objB[currentKey])) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2454,12 +2454,12 @@
     react-router "^5.1.2"
     use-query-params "^1.2.2"
 
-"@homebound/rtl-utils@^2.51.0":
-  version "2.51.0"
-  resolved "https://registry.npmjs.org/@homebound/rtl-utils/-/rtl-utils-2.51.0.tgz"
-  integrity sha512-vS4WHtxKCAVmj8Rqf7Q/NvPkBKRBTZm0hICRvjZRaPwHsYgSfZHYc7fRdavvFmWevm6PYEWzVR0TPQXO0Nb7yw==
+"@homebound/rtl-utils@^2.59.3":
+  version "2.59.3"
+  resolved "https://registry.yarnpkg.com/@homebound/rtl-utils/-/rtl-utils-2.59.3.tgz#798dca39a7fbce3017e3a69b5a01b59d3f237c53"
+  integrity sha512-yLIvQJxmJyUNmKKx0VS6bPFUg5nXqUXOH4o++sT4IZej/aK2Iy9RwKcQOYrJZDRmz8IuFfO6/G3f5KVWVCftFw==
   dependencies:
-    "@testing-library/react" "^12.0.0"
+    "@testing-library/react" "^12.1.2"
 
 "@homebound/truss@^1.111.3":
   version "1.111.3"
@@ -5257,13 +5257,14 @@
     "@types/react-test-renderer" ">=16.9.0"
     react-error-boundary "^3.1.0"
 
-"@testing-library/react@^12.0.0":
-  version "12.0.0"
-  resolved "https://registry.npmjs.org/@testing-library/react/-/react-12.0.0.tgz"
-  integrity sha512-sh3jhFgEshFyJ/0IxGltRhwZv2kFKfJ3fN1vTZ6hhMXzz9ZbbcTgmDYM4e+zJv+oiVKKEWZPyqPAh4MQBI65gA==
+"@testing-library/react@^12.1.2":
+  version "12.1.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-12.1.5.tgz#bb248f72f02a5ac9d949dea07279095fa577963b"
+  integrity sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@testing-library/dom" "^8.0.0"
+    "@types/react-dom" "<18.0.0"
 
 "@testing-library/user-event@^13.2.1":
   version "13.5.0"
@@ -5545,6 +5546,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@<18.0.0":
+  version "17.0.15"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.15.tgz#f2c8efde11521a4b7991e076cb9c70ba3bb0d156"
+  integrity sha512-Tr9VU9DvNoHDWlmecmcsE5ZZiUkYx+nKBzum4Oxe1K0yJVyBlfbq7H3eXjxXqJczBKqPGq3EgfTru4MgKb9+Yw==
+  dependencies:
+    "@types/react" "^17"
+
 "@types/react-dom@>=16.9.0":
   version "17.0.9"
   resolved "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.9.tgz"
@@ -5630,6 +5638,15 @@
   version "16.14.5"
   resolved "https://registry.npmjs.org/@types/react/-/react-16.14.5.tgz"
   integrity sha512-YRRv9DNZhaVTVRh9Wmmit7Y0UFhEVqXqCSw3uazRWMxa2x85hWQZ5BN24i7GXZbaclaLXEcodEeIHsjBA8eAMw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@^17":
+  version "17.0.44"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.44.tgz#c3714bd34dd551ab20b8015d9d0dbec812a51ec7"
+  integrity sha512-Ye0nlw09GeMp2Suh8qoOv0odfgCoowfM/9MG6WeRD60Gq9wS90bdkdRtYbRkNhXOpG4H+YXGvj4wOWhAC0LJ1g==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"


### PR DESCRIPTION
This should dramatically increase the effectiveness of our per-row
memoization, given that otherwise basically any re-calc of the
GridTable.rows prop (due to new rows/different group by/etc)
would invalidate every single row, and not just the ones with
changed `data` props.

Note that this is now only possible b/c of our recent PR to double
down on `GridDataRow.data` as required for all tables, and not
interleaving "misc data" directly into the `GridDataRow`.