### PR TITLE
feat: SC-22182 - Support white background on table

### DIFF
--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -432,6 +432,8 @@ function renderDiv<R extends Kinded>(
           ? Css.addIn(`& > div:nth-of-type(n+${headerRows.length + totalsRows.length + 2}) > *`, style.betweenRowsCss).$
           : {}),
         ...(style.firstNonHeaderRowCss ? Css.addIn(`& > div:nth-of-type(2) > *`, style.firstNonHeaderRowCss).$ : {}),
+        ...(style.lastRowCss && Css.addIn("& > div:last-of-type", style.lastRowCss).$),
+        ...(style.firstRowCss && Css.addIn("& > div:first-of-type", style.firstRowCss).$),
         ...style.rootCss,
         ...(style.minWidthPx ? Css.mwPx(style.minWidthPx).$ : {}),
         ...xss,
@@ -467,10 +469,12 @@ function renderTable<R extends Kinded>(
   return (
     <table
       css={{
-        ...Css.w100.add("borderCollapse", "collapse").$,
-        ...Css.addIn("& > tbody > tr ", style.betweenRowsCss || {})
+        ...Css.w100.add("borderCollapse", "separate").add("borderSpacing", "0").$,
+        ...Css.addIn("& > tbody > tr > * ", style.betweenRowsCss || {})
           // removes border between header and second row
-          .addIn("& > tbody > tr:first-of-type", style.firstNonHeaderRowCss || {}).$,
+          .addIn("& > tbody > tr:first-of-type > *", style.firstNonHeaderRowCss || {}).$,
+        ...Css.addIn("& > tbody > tr:last-of-type", style.lastRowCss).$,
+        ...Css.addIn("& > tbody > tr:first-of-type", style.firstRowCss).$,
         ...style.rootCss,
         ...(style.minWidthPx ? Css.mwPx(style.minWidthPx).$ : {}),
         ...xss,
@@ -621,9 +625,10 @@ const VirtualRoot = memoizeOne<(gs: GridStyle, columns: GridColumn<any>[], id: s
             ...Css.addIn("& > div + div > div > *", gs.betweenRowsCss || {}).$,
             // Table list styles only
             ...(isHeader
-              ? {}
+              ? Css.addIn("& > div:first-of-type > *", gs.firstRowCss).$
               : {
                   ...Css.addIn("& > div:first-of-type > *", gs.firstNonHeaderRowCss).$,
+                  ...Css.addIn("& > div:last-of-type > *", gs.lastRowCss).$,
                 }),
             ...gs.rootCss,
             ...(gs.minWidthPx ? Css.mwPx(gs.minWidthPx).$ : {}),

--- a/src/components/Table/TableActions.tsx
+++ b/src/components/Table/TableActions.tsx
@@ -1,0 +1,18 @@
+import { ReactNode } from "react";
+import { Css, Margin, Only, Xss } from "src/Css";
+
+type TableActionsXss = Xss<Margin>;
+
+interface TableActionsProps<X> {
+  xss?: X;
+  children: ReactNode;
+  onlyLeft?: boolean;
+  onlyRight?: boolean;
+}
+
+/** Provides default spacing for Actions sitting above a table (Filters, Search, etc...) */
+export function TableActions<X extends Only<TableActionsXss, X>>(props: TableActionsProps<X>) {
+  const { xss, children, onlyLeft, onlyRight } = props;
+  const alignmentStyles = onlyLeft ? Css.jcfs.$ : onlyRight ? Css.jcfe.$ : Css.jcsb.$;
+  return <div css={{ ...Css.df.aic.pb2.gap1.$, ...xss, ...alignmentStyles }}>{children}</div>;
+}


### PR DESCRIPTION
Changes include:
- Allows for adding a border around the table
- Allows for having the table all white, which also applies a 8px border radius on the table corners.
- Moves TableActions component to Beam from internal-frontend

Added a new Storybook for the Design QA that allows them to use the controls to see different instances of the table.