### PR TITLE
feat: Add borderless to NumberField

### DIFF
--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -46,6 +46,8 @@ export interface NumberFieldProps {
    * @default true */
   useGrouping?: boolean;
   hideErrorMessage?: boolean;
+  // Typically used for compact fields in a table. Removes border and uses an box-shadow for focus behavior
+  borderless?: boolean;
 }
 
 export function NumberField(props: NumberFieldProps) {


### PR DESCRIPTION
[SC-22763](https://app.shortcut.com/homebound-team/story/22763/inline-editing-predecessors-successors)

Needed to override the background color of the field

<img width="483" alt="Screen Shot 2022-11-10 at 07 27 51" src="https://user-images.githubusercontent.com/106678994/201104143-c33588a5-7e4b-447b-a164-b4e2fa59a863.png">
