### PR TITLE
feat: [SC-19452] Chip custom title support

### DIFF
--- a/src/components/Chip.stories.tsx
+++ b/src/components/Chip.stories.tsx
@@ -34,3 +34,7 @@ export function ColoredChips() {
     </div>
   );
 }
+
+export function ChipWithCustomTitle() {
+  return <Chip text="Chip text content, hover me" title="Chip has a custom title, different than the content" />;
+}

--- a/src/components/Chip.test.tsx
+++ b/src/components/Chip.test.tsx
@@ -18,4 +18,10 @@ describe("Chip", () => {
     const r = await render(<Chip text="Chip text content" data-testid="custom" />);
     expect(r.custom().textContent).toBe("Chip text content");
   });
+
+  it("can render with text different than title", async () => {
+    const r = await render(<Chip text="Chip text content" title="title is different" />);
+    expect(r.chip().textContent).toBe("Chip text content");
+    expect(r.chip()).toHaveAttribute("title", "title is different");
+  });
 });

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -17,13 +17,14 @@ export const ChipTypes: Record<ChipType, ChipType> = {
 
 export interface ChipProps<X> {
   text: string;
+  title?: string;
   xss?: X;
   type?: ChipType;
 }
 
 /** Kinda like a chip, but read-only, so no `onClick` or `hover`. */
 export function Chip<X extends Only<Xss<Margin>, X>>({ type = ChipTypes.neutral, ...props }: ChipProps<X>) {
-  const { text, xss = {} } = props;
+  const { text, title = text, xss = {} } = props;
   const { fieldProps } = usePresentationContext();
   const compact = fieldProps?.compact;
   const tid = useTestIds(props, "chip");
@@ -36,7 +37,7 @@ export function Chip<X extends Only<Xss<Margin>, X>>({ type = ChipTypes.neutral,
         ...xss,
       }}
       {...tid}
-      title={text}
+      title={title}
     >
       <span css={Css.lineClamp1.breakAll.$}>{text}</span>
     </span>

--- a/src/components/Chips.stories.tsx
+++ b/src/components/Chips.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { Chips } from "src/components/Chips";
+import { Chips, ChipValue } from "src/components/Chips";
 import { PresentationProvider } from "src/components/PresentationContext";
 import { Css } from "src/Css";
 
@@ -29,4 +29,12 @@ export function DefaultChips() {
       </div>
     </>
   );
+}
+
+export function ChipsWithCustomTitles() {
+  const customChips: ChipValue[] = [
+    { text: "Chip 1 Content", title: "Custom title 1" },
+    { text: "Chip 2 Content", title: "Custom title 2" },
+  ];
+  return <Chips values={customChips} />;
 }

--- a/src/components/Chips.tsx
+++ b/src/components/Chips.tsx
@@ -5,8 +5,13 @@ import { Css, Margin, Only, Xss } from "src/Css";
 
 type ChipsXss = Xss<Margin>;
 
+export interface ChipValue {
+  text: string;
+  title: string;
+}
+
 export interface ChipsProps<X> {
-  values: string[];
+  values: string[] | ChipValue[];
   xss?: X;
 }
 
@@ -22,9 +27,10 @@ export function Chips<X extends Only<ChipsXss, X>>(props: ChipsProps<X>) {
         ...xss,
       }}
     >
-      {values.map((value, i) => (
-        <Chip key={i} text={value} />
-      ))}
+      {values.map((value, i) => {
+        const { text, title } = (value.hasOwnProperty("text") ? value : { text: value }) as ChipValue;
+        return <Chip key={i} text={text} title={title} />;
+      })}
     </div>
   );
 }


### PR DESCRIPTION
[SC-19452]
Based on the requirement to have the chip title to display detailed information different than the chip content, we are adding support for a object having text and title properties, adding also unit tests and stories to cover this usage
![imagen](https://user-images.githubusercontent.com/72685215/187533450-43333559-d7e2-41c8-bb9d-c5c484438dd8.png)
