### PR TITLE
fix: Support virtualized content in ModalBody

### DIFF
--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -55,7 +55,12 @@ export function BeamProvider({ children, ...presentationProps }: BeamProviderPro
   const [, tick] = useReducer((prev) => prev + 1, 0);
   const modalRef = useRef<ModalProps | undefined>();
   const modalHeaderDiv = useMemo(() => document.createElement("div"), []);
-  const modalBodyDiv = useMemo(() => document.createElement("div"), []);
+  const modalBodyDiv = useMemo(() => {
+    const el = document.createElement("div");
+    // Ensure this wrapping div takes up the full height of its container in the case of a virtualized table within.
+    el.style.height = "100%";
+    return el;
+  }, []);
   const modalCanCloseChecksRef = useRef<CheckFn[]>([]);
   const modalFooterDiv = useMemo(() => document.createElement("div"), []);
   const drawerContentStackRef = useRef<ContentStack[]>([]);

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -2,7 +2,12 @@ import { Meta } from "@storybook/react";
 import { useEffect } from "react";
 import { Button, ModalBody, ModalFooter, ModalHeader, ModalProps, OpenModal, useModal } from "src/components/index";
 import { Modal } from "src/components/Modal/Modal";
-import { TestModalContent, TestModalContentProps, TestModalFilterTable } from "src/components/Modal/TestModalContent";
+import {
+  TestModalContent,
+  TestModalContentProps,
+  TestModalFilterTable,
+  VirtualizedTable,
+} from "src/components/Modal/TestModalContent";
 import { FormStateApp } from "src/forms/FormStateApp";
 import { noop } from "src/utils/index";
 import { withBeamDecorator, withDimensions } from "src/utils/sb";
@@ -27,6 +32,17 @@ export const HeaderWithComponents = () => <ModalExample size="lg" withTag />;
 export const WithDatePicker = () => <ModalExample withDateField />;
 export const WithFieldInHeader = () => <ModalExample withTextArea />;
 export const WithDrawHeaderBorder = () => <ModalExample drawHeaderBorder={true} />;
+export const VirtualizedTableInBody = () => {
+  const { openModal } = useModal();
+  const open = () =>
+    openModal({
+      content: <VirtualizedTable />,
+      size: { width: "xl", height: 800 },
+    });
+  // Immediately open the modal for Chromatic snapshots
+  useEffect(open, [openModal]);
+  return <Button label="Open" onClick={open} />;
+};
 
 export const ButtonsInFooter = () => {
   const { openModal, setSize } = useModal();

--- a/src/components/Modal/TestModalContent.tsx
+++ b/src/components/Modal/TestModalContent.tsx
@@ -2,6 +2,7 @@ import { action } from "@storybook/addon-actions";
 import { useState } from "react";
 import { Button } from "src/components/Button";
 import { InternalUser } from "src/components/Filters/testDomain";
+import { ScrollableContent, ScrollableParent } from "src/components/Layout";
 import { ModalBody, ModalFooter, ModalHeader } from "src/components/Modal/Modal";
 import { useModal } from "src/components/Modal/useModal";
 import { GridColumn, GridDataRow, GridTable, simpleHeader, SimpleHeaderAndData } from "src/components/Table";
@@ -89,6 +90,43 @@ export function TestModalFilterTable() {
       <ModalBody>
         <TextField label="Search" value={filter} onChange={setFilter} />
         <GridTable columns={columns} rows={rows} filter={filter} xss={Css.mt1.$} />
+      </ModalBody>
+      <ModalFooter>
+        <Button label="Cancel" onClick={closeModal} variant="tertiary" />
+      </ModalFooter>
+    </>
+  );
+}
+
+export function VirtualizedTable() {
+  const [filter, setFilter] = useState<string>();
+  const { closeModal } = useModal();
+  return (
+    <>
+      <ModalHeader>Filterable table</ModalHeader>
+      {/* Define `virtualized` on ModalBody to
+          (1) disable the modal's scrollbar, as it'll be introduced by the virtualized content.
+          (2) adjust padding to keep the scrollbar to the far right of the screen */}
+      <ModalBody virtualized>
+        {/*
+        Using ScrollableParent and ScrollableContent to keep TextField stuck to the top while ensuring
+        GridTable's scrollbar takes up only the 100% of the scrollable content area, and not all of ModalBody's.
+
+        However, if the only content within the ModalBody is the virtualized table, then there is no need for the
+        ScrollableParent and ScrollableContent. Would be much more simple, such as:
+        ```
+          <ModalBody virtualized>
+            <GridTable as="virtual" ... />
+          </ModalBod>
+        ```
+        */}
+
+        <ScrollableParent xss={Css.h100.$}>
+          <TextField label="Search" value={filter} onChange={setFilter} />
+          <ScrollableContent virtualized>
+            <GridTable as="virtual" columns={columns} rows={rows} filter={filter} xss={Css.mt1.$} />
+          </ScrollableContent>
+        </ScrollableParent>
       </ModalBody>
       <ModalFooter>
         <Button label="Cancel" onClick={closeModal} variant="tertiary" />

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -483,7 +483,9 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
   return (
     <RowStateContext.Provider value={rowStateContext}>
       <PresentationProvider fieldProps={fieldProps} wrap={style?.presentationSettings?.wrap}>
-        <div ref={resizeRef} css={Css.w100.$} />
+        {/* If virtualized take some pixels off the width to accommodate when virtuoso's scrollbar is introduced. */}
+        {/* Otherwise a horizontal scrollbar will _always_ appear once the vertical scrollbar is needed */}
+        <div ref={resizeRef} css={Css.w100.if(as === "virtual").w("calc(100% - 20px)").$} />
         {renders[_as](
           style,
           id,


### PR DESCRIPTION
Changes include:
- ModalBody portal div adds 'height: 100%'.
- Consolidated the 'modalBodyRef' and 'contentRef'. Doesn't appear 'contentRef' was actually needed.
- Adjusts styles to ModalBody wrapping element when 'virtualized' prop is defined.
- Adjusts GridTable's resize reference div to accommodate virtuoso's scrollbar.