### PR TITLE
fix: Modal should not close if interacting with another dialog ontop of it - such as a Lightbox

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -52,8 +52,8 @@ export function Modal(props: ModalProps) {
       onClose: closeModal,
       isDismissable: true,
       shouldCloseOnInteractOutside: (el) => {
-        // Do not close the Modal if the user is interacting with the Tribute mentions dropdown (via RichTextField).
-        return !el.closest(".tribute-container");
+        // Do not close the Modal if the user is interacting with the Tribute mentions dropdown (via RichTextField) or with another 3rd party dialog (such as a lightbox) on top of it.
+        return !(el.closest(".tribute-container") || el.closest("[role='dialog']"));
       },
     },
     ref,


### PR DESCRIPTION
Blueprint's To Do modal includes a list of attachments. These attachments can be images that trigger a 3rd party lightbox component, that was closing both the modal and the lightbox component if you interacted with the lightbox.
This PR allows for keeping the modal open if the user is interacting with another dialog on top of it.