### PR TITLE
fix: Virutalized table sticky header to apply zIndex of 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0",
     "react-stately": "^3.12.2",
-    "react-virtuoso": "^2.4.0",
+    "react-virtuoso": "2.10.2",
     "tributejs": "^5.1.3",
     "trix": "^1.3.1",
     "use-debounce": "^7.0.1",

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -23,6 +23,7 @@ import {
   numericColumn,
   simpleHeader,
   SimpleHeaderAndData,
+  useGridTableApi,
 } from "src/components/index";
 import { Css, Palette } from "src/Css";
 import { TextField } from "src/inputs";
@@ -957,7 +958,7 @@ export function StickyColumnsAndHeader() {
   const rows: GridDataRow<Row>[] = useMemo(
     () => [
       simpleHeader,
-      ...zeroTo(500).map((i) => ({ kind: "data" as const, id: String(i), data: { name: `ccc ${i}`, value: i } })),
+      ...zeroTo(50).map((i) => ({ kind: "data" as const, id: String(i), data: { name: `ccc ${i}`, value: i } })),
     ],
     [],
   );
@@ -973,6 +974,32 @@ export function StickyColumnsAndHeader() {
   return (
     <div ref={scrollWrap} css={Css.wPx(500).hPx(500).overflowAuto.$}>
       <GridTable columns={[nameColumn, valueColumn, actionColumn]} rows={rows} stickyHeader />
+    </div>
+  );
+}
+
+export function StickyColumnsAndHeaderVirtualized() {
+  const nameColumn: GridColumn<Row> = { header: "Name", data: ({ name }) => name, w: "200px", sticky: "left" };
+  const valueColumn: GridColumn<Row> = { header: "Value", data: ({ value }) => value, w: "200px" };
+  const actionColumn: GridColumn<Row> = { header: "Actions", data: "Actions", w: "200px" };
+  const rows: GridDataRow<Row>[] = useMemo(
+    () => [
+      simpleHeader,
+      ...zeroTo(50).map((i) => ({ kind: "data" as const, id: String(i), data: { name: `ccc ${i}`, value: i } })),
+    ],
+    [],
+  );
+
+  const api = useGridTableApi<Row>();
+
+  // Scroll the list prior to snapshot to ensure sticky header lays on top of sticky columns.
+  useEffect(() => {
+    api.scrollToIndex(5);
+  });
+
+  return (
+    <div css={Css.wPx(500).hPx(500).$}>
+      <GridTable columns={[nameColumn, valueColumn, actionColumn]} rows={rows} stickyHeader as="virtual" api={api} />
     </div>
   );
 }

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -654,6 +654,7 @@ function renderVirtual<R extends Kinded>(
         }
       }}
       components={{
+        TopItemList: VirtualHeader(listStyle, columns, id, firstLastColumnWidth, xss),
         List: VirtualRoot(listStyle, columns, id, firstLastColumnWidth, xss),
         Footer: () => <div css={footerStyle} />,
       }}
@@ -742,6 +743,24 @@ const VirtualRoot = memoizeOne<
         }}
         data-testid={id}
       >
+        {children}
+      </div>
+    );
+  });
+});
+
+const VirtualHeader = memoizeOne<
+  (
+    gs: GridStyle,
+    columns: GridColumn<any>[],
+    id: string,
+    firstLastColumnWidth: number | undefined,
+    xss: any,
+  ) => Components["TopItemList"]
+>((gs, _columns, id, _firstLastColumnWidth, xss) => {
+  return React.forwardRef(function VirtualHeader({ style, children }, ref) {
+    return (
+      <div ref={ref as MutableRefObject<HTMLDivElement>} style={{ ...style, ...{ zIndex: 2 } }}>
         {children}
       </div>
     );

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -654,7 +654,10 @@ function renderVirtual<R extends Kinded>(
         }
       }}
       components={{
-        TopItemList: VirtualHeader(listStyle, columns, id, firstLastColumnWidth, xss),
+        // Applying a zIndex: 2 to ensure it stays on top of sticky columns
+        TopItemList: React.forwardRef((props, ref) => (
+          <div {...props} ref={ref as MutableRefObject<HTMLDivElement>} style={{ ...props.style, ...{ zIndex: 2 } }} />
+        )),
         List: VirtualRoot(listStyle, columns, id, firstLastColumnWidth, xss),
         Footer: () => <div css={footerStyle} />,
       }}
@@ -743,24 +746,6 @@ const VirtualRoot = memoizeOne<
         }}
         data-testid={id}
       >
-        {children}
-      </div>
-    );
-  });
-});
-
-const VirtualHeader = memoizeOne<
-  (
-    gs: GridStyle,
-    columns: GridColumn<any>[],
-    id: string,
-    firstLastColumnWidth: number | undefined,
-    xss: any,
-  ) => Components["TopItemList"]
->((gs, _columns, id, _firstLastColumnWidth, xss) => {
-  return React.forwardRef(function VirtualHeader({ style, children }, ref) {
-    return (
-      <div ref={ref as MutableRefObject<HTMLDivElement>} style={{ ...style, ...{ zIndex: 2 } }}>
         {children}
       </div>
     );

--- a/src/inputs/internal/VirtualizedOptions.tsx
+++ b/src/inputs/internal/VirtualizedOptions.tsx
@@ -1,8 +1,7 @@
 import { Node } from "@react-types/shared";
 import React, { useEffect, useRef } from "react";
 import { SelectState } from "react-stately";
-import { Virtuoso } from "react-virtuoso";
-import { VirtuosoHandle } from "react-virtuoso/dist/components";
+import { Virtuoso, VirtuosoHandle } from "react-virtuoso";
 import { LoadingDots } from "src/inputs/internal/LoadingDots";
 import { Option } from "src/inputs/internal/Option";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -14636,10 +14636,10 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react-virtuoso@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.npmjs.org/react-virtuoso/-/react-virtuoso-2.4.0.tgz"
-  integrity sha512-hjo+ERHcZU5XOnpXMVEhm6mSiPi6oz8xbwKjWTfozbUGPaVAT+9wzU202Y50NOHVXekBVCGL02W2++PKi8z2Tw==
+react-virtuoso@2.10.2:
+  version "2.10.2"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-2.10.2.tgz#a4002f05019a07c69fca342c5b745451e2baa2ce"
+  integrity sha512-nQ8Wt/q64q6walcXo4y9SXkvZqjwuLiNUv7aKW3poKoZno8agTgeqcX1GMq3GPlaJ8wR5XMGwBxX4HONBMAGfg==
   dependencies:
     "@virtuoso.dev/react-urx" "^0.2.12"
     "@virtuoso.dev/urx" "^0.2.12"


### PR DESCRIPTION
This fixes an issue where sticky columns were layering on top of the sticky header when virtualized.
Uses the Virtuoso's 'TopItemList' component to apply styling directly to the TopItemList vs the rest of the list.