### PR TITLE
feat: Support setting group rows as initially collasped

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -35,11 +35,12 @@ const rows: GridDataRow<Row>[] = [
 ];
 
 // Make a `NestedRow` ADT for a table with a header + 3 levels of nesting
+type TotalsRow = { kind: "totals"; id: string; data: {} };
 type HeaderRow = { kind: "header"; id: string; data: {} };
 type ParentRow = { kind: "parent"; id: string; data: { name: string } };
 type ChildRow = { kind: "child"; id: string; data: { name: string } };
 type GrandChildRow = { kind: "grandChild"; id: string; data: { name: string } };
-type NestedRow = HeaderRow | ParentRow | ChildRow | GrandChildRow;
+type NestedRow = TotalsRow | HeaderRow | ParentRow | ChildRow | GrandChildRow;
 
 // I tried https://github.com/keiya01/react-performance-testing#count-renders but
 // it didn't work with our fake timers, so this is easier for now.
@@ -50,18 +51,21 @@ beforeEach(() => (renderedNameColumn = []));
 // TODO Move this to the bottom of the file in it's own PR
 const nestedColumns: GridColumn<NestedRow>[] = [
   {
+    totals: emptyCell,
     header: (data, { row }) => <Collapse id={row.id} />,
     parent: (data, { row }) => <Collapse id={row.id} />,
     child: (data, { row }) => (row.children ? <Collapse id={row.id} /> : ""),
     grandChild: () => "",
   },
   selectColumn<NestedRow>({
+    totals: emptyCell,
     header: (data, { row }) => ({ content: <Select id={row.id} /> }),
     parent: (data, { row }) => ({ content: <Select id={row.id} /> }),
     child: (data, { row }) => ({ content: <Select id={row.id} /> }),
     grandChild: (data, { row }) => ({ content: <Select id={row.id} /> }),
   }),
   {
+    totals: emptyCell,
     header: () => "Name",
     parent: (data, { row }) => ({
       content() {
@@ -1092,7 +1096,7 @@ describe("GridTable", () => {
   it("persists collapse", async () => {
     const tableIdentifier = "gridTableTest";
     // Given that parent 2 is set to collapsed in local storage
-    localStorage.setItem(tableIdentifier, JSON.stringify(["p2", "p2c1"]));
+    sessionStorage.setItem(tableIdentifier, JSON.stringify(["p2", "p2c1"]));
     // And two parents with a child each
     const rows: GridDataRow<NestedRow>[] = [
       simpleHeader,
@@ -1122,7 +1126,7 @@ describe("GridTable", () => {
     expect(row(r, 4)).toBeUndefined();
 
     // Unset local storage
-    localStorage.setItem(tableIdentifier, "");
+    sessionStorage.setItem(tableIdentifier, "");
   });
 
   it("updates collapse state in header when collapsing and expanding the parent rows", async () => {
@@ -1754,15 +1758,12 @@ describe("GridTable", () => {
     expect(cell(r, 1, 1)).toHaveStyleRule("background-color", Palette.LightBlue50);
   });
 
-  it("can render with rows initially collapsed", async () => {
+  it("can render with rows with initCollapsed defined", async () => {
     // Given rows with multiple levels of nesting where one parent is initially collapsed and one child is initially collapsed
     const rows: GridDataRow<NestedRow>[] = [
       simpleHeader,
       {
-        kind: "parent",
-        id: "p1",
-        data: { name: "parent 1" },
-        initCollapsed: true,
+        ...{ kind: "parent", id: "p1", data: { name: "parent 1" }, initCollapsed: true },
         children: [
           {
             ...{ kind: "child", id: "p1c1", data: { name: "child p1c1" } },
@@ -1771,9 +1772,7 @@ describe("GridTable", () => {
         ],
       },
       {
-        kind: "parent",
-        id: "p2",
-        data: { name: "parent 2" },
+        ...{ kind: "parent", id: "p2", data: { name: "parent 2" } },
         children: [
           {
             ...{ kind: "child", id: "p2c1", data: { name: "child p2c1" }, initCollapsed: true },
@@ -1816,10 +1815,10 @@ describe("GridTable", () => {
     expect(cell(r, 1, 2).textContent).toBe("parent 1");
 
     // And the local storage value is initially set with the current state
-    expect(localStorage.getItem(tableIdentifier)).toBe('["p1"]');
+    expect(sessionStorage.getItem(tableIdentifier)).toBe('["p1"]');
   });
 
-  it("ignores initCollapsed on rows if persistCollapse is set and available in localStorage", async () => {
+  it("ignores initCollapsed on rows if persistCollapse is set and available in sessionStorage", async () => {
     const tableIdentifier = "persistCollapse";
     // Given rows with a group row that is initially collapsed
     const rows: GridDataRow<NestedRow>[] = [
@@ -1830,15 +1829,91 @@ describe("GridTable", () => {
       },
     ];
 
-    localStorage.setItem(tableIdentifier, "[]");
+    sessionStorage.setItem(tableIdentifier, "[]");
 
-    // When initially rendering the table with a 'persistCollapse' value, but an associated local storage item has not been set
+    // When initially rendering the table with a 'persistCollapse' value with an existing sessionStorage value
     const r = await render(<GridTable columns={nestedColumns} rows={rows} persistCollapse={tableIdentifier} />);
 
     // Then expect "parent 1" to not be collapsed
     expect(cell(r, 1, 0).textContent).toBe("-");
     expect(cell(r, 1, 2).textContent).toBe("parent 1");
     expect(cell(r, 2, 2).textContent).toBe("child p1c1");
+  });
+
+  it("can update table with new rows with initCollapsed set and updates sessionStorage with new values", async () => {
+    // Given a table that can update its set of rows and persists its collapse state
+    function TestComponent() {
+      const [rows, setRows] = useState<GridDataRow<NestedRow>[]>(staticRows);
+      return (
+        <>
+          <button onClick={() => setRows(initRows)} data-testid="initRows" />
+          <button onClick={() => setRows(newRows)} data-testid="updateRows" />
+          <GridTable
+            columns={nestedColumns}
+            rows={rows}
+            persistCollapse={tableIdentifier}
+            fallbackMessage="Loading..."
+          />
+        </>
+      );
+    }
+
+    const tableIdentifier = "persistCollapse";
+    const staticRows: GridDataRow<NestedRow>[] = [{ kind: "totals" as const, id: "totals", data: {} }, simpleHeader];
+    const initRows: GridDataRow<NestedRow>[] = [
+      ...staticRows,
+      {
+        ...{ kind: "parent", id: "p1", data: { name: "parent 1" }, initCollapsed: true },
+        children: [{ kind: "child", id: "p1c1", data: { name: "child p1c1" } }],
+      },
+      {
+        ...{ kind: "parent", id: "p2", data: { name: "parent 2" }, initCollapsed: true },
+        children: [{ kind: "child", id: "p2c1", data: { name: "child p2c1" } }],
+      },
+    ];
+
+    const newRows: GridDataRow<NestedRow>[] = [
+      ...initRows,
+      {
+        ...{ kind: "parent", id: "p3", data: { name: "parent 3" }, initCollapsed: true },
+        children: [{ kind: "child", id: "p3c1", data: { name: "child p3c1" } }],
+      },
+    ];
+
+    // With the sessionStorage value differing from the initial row set.
+    sessionStorage.setItem(tableIdentifier, "[]");
+
+    // When rendering the table
+    const r = await render(<TestComponent />);
+
+    // Then expect the fallback message
+    expect(cell(r, 2, 0).textContent).toBe("Loading...");
+
+    // When initializing the first set of rows
+    click(r.initRows);
+
+    // Then expect "parent 1" and "parent 2" to be expanded, as their `initCollapsed` properties were ignored due to the sessionStorage
+    expect(cell(r, 2, 0).textContent).toBe("-");
+    expect(cell(r, 4, 0).textContent).toBe("-");
+
+    // When expanding parent 2
+    click(r.collapse_2);
+
+    // Then expect parent 2 to now be expanded
+    expect(cell(r, 4, 0).textContent).toBe("+");
+
+    // When updating the set of rows
+    click(r.updateRows);
+
+    // Then expect "parent 1" to remain not collapsed
+    expect(cell(r, 2, 0).textContent).toBe("-");
+    // And parent 2 to remain expanded, as it was updated since the initial render
+    expect(cell(r, 4, 0).textContent).toBe("+");
+    // And parent 3, the newly added row, to be collapsed based on its `initCollapsed` prop
+    expect(cell(r, 5, 0).textContent).toBe("+");
+
+    // And the local storage value is updated with the current state
+    expect(sessionStorage.getItem(tableIdentifier)).toBe('["p2","p3"]');
   });
 });
 

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -309,7 +309,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
   const style = resolveStyles(maybeStyle);
 
   const { rowState } = api;
-  rowState.rows = rows;
+  rowState.setRows(rows);
 
   useEffect(() => {
     rowState.activeRowId = activeRowId;

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -301,7 +301,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
 
   const api = useMemo<GridTableApiImpl<R>>(() => {
     const api = (props.api as GridTableApiImpl<R>) ?? new GridTableApiImpl();
-    api.init(persistCollapse, virtuosoRef);
+    api.init(persistCollapse, virtuosoRef, rows);
     api.setActiveRowId(activeRowId);
     return api;
   }, [props.api]);
@@ -1026,6 +1026,8 @@ export type GridDataRow<R extends Kinded> = {
   /** Whether to pin this sort to the first/last of its parent's children. */
   pin?: "first" | "last";
   data: unknown;
+  /** Whether to have the row collapsed (children not visible) on initial load. This will be ignore in subsequent re-renders of the table */
+  initCollapsed?: boolean;
 } & IfAny<R, {}, DiscriminateUnion<R, "kind", R["kind"]>>;
 
 // Use IfAny so that GridDataRow<any> doesn't devolve into any

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -50,10 +50,12 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
   virtuosoRef: MutableRefObject<VirtuosoHandle | null> = { current: null };
 
   /** Called once by the GridTable when it takes ownership of this api instance. */
-  init(persistCollapse: string | undefined, virtuosoRef: MutableRefObject<VirtuosoHandle | null>) {
-    if (persistCollapse) {
-      this.rowState.loadPersistedCollapse(persistCollapse);
-    }
+  init(
+    persistCollapse: string | undefined,
+    virtuosoRef: MutableRefObject<VirtuosoHandle | null>,
+    rows: GridDataRow<R>[],
+  ) {
+    this.rowState.loadCollapse(persistCollapse, rows);
     this.virtuosoRef = virtuosoRef;
   }
 

--- a/src/components/Table/RowState.ts
+++ b/src/components/Table/RowState.ts
@@ -92,12 +92,9 @@ export class RowState {
       ) {
         // Flatten out the existing rows to make checking for new rows easier
         const flattenedExistingIds = flattenRows(this.rows).map((r) => r.id);
-        const newCollapsedIds: string[] = [];
-
-        // If the `maybeNewRow` is not yet in `this.rows`, then add it to newCollapsedIds
-        maybeNewCollapsedRows.forEach(
-          (maybeNewRow) => !flattenedExistingIds.includes(maybeNewRow.id) && newCollapsedIds.push(maybeNewRow.id),
-        );
+        const newCollapsedIds: string[] = maybeNewCollapsedRows
+          .filter((maybeNewRow) => !flattenedExistingIds.includes(maybeNewRow.id))
+          .map((row) => row.id);
 
         // If there are new rows that should be collapsed then update the collapsedRows arrays
         if (newCollapsedIds.length > 0) {


### PR DESCRIPTION
Adds new property on GridDataRow, 'initCollapsed'. By setting this to true it will signal to the table to initially render this row as collapsed. As the name describes, this is only applied/read on initial render. If the user has also set up the 'persistCollapse' then any values available in the localStorage will trump those set on GridDataRow.

Includes tests