### PR TITLE
fix: Bump Truss

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@homebound/eslint-config": "1.5.1",
     "@homebound/rtl-react-router-utils": "^1.0.3",
     "@homebound/rtl-utils": "^2.59.3",
-    "@homebound/truss": "^1.113.0",
+    "@homebound/truss": "^1.115.0",
     "@homebound/tsconfig": "^1.0.3",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.7",
     "@semantic-release/exec": "^6.0.3",

--- a/src/Css.ts
+++ b/src/Css.ts
@@ -1115,6 +1115,17 @@ export type Font = "fontSize" | "fontWeight" | "lineHeight";
 
 type Brand<K, T> = K & { __brand: T };
 type Breakpoint = Brand<string, "Breakpoint">;
+export type BreakpointKey = "print" | "sm" | "md" | "smOrMd" | "mdAndUp" | "mdAndDown" | "lg" | "mdOrLg";
+export enum Breakpoints {
+  print = "@media print",
+  sm = "@media screen and (max-width:599px)",
+  md = "@media screen and (min-width:600px) and (max-width:1024px)",
+  smOrMd = "@media screen and (max-width:1024px)",
+  mdAndUp = "@media screen and (min-width:600px)",
+  mdAndDown = "@media screen and (max-width:1024px)",
+  lg = "@media screen and (min-width:1025px)",
+  mdOrLg = "@media screen and (min-width:600px)",
+}
 export const print = "@media print" as Breakpoint;
 export const sm = "@media screen and (max-width:599px)" as Breakpoint;
 export const md = "@media screen and (min-width:600px) and (max-width:1024px)" as Breakpoint;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3063,10 +3063,10 @@
   dependencies:
     "@testing-library/react" "^12.1.2"
 
-"@homebound/truss@^1.113.0":
-  version "1.113.0"
-  resolved "https://registry.yarnpkg.com/@homebound/truss/-/truss-1.113.0.tgz#20f5adaacd6fc80485b3e8b61c90b905975641f9"
-  integrity sha512-yfJbvT2pCUB3TN0l8DOHfa340CSaVi3043GWFmsuFO7SLrfcBlMLeOzwtAGeQLsAnCbunVG/YtXycTzGX9Fiiw==
+"@homebound/truss@^1.115.0":
+  version "1.115.0"
+  resolved "https://registry.yarnpkg.com/@homebound/truss/-/truss-1.115.0.tgz#f38dc322abf4787ac524dc227ce07f3691435f06"
+  integrity sha512-d8HTAA65nLy9OD5OcU6uw/uiRXrKMuTc6uq2Y2TTjqacrX8e18mWtnEkegZVERAV/MkGn2bbWgz07BBBQ/M21A==
   dependencies:
     csstype "^2.6.10"
     ts-node "^10.7.0"


### PR DESCRIPTION
- bumping beam to have the new truss breakpoint exports - truss v1.115.0