### PR TITLE
fix(number-field): expose `clearable` prop

### DIFF
--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -20,6 +20,7 @@ export interface NumberFieldProps {
   value: number | undefined;
   onChange: (value: number | undefined) => void;
   compact?: boolean;
+  clearable?: boolean;
   /** Whether the field is disabled. If a ReactNode, it's treated as a "disabled reason" that's shown in a tooltip. */
   disabled?: boolean | ReactNode;
   required?: boolean;


### PR DESCRIPTION
`<NumberField />` already drills through `{...otherProps}` to the underlying TextFieldBase, but the TS Type doesn't like `clearable` because it's not declared.

I started down the avenue of having NumberFieldProps extend TextFieldBaseProps but it started to spiral and I want a quick win. It was starting to look like `extends Omit<TextFieldBaseProps<Xss<"justifyContent" | "textAlign">>, "onChange">` but then there were issues with `inputProps={inputProps}` "always being overridden by the spread of `{...otherProps}`" and I opted for path of least resistance.

I can reattempt `extends` if there's demand for it, otherwise this is a cheap free win and I'm here for it.