### PR TITLE
fix: Expandable Column fixes

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -6,6 +6,7 @@ import {
   actionColumn,
   Button,
   cardStyle,
+  Chips,
   collapseColumn,
   CollapseToggle,
   column,
@@ -1146,6 +1147,7 @@ type ExpandableData = {
     lastName: string | undefined;
     birthdate: string | undefined;
     age: number | undefined;
+    favoriteSports: string[] | undefined;
     occupation: string | undefined;
     manager: string | undefined;
   };
@@ -1166,6 +1168,7 @@ export function ExpandableColumns() {
           lastName: "Dow",
           birthdate: "Jan 29, 1986",
           age: 36,
+          favoriteSports: ["Basketball", "Football"],
           occupation: "Software Engineer",
           manager: "Steve Thompson",
         },
@@ -1221,6 +1224,14 @@ export function ExpandableColumns() {
         header: emptyCell,
         data: ({ manager }) => manager,
         w: "280px",
+      }),
+      column<ExpandableRow>({
+        expandableHeader: () => "Favorite Sports",
+        header: emptyCell,
+        data: ({ favoriteSports = [] }, { expanded }) =>
+          expanded ? <Chips values={favoriteSports} /> : favoriteSports.length,
+        w: "160px",
+        expandColumns: "280px",
       }),
     ],
     [],

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1231,7 +1231,7 @@ export function ExpandableColumns() {
         data: ({ favoriteSports = [] }, { expanded }) =>
           expanded ? <Chips values={favoriteSports} /> : favoriteSports.length,
         w: "160px",
-        expandColumns: "280px",
+        expandedWidth: "280px",
       }),
     ],
     [],

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -914,7 +914,7 @@ describe("GridTable", () => {
 
     it("returns expandedColumns value if is a number and column is currently expanded", () => {
       expect(
-        calcColumnSizes([{ id: "c1", w: "10%", expandColumns: "300px" }, { w: 2 }] as any, undefined, undefined, [
+        calcColumnSizes([{ id: "c1", w: "10%", expandedWidth: "300px" }, { w: 2 }] as any, undefined, undefined, [
           "c1",
         ]).join(" "),
       ).toEqual("300px ((100% - 0% - 300px) * (2 / 2))");
@@ -2452,7 +2452,7 @@ describe("GridTable", () => {
               expandableHeader: () => "Client name",
               header: () => "Name",
               data: ({ firstName }) => firstName,
-              expandColumns: "300px",
+              expandedWidth: "300px",
               initExpanded: true,
               w: "200px",
             }),

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -2443,8 +2443,8 @@ describe("GridTable", () => {
       expect(cell(r, 1, 1)).toHaveTextContent("Last name");
     });
 
-    it("can expand columns when `expandColumns` defines a number (pixel width)", async () => {
-      // Given a table with `expandColumns` defined as a number and is initially expanded
+    it("can expand columns when `expandedWidth` defines a value", async () => {
+      // Given a table with `expandedWidth` defined
       const r = await render(
         <GridTable
           columns={[

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -878,25 +878,25 @@ describe("GridTable", () => {
 
   describe("column sizes", () => {
     it("as=virtual defaults to fr widths", () => {
-      expect(calcColumnSizes([{}, {}], undefined, undefined).join(" ")).toEqual(
+      expect(calcColumnSizes([{ id: "c1" }, { id: "c2" }], undefined, undefined, []).join(" ")).toEqual(
         "((100% - 0% - 0px) * (1 / 2)) ((100% - 0% - 0px) * (1 / 2))",
       );
     });
 
     it("as=virtual treats numbers as fr", () => {
-      expect(calcColumnSizes([{ w: 1 }, { w: 2 }] as any, undefined, undefined).join(" ")).toEqual(
+      expect(calcColumnSizes([{ w: 1 }, { w: 2 }] as any, undefined, undefined, []).join(" ")).toEqual(
         "((100% - 0% - 0px) * (1 / 3)) ((100% - 0% - 0px) * (2 / 3))",
       );
     });
 
     it("as=virtual accepts percentages ", () => {
-      expect(calcColumnSizes([{ w: "10%" }, { w: 2 }] as any, undefined, undefined).join(" ")).toEqual(
+      expect(calcColumnSizes([{ w: "10%" }, { w: 2 }] as any, undefined, undefined, []).join(" ")).toEqual(
         "10% ((100% - 10% - 0px) * (2 / 2))",
       );
     });
 
     it("as=virtual rejects relative units", () => {
-      expect(() => calcColumnSizes([{ w: "auto" }] as any, undefined, undefined).join(" ")).toThrow(
+      expect(() => calcColumnSizes([{ w: "auto" }] as any, undefined, undefined, []).join(" ")).toThrow(
         "Beam Table column width definition only supports px, percentage, or fr units",
       );
     });
@@ -907,8 +907,17 @@ describe("GridTable", () => {
           [{ w: "200px" }, { w: "100px" }, { w: "10%" }, { w: "20%" }, { w: 2 }, {}] as any,
           undefined,
           undefined,
+          [],
         ).join(" "),
       ).toEqual("200px 100px 10% 20% ((100% - 30% - 300px) * (2 / 3)) ((100% - 30% - 300px) * (1 / 3))");
+    });
+
+    it("returns expandedColumns value if is a number and column is currently expanded", () => {
+      expect(
+        calcColumnSizes([{ id: "c1", w: "10%", expandColumns: "300px" }, { w: 2 }] as any, undefined, undefined, [
+          "c1",
+        ]).join(" "),
+      ).toEqual("300px ((100% - 0% - 300px) * (2 / 2))");
     });
   });
 
@@ -2432,6 +2441,32 @@ describe("GridTable", () => {
       // Then the column is initially expanded
       expect(cell(r, 1, 0)).toHaveTextContent("First name");
       expect(cell(r, 1, 1)).toHaveTextContent("Last name");
+    });
+
+    it("can expand columns when `expandColumns` defines a number (pixel width)", async () => {
+      // Given a table with `expandColumns` defined as a number and is initially expanded
+      const r = await render(
+        <GridTable
+          columns={[
+            column<ExpandableRow>({
+              expandableHeader: () => "Client name",
+              header: () => "Name",
+              data: ({ firstName }) => firstName,
+              expandColumns: "300px",
+              initExpanded: true,
+              w: "200px",
+            }),
+          ]}
+          rows={[
+            { kind: "header", id: "header", data: {} },
+            { kind: "expandableHeader", id: "expandableHeader", data: {} },
+            { kind: "data", id: "user:1", data: { firstName: "Brandon", lastName: "Dow", age: 36 } },
+          ]}
+        />,
+      );
+
+      // Then the column's width is initially set to the `column.expandColumns` property
+      expect(cell(r, 0, 0)).toHaveStyleRule("width", "calc(300px)");
     });
 
     it("auto assigns 'visibleColumnsStorageKey'", async () => {

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -232,14 +232,10 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = {}
       tableState.columns
         .filter((c) => tableState.visibleColumnIds.includes(c.id))
         .flatMap((c) =>
-          c.expandColumns && Array.isArray(c.expandColumns) && tableState.expandedColumnIds.includes(c.id)
-            ? [c, ...c.expandColumns]
-            : [c],
+          c.expandColumns && tableState.expandedColumnIds.includes(c.id) ? [c, ...c.expandColumns] : [c],
         ) as GridColumnWithId<R>[],
     [tableState],
   );
-
-  const expandedColumnIds: string[] = useComputed(() => tableState.expandedColumnIds, [tableState]);
 
   // Initialize the sort state. This will only happen on the first render.
   // Once the `TableState.sort` is defined, it will not re-initialize.
@@ -264,6 +260,7 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = {}
   // here instead.
   const { getCount } = useRenderCount();
 
+  const expandedColumnIds: string[] = useComputed(() => tableState.expandedColumnIds, [tableState]);
   const columnSizes = useSetupColumnSizes(style, columns, resizeTarget ?? resizeRef, expandedColumnIds);
 
   // Make a single copy of our current collapsed state, so we'll have a single observer.

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -232,10 +232,14 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = {}
       tableState.columns
         .filter((c) => tableState.visibleColumnIds.includes(c.id))
         .flatMap((c) =>
-          c.expandColumns && tableState.expandedColumnIds.includes(c.id) ? [c, ...c.expandColumns] : [c],
+          c.expandColumns && Array.isArray(c.expandColumns) && tableState.expandedColumnIds.includes(c.id)
+            ? [c, ...c.expandColumns]
+            : [c],
         ) as GridColumnWithId<R>[],
     [tableState],
   );
+
+  const expandedColumnIds: string[] = useComputed(() => tableState.expandedColumnIds, [tableState]);
 
   // Initialize the sort state. This will only happen on the first render.
   // Once the `TableState.sort` is defined, it will not re-initialize.
@@ -260,7 +264,7 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = {}
   // here instead.
   const { getCount } = useRenderCount();
 
-  const columnSizes = useSetupColumnSizes(style, columns, resizeTarget ?? resizeRef);
+  const columnSizes = useSetupColumnSizes(style, columns, resizeTarget ?? resizeRef, expandedColumnIds);
 
   // Make a single copy of our current collapsed state, so we'll have a single observer.
   const collapsedIds = useComputed(() => tableState.collapsedIds, [tableState]);
@@ -666,7 +670,11 @@ function renderVirtual<R extends Kinded>(
         return visibleDataRows[index][1];
       }}
       totalCount={
-        (headerRows.length || 0) + (totalsRows.length || 0) + (firstRowMessage ? 1 : 0) + (visibleDataRows.length || 0)
+        headerRows.length +
+        totalsRows.length +
+        expandableHeaderRows.length +
+        (firstRowMessage ? 1 : 0) +
+        visibleDataRows.length
       }
     />
   );

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -166,7 +166,8 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
           (sortOn === "server" && !!column.serverSideSortKey);
         const alignment = getAlignment(column, maybeContent);
         const justificationCss = getJustification(column, maybeContent, as, alignment);
-        const isExpandable = column.expandColumns !== undefined;
+        const isExpandable =
+          (column.expandColumns && column.expandColumns.length > 0) || column.expandedWidth !== undefined;
 
         const content = toContent(
           maybeContent,

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -118,7 +118,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
       {columns.map((column, columnIndex) => {
         // Need to keep track of the expanded columns so we can add borders as expected for the header rows
         const isExpanded = tableState.expandedColumnIds.includes(column.id);
-        const numExpandedColumns = isExpanded && Array.isArray(column.expandColumns) ? column.expandColumns.length : 0;
+        const numExpandedColumns = isExpanded ? column.expandColumns?.length ?? 0 : 0;
 
         const { wrapAction = true, isAction = false } = column;
 

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -118,6 +118,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
       {columns.map((column, columnIndex) => {
         // Need to keep track of the expanded columns so we can add borders as expected for the header rows
         const isExpanded = tableState.expandedColumnIds.includes(column.id);
+        const numExpandedColumns = isExpanded && Array.isArray(column.expandColumns) ? column.expandColumns.length : 0;
 
         const { wrapAction = true, isAction = false } = column;
 
@@ -131,12 +132,13 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
           }
         }
 
-        // When using the variation of the table with an EXPANDABLE_HEADER, then our HEADER row required special border styling
+        // When using the variation of the table with an EXPANDABLE_HEADER, then our HEADER and TOTAL rows have special border styling
+        // Keep track of the when we get to the last expanded column so we can apply this styling properly.
         if (hasExpandableHeader && (isHeader || isTotals)) {
           // When the value of `currentExpandedColumnCount` is 0, then we have started over.
           // If the current column `isExpanded`, then store the number of expandable columns.
           if (currentExpandedColumnCount === 0 && isExpanded) {
-            currentExpandedColumnCount = column.expandColumns?.length ?? 0;
+            currentExpandedColumnCount = numExpandedColumns;
           } else if (currentExpandedColumnCount > 0) {
             // If value is great than 0, then decrement. Once the value equals 0, then the special styling will be applied below.
             currentExpandedColumnCount -= 1;
@@ -150,11 +152,13 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
         }
         const maybeContent = applyRowFn(column, row, api, level, isExpanded);
 
-        const numExpandedColumns = isExpandableHeader && isExpanded ? column.expandColumns?.length ?? 0 : 0;
-
-        currentColspan = isGridCellContent(maybeContent)
-          ? maybeContent.colspan ?? numExpandedColumns + 1
-          : numExpandedColumns + 1;
+        // Only use the `numExpandedColumns` as the `colspan` when rendering the "Expandable Header"
+        currentColspan =
+          isGridCellContent(maybeContent) && typeof maybeContent.colspan === "number"
+            ? maybeContent.colspan
+            : isExpandableHeader
+            ? numExpandedColumns + 1
+            : 1;
         const revealOnRowHover = isGridCellContent(maybeContent) ? maybeContent.revealOnRowHover : false;
 
         const canSortColumn =
@@ -162,7 +166,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
           (sortOn === "server" && !!column.serverSideSortKey);
         const alignment = getAlignment(column, maybeContent);
         const justificationCss = getJustification(column, maybeContent, as, alignment);
-        const isExpandable = column.expandColumns !== undefined && column.expandColumns.length > 0;
+        const isExpandable = column.expandColumns !== undefined;
 
         const content = toContent(
           maybeContent,
@@ -267,14 +271,11 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
 
         const cellOnClick = applyCellHighlight ? () => api.setActiveCellId(cellId) : undefined;
 
-        // If the expandable header is expanded, then we need to set a colspan on it which includes all expanded columns + this column.
-        const expandableHeaderColSpan = (isExpandableHeader && isExpanded ? column.expandColumns?.length ?? 0 : 0) + 1;
-
         const renderFn: RenderCellFn<any> =
           (rowStyle?.renderCell || rowStyle?.rowLink) && wrapAction
             ? rowLinkRenderFn(as)
             : isHeader || isTotals || isExpandableHeader
-            ? headerRenderFn(column, as, expandableHeaderColSpan)
+            ? headerRenderFn(column, as, currentColspan)
             : rowStyle?.onClick && wrapAction
             ? rowClickRenderFn(as, api)
             : defaultRenderFn(as);

--- a/src/components/Table/hooks/useSetupColumnSizes.ts
+++ b/src/components/Table/hooks/useSetupColumnSizes.ts
@@ -1,7 +1,7 @@
 import { useResizeObserver } from "@react-aria/utils";
 import { MutableRefObject, useCallback, useEffect, useRef, useState } from "react";
 import { GridStyle } from "src/components/Table/TableStyles";
-import { GridColumn } from "src/components/Table/types";
+import { GridColumnWithId } from "src/components/Table/types";
 import { calcColumnSizes } from "src/components/Table/utils/columns";
 import { useDebouncedCallback } from "use-debounce";
 
@@ -26,8 +26,9 @@ import { useDebouncedCallback } from "use-debounce";
  */
 export function useSetupColumnSizes(
   style: GridStyle,
-  columns: GridColumn<any>[],
+  columns: GridColumnWithId<any>[],
   resizeRef: MutableRefObject<HTMLElement | null>,
+  expandedColumnIds: string[],
 ): string[] {
   // Calculate the column sizes immediately rather than via the `debounce` method.
   // We do this for Storybook integrations that may use MockDate. MockDate changes the behavior of `new Date()`,
@@ -36,12 +37,14 @@ export function useSetupColumnSizes(
   const [tableWidth, setTableWidth] = useState<number | undefined>();
 
   // Calc our initial/first render sizes where we won't have a width yet
-  const [columnSizes, setColumnSizes] = useState<string[]>(calcColumnSizes(columns, tableWidth, style.minWidthPx));
+  const [columnSizes, setColumnSizes] = useState<string[]>(
+    calcColumnSizes(columns, tableWidth, style.minWidthPx, expandedColumnIds),
+  );
 
   const setTableAndColumnWidths = useCallback(
     (width: number) => {
       setTableWidth(width);
-      setColumnSizes(calcColumnSizes(columns, width, style.minWidthPx));
+      setColumnSizes(calcColumnSizes(columns, width, style.minWidthPx, expandedColumnIds));
     },
     [setTableWidth, setColumnSizes, columns, style],
   );

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -53,6 +53,10 @@ export type GridColumn<R extends Kinded> = {
    * - The default value is `1fr`
    */
   w?: number | string;
+  /** Represents the width the column will get when expanded. This prop is treated the same as the `GridColumn.w` prop.
+   *  Example: Collapsed state shows number of books. Expanded state shows titles of books.
+   */
+  expandedWidth?: number | string;
   /** The minimum width the column can shrink to */
   mw?: string;
   /** The column's default alignment for each cell. */
@@ -75,20 +79,15 @@ export type GridColumn<R extends Kinded> = {
   canHide?: boolean;
   /** Flag that will allow to know which hide-able columns are visible on initial load */
   initVisible?: boolean;
-  /**
-   * Either
-   * 1. A list of columns that should only be shown when this column is "expanded", or...
-   * 2. `number | string` representing width to allow for the column to expand itself larger. This prop is treated the same as the `GridColumn.w` prop.
-   *     Example: Collapsed state shows number of books. Expanded state shows titles of books.
-   */
-  expandColumns?: GridColumn<R>[] | number | string;
+  /** A list of columns that should only be shown when this column is "expanded" */
+  expandColumns?: GridColumn<R>[];
   /** Determines whether the group should initially be expanded on load of the table */
   initExpanded?: boolean;
 };
 
 export type GridColumnWithId<R extends Kinded> = GridColumn<R> & {
   id: string;
-  expandColumns?: GridColumnWithId<R>[] | number | string;
+  expandColumns?: GridColumnWithId<R>[];
 };
 
 export const nonKindGridColumnKeys = [

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -75,15 +75,20 @@ export type GridColumn<R extends Kinded> = {
   canHide?: boolean;
   /** Flag that will allow to know which hide-able columns are visible on initial load */
   initVisible?: boolean;
-  /** A list of columns that should only be shown when this column is "expanded" */
-  expandColumns?: GridColumn<R>[];
+  /**
+   * Either
+   * 1. A list of columns that should only be shown when this column is "expanded", or...
+   * 2. `number | string` representing width to allow for the column to expand itself larger. This prop is treated the same as the `GridColumn.w` prop.
+   *     Example: Collapsed state shows number of books. Expanded state shows titles of books.
+   */
+  expandColumns?: GridColumn<R>[] | number | string;
   /** Determines whether the group should initially be expanded on load of the table */
   initExpanded?: boolean;
 };
 
 export type GridColumnWithId<R extends Kinded> = GridColumn<R> & {
   id: string;
-  expandColumns?: GridColumnWithId<R>[];
+  expandColumns?: GridColumnWithId<R>[] | number | string;
 };
 
 export const nonKindGridColumnKeys = [

--- a/src/components/Table/utils/columns.tsx
+++ b/src/components/Table/utils/columns.tsx
@@ -97,9 +97,10 @@ function nonKindDefaults() {
  * Enforces only fixed-sized units (% and px)
  */
 export function calcColumnSizes(
-  columns: GridColumn<any>[],
+  columns: GridColumnWithId<any>[],
   tableWidth: number | undefined,
   tableMinWidthPx: number = 0,
+  expandedColumnIds: string[],
 ): string[] {
   // For both default columns (1fr) as well as `w: 4fr` columns, we translate the width into an expression that looks like:
   // calc((100% - allOtherPercent - allOtherPx) * ((myFr / totalFr))`
@@ -110,7 +111,9 @@ export function calcColumnSizes(
   // by react-virtuoso), even if they have the same width, for some reason `fr` units between the two
   // will resolve every slightly differently, where as this approach they will match exactly.
   const { claimedPercentages, claimedPixels, totalFr } = columns.reduce(
-    (acc, { w }) => {
+    (acc, { id, w: _w, expandColumns }) => {
+      const w = expandedColumnIds.includes(id) && !Array.isArray(expandColumns) ? expandColumns : _w;
+
       if (typeof w === "undefined") {
         return { ...acc, totalFr: acc.totalFr + 1 };
       } else if (typeof w === "number") {
@@ -139,7 +142,9 @@ export function calcColumnSizes(
     return `((100% - ${claimedPercentages}% - ${claimedPixels}px) * (${myFr} / ${totalFr}))`;
   }
 
-  let sizes = columns.map(({ w }) => {
+  let sizes = columns.map(({ id, expandColumns, w: _w }) => {
+    const w = expandedColumnIds.includes(id) && !Array.isArray(expandColumns) ? expandColumns : _w;
+
     if (typeof w === "undefined") {
       return fr(1);
     } else if (typeof w === "string") {
@@ -163,15 +168,20 @@ export function assignDefaultColumnIds<T extends Kinded>(columns: GridColumn<T>[
   // Note: we are not _always_ spreading the `c` property as we need to be able to return the whole proxy object that
   // exists as part of `selectColumn` and `collapseColumn`.
   return columns.map((c, idx) => {
-    const { expandColumns = [] } = c;
-    const expandColumnsWithId: GridColumnWithId<T>[] | undefined = expandColumns.map((ec, ecIdx) => ({
-      ...ec,
-      id: ec.id ?? (`${generateColumnId(idx)}_${ecIdx}` as string),
-      // Defining this as undefined to make TS happy for now.
-      // If we do not explicitly set to `undefined`, TS thinks `expandColumns` could still be of type GridColumn<T> (not WithId).
-      // We only support a single level of expanding columns, so this is safe to do.
-      expandColumns: undefined,
-    }));
+    const { expandColumns } = c;
+    const expandColumnsWithId: GridColumnWithId<T>[] | number | string | undefined =
+      expandColumns === undefined
+        ? undefined
+        : Array.isArray(expandColumns)
+        ? expandColumns.map((ec, ecIdx) => ({
+            ...ec,
+            id: ec.id ?? (`${generateColumnId(idx)}_${ecIdx}` as string),
+            // Defining this as undefined to make TS happy for now.
+            // If we do not explicitly set to `undefined`, TS thinks `expandColumns` could still be of type GridColumn<T> (not WithId).
+            // We only support a single level of expanding columns, so this is safe to do.
+            expandColumns: undefined,
+          }))
+        : expandColumns;
 
     return Object.assign(c, { id: c.id ?? generateColumnId(idx), expandColumns: expandColumnsWithId });
   });


### PR DESCRIPTION
Two issues addressed:
1. Columns should be expandable to a larger width, they do not necessarily need to show more columns. Updated so 'expandColumns' prop can accept a number value, which is used as the pixels to grow the column to.
2. Virtualized GridTable forgot to account for the expandable header when calculating the total number of rows.