### PR TITLE
fix: Ability to omit bottom padding from ScrollableContent

### DIFF
--- a/src/components/Layout/ScrollableContent.tsx
+++ b/src/components/Layout/ScrollableContent.tsx
@@ -4,9 +4,14 @@ import { FullBleed } from "src/components/Layout/FullBleed";
 import { scrollContainerBottomPadding, useScrollableParent } from "src/components/Layout/ScrollableParent";
 import { Css } from "src/Css";
 
+interface ScrollableContentProps {
+  children: ReactNode;
+  virtualized?: boolean;
+  omitBottomPadding?: true;
+}
 /** Helper component for placing scrollable content within a `ScrollableParent`. */
-export function ScrollableContent(props: { children: ReactNode; virtualized?: boolean }): ReactPortal | JSX.Element {
-  const { children, virtualized = false } = props;
+export function ScrollableContent(props: ScrollableContentProps): ReactPortal | JSX.Element {
+  const { children, virtualized = false, omitBottomPadding } = props;
   const { scrollableEl, setPortalTick, pl } = useScrollableParent();
 
   useEffect(() => {
@@ -24,7 +29,11 @@ export function ScrollableContent(props: { children: ReactNode; virtualized?: bo
 
   return createPortal(
     !virtualized ? (
-      <div css={scrollContainerBottomPadding}>{children}</div>
+      omitBottomPadding ? (
+        children
+      ) : (
+        <div css={scrollContainerBottomPadding}>{children}</div>
+      )
     ) : (
       // To prevent Virtuoso's scrollbar from being set in based on the Layout's padding, we will use the FullBleed component w/o padding to push it back over
       <FullBleed omitPadding>

--- a/src/components/Layout/ScrollableParent.tsx
+++ b/src/components/Layout/ScrollableParent.tsx
@@ -61,8 +61,6 @@ export function ScrollableParent(props: PropsWithChildren<ScrollableParentContex
        * Otherwise, the flex-item's min-height/width is based on the content of the flex-item, which maybe overflow the container.
        * See https://stackoverflow.com/questions/42130384/why-should-i-specify-height-0-even-if-i-specified-flex-basis-0-in-css3-flexbox */}
       <Tag css={{ ...Css.mh0.mw0.fg1.df.fdc.$, ...otherXss }}>
-        {/* Use `overflow: overlay` to prevent scrollbar from pushing content in when rendered. This is only supported in Webkit browsers, so we also keep `overflow: auto` as a fallback for other browsers.*/}
-        {/* `overlay` needs to be applied using `addIn` otherwise the two `overflow` properties will be merged. */}
         <div
           css={{
             ...Css.pl(context.pl).pr(context.pr).$,


### PR DESCRIPTION
In Blueprint there are pages such as Documents and To Dos which nest their scroll handling. There are potentially better ways to achieve this, but the simplest way at the moment is using this prop.