### PR TITLE
fix: 'Today' bgColor should be overwritten if 'selected'

### DIFF
--- a/src/components/internal/DatePicker/Day.tsx
+++ b/src/components/internal/DatePicker/Day.tsx
@@ -43,9 +43,9 @@ export function Day(props: DayProps) {
       <div
         css={{
           ...Css.relative.br4.df.aic.jcc.wPx(28).hPx(30).mtPx(2).br4.$,
+          ...(today && Css.bgGray100.$),
           ...(selected && Css.white.bgLightBlue700.$),
           ...(disabled && Css.gray500.$),
-          ...(today && Css.bgGray100.$),
         }}
       >
         <div css={Css.mtPx(-2).$}>{children}</div>


### PR DESCRIPTION
## Before
<img width="278" alt="Screen Shot 2022-06-13 at 12 44 01 PM" src="https://user-images.githubusercontent.com/1143861/173403496-6dbe05b4-118b-4851-a076-a4d9f8f6c60d.png">

## After
<img width="274" alt="Screen Shot 2022-06-13 at 12 43 46 PM" src="https://user-images.githubusercontent.com/1143861/173403504-78984bd1-34c7-4b93-972d-8d273a70a44c.png">

