### PR TITLE
fix: Move snackbar to bottom left

### DIFF
--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -7,7 +7,7 @@ interface SnackbarProps {
 
 export function Snackbar({ notices }: SnackbarProps) {
   return (
-    <div css={Css.fixed.bottom3.right3.df.fdc.aife.gapPx(12).$}>
+    <div css={Css.fixed.bottom3.left3.df.fdc.aifs.gapPx(12).$}>
       {notices.map((data) => (
         <SnackbarNotice key={data.id} {...data} />
       ))}


### PR DESCRIPTION
Moving to bottom left instead of bottom right as we're planning to float the Help Center icon to the bottom right