### PR TITLE
feat: Support compact ToggleChips

### DIFF
--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -12,12 +12,12 @@ export interface ChipProps<X> {
 export function Chip<X extends Only<Xss<Margin>, X>>(props: ChipProps<X>) {
   const { text, xss = {} } = props;
   const { fieldProps } = usePresentationContext();
-  const typeScale = fieldProps?.typeScale ?? "sm";
+  const compact = fieldProps?.compact;
   const tid = useTestIds(props, "chip");
   return (
     <span
       css={{
-        ...Css[typeScale].dif.aic.br16.pl1.px1.pyPx(2).gray900.bgGray200.$,
+        ...Css[compact ? "xs" : "sm"].dif.aic.br16.pl1.px1.pyPx(2).gray900.bgGray200.$,
         ...xss,
       }}
       {...tid}

--- a/src/components/ToggleChip.stories.tsx
+++ b/src/components/ToggleChip.stories.tsx
@@ -1,6 +1,6 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
-import { Css, ToggleChip } from "src/index";
+import { Css, PresentationProvider, ToggleChip } from "src/index";
 
 export default {
   component: ToggleChip,
@@ -9,10 +9,23 @@ export default {
 
 export function DefaultToggleChip() {
   return (
-    <div css={Css.wPx(300).df.fdc.aifs.childGap2.$}>
-      <ToggleChip text="First Last" onClick={action("click")} />
-      <ToggleChip text="Disabled Chip" disabled onClick={action("click")} />
-      <ToggleChip text={"First Last ".repeat(10)} onClick={action("click")} />
+    <div css={Css.df.fdc.gap4.$}>
+      <div css={Css.wPx(300).df.fdc.aifs.gap2.$}>
+        <ToggleChip text="First Last" onClick={action("click")} />
+        <ToggleChip text="Disabled Chip" disabled onClick={action("click")} />
+        <ToggleChip text={"First Last ".repeat(10)} onClick={action("click")} />
+      </div>
+
+      <div>
+        <h2 css={Css.mb1.$}>Compact</h2>
+        <div css={Css.wPx(300).df.fdc.aifs.gap2.$}>
+          <PresentationProvider fieldProps={{ compact: true }}>
+            <ToggleChip text="First Last" onClick={action("click")} />
+            <ToggleChip text="Disabled Chip" disabled onClick={action("click")} />
+            <ToggleChip text={"First Last ".repeat(10)} onClick={action("click")} />
+          </PresentationProvider>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/ToggleChip.tsx
+++ b/src/components/ToggleChip.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Icon } from "src/components/Icon";
-import { Css, Margin, Only, Palette, px, Xss } from "src/Css";
+import { usePresentationContext } from "src/components/PresentationContext";
+import { Css, Margin, Only, Palette, Xss } from "src/Css";
 import { useTestIds } from "src/utils/useTestIds";
 
 type ToggleChipXss = Xss<Margin>;
@@ -14,17 +15,20 @@ export interface ToggleChipProps<X> {
 
 export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipProps<X>) {
   const { text, onClick, xss = {}, disabled = false } = props;
+  const { fieldProps } = usePresentationContext();
+  // If compact, then use a smaller type scale
+  const compact = fieldProps?.compact;
   const tid = useTestIds(props, "chip");
   return (
     <button
       type="button"
       css={{
-        ...Css.dif.aic.br16.sm.pl1
+        ...Css[compact ? "xs" : "sm"].dif.aic.br16.pl1
           // Use a lower right-padding to get closer to the `X` circle
           .prPx(4)
           .pyPx(2)
           .gray900.bgGray200.if(disabled)
-          .mh(px(28)).gray600.$,
+          .mhPx(compact ? 20 : 28).gray600.$,
         ":hover:not(:disabled)": Css.bgGray300.$,
         ":disabled": Css.cursorNotAllowed.$,
         ...xss,
@@ -38,7 +42,7 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
       </span>
       {!disabled && (
         <span css={Css.fs0.br16.bgGray400.$}>
-          <Icon icon="x" color={Palette.Gray700} />
+          <Icon icon="x" color={Palette.Gray700} inc={compact ? 2 : undefined} />
         </span>
       )}
     </button>


### PR DESCRIPTION
Chips only support two sizes, so rather than supporting any typescale, define type scale on 'compact' or not.