### PR TITLE
fix: Improve Accordion height animation

### DIFF
--- a/src/components/Accordion.stories.tsx
+++ b/src/components/Accordion.stories.tsx
@@ -16,7 +16,7 @@ export function AccordionVariations() {
           Our modern approach to homebuilding makes the process easier and more personal than ever before.
         </div>
       </Accordion>
-      <Accordion title="Default expanded" defaultExpanded>
+      <Accordion title="Default expanded" disabled defaultExpanded>
         <div css={Css.sm.$}>
           Our modern approach to homebuilding makes the process easier and more personal than ever before.
         </div>

--- a/src/components/Accordion.stories.tsx
+++ b/src/components/Accordion.stories.tsx
@@ -16,7 +16,7 @@ export function AccordionVariations() {
           Our modern approach to homebuilding makes the process easier and more personal than ever before.
         </div>
       </Accordion>
-      <Accordion title="Default expanded" disabled defaultExpanded>
+      <Accordion title="Default expanded" defaultExpanded>
         <div css={Css.sm.$}>
           Our modern approach to homebuilding makes the process easier and more personal than ever before.
         </div>

--- a/src/components/Accordion.test.tsx
+++ b/src/components/Accordion.test.tsx
@@ -5,33 +5,40 @@ describe(Accordion, () => {
   it("displays the correct content", async () => {
     // Given an accordion component
     // When rendered
-    const r = await render(<Accordion title="Test title"> Test description </Accordion>);
+    const r = await render(<Accordion title="Test title">Test description</Accordion>);
 
     // Then it shows the correct title
     expect(r.accordion_title()).toHaveTextContent("Test title");
     // And the description will be hidden by default
-    expect(r.accordion_details()).toHaveStyleRule("max-height", "0");
+    expect(r.accordion_content).toNotBeInTheDom();
     // And the border bottom is not displayed by default
     expect(r.accordion_container()).not.toHaveStyleRule("border-bottom-width", "1px");
     // And the dropdown button is enabled by default
-    expect(r.accordion_title()).not.toBeDisabled()
+    expect(r.accordion_title()).not.toBeDisabled();
   });
 
   it("can expand by default", async () => {
     // Given an accordion component with defaultExpanded set
     // When rendered
-    const r = await render(<Accordion title="Test title" defaultExpanded> Test description</Accordion>);
+    const r = await render(
+      <Accordion title="Test title" defaultExpanded>
+        Test description
+      </Accordion>,
+    );
 
     // Then it shows the correct title and description
     expect(r.accordion_title()).toHaveTextContent("Test title");
-    expect(r.accordion_details()).not.toHaveStyleRule("max-height", "0");
-    expect(r.accordion_details()).toHaveTextContent("Test description");
+    expect(r.accordion_content()).toHaveTextContent("Test description");
   });
 
   it("can display the bottom border", async () => {
     // Given an accordion component with bottomSection set
     // When rendered
-    const r = await render(<Accordion title="Test title" bottomBorder> Test description </Accordion>);
+    const r = await render(
+      <Accordion title="Test title" bottomBorder>
+        Test description
+      </Accordion>,
+    );
 
     // Then it shows the bottom border
     expect(r.accordion_container()).toHaveStyleRule("border-bottom-width", "1px");
@@ -41,20 +48,28 @@ describe(Accordion, () => {
   it("can hide the top border", async () => {
     // Given an accordion component with topSection set as false
     // When rendered
-    const r = await render(<Accordion title="Test title" topBorder={false}>Test description</Accordion>);
+    const r = await render(
+      <Accordion title="Test title" topBorder={false}>
+        Test description
+      </Accordion>,
+    );
 
     // Then it hides the top border
     expect(r.accordion_container()).not.toHaveStyleRule("border-top-width", "1px");
   });
 
   it("can be disabled", async () => {
-    // Given an accordion component with disabled set
+    // Given an accordion component with disabled set and expanded
     // When rendered
-    const r = await render(<Accordion title="Test title" disabled>Test description</Accordion>);
+    const r = await render(
+      <Accordion title="Test title" disabled defaultExpanded>
+        Test description
+      </Accordion>,
+    );
 
     // Then the dropdown button is disabled
     expect(r.accordion_title()).toBeDisabled();
-    // And the description will be hidden by default
-    expect(r.accordion_details()).toHaveStyleRule("max-height", "0");
+    // And the content is not displayed
+    expect(r.accordion_content).toNotBeInTheDom();
   });
 });

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -94,7 +94,7 @@ export function Accordion(props: AccordionProps) {
         css={Css.overflowHidden.hPx(contentHeight).add("transition", "height 250ms ease-in-out").$}
       >
         {expanded && (
-          <div css={Css.px2.pb2.pt1.$} ref={contentRef}>
+          <div css={Css.px2.pb2.pt1.$} ref={contentRef} {...testIds.content}>
             {children}
           </div>
         )}

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -1,5 +1,5 @@
 import { useId } from "@react-aria/utils";
-import { Dispatch, ReactNode, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, ReactNode, SetStateAction, useEffect, useRef, useState } from "react";
 import { useFocusRing } from "react-aria";
 import { Icon } from "src/components/Icon";
 import { Css, Palette } from "src/Css";
@@ -37,12 +37,21 @@ export function Accordion(props: AccordionProps) {
   } = props;
   const testIds = useTestIds(props, "accordion");
   const id = useId();
-  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [expanded, setExpanded] = useState(defaultExpanded && !disabled);
   const { isFocusVisible, focusProps } = useFocusRing();
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [contentHeight, setContentHeight] = useState(0);
 
   useEffect(() => {
-    setExpanded(defaultExpanded);
-  }, [defaultExpanded]);
+    setExpanded(defaultExpanded && !disabled);
+  }, [defaultExpanded, disabled]);
+
+  useEffect(() => {
+    // When the `expanded` value changes - If true, it means the Accordion's content has been rendered, Otherwise, it's been hidden
+    // Then when the content is displayed, the calculate its height so we can give this value to the container to animate height smoothly.
+    // When content is removed, simply set the height back to 0
+    setContentHeight(expanded && contentRef.current ? contentRef.current.scrollHeight : 0);
+  }, [expanded]);
 
   return (
     <div
@@ -82,15 +91,13 @@ export function Accordion(props: AccordionProps) {
         {...testIds.details}
         id={id}
         aria-hidden={!expanded}
-        css={{
-          // Use max-height for grow/shrink animation (remove close animation for AccordionList to avoid delays)
-          ...Css.overflowHidden
-            .maxhPx(1000)
-            .add("transition", `max-height ${expanded || !index ? "250ms" : "0"} ease-in-out`).$,
-          ...(!expanded || disabled ? Css.maxh0.$ : {}),
-        }}
+        css={Css.overflowHidden.hPx(contentHeight).add("transition", "height 250ms ease-in-out").$}
       >
-        <div css={Css.px2.pb2.pt1.$}>{children}</div>
+        {expanded && (
+          <div css={Css.px2.pb2.pt1.$} ref={contentRef}>
+            {children}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/AccordionList.test.tsx
+++ b/src/components/AccordionList.test.tsx
@@ -5,7 +5,7 @@ import { AccordionList } from "./AccordionList";
 
 describe(AccordionList, () => {
   const accordions: AccordionProps[] = [
-    { title: "First accordion title", children: <div>Fisrt accordion description</div> },
+    { title: "First accordion title", children: <div>First accordion description</div> },
     { title: "Second accordion title", children: <div>Second accordion description</div> },
     { title: "Third accordion title", children: <div>Third accordion description</div> },
   ];
@@ -33,11 +33,7 @@ describe(AccordionList, () => {
     click(r.accordionList_title_1());
 
     // Then both accordions are be expanded
-    expect(r.accordionList_details_0()).not.toHaveStyleRule("max-height", "0");
-    expect(r.accordionList_details_1()).not.toHaveStyleRule("max-height", "0");
-
-    // And the third one is still collapsed
-    expect(r.accordionList_details_2()).toHaveStyleRule("max-height", "0");
+    expect(r.getAllByTestId("accordionList_content")).toHaveLength(2);
   });
 
   it("can have only one accordion expanded", async () => {
@@ -46,13 +42,12 @@ describe(AccordionList, () => {
 
     // When the first accordions is selected
     click(r.accordionList_title_0());
-    // Then it shows as expanded
-    expect(r.accordionList_details_0()).not.toHaveStyleRule("max-height", "0");
+    // Then one accordion's content is shown
+    expect(r.accordionList_content()).toHaveTextContent("First accordion description");
 
     // And when a second accordion is selected
     click(r.accordionList_title_1());
-    // Then the first accordion is collapsed and the second is expanded
-    expect(r.accordionList_details_0()).toHaveStyleRule("max-height", "0");
-    expect(r.accordionList_details_1()).not.toHaveStyleRule("max-height", "0");
+    // Then, still, only one accordion's content is shown.
+    expect(r.accordionList_content()).toHaveTextContent("Second accordion description");
   });
 });


### PR DESCRIPTION
No longer use max-height for animating as it results in inconsistent animation timings depending on size of the content. The proposed way in this PR is to animate the height. We now hide the Accordion's content until it has been expanded. Once expanded and the content is rendered, then a useEffect runs to calculate the contents height. That height is then applied to the wrapping element to animate its height to that of the content. It now requires two renders to complete the animations, but it is much smoother and the second render should be very minimal