### PR TITLE
fix: SC-22070 Export ButtonModal

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,6 +13,7 @@ export { BeamProvider } from "./BeamContext";
 export * from "./Button";
 export * from "./ButtonDatePicker";
 export * from "./ButtonGroup";
+export * from "./ButtonModal";
 export * from "./ButtonMenu";
 export * from "./Copy";
 export * from "./CssReset";


### PR DESCRIPTION
I tried to use this new component in `internal-frontend`, but it wasn't exported.