### PR TITLE
feat: add type to chip

### DIFF
--- a/src/components/Chip.stories.tsx
+++ b/src/components/Chip.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { Chip } from "src/components/Chip";
+import { Chip, ChipTypes } from "src/components/Chip";
 import { Css } from "src/Css";
 
 export default {
@@ -25,9 +25,9 @@ export function ColoredChips() {
     <div>
       <div css={Css.df.wPx(500).$}>
         <Chip text="default" />
-        <Chip text="caution" type="caution" />
-        <Chip text="warning" type="warning" />
-        <Chip text="success" type="success" />
+        <Chip text="caution" type={ChipTypes.caution} />
+        <Chip text="warning" type={ChipTypes.warning} />
+        <Chip text="success" type={ChipTypes.success} />
       </div>
     </div>
   );

--- a/src/components/Chip.stories.tsx
+++ b/src/components/Chip.stories.tsx
@@ -19,3 +19,16 @@ export function DefaultChip() {
     </div>
   );
 }
+
+export function ColoredChips() {
+  return (
+    <div>
+      <div css={Css.df.wPx(500).$}>
+        <Chip text="default" />
+        <Chip text="caution" type="caution" />
+        <Chip text="warning" type="warning" />
+        <Chip text="success" type="success" />
+      </div>
+    </div>
+  );
+}

--- a/src/components/Chip.test.tsx
+++ b/src/components/Chip.test.tsx
@@ -1,11 +1,17 @@
 import { Chip } from "src/components/Chip";
 import { render } from "src/utils/rtl";
