### PR TITLE
feat: [SC-20356]  forceSameBrowserTab to make safari open link in same window

### DIFF
--- a/src/components/ButtonMenu.tsx
+++ b/src/components/ButtonMenu.tsx
@@ -47,8 +47,6 @@ type MenuItemBase = {
   onClick: string | VoidFunction;
   disabled?: boolean;
   destructive?: boolean;
-  /** If using a string as the onClick value, and setting this to true will force the browser to open the link in the same browser window as a new tab */
-  forceSameBrowserTab?: boolean;
 };
 
 export type IconMenuItemType = MenuItemBase & {

--- a/src/components/ButtonMenu.tsx
+++ b/src/components/ButtonMenu.tsx
@@ -47,6 +47,8 @@ type MenuItemBase = {
   onClick: string | VoidFunction;
   disabled?: boolean;
   destructive?: boolean;
+  /** If using a string as the onClick value, and setting this to true will force the browser to open the link in the same browser window as a new tab */
+  forceSameBrowserTab?: boolean;
 };
 
 export type IconMenuItemType = MenuItemBase & {

--- a/src/components/internal/MenuItem.tsx
+++ b/src/components/internal/MenuItem.tsx
@@ -20,7 +20,7 @@ interface MenuItemProps {
 export function MenuItemImpl(props: MenuItemProps) {
   const { item, state, onClose } = props;
   const menuItem = item.value;
-  const { disabled: isDisabled, onClick, label, destructive } = menuItem;
+  const { disabled: isDisabled, onClick, label, destructive, forceSameBrowserTab } = menuItem;
   const isFocused = state.selectionManager.focusedKey === item.key;
   const ref = useRef<HTMLLIElement>(null);
   const history = useHistory();
@@ -34,7 +34,8 @@ export function MenuItemImpl(props: MenuItemProps) {
         if (typeof onClick === "string") {
           // if it is an absolute URL, then open in new window. Assuming this should leave the App
           if (isAbsoluteUrl(onClick)) {
-            window.open(onClick, "_blank", "noopener,noreferrer");
+            if (forceSameBrowserTab) (window.open(onClick, "_blank") as Window).opener = null;
+            else window.open(onClick, "_blank", "noopener,noreferrer");
             return;
           }
 

--- a/src/components/internal/MenuItem.tsx
+++ b/src/components/internal/MenuItem.tsx
@@ -20,7 +20,7 @@ interface MenuItemProps {
 export function MenuItemImpl(props: MenuItemProps) {
   const { item, state, onClose } = props;
   const menuItem = item.value;
-  const { disabled: isDisabled, onClick, label, destructive, forceSameBrowserTab } = menuItem;
+  const { disabled: isDisabled, onClick, label, destructive } = menuItem;
   const isFocused = state.selectionManager.focusedKey === item.key;
   const ref = useRef<HTMLLIElement>(null);
   const history = useHistory();
@@ -34,8 +34,13 @@ export function MenuItemImpl(props: MenuItemProps) {
         if (typeof onClick === "string") {
           // if it is an absolute URL, then open in new window. Assuming this should leave the App
           if (isAbsoluteUrl(onClick)) {
-            if (forceSameBrowserTab) (window.open(onClick, "_blank") as Window).opener = null;
-            else window.open(onClick, "_blank", "noopener,noreferrer");
+            // We want to do `window.open(url, "_blank", "noopener,noreferrer")` but that Safari treats
+            // that as "open in new window", this happens when safari has the "Open pages in tabs instead of windows" set to "Automatically" (which is the default)
+            // see https://support.apple.com/guide/safari/tabs-ibrw1045/mac (Open pages in tabs instead of windows) for other behaviors
+            //
+            // So we do this instead, and at least null out the opener
+            // as a way to manually mimic the `"noopener"` flag.
+            (window.open(onClick, "_blank") as Window).opener = null;
             return;
           }
 


### PR DESCRIPTION
Adding forceSameBrowserTab to MenuItemBase to allow safari to open the link provided in the same browser window.

Explanation:
`window.open(url, "_blank", "noopener,noreferrer")` works as expected on all main browser, but with safari there is a particular behavior.

in Safari -> Preferences -> Tabs -> Open pages in tabs instead of windows is set to `Automatic`. Using the `features` param in `windown.open` makes the browser to open a new tab.

Adding this param makes the button to use the `window.open(url, target)` syntax, that gets by default a new tab behavior, and forces the `opener` to null to prevent exposin the origin window tab. As a caveat, this does exposes the referrer.

This behavior is also overridable if safari option is set to `Never` or `Always` so is not that `forced` really.

Please review it, i'm not 100% sure is required, due to is only an issue on safari and is option controled.