### PR TITLE
fix(button): resolve potential disable issue

### DIFF
--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -97,4 +97,12 @@ describe("Button", () => {
     expect(r.button()).not.toBeDisabled();
     expect(onError).toBeCalledWith("Promise error");
   });
+
+  it("stays enabled with a sync function", async () => {
+    const r = await render(<Button label="Button" onClick={() => {}} />);
+
+    click(r.button);
+
+    expect(r.button()).not.toBeDisabled();
+  });
 });

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -58,9 +58,11 @@ export function Button(props: ButtonProps) {
       onPress: asLink
         ? noop
         : (e) => {
-            setOnPressRunning(true);
-            const result = Promise.resolve(onPress(e));
-            result.finally(() => setOnPressRunning(false));
+            const result = onPress(e);
+            if (isPromise(result)) {
+              setOnPressRunning(true);
+              result.finally(() => setOnPressRunning(false));
+            }
             return result;
           },
       elementType: asLink ? "a" : "button",
@@ -185,3 +187,7 @@ const iconStyles: Record<ButtonSize, IconProps["xss"]> = {
 
 export type ButtonSize = "sm" | "md" | "lg";
 export type ButtonVariant = "primary" | "secondary" | "tertiary" | "danger" | "text";
+
+function isPromise(obj: void | Promise<void>): obj is Promise<void> {
+  return typeof obj === "object" && "then" in obj && typeof obj.then === "function";
+}


### PR DESCRIPTION
Async Button has a nuanced bug where we can stomp `props.disabled` even if it's `true` if the developer toggles it before the promise has settled. If `props.disabled === true` but our promise settles and sets `setIsDisabled(false)` then despite the developer passing in `<Button disabled={true} />` it'll reenable.

Technically a developer issue, if you have `disabled={!selected.length}`, then maybe don't clear it before your mutation has even _run_, but `disabled={true}` possibly not disabling a button should be avoided nevertheless.