### PR TITLE
fix: Support custom storage key for visible columns

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -2434,7 +2434,7 @@ describe("GridTable", () => {
       expect(cell(r, 1, 1)).toHaveTextContent("Last name");
     });
 
-    it("auto assigns 'visibleColumnStorageKey'", async () => {
+    it("auto assigns 'visibleColumnsStorageKey'", async () => {
       jest.spyOn(Object.getPrototypeOf(window.sessionStorage), "setItem");
 
       // Given some hide-able columns
@@ -2450,7 +2450,7 @@ describe("GridTable", () => {
       expect(sessionStorage.setItem).toHaveBeenLastCalledWith("nameValueAction", '["name","action"]');
     });
 
-    it("accepts a specified 'visibleColumnStorageKey'", async () => {
+    it("accepts a specified 'visibleColumnsStorageKey'", async () => {
       jest.spyOn(Object.getPrototypeOf(window.sessionStorage), "setItem");
 
       // Given some hide-able columns
@@ -2459,9 +2459,9 @@ describe("GridTable", () => {
         { id: "value", header: () => "Value", data: ({ value }) => value, canHide: true },
       ];
 
-      // And a table with setting the `visibleColumnStorageKey`
-      await render(<GridTable columns={columns} rows={rows} visibleColumnStorageKey="testStorageKey" />);
-      // Then the visible column session storage is defined using the `visibleColumnStorageKey` prop
+      // And a table with setting the `visibleColumnsStorageKey`
+      await render(<GridTable columns={columns} rows={rows} visibleColumnsStorageKey="testStorageKey" />);
+      // Then the visible column session storage is defined using the `visibleColumnsStorageKey` prop
       expect(sessionStorage.setItem).toHaveBeenLastCalledWith("testStorageKey", '["name"]');
     });
   });

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -2433,6 +2433,37 @@ describe("GridTable", () => {
       expect(cell(r, 1, 0)).toHaveTextContent("First name");
       expect(cell(r, 1, 1)).toHaveTextContent("Last name");
     });
+
+    it("auto assigns 'visibleColumnStorageKey'", async () => {
+      jest.spyOn(Object.getPrototypeOf(window.sessionStorage), "setItem");
+
+      // Given some hide-able columns
+      const columns: GridColumn<Row>[] = [
+        { id: "name", header: () => "Name", data: ({ name }) => name, canHide: true, initVisible: true },
+        { id: "value", header: () => "Value", data: ({ value }) => value, canHide: true },
+        { id: "action", header: () => "Action", data: () => "action" },
+      ];
+
+      // Given a table
+      await render(<GridTable columns={columns} rows={rows} />);
+      // Then the visible column session storage is defined using a key build via the columns' `id` prop
+      expect(sessionStorage.setItem).toHaveBeenLastCalledWith("nameValueAction", '["name","action"]');
+    });
+
+    it("accepts a specified 'visibleColumnStorageKey'", async () => {
+      jest.spyOn(Object.getPrototypeOf(window.sessionStorage), "setItem");
+
+      // Given some hide-able columns
+      const columns: GridColumn<Row>[] = [
+        { id: "name", header: () => "Name", data: ({ name }) => name, canHide: true, initVisible: true },
+        { id: "value", header: () => "Value", data: ({ value }) => value, canHide: true },
+      ];
+
+      // And a table with setting the `visibleColumnStorageKey`
+      await render(<GridTable columns={columns} rows={rows} visibleColumnStorageKey="testStorageKey" />);
+      // Then the visible column session storage is defined using the `visibleColumnStorageKey` prop
+      expect(sessionStorage.setItem).toHaveBeenLastCalledWith("testStorageKey", '["name"]');
+    });
   });
 });
 

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -161,6 +161,11 @@ export interface GridTableProps<R extends Kinded, X> {
    * Expected format is `${row.kind}_${row.id}_${column.id}`.
    */
   activeCellId?: string;
+  /**
+   * Defines the session storage key for which columns are visible. If not provided, a default storage key will be used based on column order and/or `GridColumn.id`
+   * This is beneficial when looking at the same table, but of a different subject (i.e. Project A's PreCon Schedule vs Project A's Construction schedule)
+   */
+  visibleColumnStorageKey?: string;
 }
 
 /**
@@ -199,6 +204,7 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = {}
     resizeTarget,
     activeRowId,
     activeCellId,
+    visibleColumnStorageKey,
   } = props;
 
   const columnsWithIds = useMemo(() => assignDefaultColumnIds(_columns), [_columns]);
@@ -220,7 +226,7 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = {}
   const { tableState } = api;
 
   tableState.setRows(rows);
-  tableState.setColumns(columnsWithIds);
+  tableState.setColumns(columnsWithIds, visibleColumnStorageKey);
   const columns: GridColumnWithId<R>[] = useComputed(
     () =>
       tableState.columns

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -165,7 +165,7 @@ export interface GridTableProps<R extends Kinded, X> {
    * Defines the session storage key for which columns are visible. If not provided, a default storage key will be used based on column order and/or `GridColumn.id`
    * This is beneficial when looking at the same table, but of a different subject (i.e. Project A's PreCon Schedule vs Project A's Construction schedule)
    */
-  visibleColumnStorageKey?: string;
+  visibleColumnsStorageKey?: string;
 }
 
 /**
@@ -204,7 +204,7 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = {}
     resizeTarget,
     activeRowId,
     activeCellId,
-    visibleColumnStorageKey,
+    visibleColumnsStorageKey,
   } = props;
 
   const columnsWithIds = useMemo(() => assignDefaultColumnIds(_columns), [_columns]);
@@ -226,7 +226,7 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = {}
   const { tableState } = api;
 
   tableState.setRows(rows);
-  tableState.setColumns(columnsWithIds, visibleColumnStorageKey);
+  tableState.setColumns(columnsWithIds, visibleColumnsStorageKey);
   const columns: GridColumnWithId<R>[] = useComputed(
     () =>
       tableState.columns

--- a/src/components/Table/utils/TableState.ts
+++ b/src/components/Table/utils/TableState.ts
@@ -211,10 +211,10 @@ export class TableState {
     this.rows = rows;
   }
 
-  setColumns(columns: GridColumnWithId<any>[]): void {
+  setColumns(columns: GridColumnWithId<any>[], visibleColumnStorageKey: string | undefined): void {
     if (columns !== this.columns) {
       this.columns = columns;
-      this.visibleColumnStorageKey = camelCase(columns.map((c) => c.id).join());
+      this.visibleColumnStorageKey = visibleColumnStorageKey ?? camelCase(columns.map((c) => c.id).join());
       this.visibleColumns.replace(readOrSetLocalVisibleColumnState(columns, this.visibleColumnStorageKey));
       const expandedColumnIds = columns.filter((c) => c.initExpanded).map((c) => c.id);
       this.expandedColumns.replace(expandedColumnIds);

--- a/src/components/Table/utils/TableState.ts
+++ b/src/components/Table/utils/TableState.ts
@@ -53,7 +53,7 @@ export class TableState {
   private expandedColumns = new ObservableSet<string>();
   // An observable set of column ids to keep track of which columns are visible
   public visibleColumns = new ObservableSet<string>();
-  private visibleColumnStorageKey: string = "";
+  private visibleColumnsStorageKey: string = "";
 
   /**
    * Creates the `RowState` for a given `GridTable`.
@@ -211,18 +211,18 @@ export class TableState {
     this.rows = rows;
   }
 
-  setColumns(columns: GridColumnWithId<any>[], visibleColumnStorageKey: string | undefined): void {
+  setColumns(columns: GridColumnWithId<any>[], visibleColumnsStorageKey: string | undefined): void {
     if (columns !== this.columns) {
       this.columns = columns;
-      this.visibleColumnStorageKey = visibleColumnStorageKey ?? camelCase(columns.map((c) => c.id).join());
-      this.visibleColumns.replace(readOrSetLocalVisibleColumnState(columns, this.visibleColumnStorageKey));
+      this.visibleColumnsStorageKey = visibleColumnsStorageKey ?? camelCase(columns.map((c) => c.id).join());
+      this.visibleColumns.replace(readOrSetLocalVisibleColumnState(columns, this.visibleColumnsStorageKey));
       const expandedColumnIds = columns.filter((c) => c.initExpanded).map((c) => c.id);
       this.expandedColumns.replace(expandedColumnIds);
     }
   }
 
   setVisibleColumns(ids: string[]) {
-    sessionStorage.setItem(this.visibleColumnStorageKey, JSON.stringify(ids));
+    sessionStorage.setItem(this.visibleColumnsStorageKey, JSON.stringify(ids));
     this.visibleColumns.replace(ids);
   }
 


### PR DESCRIPTION
After attempting upgrade Beam in internal-frontend, I noticed the Project Schedule's EditColumnsButton + useColumns implementation used a custom session storage key to differentiate the visible column states between project stages. This PR adds that ability back and updates tests.