### PR TITLE
feat: Support contrast variant of Buttons

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -21,6 +21,7 @@ export const parameters: Parameters = {
       { name: "light", value: "#F8F8F8" },
       // Adding this to help view with off white hover states
       { name: "white", value: "#FFF" },
+      { name: "dark", value: "rgba(53,53,53,1)" },
     ],
     // Defaulting to an off white to better see the color palette
     default: "light",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@emotion/react": "^11.1.5",
     "@homebound/rtl-react-router-utils": "^1.0.3",
     "@homebound/rtl-utils": "^2.59.3",
-    "@homebound/truss": "^1.111.3",
+    "@homebound/truss": "^1.113.0",
     "@homebound/tsconfig": "^1.0.3",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^9.0.0",

--- a/src/Css.ts
+++ b/src/Css.ts
@@ -237,6 +237,13 @@ class CssBuilder<T extends Properties1> {
   get jcsa() { return this.add("justifyContent", "space-around"); }
   get jcse() { return this.add("justifyContent", "space-evenly"); }
   jc(value: Properties["justifyContent"]) { return this.add("justifyContent", value); }
+  get jifs() { return this.add("justifyItems", "flex-start"); }
+  get jife() { return this.add("justifyItems", "flex-end"); }
+  get jic() { return this.add("justifyItems", "center"); }
+  get jisb() { return this.add("justifyItems", "space-between"); }
+  get jisa() { return this.add("justifyItems", "space-around"); }
+  get jise() { return this.add("justifyItems", "space-evenly"); }
+  ji(value: Properties["justifyItems"]) { return this.add("justifyItems", value); }
   get asfs() { return this.add("alignSelf", "flex-start"); }
   get asfe() { return this.add("alignSelf", "flex-end"); }
   get asc() { return this.add("alignSelf", "center"); }

--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -1,6 +1,5 @@
-import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
-import { Button, ButtonProps } from "src";
+import { Button, ButtonSize, ButtonVariant } from "src";
 import { Css } from "src/Css";
 import { withRouter } from "src/utils/sb";
 
@@ -8,147 +7,86 @@ export default {
   title: "Components/Button",
   component: Button,
   decorators: [withRouter()],
-  args: { onClick: action("onPress") },
-  argTypes: {
-    autoFocus: { control: false },
-    variant: { control: false },
-    icon: { control: false },
-    size: { control: false },
-    children: { control: false },
-  },
   parameters: {
     // To better view the hover state
     backgrounds: { default: "white" },
   },
-} as Meta<ButtonProps>;
+} as Meta;
 
-export function ButtonVariations(args: ButtonProps) {
+const sizes: ButtonSize[] = ["sm", "md", "lg"];
+const variants: ButtonVariant[] = ["primary", "secondary", "tertiary", "danger"];
+
+export function ButtonVariations({ contrast = false }: { contrast?: boolean }) {
   return (
-    <div css={Css.dg.fdc.childGap2.$}>
-      <div>
-        <h2>Primary</h2>
-        <div css={buttonRowStyles}>
-          <Button {...args} label="Primary Button" autoFocus />
-          <Button {...args} disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} size="md" label="Primary Button" />
-          <Button {...args} size="md" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} size="lg" label="Primary Button" />
-          <Button {...args} size="lg" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} icon="plus" label="Primary Button" />
-          <Button {...args} disabled icon="plus" label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} size="md" icon="plus" label="Primary Button" />
-          <Button {...args} size="md" disabled icon="plus" label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} size="lg" icon="plus" label="Primary Button" />
-          <Button {...args} size="lg" disabled icon="plus" label="Disabled" />
-        </div>
+    <div css={Css.if(contrast).white.$}>
+      <div css={Css.dg.gtc("repeat(4, max-content)").jifs.gap("8px 16px").$}>
+        {variants.map((variant, idx) => {
+          const variantName = variant.charAt(0).toUpperCase() + variant.slice(1);
+          return (
+            <>
+              <h2 css={Css.xl.gc("1/5").if(idx !== 0).mt3.$}>{variantName}</h2>
+              {sizes.map((size) => (
+                <>
+                  <Button size={size} variant={variant} label={`${variantName} button`} contrast={contrast} />
+                  <Button size={size} variant={variant} disabled label="Disabled" contrast={contrast} />
+                  <Button
+                    size={size}
+                    variant={variant}
+                    icon="plus"
+                    label={`${variantName} button`}
+                    contrast={contrast}
+                  />
+                  <Button size={size} variant={variant} disabled icon="plus" label="Disabled" contrast={contrast} />
+                </>
+              ))}
+            </>
+          );
+        })}
       </div>
 
