### PR TITLE
feat: Sort within pinned rows.

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -712,27 +712,27 @@ describe("GridTable", () => {
           sorting={{ on: "client", initial: [1, "ASC"] }}
           rows={[
             simpleHeader,
-            // And the 1st row is pinned first
-            { kind: "data", id: "1", pin: "first", data: { name: "a", value: 11 } },
-            { kind: "data", id: "2", pin: "first", data: { name: "b", value: 10 } },
+            // And the first rows are actually pinned last
+            { kind: "data", id: "5", pin: "last", data: { name: "e", value: 21 } },
+            { kind: "data", id: "6", pin: "last", data: { name: "f", value: 20 } },
             // And the middle rows need sorted
             { kind: "data", id: "3", data: { name: "c", value: 3 } },
             { kind: "data", id: "4", data: { name: "d", value: 1 } },
-            // And the last rows are pinned last
-            { kind: "data", id: "5", pin: "last", data: { name: "e", value: 20 } },
-            { kind: "data", id: "6", pin: "last", data: { name: "f", value: 21 } },
+            // And the last rows are actually pinned first
+            { kind: "data", id: "1", pin: "first", data: { name: "a", value: 11 } },
+            { kind: "data", id: "2", pin: "first", data: { name: "b", value: 10 } },
           ]}
         />,
       );
-      // Then the a/b rows stayed first
-      expect(cell(r, 1, 0)).toHaveTextContent("a");
-      expect(cell(r, 2, 0)).toHaveTextContent("b");
+      // Then the a/b rows stayed first (b has a lower value so was nudged first)
+      expect(cell(r, 1, 0)).toHaveTextContent("b");
+      expect(cell(r, 2, 0)).toHaveTextContent("a");
       // And the middle rows swapped
       expect(cell(r, 3, 0)).toHaveTextContent("d");
       expect(cell(r, 4, 0)).toHaveTextContent("c");
-      // And the last rows stayed last
-      expect(cell(r, 5, 0)).toHaveTextContent("e");
-      expect(cell(r, 6, 0)).toHaveTextContent("f");
+      // And the last rows stayed last (f has a lower value so was nudged first)
+      expect(cell(r, 5, 0)).toHaveTextContent("f");
+      expect(cell(r, 6, 0)).toHaveTextContent("e");
     });
 
     it("can pin rows last", async () => {

--- a/src/components/Table/sortRows.test.ts
+++ b/src/components/Table/sortRows.test.ts
@@ -80,6 +80,22 @@ describe("sortRows", () => {
     // Then expected case sensitive sort in descending correct order
     expect(rowsToIdArray(sorted)).toEqual(["2", "2.2", "2.1", "2.3", "1", "header", "3"]);
   });
+
+  it("can sort within pinned rows", () => {
+    // Given a set of unsorted rows
+    const rows: GridDataRow<Row>[] = [
+      // And this row is not pinned, so should come last
+      { kind: "parent", id: "3", data: { name: "a" } },
+      // And this row is pinned, so should come first
+      { kind: "parent", id: "2", data: { name: "c" }, pin: "first" },
+      // And this row is pinned and also before the other pin
+      { kind: "parent", id: "1", data: { name: "b" }, pin: "first" },
+    ];
+    // When sorting them in descending order based on the name property
+    const sorted = sortRows([nameColumn], rows, [0, "ASC"], true);
+    // Then expected case sensitive sort in descending correct order
+    expect(rowsToIdArray(sorted)).toEqual(["1", "2", "3"]);
+  });
 });
 
 type HeaderRow = { kind: "header" };

--- a/src/components/Table/sortRows.ts
+++ b/src/components/Table/sortRows.ts
@@ -39,7 +39,7 @@ function sortBatch<R extends Kinded>(
     const v2e = v2 === null || v2 === undefined;
     if ((a.pin || b.pin) && !(a.pin === b.pin)) {
       const ap = a.pin === "first" ? -1 : a.pin === "last" ? 1 : 0;
-      const bp = b.pin === "first" ? -1 : a.pin === "last" ? 1 : 0;
+      const bp = b.pin === "first" ? -1 : b.pin === "last" ? 1 : 0;
       return ap === bp ? 0 : ap < bp ? -1 : 1;
     } else if ((v1e && v2e) || v1 === v2) {
       return 0;

--- a/src/components/Table/sortRows.ts
+++ b/src/components/Table/sortRows.ts
@@ -37,7 +37,7 @@ function sortBatch<R extends Kinded>(
     const v2 = sortValue(applyRowFn(column, b, {} as any, 0), caseSensitive);
     const v1e = v1 === null || v1 === undefined;
     const v2e = v2 === null || v2 === undefined;
-    if (a.pin || b.pin) {
+    if ((a.pin || b.pin) && !(a.pin === b.pin)) {
       const ap = a.pin === "first" ? -1 : a.pin === "last" ? 1 : 0;
       const bp = b.pin === "first" ? -1 : a.pin === "last" ? 1 : 0;
       return ap === bp ? 0 : ap < bp ? -1 : 1;


### PR DESCRIPTION
I.e. to put all of the favorited documents first, but then within
those still sort by the given column.

This basically becomes a way to add an "always on" first sort.