### PR TITLE
fix: Update vertical padding on flexible row height

### DIFF
--- a/src/components/Table/styles.tsx
+++ b/src/components/Table/styles.tsx
@@ -72,7 +72,7 @@ function memoizedTableStyles() {
         totalsCellCss: Css.bgWhite.gray700.smEm.hPx(52).pt0.pbPx(12).boxShadow("none").$,
         cellCss: {
           ...Css.gray900.xs.bgWhite.aic.pxPx(12).boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$,
-          ...(rowHeight === "flexible" ? Css.py2.$ : Css.nowrap.hPx(inlineEditing ? 48 : 36).$),
+          ...(rowHeight === "flexible" ? Css.pyPx(12).$ : Css.nowrap.hPx(inlineEditing ? 48 : 36).$),
         },
         presentationSettings: { borderless: true, typeScale: "xs", wrap: rowHeight === "flexible" },
         levels: grouped ? groupedLevels : defaultLevels,


### PR DESCRIPTION
Moving from 16px of padding on top and bottom to 12px in hopes to eliminate unnecessary white-space.