### PR TITLE
feat: StaticField Label has the ability to show ReactNode

### DIFF
--- a/src/forms/StaticField.stories.tsx
+++ b/src/forms/StaticField.stories.tsx
@@ -3,6 +3,7 @@ import { Chips } from "src/components/Chips";
 import { FieldGroup, FormLines } from "src/forms/FormLines";
 import { StaticField as StaticFieldComponent } from "src/forms/StaticField";
 import { TextField } from "src/inputs";
+import { ButtonModal, Css } from "..";
 
 export default {
   component: StaticFieldComponent,
@@ -16,6 +17,17 @@ export function StaticField() {
       <FieldGroup widths={["100px", "100px", "200px"]}>
         <StaticFieldComponent label="First" value="Bob" />
         <StaticFieldComponent label="First" value="Bob" />
+        <StaticFieldComponent
+          label={
+            <>
+              <span>First</span>
+              <span css={Css.xs.ml1.$}>
+                <ButtonModal content={<>Modal</>} variant="text" hideEndAdornment trigger={{ label: "See Details" }} />
+              </span>
+            </>
+          }
+          value="Bob"
+        />
         <TextField label="First (read only TextField)" value="Bob" onChange={() => {}} readOnly />
       </FieldGroup>
       <StaticFieldComponent label="First">

--- a/src/forms/StaticField.tsx
+++ b/src/forms/StaticField.tsx
@@ -5,14 +5,14 @@ import { defaultTestId } from "src/utils/defaultTestId";
 import { useTestIds } from "src/utils/useTestIds";
 
 interface StaticFieldProps {
-  label: string;
+  label: ReactNode;
   value?: string;
   children?: ReactNode;
 }
 
 export function StaticField(props: StaticFieldProps) {
   const { label, value, children } = props;
-  const tid = useTestIds(props, defaultTestId(label));
+  const tid = useTestIds(props, typeof label === "string" ? defaultTestId(label) : "staticField");
   const id = useId();
   return (
     <div>


### PR DESCRIPTION
# [SC-21300](https://app.shortcut.com/homebound-team/story/21300/ui-lot-configuration-on-project-overview-page)

Update the StaticField to reuse on this design to pass a ReactNode on the label in this case we need a combination label and buttonModal

Figma
<img width="562" alt="Screen Shot 2022-11-02 at 11 20 30" src="https://user-images.githubusercontent.com/106679157/199558127-a8535edd-4d9b-4fb7-a61b-bc84673a6859.png">

Storybook
<img width="255" alt="Screen Shot 2022-11-02 at 11 26 17" src="https://user-images.githubusercontent.com/106679157/199559450-39e284e5-cf24-469f-b09b-4d44ec02541a.png">

<img width="216" alt="Screen Shot 2022-11-02 at 11 26 20" src="https://user-images.githubusercontent.com/106679157/199559451-e01882d6-e134-43e1-b61a-b6edc1933b1a.png">

