### PR TITLE
fix: Always apply 'h100' on ScrollableContent wrapper

### DIFF
--- a/src/components/Layout/ScrollableContent.tsx
+++ b/src/components/Layout/ScrollableContent.tsx
@@ -30,7 +30,7 @@ export function ScrollableContent(props: ScrollableContentProps): ReactPortal | 
   return createPortal(
     <div
       css={{
-        ...Css.pr(pr).pl(pl).if(virtualized).pr0.h100.$,
+        ...Css.h100.pr(pr).pl(pl).if(virtualized).pr0.$,
         ...(bgColor && Css.bgColor(bgColor).$),
         ...(!omitBottomPadding && !virtualized && scrollContainerBottomPadding),
       }}


### PR DESCRIPTION
This fixes issues where users may have a Virtualized component within the ScrollableContent, but forgot to set the ScrollableContent.virtualized prop