### PR TITLE
feat: add Icon to Tags (sc-22870)

### DIFF
--- a/src/components/Tag.stories.tsx
+++ b/src/components/Tag.stories.tsx
@@ -13,7 +13,7 @@ export default {
   },
 } as Meta;
 
-export function Tags() {
+export function NoIcon() {
   return (
     <div css={Css.df.fdc.aifs.gap1.$}>
       <Tag text="Neutral" />
@@ -28,7 +28,7 @@ export function Tags() {
   );
 }
 
-export function TagsWithAnIcon() {
+export function WithAnIcon() {
   return (
     <div css={Css.df.fdc.aifs.gap1.$}>
       <Tag text="Neutral" icon="helpCircle" />

--- a/src/components/Tag.stories.tsx
+++ b/src/components/Tag.stories.tsx
@@ -5,11 +5,11 @@ import { Tag } from "./Tag";
 export default {
   title: "Workspace/Components/Tags",
   component: Tag,
-  parameters: { 
+  parameters: {
     design: {
       type: "figma",
       url: "https://www.figma.com/file/aWUE4pPeUTgrYZ4vaTYZQU/%E2%9C%A8Beam-Design-System?node-id=36241%3A102420",
-    }
+    },
   },
 } as Meta;
 
@@ -23,6 +23,21 @@ export function Tags() {
       <Tag text="success" type="success" />
       <div css={Css.wPx(200).$}>
         <Tag text="Tag text that will truncate as it is too long." />
+      </div>
+    </div>
+  );
+}
+
+export function TagsWithAnIcon() {
+  return (
+    <div css={Css.df.fdc.aifs.gap1.$}>
+      <Tag text="Neutral" icon="helpCircle" />
+      <Tag text="info" type="info" icon="infoCircle" />
+      <Tag text="caution" type="caution" icon="infoCircle" />
+      <Tag text="warning" type="warning" icon="error" />
+      <Tag text="success" type="success" icon="checkCircle" />
+      <div css={Css.wPx(200).$}>
+        <Tag text="Tag text that will truncate as it is too long." icon="infoCircle" />
       </div>
     </div>
   );

--- a/src/components/Tag.test.tsx
+++ b/src/components/Tag.test.tsx
@@ -13,4 +13,10 @@ describe("Tag", () => {
     const r = await render(<Tag text="test" data-testid="testTag" xss={Css.mt1.$} />);
     expect(r.testTag()).toHaveStyleRule("margin-top", "8px");
   });
+
+  it("renders with icon", async () => {
+    const r = await render(<Tag text="text" data-testid="testTag" icon="infoCircle" />);
+    const iconElement = r.container.querySelector(`[data-icon="infoCircle"]`)!;
+    expect(iconElement).toBeInTheDocument();
+  });
 });

--- a/src/components/Tag.test.tsx
+++ b/src/components/Tag.test.tsx
@@ -15,7 +15,7 @@ describe("Tag", () => {
   });
 
   it("renders with icon", async () => {
-    const r = await render(<Tag text="text" data-testid="testTag" icon="infoCircle" />);
+    const r = await render(<Tag text="text" icon="infoCircle" />);
     const iconElement = r.container.querySelector(`[data-icon="infoCircle"]`)!;
     expect(iconElement).toBeInTheDocument();
   });

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -20,7 +20,7 @@ export function Tag<X extends Only<Xss<TagXss>, X>>({ text, type, xss, ...otherP
   return (
     <span
       {...tid}
-      css={{ ...Css.dif.tinySb.ttu.aic.gap(0.5).px(0.75).py(0.25).gray900.br4.$, ...typeStyles, ...xss }}
+      css={{ ...Css.dif.tinySb.ttu.aic.gap(0.5).pxPx(6).pyPx(2).gray900.br4.$, ...typeStyles, ...xss }}
       title={text}
     >
       {/* Nesting `lineClamp` styles as the padding bottom set would expose the remainder of the text if applied on the same element */}

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -20,12 +20,16 @@ export function Tag<X extends Only<Xss<TagXss>, X>>({ text, type, xss, ...otherP
   return (
     <span
       {...tid}
-      css={{ ...Css.dif.tinySb.ttu.aic.gap(0.5).pxPx(6).pyPx(2).gray900.br4.$, ...typeStyles, ...xss }}
+      css={{ ...Css.dif.tinySb.ttu.aic.gapPx(4).pxPx(6).pyPx(2).gray900.br4.$, ...typeStyles, ...xss }}
       title={text}
     >
       {/* Nesting `lineClamp` styles as the padding bottom set would expose the remainder of the text if applied on the same element */}
       {/* Using `lineClamp1` instead of `truncate` as `truncate` requires a width set to properly truncate and `lineClamp` can smartly do it based on the parent's width */}
-      {otherProps.icon && <Icon icon={otherProps.icon} inc={1.5} />}
+      {otherProps.icon && (
+        <span css={Css.fs0.$}>
+          <Icon icon={otherProps.icon} inc={1.5} />
+        </span>
+      )}
       <span css={Css.lineClamp1.breakAll.$}>{text}</span>
     </span>
   );

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,3 +1,4 @@
+import { Icon, IconKey } from "src/components";
 import { Css, Margin, Only, Xss } from "src/Css";
 import { useTestIds } from "src/utils";
 
@@ -8,6 +9,7 @@ interface TagProps<X> {
   // Defaults to "neutral"
   type?: TagType;
   xss?: X;
+  icon?: IconKey;
 }
 
 /** Tag used for indicating a status */
@@ -16,9 +18,14 @@ export function Tag<X extends Only<Xss<TagXss>, X>>({ text, type, xss, ...otherP
   const tid = useTestIds(otherProps);
 
   return (
-    <span {...tid} css={{ ...Css.dib.tinySb.ttu.px1.pyPx(4).gray900.br4.$, ...typeStyles, ...xss }} title={text}>
+    <span
+      {...tid}
+      css={{ ...Css.dif.tinySb.ttu.aic.gap(0.5).px(0.75).py(0.25).gray900.br4.$, ...typeStyles, ...xss }}
+      title={text}
+    >
       {/* Nesting `lineClamp` styles as the padding bottom set would expose the remainder of the text if applied on the same element */}
       {/* Using `lineClamp1` instead of `truncate` as `truncate` requires a width set to properly truncate and `lineClamp` can smartly do it based on the parent's width */}
+      {otherProps.icon && <Icon icon={otherProps.icon} inc={1.5} />}
       <span css={Css.lineClamp1.breakAll.$}>{text}</span>
     </span>
   );
@@ -27,13 +34,13 @@ export function Tag<X extends Only<Xss<TagXss>, X>>({ text, type, xss, ...otherP
 function getStyles(type?: TagType) {
   switch (type) {
     case "info":
-      return Css.bgLightBlue200.$;
+      return Css.bgLightBlue100.$;
     case "caution":
-      return Css.bgYellow600.$;
+      return Css.bgYellow200.$;
     case "warning":
       return Css.bgRed100.$;
     case "success":
-      return Css.bgGreen300.$;
+      return Css.bgGreen100.$;
     default:
       // Neutral case
       return Css.bgGray200.$;


### PR DESCRIPTION
<img width="718" alt="image" src="https://user-images.githubusercontent.com/13225733/199130550-eb5d85f6-b812-4f27-aff5-503c7a8b4d6d.png">

Changes in Tags include:
- muting the background colors
- adjusting the padding to make them smaller
- supporting the ability to add an icon if desired