### PR TITLE
feat(bound-select-field): dirty indicator

### DIFF
--- a/src/forms/BoundSelectField.test.tsx
+++ b/src/forms/BoundSelectField.test.tsx
@@ -62,6 +62,30 @@ describe("BoundSelectField", () => {
     // Then formState has the latest value when onBlur is called
     expect(autoSave).toBeCalledWith("s:2");
   });
+
+  it("shows dirty indicator", async () => {
+    const author = createObjectState(formConfig, { favoriteSport: "s:1" });
+    const r = await render(<BoundSelectField field={author.favoriteSport} options={sports} isDirtyIndicator />);
+    r.favoriteSport().focus();
+    click(r.getByRole("option", { name: "Soccer" }));
+    expect(r.favoriteSport_isDirtyIndicator()).toBeInTheDocument();
+  });
+
+  it("ignores isDirtyIndicator if fieldDecoration is provided", async () => {
+    const author = createObjectState(formConfig, { favoriteSport: "s:1" });
+    const r = await render(
+      <BoundSelectField
+        field={author.favoriteSport}
+        options={sports}
+        isDirtyIndicator
+        fieldDecoration={() => <div data-testid="lookforme" />}
+      />,
+    );
+    r.favoriteSport().focus();
+    click(r.getByRole("option", { name: "Soccer" }));
+    expect(r.lookforme()).toBeInTheDocument();
+    expect(r.queryByTestId("favoriteSport_isDirtyIndicator")).not.toBeInTheDocument();
+  });
 });
 
 const formConfig: ObjectConfig<AuthorInput> = {

--- a/src/forms/BoundSelectField.tsx
+++ b/src/forms/BoundSelectField.tsx
@@ -5,12 +5,15 @@ import { HasIdAndName, Optional } from "src/types";
 import { maybeCall } from "src/utils";
 import { defaultLabel } from "src/utils/defaultLabel";
 import { useTestIds } from "src/utils/useTestIds";
+import { Css } from "..";
 
 export type BoundSelectFieldProps<O, V extends Value> = Omit<SelectFieldProps<O, V>, "value" | "onSelect" | "label"> & {
-  // Allow `onSelect` to be overridden to do more than just `field.set`.
+  /** Allow `onSelect` to be overridden to do more than just `field.set`. */
   onSelect?: (value: V | undefined, opt: O | undefined) => void;
   field: FieldState<any, V | null | undefined>;
   label?: string;
+  /** Passes an indicator via fieldDecoration. If fieldDecoration is provided, this props is ignored */
+  isDirtyIndicator?: boolean;
 };
 
 /**
@@ -35,11 +38,13 @@ export function BoundSelectField<T extends object, V extends Value>(
     options,
     readOnly,
     getOptionValue = (opt: T) => (opt as any).id, // if unset, assume O implements HasId
-    getOptionLabel = (opt: T) => (opt as any).name, // if unset, assume O implements HasName
+    getOptionLabel = (opt: T) => (opt as any).name ?? (opt as any).label, // if unset, assume O implements HasName
     onSelect = (value) => field.set(value),
     label = defaultLabel(field.key),
     onBlur,
     onFocus,
+    fieldDecoration,
+    isDirtyIndicator,
     ...others
   } = props;
   const testId = useTestIds(props, field.key);
@@ -67,6 +72,12 @@ export function BoundSelectField<T extends object, V extends Value>(
             field.focus();
             maybeCall(onFocus);
           }}
+          fieldDecoration={
+            fieldDecoration ??
+            (isDirtyIndicator && field.dirty
+              ? () => <div css={Css.wPx(8).hPx(8).br100.bgYellow600.$} {...testId.isDirtyIndicator} />
+              : undefined)
+          }
           {...others}
           {...testId}
         />


### PR DESCRIPTION
I started doing this in BluePrint then realized it should probably have some first-class support in Beam. Shows an indicator if an input is dirty/has not been saved yet.

<img width="315" alt="image" src="https://user-images.githubusercontent.com/20718430/180315407-fb107454-c822-412c-9fec-d47d97e77956.png">

In the future I suppose we could add this to the other BoundXFields. 
