### PR TITLE
feat: add NavLink side contrast variant

### DIFF
--- a/src/components/NavLink.stories.tsx
+++ b/src/components/NavLink.stories.tsx
@@ -26,12 +26,13 @@ export default {
 
 export function BaseStates() {
   const sideNavStyles = getNavLinkStyles("side");
+  const sideContrastNavStyles = getNavLinkStyles("side", true);
   const globalNavStyles = getNavLinkStyles("global");
   const args = { href: "", className: navLink };
 
   return (
     <div css={Css.df.childGap2.$}>
-      <div css={Css.df.fdc.childGap2.$}>
+      <div css={Css.df.fdc.childGap2.p1.$}>
         <a {...args} css={sideNavStyles.baseStyles}>
           {getChildren("Side nav default")}
         </a>
@@ -51,7 +52,27 @@ export function BaseStates() {
           {getChildren("Side nav disabled")}
         </a>
       </div>
-      <div css={Css.df.fdc.childGap2.$}>
+      <div css={Css.df.fdc.childGap2.bgGray900.p1.br12.$}>
+        <a {...args} css={sideContrastNavStyles.baseStyles}>
+          {getChildren("Side contrast nav default")}
+        </a>
+        <a {...args} css={{ ...sideContrastNavStyles.baseStyles, ...sideContrastNavStyles.hoverStyles }}>
+          {getChildren("Side contrast nav hovered")}
+        </a>
+        <a {...args} css={{ ...sideContrastNavStyles.baseStyles, ...sideContrastNavStyles.pressedStyles }}>
+          {getChildren("Side contrast nav pressed")}
+        </a>
+        <a {...args} css={{ ...sideContrastNavStyles.baseStyles, ...sideContrastNavStyles.activeStyles }}>
+          {getChildren("Side contrast nav active")}
+        </a>
+        <a {...args} css={{ ...sideContrastNavStyles.baseStyles, ...sideContrastNavStyles.focusRingStyles }}>
+          {getChildren("Side contrast nav focus ring")}
+        </a>
+        <a {...args} css={{ ...sideContrastNavStyles.baseStyles, ...sideContrastNavStyles.disabledStyles }}>
+          {getChildren("Side contrast nav disabled")}
+        </a>
+      </div>
+      <div css={Css.df.fdc.childGap2.p1.$}>
         <a {...args} css={globalNavStyles.baseStyles}>
           {getChildren("Global nav default")}
         </a>

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -17,6 +17,7 @@ export interface NavLinkProps extends BeamFocusableProps {
   icon?: IconKey;
   variant: NavLinkVariant;
   openInNew?: boolean;
+  contrast?: boolean;
 }
 
 type NavLinkVariant = "side" | "global";
@@ -80,23 +81,24 @@ export function NavLink(props: NavLinkProps) {
   );
 }
 
-export function getNavLinkStyles(variant: NavLinkVariant) {
-  return navLinkVariantStyles[variant];
+export function getNavLinkStyles(variant: NavLinkVariant, contrast: boolean = false) {
+  return navLinkVariantStyles(contrast)[variant];
 }
 
 const baseStyles = Css.df.aic.hPx(32).pyPx(6).px1.br4.smEm.outline0.$;
 
-const navLinkVariantStyles: Record<
-  NavLinkVariant,
-  { baseStyles: {}; hoverStyles: {}; disabledStyles: {}; focusRingStyles: {}; activeStyles: {}; pressedStyles: {} }
-> = {
+const navLinkVariantStyles: (
+  contrast: boolean
+) => Record<NavLinkVariant, { baseStyles: {}; hoverStyles: {}; disabledStyles: {}; focusRingStyles: {}; activeStyles: {}; pressedStyles: {} }> = (
+  contrast,
+) => ({
   side: {
-    baseStyles: { ...baseStyles, ...Css.gray700.$ },
-    activeStyles: Css.lightBlue700.bgLightBlue50.$,
-    disabledStyles: Css.gray400.cursorNotAllowed.$,
-    focusRingStyles: Css.bgLightBlue50.bshFocus.$,
-    hoverStyles: Css.gray700.bgGray100.$,
-    pressedStyles: Css.gray700.bgGray200.$,
+    baseStyles: { ...baseStyles, ...Css.gray700.if(contrast).gray600.$ },
+    activeStyles: Css.lightBlue700.bgLightBlue50.if(contrast).white.bgGray700.$,
+    disabledStyles: Css.gray400.cursorNotAllowed.if(contrast).gray800.$,
+    focusRingStyles: Css.bgLightBlue50.bshFocus.if(contrast).bgGray700.white.$,
+    hoverStyles: Css.gray700.bgGray100.if(contrast).bgGray800.gray600.$,
+    pressedStyles: Css.gray700.bgGray200.if(contrast).bgGray200.gray800.$,
   },
   global: {
     baseStyles: { ...baseStyles, ...Css.add("width", "max-content").gray500.$ },
@@ -108,5 +110,5 @@ const navLinkVariantStyles: Record<
     ).$,
     hoverStyles: Css.gray500.bgGray900.$,
     pressedStyles: Css.gray500.bgGray700.$,
-  },
-};
+  }
+});


### PR DESCRIPTION
As part of the design of [SC-17566](https://app.shortcut.com/homebound-team/story/17566/new-development-level-navigation) there's need to add a contrast prop to NavLink side variant.

![imagen](https://user-images.githubusercontent.com/35903168/175142363-90fd56c0-f8e7-4c95-81f5-44536fd29542.png)
