### PR TITLE
feat: (SC-24529) Add toggleCollapse to GridTableApi

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -6,6 +6,7 @@ import {
   actionColumn,
   Button,
   cardStyle,
+  collapseColumn,
   CollapseToggle,
   column,
   condensedStyle,
@@ -1082,6 +1083,56 @@ export function RevealOnRowHover() {
           { kind: "data", id: "1", data: { name: "Hover over me to reveal the number!", value: 7 } },
         ]}
       />
+    </>
+  );
+}
+
+export function Toggle_Custom_Collapse() {
+  const api = useGridTableApi<Row | ChildRow>();
+
+  const collapseCol = collapseColumn<Row | ChildRow>({
+    data: () => emptyCell,
+  });
+
+  const nameCol: GridColumn<Row | ChildRow> = {
+    header: "Name",
+    data: ({ name }, { row }) => {
+      return (
+        <>
+          <Button label={name!} variant="text" onClick={() => api.toggleCollapsedRow(row.id)} />
+          <CollapseToggle compact row={row} />
+        </>
+      );
+    },
+    child: ({ name }) => ({ content: name }),
+    mw: "160px",
+  };
+
+  return (
+    <>
+      <GridTable
+        columns={[collapseCol, nameCol]}
+        style={{ rowHeight: "fixed" }}
+        rows={[
+          simpleHeader,
+          {
+            id: "p1",
+            kind: "data",
+            data: { name: "Parent", value: 1 },
+            children: [
+              {
+                id: "c1",
+                kind: "child",
+                data: { name: "Child" },
+              },
+            ],
+          },
+        ]}
+        api={api}
+      />
+      <div>
+        <Button label={"Toggle Collpase"} variant="secondary" size="sm" onClick={() => api.toggleCollapsedRow("p1")} />
+      </div>
     </>
   );
 }

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1087,7 +1087,7 @@ export function RevealOnRowHover() {
   );
 }
 
-export function Toggle_Custom_Collapse() {
+export function ToggleCustomCollapse() {
   const api = useGridTableApi<Row | ChildRow>();
 
   const collapseCol = collapseColumn<Row | ChildRow>({

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -48,6 +48,9 @@ export type GridTableApi<R extends Kinded> = {
 
   /** Set selected state of a row by id */
   selectRow: (id: string, selected?: boolean) => void;
+
+  /** Toggle collapse state of a row by id */
+  toggleCollapsedRow: (id: string) => void;
 };
 
 // Using `FooImpl`to keep the public GridTableApi definition separate.
@@ -101,5 +104,9 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
 
   public selectRow(id: string, selected: boolean = true) {
     this.tableState.selectRow(id, selected);
+  }
+
+  public toggleCollapsedRow(id: string) {
+    this.tableState.toggleCollapsed(id);
   }
 }


### PR DESCRIPTION
Updates GridTableApi to include a function to toggle collapse row.

This update needed for this ticket (https://app.shortcut.com/homebound-team/story/24301/linked-rows-on-create-flow)

![ezgif-5-894a44d841](https://user-images.githubusercontent.com/108748822/199516678-ffc4e675-7e89-441a-9de0-94c5cd57347c.gif)
