### PR TITLE
SC-18440: feat(snackbar): notify Snackbar an offset is needed

### DIFF
--- a/src/components/Snackbar/Snackbar.stories.tsx
+++ b/src/components/Snackbar/Snackbar.stories.tsx
@@ -2,7 +2,7 @@ import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
 import { useCallback, useEffect, useState } from "react";
 import { Button, ButtonVariant, useSnackbar } from "src/components";
-import { Snackbar } from "src/components/Snackbar/Snackbar";
+import { Offset, Snackbar } from "src/components/Snackbar/Snackbar";
 import { SnackbarNoticeProps } from "src/components/Snackbar/SnackbarNotice";
 import { Css } from "src/Css";
 import { withBeamDecorator } from "src/utils/sb";
@@ -10,6 +10,7 @@ import { withBeamDecorator } from "src/utils/sb";
 interface SnackBarStoryProps extends Omit<SnackbarNoticeProps, "action"> {
   actionLabel?: string;
   actionVariant?: ButtonVariant;
+  offset?: Offset;
 }
 
 export default {
@@ -23,6 +24,7 @@ export default {
     message: "Hey there, I am a snackbar notice!",
     actionLabel: "",
     actionVariant: undefined,
+    offset: { bottom: 200 },
   },
   argTypes: {
     icon: { control: { type: "select", options: [undefined, "error", "info", "success", "warning"] } },
@@ -31,6 +33,7 @@ export default {
       name: "action.variant",
     },
     actionLabel: { name: "action.label" },
+    offset: { name: "offset" },
   },
   parameters: { controls: { exclude: "notices" } },
 } as Meta<SnackBarStoryProps>;
@@ -54,6 +57,38 @@ export function Customizable(args: SnackBarStoryProps) {
         })
       }
       label="Trigger notice"
+    />
+  );
+}
+
+export function CustomOffset(args: SnackBarStoryProps) {
+  const [show, setShow] = useState(true);
+
+  return (
+    <div css={Css.df.fdc.aifs.gap3.$}>
+      <Button label={show ? "Dismount Triggerer" : "Re-mount Triggerer"} onClick={() => setShow(!show)} />
+      {show && <CustomOffsetComponent {...args} />}
+    </div>
+  );
+}
+
+function CustomOffsetComponent(props: SnackBarStoryProps) {
+  const { triggerNotice, useSnackbarOffset } = useSnackbar();
+  const { actionLabel, actionVariant, offset, ...noticeProps } = props;
+
+  useSnackbarOffset(offset ?? {});
+
+  return (
+    <Button
+      label="Trigger Notice"
+      onClick={() =>
+        triggerNotice({
+          ...noticeProps,
+          ...(actionLabel
+            ? { action: { label: actionLabel, variant: actionVariant, onClick: action(`${actionLabel} clicked`) } }
+            : undefined),
+        })
+      }
     />
   );
 }

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -3,14 +3,19 @@ import { Css } from "src/Css";
 
 interface SnackbarProps {
   notices: SnackbarNoticeProps[];
+  offset: Offset;
 }
 
-export function Snackbar({ notices }: SnackbarProps) {
+export function Snackbar({ notices, offset }: SnackbarProps) {
   return (
-    <div css={Css.fixed.bottom3.left3.df.fdc.aifs.gapPx(12).$}>
+    <div css={Css.fixed.bottomPx(offset.bottom ?? 24).left3.df.fdc.aifs.gapPx(12).$}>
       {notices.map((data) => (
         <SnackbarNotice key={data.id} {...data} />
       ))}
     </div>
   );
 }
+
+export type Offset = {
+  bottom?: number;
+};

--- a/src/components/Snackbar/SnackbarContext.tsx
+++ b/src/components/Snackbar/SnackbarContext.tsx
@@ -1,18 +1,22 @@
 import React, { createContext, PropsWithChildren, useContext, useMemo, useState } from "react";
-import { Snackbar } from "src/components/Snackbar/Snackbar";
 import { SnackbarNoticeProps } from "src/components/Snackbar/SnackbarNotice";
+import { Offset, Snackbar } from "./Snackbar";
 
-export type SnackbarContextProps = { setNotices: React.Dispatch<React.SetStateAction<SnackbarNoticeProps[]>> };
+export type SnackbarContextProps = {
+  setNotices: React.Dispatch<React.SetStateAction<SnackbarNoticeProps[]>>;
+  setOffset: React.Dispatch<React.SetStateAction<Offset>>;
+};
 
-export const SnackbarContext = createContext<SnackbarContextProps>({ setNotices: () => {} });
+export const SnackbarContext = createContext<SnackbarContextProps>({ setNotices: () => {}, setOffset: () => {} });
 
 export function SnackbarProvider(props: PropsWithChildren<{}>) {
   const [notices, setNotices] = useState<SnackbarNoticeProps[]>([]);
-  const contextValue = useMemo(() => ({ setNotices }), []);
+  const [offset, setOffset] = useState<Offset>({});
+  const contextValue = useMemo(() => ({ setNotices, setOffset }), []);
   return (
     <SnackbarContext.Provider value={contextValue}>
       {props.children}
-      <Snackbar notices={notices} />
+      <Snackbar notices={notices} offset={offset} />
     </SnackbarContext.Provider>
   );
 }

--- a/src/components/Snackbar/useSnackbar.tsx
+++ b/src/components/Snackbar/useSnackbar.tsx
@@ -1,15 +1,17 @@
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useSnackbarContext } from "src/components/Snackbar/SnackbarContext";
 import { SnackbarNoticeProps } from "src/components/Snackbar/SnackbarNotice";
 import { maybeCall } from "src/utils";
+import { Offset } from "./Snackbar";
 
 export interface UseSnackbarHook {
   triggerNotice: (props: TriggerNoticeProps) => { close: () => void };
   closeNotice: (id: string) => void;
+  useSnackbarOffset: (offset: Offset) => void;
 }
 
 export function useSnackbar(): UseSnackbarHook {
-  const { setNotices } = useSnackbarContext();
+  const { setNotices, setOffset } = useSnackbarContext();
 
   const onClose = useCallback((noticeId: string) => {
     setNotices((prev) => {
@@ -68,7 +70,13 @@ export function useSnackbar(): UseSnackbarHook {
 
   const closeNotice = useCallback((id: string) => onClose(id), [onClose]);
 
-  return { triggerNotice, closeNotice };
+  const useSnackbarOffset = ({ bottom }: Offset) =>
+    useEffect(() => {
+      setOffset({ bottom });
+      return () => setOffset({});
+    }, [bottom]);
+
+  return { triggerNotice, closeNotice, useSnackbarOffset };
 }
 
 let snackbarId = 1;


### PR DESCRIPTION
Supersedes #574 
- [sc-18440](https://app.shortcut.com/homebound-team/story/18440/update-snackbar-to-accept-a-bottom-offset)
- Add prop via provider to set `bottomOffset` of snackbar
- Add `z-index` to snackbar to have it render above other fixed elements in the viewport