### PR TITLE
fix: auto save status provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "format": "prettier --loglevel warn --write \"**/*.{ts,tsx,css,md}\""
   },
   "dependencies": {
-    "@homebound/form-state": "2.15.1",
+    "@homebound/form-state": "^2.15.2",
     "@internationalized/number": "^3.0.3",
     "@react-aria/utils": "^3.11.3",
     "@react-hook/resize-observer": "^1.2.2",

--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -1,3 +1,4 @@
+import { AutoSaveStatusProvider } from "@homebound/form-state";
 import { createContext, MutableRefObject, PropsWithChildren, useContext, useMemo, useReducer, useRef } from "react";
 import { OverlayProvider } from "react-aria";
 import { Modal, ModalProps } from "src/components/Modal/Modal";
@@ -85,15 +86,17 @@ export function BeamProvider({ children, ...presentationProps }: BeamProviderPro
   return (
     <BeamContext.Provider value={{ ...context }}>
       <PresentationProvider {...presentationProps}>
-        <SnackbarProvider>
-          {/* OverlayProvider is required for Modals generated via React-Aria */}
-          <OverlayProvider>
-            {children}
-            {/*If the drawer is open, assume it will show modal content internally. */}
-            {modalRef.current && drawerContentStackRef.current.length === 0 && <Modal {...modalRef.current} />}
-          </OverlayProvider>
-          <SuperDrawer />
-        </SnackbarProvider>
+        <AutoSaveStatusProvider>
+          <SnackbarProvider>
+            {/* OverlayProvider is required for Modals generated via React-Aria */}
+            <OverlayProvider>
+              {children}
+              {/*If the drawer is open, assume it will show modal content internally. */}
+              {modalRef.current && drawerContentStackRef.current.length === 0 && <Modal {...modalRef.current} />}
+            </OverlayProvider>
+            <SuperDrawer />
+          </SnackbarProvider>
+        </AutoSaveStatusProvider>
       </PresentationProvider>
     </BeamContext.Provider>
   );

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,3 +1,4 @@
+import { AutoSaveStatusProvider } from "@homebound/form-state";
 import useResizeObserver from "@react-hook/resize-observer";
 import { MutableRefObject, ReactNode, useEffect, useRef, useState } from "react";
 import { FocusScope, OverlayContainer, useDialog, useModal, useOverlay, usePreventScroll } from "react-aria";
@@ -94,44 +95,46 @@ export function Modal(props: ModalProps) {
 
   return (
     <OverlayContainer>
-      <div css={Css.underlay.z4.$} {...underlayProps} {...testId.underlay}>
-        <FocusScope contain restoreFocus autoFocus>
-          <div
-            css={
-              Css.br24.bgWhite.bshModal.overflowHidden
-                .maxh("90vh")
-                .df.fdc.wPx(width)
-                .mh(px(defaultMinHeight))
-                .if(isFixedHeight)
-                .hPx(height).$
-            }
-            ref={ref}
-            {...overlayProps}
-            {...dialogProps}
-            {...modalProps}
-            {...testId}
-          >
-            {/* Setup three children (header, content, footer), and flex grow the content. */}
-            <header css={Css.df.p3.fs0.if(drawHeaderBorder).bb.bGray200.$}>
-              <h1 css={Css.fg1.xl2Em.gray900.$} ref={modalHeaderRef} {...titleProps} {...testId.title} />
-              <span css={Css.fs0.pl1.$}>
-                <IconButton icon="x" onClick={closeModal} {...testId.titleClose} />
-              </span>
-            </header>
-            <main
-              ref={contentRef}
-              css={Css.fg1.overflowYAuto.if(hasScroll).bb.bGray200.if(!!forceScrolling).overflowYScroll.$}
+      <AutoSaveStatusProvider>
+        <div css={Css.underlay.z4.$} {...underlayProps} {...testId.underlay}>
+          <FocusScope contain restoreFocus autoFocus>
+            <div
+              css={
+                Css.br24.bgWhite.bshModal.overflowHidden
+                  .maxh("90vh")
+                  .df.fdc.wPx(width)
+                  .mh(px(defaultMinHeight))
+                  .if(isFixedHeight)
+                  .hPx(height).$
+              }
+              ref={ref}
+              {...overlayProps}
+              {...dialogProps}
+              {...modalProps}
+              {...testId}
             >
-              {/* We'll include content here, but we expect ModalBody and ModalFooter to use their respective portals. */}
-              {content}
-              <div ref={modalBodyRef} />
-            </main>
-            <footer css={Css.fs0.$}>
-              <div ref={modalFooterRef} />
-            </footer>
-          </div>
-        </FocusScope>
-      </div>
+              {/* Setup three children (header, content, footer), and flex grow the content. */}
+              <header css={Css.df.p3.fs0.if(drawHeaderBorder).bb.bGray200.$}>
+                <h1 css={Css.fg1.xl2Em.gray900.$} ref={modalHeaderRef} {...titleProps} {...testId.title} />
+                <span css={Css.fs0.pl1.$}>
+                  <IconButton icon="x" onClick={closeModal} {...testId.titleClose} />
+                </span>
+              </header>
+              <main
+                ref={contentRef}
+                css={Css.fg1.overflowYAuto.if(hasScroll).bb.bGray200.if(!!forceScrolling).overflowYScroll.$}
+              >
+                {/* We'll include content here, but we expect ModalBody and ModalFooter to use their respective portals. */}
+                {content}
+                <div ref={modalBodyRef} />
+              </main>
+              <footer css={Css.fs0.$}>
+                <div ref={modalFooterRef} />
+              </footer>
+            </div>
+          </FocusScope>
+        </div>
+      </AutoSaveStatusProvider>
     </OverlayContainer>
   );
 }

--- a/src/components/SuperDrawer/SuperDrawer.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.tsx
@@ -1,4 +1,5 @@
 import { Global } from "@emotion/react";
+import { AutoSaveStatusProvider } from "@homebound/form-state";
 import { AnimatePresence, motion } from "framer-motion";
 import { ReactPortal, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
@@ -102,55 +103,57 @@ export function SuperDrawer(): ReactPortal | null {
               // Preventing clicks from triggering parent onClick
               onClick={(e) => e.stopPropagation()}
             >
-              <header css={Css.df.p3.bb.bGray200.df.aic.jcsb.gap2.$}>
-                {/* Left */}
-                <div css={Css.df.aic.$}>
-                  <div css={Css.xl2Em.gray900.mr2.$} {...testId.title} ref={drawerHeaderRef}>
-                    {!modalState.current && (title || null)}
+              <AutoSaveStatusProvider>
+                <header css={Css.df.p3.bb.bGray200.df.aic.jcsb.gap2.$}>
+                  {/* Left */}
+                  <div css={Css.df.aic.$}>
+                    <div css={Css.xl2Em.gray900.mr2.$} {...testId.title} ref={drawerHeaderRef}>
+                      {!modalState.current && (title || null)}
+                    </div>
+                    {!modalState.current && (titleLeftContent || null)}
                   </div>
-                  {!modalState.current && (titleLeftContent || null)}
-                </div>
-                {/* Right */}
-                {!modalState.current && (
-                  // Forcing height to 32px to match title height
-                  <div css={Css.df.childGap3.aic.hPx(32).fs0.$}>
-                    {titleRightContent || null}
-                    {/* Disable buttons is handlers are not given or if childContent is shown */}
-                    <ButtonGroup
-                      buttons={[
-                        {
-                          icon: "chevronLeft",
-                          onClick: () => onPrevClick && onPrevClick(),
-                          disabled: !onPrevClick || isDetail,
-                        },
-                        {
-                          icon: "chevronRight",
-                          onClick: () => onNextClick && onNextClick(),
-                          disabled: !onNextClick || isDetail,
-                        },
-                      ]}
-                      {...testId.headerActions}
-                    />
-                    <IconButton icon="x" onClick={closeDrawer} {...testId.close} />
+                  {/* Right */}
+                  {!modalState.current && (
+                    // Forcing height to 32px to match title height
+                    <div css={Css.df.childGap3.aic.hPx(32).fs0.$}>
+                      {titleRightContent || null}
+                      {/* Disable buttons is handlers are not given or if childContent is shown */}
+                      <ButtonGroup
+                        buttons={[
+                          {
+                            icon: "chevronLeft",
+                            onClick: () => onPrevClick && onPrevClick(),
+                            disabled: !onPrevClick || isDetail,
+                          },
+                          {
+                            icon: "chevronRight",
+                            onClick: () => onNextClick && onNextClick(),
+                            disabled: !onNextClick || isDetail,
+                          },
+                        ]}
+                        {...testId.headerActions}
+                      />
+                      <IconButton icon="x" onClick={closeDrawer} {...testId.close} />
+                    </div>
+                  )}
+                </header>
+                {content}
+                {modalState.current && (
+                  // Forcing some design constraints on the modal component
+                  <div
+                    css={
+                      // topPX(81) is the offset from the header
+                      Css.fg1.topPx(81).left0.right0.bottom0.absolute.bgWhite.df.aic.jcc.fg1.fdc.z5.$
+                    }
+                  >
+                    {/* We'll include content here, but we expect ModalBody and ModalFooter to use their respective portals. */}
+                    {modalState.current.content}
+                    {/* TODO: Work in some notion of the modal size + width/height + scrolling?*/}
+                    <div ref={modalBodyRef} />
+                    <div ref={modalFooterRef} />
                   </div>
                 )}
-              </header>
-              {content}
-              {modalState.current && (
-                // Forcing some design constraints on the modal component
-                <div
-                  css={
-                    // topPX(81) is the offset from the header
-                    Css.fg1.topPx(81).left0.right0.bottom0.absolute.bgWhite.df.aic.jcc.fg1.fdc.z5.$
-                  }
-                >
-                  {/* We'll include content here, but we expect ModalBody and ModalFooter to use their respective portals. */}
-                  {modalState.current.content}
-                  {/* TODO: Work in some notion of the modal size + width/height + scrolling?*/}
-                  <div ref={modalBodyRef} />
-                  <div ref={modalFooterRef} />
-                </div>
-              )}
+              </AutoSaveStatusProvider>
             </motion.aside>
           </motion.div>
         </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2434,10 +2434,10 @@
   dependencies:
     tslib "^2.1.0"
 
-"@homebound/form-state@2.15.1":
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/@homebound/form-state/-/form-state-2.15.1.tgz#99d8c59e98e10e37348439b7360b3a39174bc8cf"
-  integrity sha512-Bukd/Sk0Xdjs6gpx4yjbvMHrvPYkODUaoN9hgJeXl7tN9tVi/JUqYIAXMSC49oVAhx6hxynp4xRAwFUgFoLQSw==
+"@homebound/form-state@^2.15.2":
+  version "2.15.2"
+  resolved "https://registry.yarnpkg.com/@homebound/form-state/-/form-state-2.15.2.tgz#14cec7bcba1ab9826a614ad0abb05a45511928ff"
+  integrity sha512-p/rJ8RjaGHQSAbhJVzk7EoPX7CDXdmHQMN22J7QQp52OKluUfMr1fhs1KeSwL+/J2asxVqsuT7rHpN3NujyYaw==
   dependencies:
     fast-deep-equal "^3.1.3"
     is-plain-object "^5.0.0"


### PR DESCRIPTION
Adds AutoSaveStatusProvider back in, backed by `@homebound/form-state` upgrade

Already did the `npm run watch-beam` and `yarn ttsc -w` stuff to test it on BluePrint ✅ 