### PR TITLE
feat: Add GridCellContent.onClick property to easily wrap content in a link/button component

### DIFF
--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from "@storybook/react";
 import { Button, ButtonSize, ButtonVariant } from "src";
 import { Css } from "src/Css";
+import { noop } from "src/utils";
 import { withRouter } from "src/utils/sb";
 
 export default {
@@ -27,16 +28,31 @@ export function ButtonVariations({ contrast = false }: { contrast?: boolean }) {
               <h2 css={Css.xl.gc("1/5").if(idx !== 0).mt3.$}>{variantName}</h2>
               {sizes.map((size) => (
                 <>
-                  <Button size={size} variant={variant} label={`${variantName} button`} contrast={contrast} />
-                  <Button size={size} variant={variant} disabled label="Disabled" contrast={contrast} />
+                  <Button
+                    size={size}
+                    variant={variant}
+                    label={`${variantName} button`}
+                    contrast={contrast}
+                    onClick={noop}
+                  />
+                  <Button size={size} variant={variant} disabled label="Disabled" contrast={contrast} onClick={noop} />
                   <Button
                     size={size}
                     variant={variant}
                     icon="plus"
                     label={`${variantName} button`}
                     contrast={contrast}
+                    onClick={noop}
                   />
-                  <Button size={size} variant={variant} disabled icon="plus" label="Disabled" contrast={contrast} />
+                  <Button
+                    size={size}
+                    variant={variant}
+                    disabled
+                    icon="plus"
+                    label="Disabled"
+                    contrast={contrast}
+                    onClick={noop}
+                  />
                 </>
               ))}
             </>
@@ -47,18 +63,18 @@ export function ButtonVariations({ contrast = false }: { contrast?: boolean }) {
       <div css={Css.mt3.$}>
         <h2 css={Css.xl.$}>Text</h2>
         <div css={Css.my1.dg.gtc("repeat(2, max-content)").jifs.gap("8px 16px").$}>
-          <Button variant="text" label="Text Button" contrast={contrast} />
-          <Button variant="text" disabled label="Disabled" contrast={contrast} />
-          <Button icon="plus" variant="text" label="Text Button" contrast={contrast} />
-          <Button icon="plus" variant="text" disabled label="Disabled" contrast={contrast} />
+          <Button variant="text" label="Text Button" contrast={contrast} onClick={noop} />
+          <Button variant="text" disabled label="Disabled" contrast={contrast} onClick={noop} />
+          <Button icon="plus" variant="text" label="Text Button" contrast={contrast} onClick={noop} />
+          <Button icon="plus" variant="text" disabled label="Disabled" contrast={contrast} onClick={noop} />
         </div>
         <p css={Css.mb1.xs.$}>
-          Example of a <Button variant="text" label="Text Button" contrast={contrast} /> placed inheriting "xs" font
-          size.
+          Example of a <Button variant="text" label="Text Button" contrast={contrast} onClick={noop} /> placed
+          inheriting "xs" font size.
         </p>
         <p css={Css.lg.$}>
-          Example of a <Button variant="text" label="Text Button" contrast={contrast} /> placed inheriting "lg" font
-          size.
+          Example of a <Button variant="text" label="Text Button" contrast={contrast} onClick={noop} /> placed
+          inheriting "lg" font size.
         </p>
       </div>
     </div>
@@ -108,11 +124,12 @@ export function ButtonWithTooltip() {
             </div>
           }
           label="Upload"
+          onClick={noop}
         />
       </div>
       <div>
         <h2>Tooltip provided via 'tooltip' property</h2>
-        <Button tooltip="Create a new entity" label="Add new" />
+        <Button tooltip="Create a new entity" label="Add new" onClick={noop} />
       </div>
     </div>
   );

--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -1,21 +1,22 @@
 import { Button } from "src/components/Button";
+import { noop } from "src/utils";
 import { click, render, withRouter } from "src/utils/rtl";
 import { useTestIds } from "src/utils/useTestIds";
 
 describe("Button", () => {
   it("can have a data-testid", async () => {
-    const r = await render(<Button label="Button" data-testid="custom" />);
+    const r = await render(<Button label="Button" data-testid="custom" onClick={noop} />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("custom");
   });
 
   it("defaults data-testid to the label", async () => {
-    const r = await render(<Button label="Button" />);
+    const r = await render(<Button label="Button" onClick={noop} />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("button");
   });
 
   it("can accept prefixed test ids", async () => {
     const testIds = useTestIds({}, "page1");
-    const r = await render(<Button label="Button" {...testIds.custom} />);
+    const r = await render(<Button label="Button" {...testIds.custom} onClick={noop} />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("page1_custom");
   });
 
@@ -29,7 +30,7 @@ describe("Button", () => {
   });
 
   it("can render a specific button type", async () => {
-    const r = await render(<Button label="Button" type="submit" />);
+    const r = await render(<Button label="Button" type="submit" onClick={noop} />);
     expect(r.button()).toHaveAttribute("type", "submit");
   });
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,11 +1,11 @@
 import { AriaButtonProps } from "@react-types/button";
 import { ButtonHTMLAttributes, ReactNode, RefObject, useMemo, useRef } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
-import { Link } from "react-router-dom";
 import { Icon, IconProps, maybeTooltip, navLink, resolveTooltip } from "src/components";
 import { Css, Palette } from "src/Css";
 import { BeamButtonProps, BeamFocusableProps } from "src/interfaces";
 import { isAbsoluteUrl, noop } from "src/utils";
+import { getButtonOrLink } from "src/utils/getInteractiveElement";
 import { useTestIds } from "src/utils/useTestIds";
 
 export interface ButtonProps extends BeamButtonProps, BeamFocusableProps {
@@ -88,6 +88,7 @@ export function Button(props: ButtonProps) {
     ...buttonProps,
     ...focusProps,
     ...hoverProps,
+    className: typeof onPress === "string" ? navLink : undefined,
     css: {
       ...Css.buttonBase.tt("inherit").$,
       ...baseStyles,
@@ -99,31 +100,11 @@ export function Button(props: ButtonProps) {
     ...tid,
   };
 
-  const button =
-    typeof onPress === "string" ? (
-      isAbsoluteUrl(onPress) || openInNew || download ? (
-        <a
-          {...buttonAttrs}
-          href={onPress}
-          className={navLink}
-          {...(download ? { download: "" } : { target: "_blank", rel: "noreferrer noopener" })}
-        >
-          {buttonContent}
-        </a>
-      ) : (
-        <Link {...buttonAttrs} to={onPress} className={navLink}>
-          {buttonContent}
-        </Link>
-      )
-    ) : (
-      <button {...buttonAttrs}>{buttonContent}</button>
-    );
-
   // If we're disabled b/c of a non-boolean ReactNode, or the caller specified tooltip text, then show it in a tooltip
   return maybeTooltip({
     title: resolveTooltip(disabled, tooltip),
     placement: "top",
-    children: button,
+    children: getButtonOrLink(buttonContent, onPress, buttonAttrs, openInNew, download),
   });
 }
 

--- a/src/components/IconButton.stories.tsx
+++ b/src/components/IconButton.stories.tsx
@@ -9,6 +9,7 @@ import {
   Icons,
   Palette,
 } from "src";
+import { noop } from "src/utils";
 import { withRouter } from "src/utils/sb";
 
 export default {
@@ -84,11 +85,12 @@ export function WithTooltip() {
             </div>
           }
           icon="arrowBack"
+          onClick={noop}
         />
       </div>
       <div>
         <h2>Tooltip provided via 'tooltip' property</h2>
-        <IconButton icon="arrowBack" tooltip="Back to previous page" />
+        <IconButton icon="arrowBack" tooltip="Back to previous page" onClick={noop} />
       </div>
     </div>
   );

--- a/src/components/IconButton.test.tsx
+++ b/src/components/IconButton.test.tsx
@@ -1,21 +1,22 @@
 import { IconButton } from "src/components/IconButton";
+import { noop } from "src/utils";
 import { click, render, withRouter } from "src/utils/rtl";
 import { useTestIds } from "src/utils/useTestIds";
 
 describe("IconButton", () => {
   it("can have a data-testid", async () => {
-    const r = await render(<IconButton icon="trash" data-testid="remove" />);
+    const r = await render(<IconButton icon="trash" data-testid="remove" onClick={noop} />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("remove");
   });
 
   it("defaults data-testid to the icon", async () => {
-    const r = await render(<IconButton icon="trash" />);
+    const r = await render(<IconButton icon="trash" onClick={noop} />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("trash");
   });
 
   it("can accept prefixed test ids", async () => {
     const testIds = useTestIds({}, "page1");
-    const r = await render(<IconButton icon="trash" {...testIds.remove} />);
+    const r = await render(<IconButton icon="trash" {...testIds.remove} onClick={noop} />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("page1_remove");
   });
 

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -81,17 +81,27 @@ export function ModalForm() {
           <FormStateApp />
         </ModalBody>
         <ModalFooter>
-          <Button label="Submit" />
+          <Button label="Submit" onClick={noop} />
         </ModalFooter>
       </>
     </OpenModal>
   );
 }
 
-interface ModalExampleProps extends Pick<ModalProps, "size" | "forceScrolling" | "drawHeaderBorder">, TestModalContentProps {}
+interface ModalExampleProps
+  extends Pick<ModalProps, "size" | "forceScrolling" | "drawHeaderBorder">,
+    TestModalContentProps {}
 
 function ModalExample(props: ModalExampleProps) {
-  const { size, showLeftAction, initNumSentences = 1, forceScrolling, withTag, withDateField, drawHeaderBorder = false } = props;
+  const {
+    size,
+    showLeftAction,
+    initNumSentences = 1,
+    forceScrolling,
+    withTag,
+    withDateField,
+    drawHeaderBorder = false,
+  } = props;
   const { openModal } = useModal();
   const open = () =>
     openModal({

--- a/src/components/SuperDrawer/SuperDrawer.stories.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.stories.tsx
@@ -17,6 +17,7 @@ import { TestModalContent } from "src/components/Modal/TestModalContent";
 import { useModal } from "src/components/Modal/useModal";
 import { GridDataRow, GridRowLookup } from "src/components/Table";
 import { Css } from "src/Css";
+import { noop } from "src/utils";
 import { withBeamDecorator, withDimensions } from "src/utils/sb";
 import { SuperDrawerContent, useSuperDrawer } from "./index";
 import { SuperDrawer as SuperDrawerComponent } from "./SuperDrawer";
@@ -363,7 +364,7 @@ function TestDetailContent({ book, onPurchase }: { book: Book; onPurchase?: () =
     <SuperDrawerContent
       actions={[
         { label: `Back to "${book.bookTitle}"`, onClick: closeDrawerDetail, variant: "tertiary" },
-        { label: `Purchase "${book.bookTitle}"`, onClick: onPurchase, disabled: !onPurchase },
+        { label: `Purchase "${book.bookTitle}"`, onClick: onPurchase ?? noop, disabled: !onPurchase },
       ]}
     >
       <h2 css={Css.xlEm.mb1.$}>{book.authorName}</h2>

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1,3 +1,4 @@
+import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
 import { observable } from "mobx";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
@@ -35,6 +36,7 @@ export default {
   component: GridTable,
   title: "Components/GridTable",
   parameters: { layout: "fullscreen", backgrounds: { default: "white" } },
+  decorators: [withRouter()],
 } as Meta;
 
 type Data = { name: string | undefined; value: number | undefined };
@@ -1102,4 +1104,44 @@ export function ActiveRowNestedCard() {
   const columns = useMemo(() => [nameColumn, nameColumn, actionColumn], []);
 
   return <GridTable columns={columns} rows={rowsWithHeader} style={nestedStyle} activeRowId="grandChild_p0c1g2" />;
+}
+
+export function TruncatingCells() {
+  const textCol: GridColumn<Row> = {
+    header: "As Text",
+    data: ({ name }) => ({ content: name }),
+  };
+  const elCol: GridColumn<Row> = {
+    header: "Truncated locally",
+    data: ({ name }) => ({
+      content: <span css={Css.green800.xsEm.truncate.$}>{name}</span>,
+    }),
+  };
+  const buttonCol: GridColumn<Row> = {
+    header: "As Button",
+    data: ({ name }) => ({ content: name, onClick: action("Name column button clicked") }),
+  };
+  const relativeLinkCol: GridColumn<Row> = {
+    header: "As Link",
+    data: ({ name }) => ({ content: <span>{name}</span>, onClick: "/relative/url" }),
+  };
+  const externalLinkCol: GridColumn<Row> = {
+    header: "As External Link",
+    data: ({ name }) => ({ content: <span>{name}</span>, onClick: "http://www.homebound.com" }),
+  };
+
+  return (
+    <div css={Css.wPx(800).$}>
+      <GridTable
+        columns={[textCol, elCol, buttonCol, relativeLinkCol, externalLinkCol]}
+        style={{ rowHeight: "fixed" }}
+        rows={[
+          simpleHeader,
+          { kind: "data", id: "1", data: { name: "Tony Stark, Iron Man", value: 1 } },
+          { kind: "data", id: "2", data: { name: "Natasha Romanova, Black Widow", value: 2 } },
+          { kind: "data", id: "3", data: { name: "Thor Odinson, God of Thunder", value: 3 } },
+        ]}
+      />
+    </div>
+  );
 }

--- a/src/components/internal/OverlayTrigger.tsx
+++ b/src/components/internal/OverlayTrigger.tsx
@@ -8,7 +8,7 @@ import { Icon } from "src/components/Icon";
 import { IconButton, IconButtonProps } from "src/components/IconButton";
 import { Popover } from "src/components/internal";
 import { Css } from "src/Css";
-import { useTestIds } from "src/utils";
+import { noop, useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
 
 interface TextButtonTriggerProps extends Pick<ButtonProps, "label" | "variant" | "size" | "icon"> {}
@@ -56,10 +56,11 @@ export function OverlayTrigger(props: OverlayTriggerProps) {
           endAdornment={<Icon icon={state.isOpen ? "chevronUp" : "chevronDown"} />}
           disabled={disabled}
           tooltip={tooltip}
+          onClick={noop}
           {...tid}
         />
       ) : (
-        <IconButton {...trigger} menuTriggerProps={menuTriggerProps} buttonRef={buttonRef} {...tid} />
+        <IconButton {...trigger} menuTriggerProps={menuTriggerProps} buttonRef={buttonRef} {...tid} onClick={noop} />
       )}
       {state.isOpen && (
         <Popover

--- a/src/inputs/Examples.stories.tsx
+++ b/src/inputs/Examples.stories.tsx
@@ -3,6 +3,7 @@ import { Meta } from "@storybook/react";
 import { useEffect } from "react";
 import { SuperDrawerContent, useSuperDrawer } from "src/components";
 import { Css } from "src/Css";
+import { noop } from "src/utils";
 import { withBeamDecorator } from "src/utils/sb";
 import { SelectField } from "./SelectField";
 import { TextAreaField } from "./TextAreaField";
@@ -25,7 +26,12 @@ export function SuperDrawerWithForm() {
 
 function DrawerWithInputs() {
   return (
-    <SuperDrawerContent actions={[{ label: "Cancel" }, { label: "Save" }]}>
+    <SuperDrawerContent
+      actions={[
+        { label: "Cancel", onClick: noop },
+        { label: "Save", onClick: noop },
+      ]}
+    >
       <form css={{ ...Css.df.fdc.childGap5.$, fieldset: Css.df.fdc.childGap2.$, legend: Css.baseEm.mb2.$ }}>
         <fieldset>
           <legend>Details</legend>

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -18,7 +18,7 @@ export interface BeamButtonProps {
    */
   disabled?: boolean | ReactNode;
   /** If function, then it is the handler that is called when the press is released over the target. Otherwise if string, it is the URL path for the link */
-  onClick?: ((e: PressEvent) => void) | string;
+  onClick: ((e: PressEvent) => void) | string;
   /** Text to be shown via a tooltip when the user hovers over the button */
   tooltip?: ReactNode;
   /** Whether to open link in a new tab. This only effects the element if the `onClick` is a `string`/URL. */

--- a/src/utils/getInteractiveElement.tsx
+++ b/src/utils/getInteractiveElement.tsx
@@ -1,0 +1,30 @@
+import { PressEvent } from "@react-types/shared";
+import { HTMLAttributes, ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { isAbsoluteUrl } from "src/utils/index";
+
+export function getButtonOrLink(
+  content: ReactNode,
+  onClick: ((e: PressEvent) => void) | string,
+  attrs: HTMLAttributes<HTMLButtonElement | HTMLAnchorElement>,
+  openInNew: boolean = false,
+  downloadLink: boolean = false,
+): JSX.Element {
+  return typeof onClick === "string" ? (
+    isAbsoluteUrl(onClick) || openInNew || downloadLink ? (
+      <a
+        {...attrs}
+        href={onClick}
+        {...(downloadLink ? { download: "" } : { target: "_blank", rel: "noreferrer noopener" })}
+      >
+        {content}
+      </a>
+    ) : (
+      <Link {...attrs} to={onClick}>
+        {content}
+      </Link>
+    )
+  ) : (
+    <button {...attrs}>{content}</button>
+  );
+}


### PR DESCRIPTION
By utilizing the new prop, then GridCells can properly truncate text when the rowHeight is fixed. This prevents users having to ensure they add proper truncation styles locally when wanting to wrap the content of the cell in an interactive element