### PR TITLE
fix: [SC-24684]  Removing error styles on disabled inputs

### DIFF
--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -219,7 +219,8 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
               ...(inputProps.disabled ? fieldStyles.disabled : {}),
               ...(showFocus ? fieldStyles.focus : {}),
               ...(showHover ? fieldStyles.hover : {}),
-              ...(errorMsg ? fieldStyles.error : {}),
+              // Only show error styles if the field is not disabled, following the pattern that the error message is also hidden
+              ...(errorMsg && !inputProps.disabled ? fieldStyles.error : {}),
               ...Css.if(multiline).aifs.px0.mhPx(textAreaMinHeight).$,
             }}
             {...hoverProps}


### PR DESCRIPTION
Adding an extra condition to render the error styles into the beam input fields, so the red border with only display if the field is enabled, following the same pattern that we have when hidding the error message if the field is disabled

ex.
![imagen](https://user-images.githubusercontent.com/72685215/200915075-0a00c33a-3cd1-4ff3-9af9-582cd624a53f.png)


after the fix
![imagen](https://user-images.githubusercontent.com/72685215/200915001-532303fd-069b-4a51-84a7-0b1f9259bbf9.png)