-      <div>
-        <h2>Secondary</h2>
-        <div css={buttonRowStyles}>
-          <Button {...args} variant="secondary" label="Secondary Button" />
-          <Button {...args} variant="secondary" disabled label="Disabled" />
+      <div css={Css.mt3.$}>
+        <h2 css={Css.xl.$}>Text</h2>
+        <div css={Css.my1.dg.gtc("repeat(2, max-content)").jifs.gap("8px 16px").$}>
+          <Button variant="text" label="Text Button" contrast={contrast} />
+          <Button variant="text" disabled label="Disabled" contrast={contrast} />
+          <Button icon="plus" variant="text" label="Text Button" contrast={contrast} />
+          <Button icon="plus" variant="text" disabled label="Disabled" contrast={contrast} />
         </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} size="md" variant="secondary" label="Secondary Button" />
-          <Button {...args} size="md" variant="secondary" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} size="lg" variant="secondary" label="Secondary Button" />
-          <Button {...args} size="lg" variant="secondary" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} icon="plus" variant="secondary" label="Secondary Button" />
-          <Button {...args} icon="plus" variant="secondary" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} icon="plus" size="md" variant="secondary" label="Secondary Button" />
-          <Button {...args} icon="plus" size="md" variant="secondary" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} icon="plus" size="lg" variant="secondary" label="Secondary Button" />
-          <Button {...args} icon="plus" size="lg" variant="secondary" disabled label="Disabled" />
-        </div>
+        <p css={Css.mb1.xs.$}>
+          Example of a <Button variant="text" label="Text Button" contrast={contrast} /> placed inheriting "xs" font
+          size.
+        </p>
+        <p css={Css.lg.$}>
+          Example of a <Button variant="text" label="Text Button" contrast={contrast} /> placed inheriting "lg" font
+          size.
+        </p>
       </div>
+    </div>
+  );
+}
 
-      <div>
-        <h2>Tertiary</h2>
-        <div css={buttonRowStyles}>
-          <Button {...args} variant="tertiary" label="Tertiary Button" />
-          <Button {...args} variant="tertiary" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} size="md" variant="tertiary" label="Tertiary Button" />
-          <Button {...args} size="md" variant="tertiary" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} icon="plus" variant="tertiary" label="Tertiary Button" />
-          <Button {...args} icon="plus" variant="tertiary" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} icon="plus" size="md" variant="tertiary" label="Tertiary Button" />
-          <Button {...args} icon="plus" size="md" variant="tertiary" disabled label="Disabled" />
-        </div>
-      </div>
+export function ContrastVariations() {
+  return <ButtonVariations contrast={true} />;
+}
+ContrastVariations.parameters = { backgrounds: { default: "dark" } };
 
-      <div>
-        <h2>Danger!</h2>
-        <div css={buttonRowStyles}>
-          <Button {...args} variant="danger" label="Danger Button" />
-          <Button {...args} variant="danger" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} size="md" variant="danger" label="Danger Button" />
-          <Button {...args} size="md" variant="danger" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} size="lg" variant="danger" label="Danger Button" />
-          <Button {...args} size="lg" variant="danger" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} icon="trash" variant="danger" label="Danger Button" />
-          <Button {...args} icon="trash" variant="danger" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} icon="trash" size="md" variant="danger" label="Danger Button" />
-          <Button {...args} icon="trash" size="md" variant="danger" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} icon="trash" size="lg" variant="danger" label="Danger Button" />
-          <Button {...args} icon="trash" size="lg" variant="danger" disabled label="Disabled" />
-        </div>
-      </div>
-
-      <div>
-        <h2>Text</h2>
-        <div css={buttonRowStyles}>
-          <Button {...args} variant="text" label="Text Button" />
-          <Button {...args} variant="text" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <Button {...args} icon="plus" variant="text" label="Text Button" />
-          <Button {...args} icon="plus" variant="text" disabled label="Disabled" />
-        </div>
-        <div css={buttonRowStyles}>
-          <p css={Css.xs.$}>
-            Example of a <Button {...args} variant="text" label="Text Button" /> placed inheriting "xs" font size.
-          </p>
-        </div>
-        <div css={buttonRowStyles}>
-          <p css={Css.lg.$}>
-            Example of a <Button {...args} variant="text" label="Text Button" /> placed inheriting "lg" font size.
-          </p>
-        </div>
+export function ButtonLink() {
+  return (
+    <div>
+      <div css={Css.dg.gtc("repeat(5, max-content)").jifs.gap("8px 16px").$}>
+        {variants.map((variant, idx) => {
+          const variantName = variant.charAt(0).toUpperCase() + variant.slice(1);
+          return (
+            <>
+              <h2 css={Css.xl.gc("1/6").if(idx !== 0).mt3.$}>{variantName}</h2>
+              <Button variant={variant} onClick="/fakePath" label="Relative URL link" />
+              <Button variant={variant} onClick="/" label="Relative URL - Open in New Tab" openInNew />
+              <Button variant={variant} onClick="https://www.homebound.com" label="Absolute URL link" />
+              <Button variant={variant} onClick="tony-stark.jpg" label="Download link" download />
+              <Button variant={variant} icon="plus" onClick="/fakePath" label="Disabled link" disabled />
+            </>
+          );
+        })}
       </div>
     </div>
   );
@@ -179,49 +117,3 @@ export function ButtonWithTooltip() {
     </div>
   );
 }
