### PR TITLE
fix: Ensure sticky columns do not become unstuck

### DIFF
--- a/src/components/Layout/ScrollableParent.tsx
+++ b/src/components/Layout/ScrollableParent.tsx
@@ -63,9 +63,10 @@ export function ScrollableParent(props: PropsWithChildren<ScrollableParentContex
       <Tag css={{ ...Css.mh0.mw0.fg1.df.fdc.$, ...otherXss }}>
         {/* Use `overflow: overlay` to prevent scrollbar from pushing content in when rendered. This is only supported in Webkit browsers, so we also keep `overflow: auto` as a fallback for other browsers.*/}
         {/* `overlay` needs to be applied using `addIn` otherwise the two `overflow` properties will be merged. */}
-        <div css={Css.pl(context.pl).pr(context.pr).if(!hasScrollableContent).h100.overflowAuto.$}>{children}</div>
+        {/* Using `margin-left` to ensure horizontally scrolled content doesn't show up within the 'gutter', but `padding-right` to keep the scrollbar to the edge of the viewport */}
+        <div css={Css.ml(context.pl).pr(context.pr).if(!hasScrollableContent).h100.overflowAuto.$}>{children}</div>
         {/* Set fg1 to take up the remaining space in the viewport.*/}
-        <div css={Css.fg1.overflowAuto.pl(context.pl).pr(context.pr).$} ref={scrollableRef} />
+        <div css={Css.fg1.overflowAuto.ml(context.pl).pr(context.pr).$} ref={scrollableRef} />
       </Tag>
     </ScrollableParentContext.Provider>
   );

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -989,7 +989,21 @@ export function StickyColumnsAndHeader() {
 
   return (
     <div ref={scrollWrap} css={Css.wPx(500).hPx(500).overflowAuto.$}>
-      <GridTable columns={[nameColumn, valueColumn, actionColumn]} rows={rows} stickyHeader />
+      <GridTable
+        columns={[
+          nameColumn,
+          valueColumn,
+          valueColumn,
+          valueColumn,
+          valueColumn,
+          valueColumn,
+          valueColumn,
+          valueColumn,
+          actionColumn,
+        ]}
+        rows={rows}
+        stickyHeader
+      />
     </div>
   );
 }
@@ -1027,7 +1041,22 @@ export function StickyColumnsAndHeaderVirtualized() {
 
   return (
     <div css={Css.wPx(500).hPx(500).$}>
-      <GridTable columns={[nameColumn, valueColumn, actionColumn]} rows={rows} stickyHeader as="virtual" api={api} />
+      <GridTable
+        columns={[
+          nameColumn,
+          valueColumn,
+          valueColumn,
+          valueColumn,
+          valueColumn,
+          valueColumn,
+          valueColumn,
+          actionColumn,
+        ]}
+        rows={rows}
+        stickyHeader
+        as="virtual"
+        api={api}
+      />
     </div>
   );
 }

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1139,38 +1139,41 @@ export function TruncatingCells() {
   const textCol: GridColumn<Row> = {
     header: "As Text",
     data: ({ name }) => ({ content: name }),
+    w: "160px",
   };
   const elCol: GridColumn<Row> = {
     header: "Truncated locally",
     data: ({ name }) => ({
       content: <span css={Css.green800.xsEm.truncate.$}>{name}</span>,
     }),
+    w: "160px",
   };
   const buttonCol: GridColumn<Row> = {
     header: "As Button",
     data: ({ name }) => ({ content: name, onClick: action("Name column button clicked") }),
+    w: "160px",
   };
   const relativeLinkCol: GridColumn<Row> = {
     header: "As Link",
     data: ({ name }) => ({ content: <span>{name}</span>, onClick: "/relative/url" }),
+    w: "160px",
   };
   const externalLinkCol: GridColumn<Row> = {
     header: "As External Link",
     data: ({ name }) => ({ content: <span>{name}</span>, onClick: "http://www.homebound.com" }),
+    w: "160px",
   };
 
   return (
-    <div css={Css.wPx(800).$}>
-      <GridTable
-        columns={[textCol, elCol, buttonCol, relativeLinkCol, externalLinkCol]}
-        style={{ rowHeight: "fixed" }}
-        rows={[
-          simpleHeader,
-          { kind: "data", id: "1", data: { name: "Tony Stark, Iron Man", value: 1 } },
-          { kind: "data", id: "2", data: { name: "Natasha Romanova, Black Widow", value: 2 } },
-          { kind: "data", id: "3", data: { name: "Thor Odinson, God of Thunder", value: 3 } },
-        ]}
-      />
-    </div>
+    <GridTable
+      columns={[textCol, elCol, buttonCol, relativeLinkCol, externalLinkCol]}
+      style={{ rowHeight: "fixed" }}
+      rows={[
+        simpleHeader,
+        { kind: "data", id: "1", data: { name: "Tony Stark, Iron Man", value: 1 } },
+        { kind: "data", id: "2", data: { name: "Natasha Romanova, Black Widow", value: 2 } },
+        { kind: "data", id: "3", data: { name: "Thor Odinson, God of Thunder", value: 3 } },
+      ]}
+    />
   );
 }

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -558,6 +558,11 @@ function renderDiv<R extends Kinded>(
     <div
       ref={tableRef as any}
       css={{
+        // Use `fit-content` to ensure the width of the table takes up the full width of its content.
+        // Otherwise, the table's width would be that of its container, which may not be as wide as the table itself.
+        // In cases where we have sticky columns on a very wide table, then the container which the columns "stick" to (which is the table),
+        // needs to be as wide as the table's content, or else we lose the "stickiness" once scrolling past width of the table's container.
+        ...Css.mw("fit-content").$,
         /*
           Using (n + 3) here to target all rows that are after the first non-header row. Since n starts at 0, we can use
           the + operator as an offset.


### PR DESCRIPTION
Adds 'min-width: fit-content' to GridTable when rendered as="div". This ensures the container in which the sticky columns live is as wide as the table's contents and prevents the columns from becoming 'unstuck' prematurely.
Changes `padding-left` to `margin-left` in the ScrollableParent to ensure content that scrolls horizontally doesn't bleed through the left padding.