### PR TITLE
fix: Do not 'restoreFocus' on Menu when it closes

### DIFF
--- a/src/components/internal/Menu.tsx
+++ b/src/components/internal/Menu.tsx
@@ -46,7 +46,7 @@ export function Menu<T>(props: PropsWithChildren<MenuProps<T>>) {
   useEffect(() => tree.update("items", { label: "items", items } as MenuSection), [items]);
 
   return (
-    <FocusScope restoreFocus>
+    <FocusScope>
       <ul
         css={{
           // Using `max-height: inherit` allows us to take advantage of the height set on the overlay container, which updates based on the available space for the overlay within the viewport


### PR DESCRIPTION
The 'restoreFocus' causes React-Aria to try and retain focus on the element which triggered the Menu component. Though, if the menu closed in order to open a Modal, then we have conflicting signals to React Aria as to where focus should go - either in the Modal or back to the Menu's trigger. Removing 'restoreFocus' to no longer attempt to put the focus back to the Menu's button once closed. Will follow up with the Adobe team to provide this example and ask for guidance on how to go about this sort of behavior.