-
-export function ButtonLink() {
-  return (
-    <div css={Css.dg.fdc.childGap2.$}>
-      <div>
-        <h2>Primary</h2>
-        <div css={buttonRowStyles}>
-          <Button onClick="/fakePath" label="Relative URL link" />
-          <Button onClick="/" label="Relative URL - Open in New Tab" openInNew />
-          <Button onClick="https://www.homebound.com" label="Absolute URL link" />
-          <Button onClick="tony-stark.jpg" label="Download link" download />
-          <Button icon="plus" onClick="/fakePath" label="Disabled link" disabled />
-        </div>
-
-        <h2>Secondary</h2>
-        <div css={buttonRowStyles}>
-          <Button variant="secondary" onClick="/fakePath" label="Relative URL link" />
-          <Button variant="secondary" onClick="/" label="Relative URL - Open in New Tab" openInNew />
-          <Button variant="secondary" onClick="https://www.homebound.com" label="Absolute URL link" />
-          <Button variant="secondary" onClick="tony-stark.jpg" label="Download link" download />
-          <Button variant="secondary" icon="plus" onClick="/fakePath" label="Disabled link" disabled />
-        </div>
-
-        <h2>Tertiary</h2>
-        <div css={buttonRowStyles}>
-          <Button variant="tertiary" onClick="/fakePath" label="Relative URL link" />
-          <Button variant="tertiary" onClick="/" label="Relative URL - Open in New Tab" openInNew />
-          <Button variant="tertiary" onClick="https://www.homebound.com" label="Absolute URL link" />
-          <Button variant="tertiary" onClick="tony-stark.jpg" label="Download link" download />
-          <Button variant="tertiary" icon="plus" onClick="/fakePath" label="Disabled link" disabled />
-        </div>
-
-        <h2>Danger</h2>
-        <div css={buttonRowStyles}>
-          <Button variant="danger" onClick="/fakePath" label="Relative URL link" />
-          <Button variant="danger" onClick="/" label="Relative URL - Open in New Tab" openInNew />
-          <Button variant="danger" onClick="https://www.homebound.com" label="Absolute URL link" />
-          <Button variant="danger" onClick="tony-stark.jpg" label="Download link" download />
-          <Button variant="danger" icon="plus" onClick="/fakePath" label="Disabled link" disabled />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-const buttonRowStyles = Css.df.childGap1.my1.$;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2461,10 +2461,10 @@
   dependencies:
     "@testing-library/react" "^12.1.2"
 
-"@homebound/truss@^1.111.3":
-  version "1.111.3"
-  resolved "https://registry.npmjs.org/@homebound/truss/-/truss-1.111.3.tgz"
-  integrity sha512-P37w4W/4mYC+QKLd+2UyWx1xIpd0OuudxEKfGB742xJFvU/4LFXU0S2e/xt4Y0RRB2xsgbo9wrGoNIOVEqpgcg==
+"@homebound/truss@^1.113.0":
+  version "1.113.0"
+  resolved "https://registry.yarnpkg.com/@homebound/truss/-/truss-1.113.0.tgz#20f5adaacd6fc80485b3e8b61c90b905975641f9"
+  integrity sha512-yfJbvT2pCUB3TN0l8DOHfa340CSaVi3043GWFmsuFO7SLrfcBlMLeOzwtAGeQLsAnCbunVG/YtXycTzGX9Fiiw==
   dependencies:
     csstype "^2.6.10"
     ts-node "^10.7.0"


### PR DESCRIPTION
**Note:** Design only provided primary and tertiary variants of buttons for 'contrast'/dark mode. Since the "text" variant is extremely similar to "tertiary", then I followed suite on those stylings. Secondary, danger made some slight modifications, but didn't want to spend too much guess work on it until design comes back with updates for these.