### PR TITLE
fix: Revert "feat: Sort within pinned rows. (#581)"

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -820,27 +820,27 @@ describe("GridTable", () => {
           sorting={{ on: "client", initial: [1, "ASC"] }}
           rows={[
             simpleHeader,
-            // And the first rows are actually pinned last
-            { kind: "data", id: "5", pin: "last", data: { name: "e", value: 21 } },
-            { kind: "data", id: "6", pin: "last", data: { name: "f", value: 20 } },
+            // And the 1st row is pinned first
+            { kind: "data", id: "1", pin: "first", data: { name: "a", value: 11 } },
+            { kind: "data", id: "2", pin: "first", data: { name: "b", value: 10 } },
             // And the middle rows need sorted
             { kind: "data", id: "3", data: { name: "c", value: 3 } },
             { kind: "data", id: "4", data: { name: "d", value: 1 } },
-            // And the last rows are actually pinned first
-            { kind: "data", id: "1", pin: "first", data: { name: "a", value: 11 } },
-            { kind: "data", id: "2", pin: "first", data: { name: "b", value: 10 } },
+            // And the last rows are pinned last
+            { kind: "data", id: "5", pin: "last", data: { name: "e", value: 20 } },
+            { kind: "data", id: "6", pin: "last", data: { name: "f", value: 21 } },
           ]}
         />,
       );
-      // Then the a/b rows stayed first (b has a lower value so was nudged first)
-      expect(cell(r, 1, 0)).toHaveTextContent("b");
-      expect(cell(r, 2, 0)).toHaveTextContent("a");
+      // Then the a/b rows stayed first
+      expect(cell(r, 1, 0)).toHaveTextContent("a");
+      expect(cell(r, 2, 0)).toHaveTextContent("b");
       // And the middle rows swapped
       expect(cell(r, 3, 0)).toHaveTextContent("d");
       expect(cell(r, 4, 0)).toHaveTextContent("c");
-      // And the last rows stayed last (f has a lower value so was nudged first)
-      expect(cell(r, 5, 0)).toHaveTextContent("f");
-      expect(cell(r, 6, 0)).toHaveTextContent("e");
+      // And the last rows stayed last
+      expect(cell(r, 5, 0)).toHaveTextContent("e");
+      expect(cell(r, 6, 0)).toHaveTextContent("f");
     });
 
     it("can pin rows last", async () => {

--- a/src/components/Table/sortRows.test.ts
+++ b/src/components/Table/sortRows.test.ts
@@ -81,7 +81,7 @@ describe("sortRows", () => {
     expect(rowsToIdArray(sorted)).toEqual(["2", "2.2", "2.1", "2.3", "1", "header", "3"]);
   });
 
-  it("can sort within pinned rows", () => {
+  it("does not sort within pinned rows", () => {
     // Given a set of unsorted rows
     const rows: GridDataRow<Row>[] = [
       // And this row is not pinned, so should come last
@@ -93,8 +93,8 @@ describe("sortRows", () => {
     ];
     // When sorting them in descending order based on the name property
     const sorted = sortRows([nameColumn], rows, [0, "ASC", undefined, undefined], true);
-    // Then expected case sensitive sort in descending correct order
-    expect(rowsToIdArray(sorted)).toEqual(["1", "2", "3"]);
+    // Then we kept the 2nd pinned row where it was
+    expect(rowsToIdArray(sorted)).toEqual(["2", "1", "3"]);
   });
 
   it("can sort within primary rows", () => {

--- a/src/components/Table/sortRows.ts
+++ b/src/components/Table/sortRows.ts
@@ -36,7 +36,10 @@ function sortBatch<R extends Kinded>(
 
   // Make a shallow copy for sorting to avoid mutating the original list
   return [...batch].sort((a, b) => {
-    if ((a.pin || b.pin) && !(a.pin === b.pin)) {
+    if (a.pin || b.pin) {
+      // If both rows are pinned, we don't sort within them, because by pinning the page is taking
+      // explicit ownership over the order of the rows (and we also don't support "levels of pins",
+      // i.e. for change events putting "just added" rows `pin: last` and the "add new" row `pin: lastest`).
       const ap = a.pin === "first" ? -1 : a.pin === "last" ? 1 : 0;
       const bp = b.pin === "first" ? -1 : b.pin === "last" ? 1 : 0;
       return ap === bp ? 0 : ap < bp ? -1 : 1;


### PR DESCRIPTION
I'd broken the behavior of the Change Events v2 line items page, which uses `pin: last` for two different uses:

* A group of "just added" CELIs that we don't want strewn all over the table by a sort, instead we want the user to see/work them in order
* The very last "add inline" psuedo CELI

And if we "sort within pins", then the "add inline" CELI can get reordered amongst the "just added" CELIs.

I had originally written this for @aTrujilloHomeBound to potentially use for "favorite documents", but they ended up not being able to use `pin`s anyway, b/c pinned rows are not filtered, and they needed favorite documents to still have filters applied to them.