### PR TITLE
fix: Textfield 'errorInTooltip' to show the tooltip on an icon, not the whole field

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -1,5 +1,6 @@
 import { DOMProps } from "@react-types/shared";
-import React, { AriaAttributes } from "react";
+import React, { AriaAttributes, ReactNode } from "react";
+import { maybeTooltip } from "src/components/Tooltip";
 import { Css, increment, Margin, Palette, Xss } from "src/Css";
 
 export interface IconProps extends AriaAttributes, DOMProps {
@@ -11,25 +12,30 @@ export interface IconProps extends AriaAttributes, DOMProps {
   inc?: number;
   /** Styles overrides */
   xss?: Xss<Margin | "visibility">;
+  tooltip?: ReactNode;
 }
 
 export const Icon = React.memo((props: IconProps) => {
-  const { icon, inc = 3, color = "currentColor", xss, ...other } = props;
+  const { icon, inc = 3, color = "currentColor", xss, tooltip, ...other } = props;
   const size = increment(inc);
-  return (
-    <svg
-      aria-hidden={true}
-      width={size}
-      height={size}
-      viewBox="0 0 24 24"
-      xmlns="http://www.w3.org/2000/svg"
-      css={{ "path, rect": Css.fill(color).$, ...xss }}
-      data-icon={icon}
-      {...other}
-    >
-      {Icons[icon]}
-    </svg>
-  );
+  return maybeTooltip({
+    title: tooltip,
+    placement: "top",
+    children: (
+      <svg
+        aria-hidden={true}
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+        css={{ "path, rect": Css.fill(color).$, ...xss }}
+        data-icon={icon}
+        {...other}
+      >
+        {Icons[icon]}
+      </svg>
+    ),
+  });
 });
 
 /**

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -11,7 +11,7 @@ import React, {
   useState,
 } from "react";
 import { chain, mergeProps, useFocusWithin, useHover } from "react-aria";
-import { IconButton, maybeTooltip } from "src/components";
+import { Icon, IconButton, maybeTooltip } from "src/components";
 import { HelperText } from "src/components/HelperText";
 import { InlineLabel, Label } from "src/components/Label";
 import { usePresentationContext } from "src/components/PresentationContext";
@@ -180,7 +180,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
         />
       )}
       {maybeTooltip({
-        title: (errorInTooltip && errorMsg) || tooltip,
+        title: tooltip,
         placement: "top",
         children: inputProps.readOnly ? (
           <div
@@ -254,6 +254,11 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
                   fieldRef.current?.focus();
                 }}
               />
+            )}
+            {errorInTooltip && errorMsg && (
+              <span css={Css.df.aic.pl1.fs0.$}>
+                <Icon icon="error" color={Palette.Red600} tooltip={errorMsg} />
+              </span>
             )}
             {!multiline && endAdornment && <span css={Css.df.aic.pl1.fs0.$}>{endAdornment}</span>}
           </div>


### PR DESCRIPTION
The conditional wrapping of the tooltip when a textfield is in error causes some usability issues. Specifically, when the field is in error and the user then corrects the problem, it will rerender removing the conditional Tooltip wrapper. This rerender loses focus on the input, which can be very annoying for users.

Updating this error state to be inline with what is design for [Beam](https://www.figma.com/file/aWUE4pPeUTgrYZ4vaTYZQU/%E2%9C%A8Beam-Design-System?node-id=1944%3A14)