### PR TITLE
feat: added `Small` width prop for SuperDrawer

### DIFF
--- a/src/components/SuperDrawer/SuperDrawer.stories.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.stories.tsx
@@ -46,6 +46,25 @@ export function Open() {
   );
 }
 
+export function SmallDrawer() {
+  const { openInDrawer, isDrawerOpen } = useSuperDrawer();
+  function open() {
+    openInDrawer({
+      title: "Drawer Title",
+      content: <TestDrawerContent book={Books[0]} />,
+      width: "small"
+    });
+  }
+  useEffect(open, [openInDrawer]);
+  return (
+    // Purposely set height to validate no scrolling behaviour
+    <div css={Css.hPx(5000).$}>
+      <h1 css={Css.xl3Em.mb1.$}>SuperDrawer Open</h1>
+      <Button label={isDrawerOpen ? "SuperDrawer is open" : "Show SuperDrawer"} onClick={open} />
+    </div>
+  );
+}
+
 export function OpenWithNoActions() {
   const { openInDrawer } = useSuperDrawer();
   function open() {

--- a/src/components/SuperDrawer/SuperDrawer.stories.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.stories.tsx
@@ -21,6 +21,7 @@ import { noop } from "src/utils";
 import { withBeamDecorator, withDimensions } from "src/utils/sb";
 import { SuperDrawerContent, useSuperDrawer } from "./index";
 import { SuperDrawer as SuperDrawerComponent } from "./SuperDrawer";
+import { SuperDrawerWidth } from "./utils";
 
 export default {
   title: "Components/Super Drawer",
@@ -52,7 +53,7 @@ export function SmallDrawer() {
     openInDrawer({
       title: "Drawer Title",
       content: <TestDrawerContent book={Books[0]} />,
-      width: "small"
+      width: SuperDrawerWidth.Small
     });
   }
   useEffect(open, [openInDrawer]);

--- a/src/components/SuperDrawer/SuperDrawer.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.tsx
@@ -7,11 +7,7 @@ import { ButtonGroup, IconButton, OpenInDrawerOpts, useSuperDrawer } from "src/c
 import { useBeamContext } from "src/components/BeamContext";
 import { Css, px } from "src/Css";
 import { useTestIds } from "src/utils";
-
-export enum SuperDrawerWidth {
-  small = 560,
-  normal = 1040
-};
+import { SuperDrawerWidth } from "./utils";
 
 /**
  * Global drawer component.
@@ -70,7 +66,7 @@ export function SuperDrawer(): ReactPortal | null {
   const isDetail = currentContent !== firstContent;
   const title = content === undefined ? '' : currentContent.title || firstContent.title;
 
-  const width = firstContent && firstContent.width === "small" ? SuperDrawerWidth.small : SuperDrawerWidth.normal;
+  const { width = SuperDrawerWidth.Normal } = firstContent ?? {}
 
   return createPortal(
     <AnimatePresence>

--- a/src/components/SuperDrawer/SuperDrawer.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.tsx
@@ -8,6 +8,11 @@ import { useBeamContext } from "src/components/BeamContext";
 import { Css, px } from "src/Css";
 import { useTestIds } from "src/utils";
 
+export enum SuperDrawerWidth {
+  small = 560,
+  normal = 1040
+};
+
 /**
  * Global drawer component.
  *
@@ -65,7 +70,7 @@ export function SuperDrawer(): ReactPortal | null {
   const isDetail = currentContent !== firstContent;
   const title = content === undefined ? '' : currentContent.title || firstContent.title;
 
-  const width = firstContent && firstContent.width === "small" ? 560 : 1040;
+  const width = firstContent && firstContent.width === "small" ? SuperDrawerWidth.small : SuperDrawerWidth.normal;
 
   return createPortal(
     <AnimatePresence>

--- a/src/components/SuperDrawer/SuperDrawer.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.tsx
@@ -65,7 +65,7 @@ export function SuperDrawer(): ReactPortal | null {
   const isDetail = currentContent !== firstContent;
   const title = content === undefined ? '' : currentContent.title || firstContent.title;
 
-  const width = !isDetail && firstContent && firstContent.width === "small" ? 560 : 1040;
+  const width = firstContent && firstContent.width === "small" ? 560 : 1040;
 
   return createPortal(
     <AnimatePresence>

--- a/src/components/SuperDrawer/SuperDrawer.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.tsx
@@ -65,6 +65,8 @@ export function SuperDrawer(): ReactPortal | null {
   const isDetail = currentContent !== firstContent;
   const title = content === undefined ? '' : currentContent.title || firstContent.title;
 
+  const width = !isDetail && firstContent && firstContent.width === "small" ? 560 : 1040;
+
   return createPortal(
     <AnimatePresence>
       {content && (
@@ -91,13 +93,13 @@ export function SuperDrawer(): ReactPortal | null {
             {/* Content container */}
             <motion.aside
               key="superDrawerContainer"
-              css={Css.bgWhite.h100.maxw(px(1040)).w100.df.fdc.relative.$}
+              css={Css.bgWhite.h100.maxw(px(width)).w100.df.fdc.relative.$}
               // Keeping initial x to 1040 as this will still work if the container is smaller
-              initial={{ x: 1040 }}
+              initial={{ x: width }}
               animate={{ x: 0 }}
               // Custom transitions settings for the translateX animation
               transition={{ ease: "linear", duration: 0.2, delay: 0.2 }}
-              exit={{ transition: { ease: "linear", duration: 0.2 }, x: 1040 }}
+              exit={{ transition: { ease: "linear", duration: 0.2 }, x: width }}
               // Preventing clicks from triggering parent onClick
               onClick={(e) => e.stopPropagation()}
             >

--- a/src/components/SuperDrawer/SuperDrawerContent.tsx
+++ b/src/components/SuperDrawer/SuperDrawerContent.tsx
@@ -32,7 +32,7 @@ export const SuperDrawerContent = ({ children, actions }: SuperDrawerContentProp
   const { kind } = contentStack.current[contentStack.current.length - 1] ?? {};
   const firstContent = contentStack.current[0]?.opts as OpenInDrawerOpts;
 
-  const width = (firstContent && firstContent.width) || SuperDrawerWidth.Normal;
+  const { width = SuperDrawerWidth.Normal } = firstContent ?? {}
 
   function wrapWithMotionAndMaybeBack(children: ReactNode): ReactNode {
     if (kind === "open") {

--- a/src/components/SuperDrawer/SuperDrawerContent.tsx
+++ b/src/components/SuperDrawer/SuperDrawerContent.tsx
@@ -4,7 +4,7 @@ import { useBeamContext } from "src/components/BeamContext";
 import { Button, ButtonProps } from "src/components/Button";
 import { OpenInDrawerOpts, useSuperDrawer } from "src/components/SuperDrawer/useSuperDrawer";
 import { Css } from "src/Css";
-import { SuperDrawerWidth } from "./SuperDrawer";
+import { SuperDrawerWidth } from "./utils";
 
 interface SuperDrawerContentProps {
   children: ReactNode;
@@ -32,7 +32,7 @@ export const SuperDrawerContent = ({ children, actions }: SuperDrawerContentProp
   const { kind } = contentStack.current[contentStack.current.length - 1] ?? {};
   const firstContent = contentStack.current[0]?.opts as OpenInDrawerOpts;
 
-  const width = firstContent && firstContent.width === "small" ? SuperDrawerWidth.small : SuperDrawerWidth.normal;
+  const width = (firstContent && firstContent.width) || SuperDrawerWidth.Normal;
 
   function wrapWithMotionAndMaybeBack(children: ReactNode): ReactNode {
     if (kind === "open") {

--- a/src/components/SuperDrawer/SuperDrawerContent.tsx
+++ b/src/components/SuperDrawer/SuperDrawerContent.tsx
@@ -2,8 +2,9 @@ import { motion } from "framer-motion";
 import { ReactNode } from "react";
 import { useBeamContext } from "src/components/BeamContext";
 import { Button, ButtonProps } from "src/components/Button";
-import { useSuperDrawer } from "src/components/SuperDrawer/useSuperDrawer";
+import { OpenInDrawerOpts, useSuperDrawer } from "src/components/SuperDrawer/useSuperDrawer";
 import { Css } from "src/Css";
+import { SuperDrawerWidth } from "./SuperDrawer";
 
 interface SuperDrawerContentProps {
   children: ReactNode;
@@ -29,6 +30,9 @@ export const SuperDrawerContent = ({ children, actions }: SuperDrawerContentProp
 
   // Determine if the current element is a new content element or an detail element
   const { kind } = contentStack.current[contentStack.current.length - 1] ?? {};
+  const firstContent = contentStack.current[0]?.opts as OpenInDrawerOpts;
+
+  const width = firstContent && firstContent.width === "small" ? SuperDrawerWidth.small : SuperDrawerWidth.normal;
 
   function wrapWithMotionAndMaybeBack(children: ReactNode): ReactNode {
     if (kind === "open") {
@@ -47,10 +51,10 @@ export const SuperDrawerContent = ({ children, actions }: SuperDrawerContentProp
         >
           <Button label="Back" icon="chevronLeft" variant="tertiary" onClick={closeDrawerDetail} />
           <motion.div
-            initial={{ x: 1040, opacity: 0 }}
+            initial={{ x: width, opacity: 0 }}
             animate={{ x: 0, opacity: 1 }}
             transition={{ ease: "linear", duration: 0.3, opacity: { delay: 0.15 } }}
-            exit={{ x: 1040, opacity: 0 }}
+            exit={{ x: width, opacity: 0 }}
             css={Css.pt2.$}
           >
             {children}

--- a/src/components/SuperDrawer/index.ts
+++ b/src/components/SuperDrawer/index.ts
@@ -2,3 +2,4 @@
 export * from "./ConfirmCloseModal";
 export * from "./SuperDrawerContent";
 export * from "./useSuperDrawer";
+export * from "./utils";

--- a/src/components/SuperDrawer/useSuperDrawer.tsx
+++ b/src/components/SuperDrawer/useSuperDrawer.tsx
@@ -20,6 +20,8 @@ export interface OpenInDrawerOpts {
   /** Adds a callback that is called _after_ close has definitely happened. */
   onClose?: () => void;
   content: ReactNode;
+  /** If set to "small", the Drawer will have a width of 560px. Otherwise 1040px */
+  width?: "small";
 }
 
 export interface OpenDetailOpts {

--- a/src/components/SuperDrawer/useSuperDrawer.tsx
+++ b/src/components/SuperDrawer/useSuperDrawer.tsx
@@ -21,7 +21,7 @@ export interface OpenInDrawerOpts {
   /** Adds a callback that is called _after_ close has definitely happened. */
   onClose?: () => void;
   content: ReactNode;
-  /** Adds the hability to change the SuperDrawer width based on some pre-defined values */
+  /** Adds the ability to change the SuperDrawer width based on some pre-defined values */
   width?: SuperDrawerWidth;
 }
 

--- a/src/components/SuperDrawer/useSuperDrawer.tsx
+++ b/src/components/SuperDrawer/useSuperDrawer.tsx
@@ -3,6 +3,7 @@ import { useBeamContext } from "src/components/BeamContext";
 import { CanCloseCheck } from "src/types";
 import { useModal } from "../Modal";
 import { ConfirmCloseModal } from "./ConfirmCloseModal";
+import { SuperDrawerWidth } from "./utils";
 
 export interface OpenInDrawerOpts {
   /** Title of the SuperDrawer */
@@ -20,8 +21,8 @@ export interface OpenInDrawerOpts {
   /** Adds a callback that is called _after_ close has definitely happened. */
   onClose?: () => void;
   content: ReactNode;
-  /** If set to "small", the Drawer will have a width of 560px. Otherwise 1040px */
-  width?: "small";
+  /** Adds the hability to change the SuperDrawer width based on some pre-defined values */
+  width?: SuperDrawerWidth;
 }
 
 export interface OpenDetailOpts {

--- a/src/components/SuperDrawer/utils.ts
+++ b/src/components/SuperDrawer/utils.ts
@@ -1,0 +1,4 @@
+export enum SuperDrawerWidth {
+  Small = 560,
+  Normal = 1040,
+};


### PR DESCRIPTION
With this PR a `width` option will be added to the `openInDrawer` from the `useSuperDrawer` hook, when this option is set to `"small"` it will set the SuperDrawer width to `560px`, if this prop is not passed the width will default to `1040px`.

# Usage
```javascript
// Example from `SuperDrawer.stories.tsx`
openInDrawer({
  title: "Drawer Title",
  content: <TestDrawerContent book={Books[0]} />,
  width: "small"
});
```