### PR TITLE
fix: Add optional param to DateFieldBase to hide calendar icon

### DIFF
--- a/src/inputs/DateFields/DateField.stories.tsx
+++ b/src/inputs/DateFields/DateField.stories.tsx
@@ -18,6 +18,7 @@ export function DateFields() {
   return samples(
     ["TextField for comparison", <TextField label="First Name" value="Foo" onChange={() => {}} />],
     ["With Label", <TestDateField label="Projected Client Presentation Date" />],
+    ["Without calendar icon", <TestDateField label="Projected Client Presentation Date" hideCalendarIcon />],
     ["Disabled", <TestDateField label="Start Date" disabled="Disabled Reason" />],
     ["Inline Label", <TestDateField label="Start Date" inlineLabel />],
     ["Read Only", <TestDateField label="Start Date" readOnly="Read only reason tooltip" />],

--- a/src/inputs/DateFields/DateFieldBase.test.tsx
+++ b/src/inputs/DateFields/DateFieldBase.test.tsx
@@ -37,14 +37,14 @@ describe(DateFieldBase, () => {
   it("renders correctly without calendar icon button", async () => {
     // Given a DateField without a calendar icon
     const r = await render(
-        <DateFieldBase
-            mode="single"
-            value={undefined}
-            label="Date"
-            onChange={noop}
-            placeholder="Select a date"
-            hideCalendarIcon
-        />,
+      <DateFieldBase
+        mode="single"
+        value={undefined}
+        label="Date"
+        onChange={noop}
+        placeholder="Select a date"
+        hideCalendarIcon
+      />,
     );
     // Calendar icon isn't rendered
     expect(r.queryByTestId("date_calendarButton")).toBeNull()

--- a/src/inputs/DateFields/DateFieldBase.test.tsx
+++ b/src/inputs/DateFields/DateFieldBase.test.tsx
@@ -46,9 +46,9 @@ describe(DateFieldBase, () => {
         hideCalendarIcon
       />,
     );
-    // Calendar icon isn't rendered
+    // Then the calendar icon isn't rendered
     expect(r.queryByTestId("date_calendarButton")).toBeNull()
-    // Sanity check placeholder
+    // And the placeholder is still there
     expect(r.date()).toHaveValue("").toHaveAttribute("placeholder", "Select a date");
   });
 

--- a/src/inputs/DateFields/DateFieldBase.test.tsx
+++ b/src/inputs/DateFields/DateFieldBase.test.tsx
@@ -34,6 +34,24 @@ describe(DateFieldBase, () => {
     expect(r.date_helperText().textContent).toBe("Helper text");
   });
 
+  it("renders correctly without calendar icon button", async () => {
+    // Given a DateField without a calendar icon
+    const r = await render(
+        <DateFieldBase
+            mode="single"
+            value={undefined}
+            label="Date"
+            onChange={noop}
+            placeholder="Select a date"
+            hideCalendarIcon
+        />,
+    );
+    // Calendar icon isn't rendered
+    expect(r.queryByTestId("date_calendarButton")).toBeNull()
+    // Sanity check placeholder
+    expect(r.date()).toHaveValue("").toHaveAttribute("placeholder", "Select a date");
+  });
+
   it("resets focus to input field when clicking calendar button and does not call onBlur", async () => {
     const onBlur = jest.fn();
     const r = await render(<DateFieldBase mode="single" value={jan2} label="Date" onChange={noop} onBlur={onBlur} />);

--- a/src/inputs/DateFields/DateFieldBase.tsx
+++ b/src/inputs/DateFields/DateFieldBase.tsx
@@ -40,6 +40,7 @@ export interface DateFieldBaseProps
   placeholder?: string;
   format?: keyof typeof dateFormats;
   iconLeft?: boolean;
+  hideCalendarIcon?: boolean;
   /**
    * Set custom logic for individual dates or date ranges to be disabled in the picker
    * exposed from `react-day-picker`: https://react-day-picker.js.org/api/DayPicker#modifiers
@@ -80,6 +81,7 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
     readOnly,
     format = "short",
     iconLeft = false,
+    hideCalendarIcon = false,
     disabledDays,
     onEnter,
     defaultOpen,
@@ -252,7 +254,7 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
       tabIndex={-1}
       {...tid.calendarButton}
     >
-      <Icon icon="calendar" color={Palette.Gray700} />
+      <Icon icon="calendar" color={Palette.Gray700}/>
     </button>
   );
 
@@ -278,8 +280,8 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
             onChange(parsed);
           }
         }}
-        endAdornment={!iconLeft && calendarButton}
-        startAdornment={iconLeft && calendarButton}
+        endAdornment={(!hideCalendarIcon && !iconLeft) && calendarButton}
+        startAdornment={(!hideCalendarIcon && iconLeft) && calendarButton}
         tooltip={resolveTooltip(disabled, undefined, readOnly)}
         {...others}
       />


### PR DESCRIPTION
[SC-18436](https://app.shortcut.com/homebound-team/story/18436/remove-calendar-icon-from-schedule)

Straightforward implementation of optional bool property. 

- `DateFieldBase` will not pass `calendarButton` to start/end adornment prop in any way if this value is true. This will eliminate any extra padding in the input field.
- Added a simple test and story view.