+import {Css} from "../Css";
 
 describe("Chip", () => {
   it("renders", async () => {
     const r = await render(<Chip text="Chip text content" />);
     expect(r.chip().textContent).toBe("Chip text content");
     expect(r.chip()).toHaveAttribute("title", "Chip text content");
+  });
+
+  it("can set type to change background color", async () => {
+    const r = await render(<Chip text="Chip" type="caution" />);
+    expect(r.chip()).toHaveStyle(`background: ${Css.bgYellow200.$}`);
   });
 
   it("can set custom testids", async () => {

--- a/src/components/Chip.test.tsx
+++ b/src/components/Chip.test.tsx
@@ -1,6 +1,6 @@
-import { Chip } from "src/components/Chip";
+import { Chip, ChipTypes } from "src/components/Chip";
 import { render } from "src/utils/rtl";
-import {Css} from "../Css";
+import { Css } from "../Css";
 
 describe("Chip", () => {
   it("renders", async () => {
@@ -10,7 +10,7 @@ describe("Chip", () => {
   });
 
   it("can set type to change background color", async () => {
-    const r = await render(<Chip text="Chip" type="caution" />);
+    const r = await render(<Chip text="Chip" type={ChipTypes.caution} />);
     expect(r.chip()).toHaveStyle(`background: ${Css.bgYellow200.$}`);
   });
 

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { usePresentationContext } from "src/components/PresentationContext";
-import { Css, Margin, Only, Xss } from "src/Css";
+import { Css, Margin, Only, Properties, Xss } from "src/Css";
 import { useTestIds } from "src/utils/useTestIds";
 
 type ChipType = "caution" | "warning" | "success" | "neutral";
@@ -41,7 +41,7 @@ export function Chip<X extends Only<Xss<Margin>, X>>({ type = ChipTypes.neutral,
   );
 }
 
-const typeStyles: Record<ChipType, { backgroundColor: string | undefined }> = {
+const typeStyles: Record<ChipType, Properties> = {
   caution: Css.bgYellow200.$,
   warning: Css.bgRed100.$,
   success: Css.bgGreen100.$,

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -3,21 +3,27 @@ import { usePresentationContext } from "src/components/PresentationContext";
 import { Css, Margin, Only, Xss } from "src/Css";
 import { useTestIds } from "src/utils/useTestIds";
 
+type TagType = "caution" | "warning" | "success";
+
 export interface ChipProps<X> {
   text: string;
   xss?: X;
+  // Defaults to "neutral"
+  type?: TagType;
 }
 
 /** Kinda like a chip, but read-only, so no `onClick` or `hover`. */
 export function Chip<X extends Only<Xss<Margin>, X>>(props: ChipProps<X>) {
-  const { text, xss = {} } = props;
+  const { text, type, xss = {} } = props;
   const { fieldProps } = usePresentationContext();
   const compact = fieldProps?.compact;
+  const typeStyles = getStyles(type);
   const tid = useTestIds(props, "chip");
   return (
     <span
       css={{
-        ...Css[compact ? "xs" : "sm"].dif.aic.br16.pl1.px1.pyPx(2).gray900.bgGray200.$,
+        ...Css[compact ? "xs" : "sm"].dif.aic.br16.pl1.px1.pyPx(2).gray900.$,
+        ...typeStyles,
         ...xss,
       }}
       {...tid}
@@ -26,4 +32,18 @@ export function Chip<X extends Only<Xss<Margin>, X>>(props: ChipProps<X>) {
       <span css={Css.lineClamp1.breakAll.$}>{text}</span>
     </span>
   );
+}
+
+function getStyles(type?: TagType) {
+  switch (type) {
+    case "caution":
+      return Css.bgYellow200.$;
+    case "warning":
+      return Css.bgRed100.$;
+    case "success":
+      return Css.bgGreen100.$;
+    default:
+      // Neutral case
+      return Css.bgGray200.$;
+  }
 }

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -3,27 +3,34 @@ import { usePresentationContext } from "src/components/PresentationContext";
 import { Css, Margin, Only, Xss } from "src/Css";
 import { useTestIds } from "src/utils/useTestIds";
 
-type TagType = "caution" | "warning" | "success";
+type ChipType = "caution" | "warning" | "success" | "neutral";
+
+// exporting for using in type prop as constant - this could be moved and become a global list for colors
+export const ChipTypes: Record<ChipType, ChipType> = {
+  caution: "caution",
+  warning: "warning",
+  success: "success",
+  neutral: "neutral",
+};
 
 export interface ChipProps<X> {
   text: string;
   xss?: X;
-  // Defaults to "neutral"
-  type?: TagType;
+  type?: ChipType;
 }
 
 /** Kinda like a chip, but read-only, so no `onClick` or `hover`. */
-export function Chip<X extends Only<Xss<Margin>, X>>(props: ChipProps<X>) {
-  const { text, type, xss = {} } = props;
+export function Chip<X extends Only<Xss<Margin>, X>>({ type = ChipTypes.neutral, ...props }: ChipProps<X>) {
+  const { text, xss = {} } = props;
   const { fieldProps } = usePresentationContext();
   const compact = fieldProps?.compact;
-  const typeStyles = getStyles(type);
   const tid = useTestIds(props, "chip");
+
   return (
     <span
       css={{
         ...Css[compact ? "xs" : "sm"].dif.aic.br16.pl1.px1.pyPx(2).gray900.$,
-        ...typeStyles,
+        ...typeStyles[type],
         ...xss,
       }}
       {...tid}
@@ -34,16 +41,9 @@ export function Chip<X extends Only<Xss<Margin>, X>>(props: ChipProps<X>) {
   );
 }
 
-function getStyles(type?: TagType) {
-  switch (type) {
-    case "caution":
-      return Css.bgYellow200.$;
-    case "warning":
-      return Css.bgRed100.$;
-    case "success":
-      return Css.bgGreen100.$;
-    default:
-      // Neutral case
-      return Css.bgGray200.$;
-  }
-}
+const typeStyles: Record<ChipType, { backgroundColor: string | undefined }> = {
+  caution: Css.bgYellow200.$,
+  warning: Css.bgRed100.$,
+  success: Css.bgGreen100.$,
+  neutral: Css.bgGray200.$,
+};


### PR DESCRIPTION
[#19307](https://app.shortcut.com/homebound-team/story/19307/chip-configuration)

Added `type` prop to  `Chip` component with styled values of `caution, warning, success`

<img width="297" alt="Screen Shot 2022-07-26 at 11 23 41 AM" src="https://user-images.githubusercontent.com/34695559/181071286-cc50779d-801c-4346-8fdb-85bf08568d33.png">
