### PR TITLE
fix: Do not pass whole column to SortHeader, only sort key

### DIFF
--- a/src/components/Table/components/SortHeader.tsx
+++ b/src/components/Table/components/SortHeader.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useContext } from "react";
 import { Icon } from "src/components/Icon";
-import { GridColumnWithId } from "src/components/Table/types";
 import { TableStateContext } from "src/components/Table/utils/TableState";
 import { Css, Palette, Properties } from "src/Css";
 import { useComputed, useHover } from "src/hooks";
@@ -10,7 +9,7 @@ interface SortHeaderProps {
   content: string;
   xss?: Properties;
   iconOnLeft?: boolean;
-  column: GridColumnWithId<any>;
+  sortKey: string;
 }
 
 /**
@@ -25,13 +24,12 @@ interface SortHeaderProps {
  *   current sort state + `toggleSort` function
  */
 export function SortHeader(props: SortHeaderProps) {
-  const { content, xss, iconOnLeft = false, column } = props;
+  const { content, xss, iconOnLeft = false, sortKey } = props;
   const { isHovered, hoverProps } = useHover({});
-  const ourSortKey = column.serverSideSortKey || column.id;
   const { tableState } = useContext(TableStateContext);
   const current = useComputed(() => tableState.sortState?.current, [tableState]);
-  const sorted = ourSortKey === current?.columnId ? current?.direction : undefined;
-  const toggleSort = useCallback(() => tableState.setSortKey(ourSortKey), [ourSortKey, tableState]);
+  const sorted = sortKey === current?.columnId ? current?.direction : undefined;
+  const toggleSort = useCallback(() => tableState.setSortKey(sortKey), [sortKey, tableState]);
 
   const tid = useTestIds(props, "sortHeader");
 

--- a/src/components/Table/utils/utils.tsx
+++ b/src/components/Table/utils/utils.tsx
@@ -46,7 +46,13 @@ export function toContent(
       : content;
 
   if (content && typeof content === "string" && isHeader && canSortColumn) {
-    return <SortHeader content={content} iconOnLeft={alignment === "right"} column={column} />;
+    return (
+      <SortHeader
+        content={content}
+        iconOnLeft={alignment === "right"}
+        sortKey={column.serverSideSortKey ?? column.id}
+      />
+    );
   } else if (content && style?.presentationSettings?.wrap === false && typeof content === "string") {
     // In order to truncate the text properly, then we need to wrap it in another element
     // as our cell element is a flex container, which don't allow for applying truncation styles directly on it.


### PR DESCRIPTION
When implementers use SortHeader directly, they are typically doing it in the middle of building their column and so cannot pass the column prop. Example:
```
const homeownerOriginalColumn = numericColumn<Row>({
    header: () => (
      <Tooltip placement="top" title="The budgeted cost from the prime contract">
        <SortHeader content={initialBudget.replace("Budget", "")} iconOnLeft />
      </Tooltip>
    ),
```

Instead, we now only require passing the sortKey string, which should be accessible at this point