### PR TITLE
feat: handle disabled selections

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -22,11 +22,13 @@ import {
   Icon,
   IconButton,
   numericColumn,
+  selectColumn,
   simpleHeader,
   SimpleHeaderAndData,
   useGridTableApi,
 } from "src/components/index";
 import { Css, Palette } from "src/Css";
+import { useComputed } from "src/hooks";
 import { TextField } from "src/inputs";
 import { NumberField } from "src/inputs/NumberField";
 import { noop } from "src/utils";
@@ -1175,5 +1177,37 @@ export function TruncatingCells() {
         { kind: "data", id: "3", data: { name: "Thor Odinson, God of Thunder", value: 3 } },
       ]}
     />
+  );
+}
+
+export function SelectableRows() {
+  const api = useGridTableApi<Row>();
+  const selectedIds = useComputed(() => api.getSelectedRows().map((r) => r.id), [api]);
+
+  const selectCol = selectColumn<Row>();
+
+  const nameCol: GridColumn<Row> = {
+    header: "Name",
+    data: ({ name }) => ({ content: name }),
+    mw: "160px",
+  };
+
+  return (
+    <>
+      <GridTable
+        columns={[selectCol, nameCol]}
+        style={{ rowHeight: "fixed" }}
+        rows={[
+          simpleHeader,
+          { kind: "data", id: "1", data: { name: "Tony Stark", value: 1 } },
+          { kind: "data", id: "2", selectable: false, data: { name: "Natasha Romanova", value: 2 } },
+          { kind: "data", id: "3", data: { name: "Thor Odinson", value: 3 } },
+        ]}
+        api={api}
+      />
+      <div>
+        <strong>Selected Row Ids:</strong> {selectedIds.length > 0 ? selectedIds.join(", ") : "None"}
+      </div>
+    </>
   );
 }

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -837,6 +837,7 @@ export type DiscriminateUnion<T, K extends keyof T, V extends T[K]> = T extends 
 type GridRowKind<R extends Kinded, P extends R["kind"]> = DiscriminateUnion<R, "kind", P> & {
   id: string;
   children: GridDataRow<R>[];
+  selectable?: false;
 };
 
 /**
@@ -1000,6 +1001,8 @@ export type GridDataRow<R extends Kinded> = {
   data: unknown;
   /** Whether to have the row collapsed (children not visible) on initial load. This will be ignore in subsequent re-renders of the table */
   initCollapsed?: boolean;
+  /** Whether row can be selected */
+  selectable?: false;
 } & IfAny<R, {}, DiscriminateUnion<R, "kind", R["kind"]>>;
 
 // Use IfAny so that GridDataRow<any> doesn't devolve into any

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -64,11 +64,7 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
   }
 
   public getSelectedRowIds(kind?: string): string[] {
-    if (kind === undefined) {
-      return this.rowState.selectedIds;
-    } else {
-      return this.getSelectedRows(kind).map((row: any) => row.id);
-    }
+    return this.getSelectedRows(kind).map((row: any) => row.id);
   }
 
   // The any is not great, but getting the overload to handle the optional kind is annoying
@@ -76,7 +72,7 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
     const ids = this.rowState.selectedIds;
     const selected: GridDataRow<R>[] = [];
     visit(this.rowState.rows, (row) => {
-      if (ids.includes(row.id) && (!kind || row.kind === kind)) {
+      if (row.selectable !== false && ids.includes(row.id) && (!kind || row.kind === kind)) {
         selected.push(row as any);
       }
     });

--- a/src/components/Table/SelectToggle.tsx
+++ b/src/components/Table/SelectToggle.tsx
@@ -3,19 +3,26 @@ import { RowStateContext } from "src/components/Table/RowState";
 import { useComputed } from "src/hooks/index";
 import { Checkbox } from "src/inputs/index";
 
+interface SelectToggleProps {
+  id: string;
+  disabled?: boolean;
+}
+
 /** Provides a checkbox to show/drive this row's selected state. */
-export function SelectToggle({ id }: { id: string }) {
+export function SelectToggle({ id, disabled }: SelectToggleProps) {
   const { rowState } = useContext(RowStateContext);
   const state = useComputed(() => rowState.getSelected(id), [rowState]);
   const selected = state === "checked" ? true : state === "unchecked" ? false : "indeterminate";
+
   return (
     <Checkbox
-      label="Select"
       checkboxOnly={true}
-      selected={selected}
+      disabled={disabled}
+      label="Select"
       onChange={(selected) => {
         rowState.selectRow(id, selected);
       }}
+      selected={selected}
     />
   );
 }

--- a/src/components/Table/columns.tsx
+++ b/src/components/Table/columns.tsx
@@ -44,7 +44,9 @@ export function selectColumn<T extends Kinded, S = {}>(columnDef?: Partial<GridC
     ...columnDef,
   };
   return newMethodMissingProxy(base, (key) => {
-    return (data: any, { row }: { row: GridDataRow<any> }) => ({ content: <SelectToggle id={row.id} /> });
+    return (data: any, { row }: { row: GridDataRow<any> }) => ({
+      content: <SelectToggle id={row.id} disabled={row.selectable === false} />,
+    });
   }) as any;
 }
 

--- a/src/inputs/CheckboxBase.tsx
+++ b/src/inputs/CheckboxBase.tsx
@@ -69,9 +69,10 @@ export function CheckboxBase(props: CheckboxBaseProps) {
         {...hoverProps}
         css={{
           ...baseStyles,
-          ...((isSelected || isIndeterminate) && filledBoxStyles),
-          ...((isSelected || isIndeterminate) && isHovered && filledBoxHoverStyles),
+          ...(((isSelected && !isDisabled) || isIndeterminate) && filledBoxStyles),
+          ...(((isSelected && !isDisabled) || isIndeterminate) && isHovered && filledBoxHoverStyles),
           ...(isDisabled && disabledBoxStyles),
+          ...(isDisabled && isSelected && disabledSelectedBoxStyles),
           ...(isFocusVisible && focusRingStyles),
           ...(isHovered && hoverBorderStyles),
           ...markStyles,
@@ -97,7 +98,8 @@ export function CheckboxBase(props: CheckboxBaseProps) {
 const baseStyles = Css.hPx(16).mw(px(16)).relative.ba.bGray300.br4.bgWhite.transition.$;
 const filledBoxStyles = Css.bLightBlue700.bgLightBlue700.$;
 const filledBoxHoverStyles = Css.bgLightBlue900.$;
-const disabledBoxStyles = Css.bGray400.bGray100.$;
+const disabledBoxStyles = Css.bgGray50.bGray100.$;
+const disabledSelectedBoxStyles = Css.bgGray400.bGray400.$;
 const disabledColor = Css.gray300.$;
 const focusRingStyles = Css.bshFocus.$;
 const hoverBorderStyles = Css.bLightBlue900.$;


### PR DESCRIPTION
- [sc-18644](https://app.shortcut.com/homebound-team/story/18644/update-gridtable-api-selection-to-exclude-disabled-selections)
- update checkbox style to show checkmark when selected and disabled
- update selection logic to exclude rows that are not `selectable`
- expose `disabled` prop in `selectToggle` to be able to display disabled state

<img src="https://user-images.githubusercontent.com/8864519/178059683-1c1ed9c2-a621-4408-beb7-9e52373e06bf.png" alt="none selected" width="200" />
<img src="https://user-images.githubusercontent.com/8864519/178059700-cee9bdcc-4ca7-4b50-b29e-f05ea3356f8d.png" alt="all selected" width="200" />

