### PR TITLE
feat: add outline-flag icon

### DIFF
--- a/src/components/Icon.stories.tsx
+++ b/src/components/Icon.stories.tsx
@@ -69,7 +69,7 @@ export const Icon = (props: IconProps) => {
     "menuOpen",
   ];
   const mediaIcons: IconProps["icon"][] = ["camera", "fileBlank", "folder", "image", "file", "images", "openBook"];
-  const miscIcons: IconProps["icon"][] = ["dollar", "userCircle", "calendar", "buildingHouse", "house", "flag"];
+  const miscIcons: IconProps["icon"][] = ["dollar", "userCircle", "calendar", "buildingHouse", "house", "flag", "outlineFlag"];
   const navigationIcons: IconProps["icon"][] = ["projects", "tasks", "finances", "templates", "tradePartners"];
 
   return (

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -323,6 +323,12 @@ export const Icons = {
   flag: (
     <path d="M19 4H6V2H4V20H3V22H4H6H7V20H6V15H19C19.553 15 20 14.552 20 14V5C20 4.448 19.553 4 19 4Z" />
   ),
+  outlineFlag: (
+    <>
+      <path xmlns="http://www.w3.org/2000/svg" d="M6.38464 14H20.3846V5H6.38464" color="transparent" stroke="black" stroke-width="2" stroke-linejoin="round"/>
+      <path xmlns="http://www.w3.org/2000/svg" d="M6.38464 2V11V21M8.38464 21H4.38464" stroke="black" stroke-width="2" stroke-linejoin="round"/>
+    </>
+  ),
   // Navigation
   projects: (
     <path d="M4 6H6V8H4V6ZM4 11H6V13H4V11ZM4 16H6V18H4V16ZM20 8V6H18.8H9.2H8.023V8H9.2H18.8H20ZM8 11H20V13H8V11ZM8 16H20V18H8V16Z" />

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -324,10 +324,7 @@ export const Icons = {
     <path d="M19 4H6V2H4V20H3V22H4H6H7V20H6V15H19C19.553 15 20 14.552 20 14V5C20 4.448 19.553 4 19 4Z" />
   ),
   outlineFlag: (
-    <>
-      <path xmlns="http://www.w3.org/2000/svg" d="M6.38464 14H20.3846V5H6.38464" color="transparent" stroke="black" stroke-width="2" stroke-linejoin="round"/>
-      <path xmlns="http://www.w3.org/2000/svg" d="M6.38464 2V11V21M8.38464 21H4.38464" stroke="black" stroke-width="2" stroke-linejoin="round"/>
-    </>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M6 2H4V20H3V22H7V20H6V15H19C19.5523 15 20 14.5523 20 14V5C20 4.44772 19.5523 4 19 4H6V2ZM6 6V13H18V6H6Z" />
   ),
   // Navigation
   projects: (


### PR DESCRIPTION
This icon contains hard-coded attributes since our current Icon/IconButton don't support any stroke property for changing it (@bdow should I implement this instead of hard-coding those values?).

![imagen](https://user-images.githubusercontent.com/35903168/184030294-3083d8df-497d-4fc2-ad88-a8b656faf898.png)

