### PR TITLE
feat: allow passing numberFormatOptions to override number formatting

### DIFF
--- a/src/inputs/NumberField.stories.tsx
+++ b/src/inputs/NumberField.stories.tsx
@@ -42,6 +42,11 @@ export function NumberFieldStyles() {
         <TestNumberField label="Margin" type="basisPoints" value={1275} />
         <TestNumberField label="Days" type="days" value={1} />
       </div>
+      <div css={Css.df.fdc.childGap2.$}>
+        <h1 css={Css.lg.$}>Custom Format Options</h1>
+        <TestNumberField label="kph" value={50} numberFormatOptions={{ style: "unit", unit: "kilometer-per-hour" }} />
+        <TestNumberField label="Euro" value={500} numberFormatOptions={{ style: "currency", currency: "EUR" }} />
+      </div>
     </div>
   );
 }

--- a/src/inputs/NumberField.stories.tsx
+++ b/src/inputs/NumberField.stories.tsx
@@ -39,6 +39,7 @@ export function NumberFieldStyles() {
         <h1 css={Css.lg.$}>Unit Types</h1>
         <TestNumberField label="Percent" type="percent" value={12.55} numFractionDigits={2} truncate />
         <TestNumberField label="Cents" type="cents" value={1000} />
+        <TestNumberField label="Dollars" type="dollars" value={1000} />
         <TestNumberField label="Margin" type="basisPoints" value={1275} />
         <TestNumberField label="Days" type="days" value={1} />
       </div>

--- a/src/inputs/NumberField.test.tsx
+++ b/src/inputs/NumberField.test.tsx
@@ -53,20 +53,20 @@ describe("NumberFieldTest", () => {
     expect(lastSet).toEqual(1400);
   });
 
-  it("can set dollars as dollars", async () => {
-    const r = await render(<TestNumberField label="Cost" type="dollars" value={1200} />);
-    expect(r.cost()).toHaveValue("$1,200");
-    type(r.cost, "14.25");
-    expect(r.cost()).toHaveValue("$14");
-    expect(lastSet).toEqual(14);
-  });
-
   it("can set dollars and cents as dollars", async () => {
-    const r = await render(<TestNumberField label="Cost" type="dollars" value={1200} numFractionDigits={2} />);
+    const r = await render(<TestNumberField label="Cost" type="dollars" value={1200} />);
     expect(r.cost()).toHaveValue("$1,200.00");
     type(r.cost, "14.25");
     expect(r.cost()).toHaveValue("$14.25");
     expect(lastSet).toEqual(14.25);
+  });
+
+  it("can set dollars as dollars only", async () => {
+    const r = await render(<TestNumberField label="Cost" type="dollars" value={1200} numFractionDigits={0} />);
+    expect(r.cost()).toHaveValue("$1,200");
+    type(r.cost, "14.25");
+    expect(r.cost()).toHaveValue("$14");
+    expect(lastSet).toEqual(14);
   });
 
   it("calls onChange with expected value for cents", async () => {

--- a/src/inputs/NumberField.test.tsx
+++ b/src/inputs/NumberField.test.tsx
@@ -104,6 +104,20 @@ describe("NumberFieldTest", () => {
     expect(r.days()).toHaveValue("1 day");
   });
 
+  it("allows override of numberFormatOptions", async () => {
+    const r = await render(
+      <TestNumberField
+        label="Cost"
+        value={1200}
+        numFractionDigits={2}
+        numberFormatOptions={{ style: "currency", currency: "USD" }}
+      />,
+    );
+    expect(r.cost()).toHaveValue("$1,200.00");
+    type(r.cost, "14.14");
+    expect(r.cost()).toHaveValue("$14.14");
+  });
+
   it("displays direction of positive values and no direction display for zero", async () => {
     const r = await render(
       <>

--- a/src/inputs/NumberField.test.tsx
+++ b/src/inputs/NumberField.test.tsx
@@ -53,6 +53,22 @@ describe("NumberFieldTest", () => {
     expect(lastSet).toEqual(1400);
   });
 
+  it("can set dollars as dollars", async () => {
+    const r = await render(<TestNumberField label="Cost" type="dollars" value={1200} />);
+    expect(r.cost()).toHaveValue("$1,200");
+    type(r.cost, "14.25");
+    expect(r.cost()).toHaveValue("$14");
+    expect(lastSet).toEqual(14);
+  });
+
+  it("can set dollars and cents as dollars", async () => {
+    const r = await render(<TestNumberField label="Cost" type="dollars" value={1200} numFractionDigits={2} />);
+    expect(r.cost()).toHaveValue("$1,200.00");
+    type(r.cost, "14.25");
+    expect(r.cost()).toHaveValue("$14.25");
+    expect(lastSet).toEqual(14.25);
+  });
+
   it("calls onChange with expected value for cents", async () => {
     const onChange = jest.fn();
     const r = await render(<NumberField label="Cost" type="cents" value={1234} onChange={onChange} />);

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -34,6 +34,8 @@ export interface NumberFieldProps {
   // If set, all positive values will be prefixed with "+". (Zero will not show +/-)
   displayDirection?: boolean;
   numFractionDigits?: number;
+  // Override for default formatting based on `type`.
+  numberFormatOptions?: Intl.NumberFormatOptions;
   truncate?: boolean;
   onEnter?: VoidFunction;
 }
@@ -71,6 +73,10 @@ export function NumberField(props: NumberFieldProps) {
   // If formatOptions isn't memo'd, a useEffect in useNumberStateField will cause jank,
   // see: https://github.com/adobe/react-spectrum/issues/1893.
   const formatOptions: Intl.NumberFormatOptions | undefined = useMemo(() => {
+    if (props.numberFormatOptions !== undefined) {
+      return props.numberFormatOptions;
+    }
+
     return type === "percent"
       ? { style: "percent", signDisplay, ...fractionFormatOptions }
       : type === "basisPoints"

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -9,7 +9,7 @@ import { Css, Xss } from "src/Css";
 import { maybeCall } from "src/utils";
 import { TextFieldBase } from "./TextFieldBase";
 
-export type NumberFieldType = "cents" | "percent" | "basisPoints" | "days";
+export type NumberFieldType = "cents" | "dollars" | "percent" | "basisPoints" | "days";
 
 // exported for testing purposes
 export interface NumberFieldProps {
@@ -83,6 +83,8 @@ export function NumberField(props: NumberFieldProps) {
       ? { style: "percent", minimumFractionDigits: 2, signDisplay }
       : type === "cents"
       ? { style: "currency", currency: "USD", minimumFractionDigits: 2, signDisplay }
+      : type === "dollars"
+      ? { style: "currency", currency: "USD", minimumFractionDigits: numFractionDigits ?? 0, signDisplay }
       : type === "days"
       ? { style: "unit", unit: "day", unitDisplay: "long", maximumFractionDigits: 0, signDisplay }
       : fractionFormatOptions;

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -58,7 +58,7 @@ export function NumberField(props: NumberFieldProps) {
     onChange,
     xss,
     displayDirection = false,
-    numFractionDigits,
+    numFractionDigits = type === "dollars" ? 2 : undefined,
     truncate = false,
     onEnter,
     ...otherProps
@@ -84,7 +84,7 @@ export function NumberField(props: NumberFieldProps) {
       : type === "cents"
       ? { style: "currency", currency: "USD", minimumFractionDigits: 2, signDisplay }
       : type === "dollars"
-      ? { style: "currency", currency: "USD", minimumFractionDigits: numFractionDigits ?? 0, signDisplay }
+      ? { style: "currency", currency: "USD", minimumFractionDigits: numFractionDigits ?? 2, signDisplay }
       : type === "days"
       ? { style: "unit", unit: "day", unitDisplay: "long", maximumFractionDigits: 0, signDisplay }
       : fractionFormatOptions;


### PR DESCRIPTION
Pass at allowing more generic number formatting beyond what's specified via `type`