### PR TITLE
feat: Stepper Progress Bar Update

### DIFF
--- a/src/components/Stepper.tsx
+++ b/src/components/Stepper.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
 import { Icon } from "src/components/Icon";
 import { Css } from "src/Css";
@@ -15,31 +15,15 @@ interface StepperBarProps {
   // The 'value' of the Step that should be displayed
   currentStep: Step["value"];
   onChange: (stepValue: string) => void;
-  resetProgress?: boolean;
 }
 
-export function Stepper({ steps, currentStep, onChange, resetProgress }: StepperBarProps) {
+export function Stepper({ steps, currentStep, onChange }: StepperBarProps) {
   if (steps.length === 0) {
     throw new Error("Stepper must be initialized with at least one step");
   }
 
-  const [progressBarStep, setProgressBarStep] = useState(-1);
-
-  useEffect(() => {
-    if (resetProgress) {
-      return setProgressBarStep(-1);
-    }
-
-    // calc step progress based index of last step that is completed
-    const stepProgress = steps.reduce((acc, step, idx) => {
-      if (step.state === "complete") {
-        acc = idx;
-      }
-      return acc;
-    }, -1);
-
-    setProgressBarStep(stepProgress);
-  }, [currentStep, progressBarStep, resetProgress, steps]);
+  // calc progress based on last completed step - return -1 when no steps completed
+  const progressBarStep = steps.reduce((acc, step, idx) => (step.state === "complete" ? idx : acc), -1);
 
   return (
     <nav aria-label="steps" css={Css.df.fdc.$}>

--- a/src/components/Stepper.tsx
+++ b/src/components/Stepper.tsx
@@ -15,20 +15,31 @@ interface StepperBarProps {
   // The 'value' of the Step that should be displayed
   currentStep: Step["value"];
   onChange: (stepValue: string) => void;
+  resetProgress?: boolean;
 }
 
-export function Stepper({ steps, currentStep, onChange }: StepperBarProps) {
+export function Stepper({ steps, currentStep, onChange, resetProgress }: StepperBarProps) {
   if (steps.length === 0) {
     throw new Error("Stepper must be initialized with at least one step");
   }
 
-  const [progressBarStep, setProgressBarStep] = useState(0);
+  const [progressBarStep, setProgressBarStep] = useState(-1);
+
   useEffect(() => {
-    const currentStepIndex = steps.findIndex((s: Step) => s.value === currentStep) || 0;
-    if (currentStepIndex > progressBarStep) {
-      setProgressBarStep(currentStepIndex);
+    if (resetProgress) {
+      return setProgressBarStep(-1);
     }
-  }, [currentStep]);
+
+    // calc step progress based index of last step that is completed
+    const stepProgress = steps.reduce((acc, step, idx) => {
+      if (step.state === "complete") {
+        acc = idx;
+      }
+      return acc;
+    }, -1);
+
+    setProgressBarStep(stepProgress);
+  }, [currentStep, progressBarStep, resetProgress, steps]);
 
   return (
     <nav aria-label="steps" css={Css.df.fdc.$}>

--- a/src/components/Stepper.tsx
+++ b/src/components/Stepper.tsx
@@ -23,7 +23,7 @@ export function Stepper({ steps, currentStep, onChange }: StepperBarProps) {
   }
 
   // calc progress based on last completed step - return -1 when no steps completed
-  const progressBarStep = steps.reduce((acc, step, idx) => (step.state === "complete" ? idx : acc), -1);
+  const lastCompletedStep = steps.map((step) => step.state).lastIndexOf("complete");
 
   return (
     <nav aria-label="steps" css={Css.df.fdc.$}>
@@ -42,7 +42,7 @@ export function Stepper({ steps, currentStep, onChange }: StepperBarProps) {
           css={
             Css.bgLightBlue600
               .add("transition", "width 200ms")
-              .h100.w(`${((progressBarStep + 1) / steps.length) * 100}%`).$
+              .h100.w(`${((lastCompletedStep + 1) / steps.length) * 100}%`).$
           }
         />
       </div>

--- a/src/forms/StepperFormApp.tsx
+++ b/src/forms/StepperFormApp.tsx
@@ -59,12 +59,12 @@ function StepperForm({ formState }: { formState: FormValue }) {
   const onBack = useCallback(() => {
     const currentStepIndex = steps.findIndex((s) => s.value === currentStep);
     setActiveStep(steps[currentStepIndex === 0 ? 0 : currentStepIndex - 1].value);
-  }, [currentStep]);
+  }, [currentStep, steps]);
 
   useEffect(() => {
     const disposer = reaction(
-      () => [formState.firstName.valid && formState.lastName.valid, formState.books.valid],
-      ([step1Valid, step2Valid], [wasStep1Valid, wasStep2Valid]) => {
+      () => [formState.firstName.valid && formState.lastName.valid, formState.books.valid, formState.birthday.valid],
+      ([step1Valid, step2Valid, step3Valid], [wasStep1Valid, wasStep2Valid, wasStep3Valid]) => {
         if (step1Valid && step1Valid !== wasStep1Valid) {
           setStep("books", { disabled: !step1Valid });
           return;
@@ -74,11 +74,16 @@ function StepperForm({ formState }: { formState: FormValue }) {
           setStep("misc", { disabled: !step2Valid });
           return;
         }
+
+        if (step3Valid && step3Valid !== wasStep3Valid) {
+          setStep("misc", { state: "complete" });
+          return;
+        }
       },
     );
     // Return the disposer in order to clean up useEffect.
     return disposer;
-  }, [setStep]);
+  }, [setStep, formState.birthday.valid, formState.books.valid, formState.firstName.valid, formState.lastName.valid]);
 
   return (
     <div>


### PR DESCRIPTION
Updates progress bar to be calculated based upon provided `step`'s `status` to unblock Lot Config / Lot Release work - [Lot Config / Lot Release PR](https://github.com/homebound-team/internal-frontend/pull/2195)

- Progress calculated in accordance to provided `step`s completion status:
   - if provided `step`'s 3rd step is the last step to have its `state === "complete` then progress bar is set to it's index, e.g. 2
   - if no step has a `state === "complete"` then progress is reset (set to `-1`)