### PR TITLE
fix: NavLink contrast prop not working

### DIFF
--- a/src/components/NavLink.stories.tsx
+++ b/src/components/NavLink.stories.tsx
@@ -25,9 +25,9 @@ export default {
 } as Meta;
 
 export function BaseStates() {
-  const sideNavStyles = getNavLinkStyles("side");
+  const sideNavStyles = getNavLinkStyles("side", false);
   const sideContrastNavStyles = getNavLinkStyles("side", true);
-  const globalNavStyles = getNavLinkStyles("global");
+  const globalNavStyles = getNavLinkStyles("global", false);
   const args = { href: "", className: navLink };
 
   return (

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -23,7 +23,7 @@ export interface NavLinkProps extends BeamFocusableProps {
 type NavLinkVariant = "side" | "global";
 
 export function NavLink(props: NavLinkProps) {
-  const { disabled: isDisabled, label, openInNew, ...otherProps } = props;
+  const { disabled: isDisabled, label, openInNew, contrast, ...otherProps } = props;
   const ariaProps = { children: label, isDisabled, ...otherProps };
   const { href, active = false, icon = false, variant } = ariaProps;
   const ref = useRef() as RefObject<HTMLAnchorElement>;
@@ -34,8 +34,8 @@ export function NavLink(props: NavLinkProps) {
   const { isFocusVisible, focusProps } = useFocusRing(ariaProps);
 
   const { baseStyles, activeStyles, focusRingStyles, hoverStyles, disabledStyles, pressedStyles } = useMemo(
-    () => getNavLinkStyles(variant),
-    [variant],
+    () => getNavLinkStyles(variant, contrast),
+    [variant, contrast],
   );
 
   const external = isAbsoluteUrl(href) || openInNew;
@@ -81,8 +81,8 @@ export function NavLink(props: NavLinkProps) {
   );
 }
 
-export function getNavLinkStyles(variant: NavLinkVariant, contrast: boolean = false) {
-  return navLinkVariantStyles(contrast)[variant];
+export function getNavLinkStyles(variant: NavLinkVariant, contrast?: boolean) {
+  return navLinkVariantStyles(!!contrast)[variant];
 }
 
 const baseStyles = Css.df.aic.hPx(32).pyPx(6).px1.br4.smEm.outline0.$;

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -23,7 +23,7 @@ export interface NavLinkProps extends BeamFocusableProps {
 type NavLinkVariant = "side" | "global";
 
 export function NavLink(props: NavLinkProps) {
-  const { disabled: isDisabled, label, openInNew, contrast, ...otherProps } = props;
+  const { disabled: isDisabled, label, openInNew, contrast=false, ...otherProps } = props;
   const ariaProps = { children: label, isDisabled, ...otherProps };
   const { href, active = false, icon = false, variant } = ariaProps;
   const ref = useRef() as RefObject<HTMLAnchorElement>;
@@ -81,8 +81,8 @@ export function NavLink(props: NavLinkProps) {
   );
 }
 
-export function getNavLinkStyles(variant: NavLinkVariant, contrast?: boolean) {
-  return navLinkVariantStyles(!!contrast)[variant];
+export function getNavLinkStyles(variant: NavLinkVariant, contrast: boolean) {
+  return navLinkVariantStyles(contrast)[variant];
 }
 
 const baseStyles = Css.df.aic.hPx(32).pyPx(6).px1.br4.smEm.outline0.$;


### PR DESCRIPTION
The prop wasn't working as expected as Alex told me in this comment https://github.com/homebound-team/beam/pull/566#issuecomment-1164750843, I was checking on the wrong storybook, this is now fixed with this PR and works as expected.