### PR TITLE
feat: GridTable shows row background on hover by default

### DIFF
--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -262,6 +262,7 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
             getCount,
             api,
             cellHighlight: "cellHighlight" in maybeStyle && maybeStyle.cellHighlight === true,
+            omitRowHover: "rowHover" in maybeStyle && maybeStyle.rowHover === false,
             ...sortProps,
           }}
         />
@@ -288,7 +289,6 @@ export function GridTable<R extends Kinded, S = {}, X extends Only<GridTableXss,
     }
 
     function visitRows(rows: ParentChildrenTuple<R>[], level: number, visible: boolean): void {
-      const length = rows.length;
       rows.forEach((row, i) => {
         if (row[0].kind === "header") {
           headerRows.push([row[0], makeRowComponent(row[0], level)]);

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -35,6 +35,7 @@ interface TableStoryProps extends GridTableProps<any, any, any> {
   grouped?: boolean;
   bordered?: boolean;
   allWhite?: boolean;
+  rowHover?: boolean;
   rowHeight?: "fixed" | "flexible";
   displayAs?: "default" | "virtual" | "table";
   totals?: boolean;
@@ -76,6 +77,7 @@ export default {
     grouped: false,
     bordered: false,
     allWhite: false,
+    rowHover: true,
     rowHeight: "flexible",
     displayAs: "default",
     totals: false,
@@ -85,6 +87,7 @@ export default {
     grouped: { name: "Group styles", control: { type: "boolean" }, if: { arg: "nestingDepth", neq: 1 } },
     bordered: { name: "Bordered", control: { type: "boolean" } },
     allWhite: { name: "All White", control: { type: "boolean" } },
+    rowHover: { name: "Row Hover styles", control: { type: "boolean" } },
     totals: { name: "Show Totals row", control: { type: "boolean" } },
     rowHeight: { name: "Row Height", control: { type: "select", options: ["flexible", "fixed"] } },
     displayAs: {
@@ -107,7 +110,7 @@ type BeamData = {
 type BeamRow = SimpleHeaderAndData<BeamData>;
 
 export function Table(props: TableStoryProps) {
-  const { nestingDepth, allWhite, grouped, rowHeight, bordered, displayAs, totals } = props;
+  const { nestingDepth, allWhite, grouped, rowHeight, bordered, displayAs, totals, rowHover } = props;
   const [filter, setFilter] = useState<string>();
 
   const [rows, columns] = useMemo(
@@ -141,6 +144,7 @@ export function Table(props: TableStoryProps) {
             ...(nestingDepth && nestingDepth > 1 ? { grouped } : {}),
             rowHeight,
             bordered,
+            rowHover,
           }}
           sorting={{ on: "client" }}
           columns={columns}

--- a/src/components/Table/TableStyles.tsx
+++ b/src/components/Table/TableStyles.tsx
@@ -54,6 +54,7 @@ export interface GridStyle {
   activeBgColor?: Palette;
 }
 
+// If adding a new `GridStyleDef`, ensure if it added to the `defKeys` in the `resolveStyles` function below
 export interface GridStyleDef {
   inlineEditing?: boolean;
   grouped?: boolean;
@@ -62,6 +63,7 @@ export interface GridStyleDef {
   cellHighlight?: boolean;
   allWhite?: boolean;
   bordered?: boolean;
+  rowHover?: boolean;
 }
 
 // Returns a "blessed" style of GridTable
@@ -75,6 +77,7 @@ function memoizedTableStyles() {
       cellHighlight = false,
       allWhite = false,
       bordered = false,
+      rowHover = true,
     } = props;
 
     const key = safeKeys(props)
@@ -127,6 +130,7 @@ function memoizedTableStyles() {
         }),
         presentationSettings: { borderless: true, typeScale: "xs", wrap: rowHeight === "flexible" },
         levels: grouped ? groupedLevels : defaultLevels,
+        rowHoverColor: Palette.LightBlue100,
       };
     }
 
@@ -217,6 +221,7 @@ export function resolveStyles(style: GridStyle | GridStyleDef): GridStyle {
     "cellHighlight",
     "allWhite",
     "bordered",
+    "rowHover",
   ];
   const keys = safeKeys(style);
   if (keys.length === 0 || keys.some((k) => defKeys.includes(k as keyof GridStyleDef))) {

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -43,6 +43,7 @@ interface RowProps<R extends Kinded, S> {
   getCount: (id: string) => object;
   api: GridTableApi<R>;
   cellHighlight: boolean;
+  omitRowHover: boolean;
 }
 
 // We extract Row to its own mini-component primarily so we can React.memo'ize it.
@@ -63,6 +64,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R, S>): ReactElement {
     getCount,
     api,
     cellHighlight,
+    omitRowHover,
     ...others
   } = props;
 
@@ -80,12 +82,15 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R, S>): ReactElement {
 
   const rowStyleCellCss = maybeApplyFunction(row as any, rowStyle?.cellCss);
   const rowCss = {
+    // Optionally include the row hover styles, by default they should be turned on.
+    ...(!omitRowHover && {
+      // Even though backgroundColor is set on the cellCss, the hover target is the row.
+      "&:hover > *": Css.bgColor(style.rowHoverColor ?? Palette.LightBlue100).$,
+    }),
     // For virtual tables use `display: flex` to keep all cells on the same row. For each cell in the row use `flexNone` to ensure they stay their defined widths
     ...(as === "table" ? {} : Css.relative.df.fg1.fs1.addIn("&>*", Css.flexNone.$).$),
-    ...((rowStyle?.rowLink || rowStyle?.onClick) && {
-      // Even though backgroundColor is set on the cellCss, the hover target is the row.
-      "&:hover > *": Css.cursorPointer.bgColor(style.rowHoverColor ?? Palette.LightBlue100).$,
-    }),
+    // Apply `cursorPointer` to the row if it has a link or `onClick` value.
+    ...((rowStyle?.rowLink || rowStyle?.onClick) && { "&:hover": Css.cursorPointer.$ }),
     ...maybeApplyFunction(row as any, rowStyle?.rowCss),
     // Maybe add the sticky header styles
     ...((isHeader || isTotals) && stickyHeader ? Css.sticky.topPx(stickyOffset).z2.$ : undefined),


### PR DESCRIPTION
Hover styles can be optionally removed in the event it is too distracting.