### PR TITLE
feat: [SC-24998]  Create number range filter type

### DIFF
--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -11,6 +11,7 @@ import {
   GridDataRow,
   GridTable,
   multiFilter,
+  numberRangeFilter,
   simpleHeader,
   SimpleHeaderAndData,
   singleFilter,
@@ -131,12 +132,15 @@ function TestFilterPage({ vertical }: { vertical?: boolean }) {
       defaultValue: { op: "BETWEEN", value: { from: jan1, to: jan19 } },
     });
 
+    const numRangeFilter = numberRangeFilter({ label: "Price", numberFieldType: "cents" });
+
     const isTest = toggleFilter({ label: "Only show test projects" });
     const doNotUse = toggleFilter({ label: "Hide 'Do Not Show'", onValue: false });
 
     return {
       marketId,
       internalUserId,
+      numRangeFilter,
       favorite,
       stage,
       status,

--- a/src/components/Filters/NumberRangeFilter.test.tsx
+++ b/src/components/Filters/NumberRangeFilter.test.tsx
@@ -37,7 +37,29 @@ describe("NumberRangeFilter", () => {
     expect(r.filter_price_max()).toHaveValue("50");
   });
 
-  it("should set and render the filter range values", async () => {
+  it("should only set the min range value", async () => {
+    // Given we have a Number Range Filter
+    const r = await render(<TestFilters defs={{ numberRange: numberRangeFilter({ label: "Price" }) }} />);
+
+    // When we set the min / max value
+    type(r.filter_price_min(), "10");
+
+    // Then we expect the min / max filter to be set
+    expect(r.filter_value()).toHaveTextContent(JSON.stringify({ numberRange: { min: 10 } }));
+  });
+
+  it("should only set the max range value", async () => {
+    // Given we have a Number Range Filter
+    const r = await render(<TestFilters defs={{ numberRange: numberRangeFilter({ label: "Price" }) }} />);
+
+    // When we set the min / max value
+    type(r.filter_price_max(), "50");
+
+    // Then we expect the min / max filter to be set
+    expect(r.filter_value()).toHaveTextContent(JSON.stringify({ numberRange: { max: 50 } }));
+  });
+
+  it("should set and render both the min / max filter range values", async () => {
     // Given we have a Number Range Filter
     const r = await render(<TestFilters defs={{ numberRange: numberRangeFilter({ label: "Price" }) }} />);
 
@@ -45,8 +67,28 @@ describe("NumberRangeFilter", () => {
     type(r.filter_price_min(), "10");
     type(r.filter_price_max(), "50");
 
-    // Then we expect the min / max filter to be set
-    expect(r.filter_value()).toHaveTextContent(JSON.stringify({ max: 50, min: 10 }));
+    // Then we expect to render the min / max values
+    expect(r.filter_price_min()).toHaveValue("10");
+    expect(r.filter_price_max()).toHaveValue("50");
+
+    // And we expect the min / max filter to be set
+    expect(r.filter_value()).toHaveTextContent(JSON.stringify({ numberRange: { max: 50, min: 10 } }));
+  });
+
+  it("should unset filter range values", async () => {
+    // Given we have a Number Range Filter
+    const r = await render(<TestFilters defs={{ numberRange: numberRangeFilter({ label: "Price" }) }} />);
+
+    // And we set the min / max value
+    type(r.filter_price_min(), "10");
+    type(r.filter_price_max(), "50");
+
+    // When we unset the min / max values
+    type(r.filter_price_min(), "");
+    type(r.filter_price_max(), "");
+
+    // Then we expect the numberRange filter to be unset
+    expect(r.filter_value()).toHaveTextContent(JSON.stringify({}));
   });
 
   it("should render the formatted range values", async () => {
@@ -75,7 +117,7 @@ describe("NumberRangeFilter", () => {
     type(r.filter_price_max(), "50");
 
     // And we expect the min / max filter to be set in cents
-    expect(r.filter_value()).toHaveTextContent(JSON.stringify({ max: 5000, min: 1000 }));
+    expect(r.filter_value()).toHaveTextContent(JSON.stringify({ numberRange: { max: 5000, min: 1000 } }));
   });
 });
 
@@ -85,7 +127,7 @@ function TestFilters(props: TestFilterProps) {
   return (
     <div>
       <Filters vertical={!!showVertical} filterDefs={defs} filter={filter} onChange={setFilter} />
-      <div data-testid="filter_value">{JSON.stringify(filter.numberRange)}</div>
+      <div data-testid="filter_value">{JSON.stringify(filter)}</div>
     </div>
   );
 }

--- a/src/components/Filters/NumberRangeFilter.test.tsx
+++ b/src/components/Filters/NumberRangeFilter.test.tsx
@@ -135,5 +135,5 @@ function TestFilters(props: TestFilterProps) {
 interface TestFilterProps {
   defs: FilterDefs<ProjectFilter>;
   showVertical?: boolean;
-  defaultValue?: NumberRangeFilterValue<number>;
+  defaultValue?: NumberRangeFilterValue;
 }

--- a/src/components/Filters/NumberRangeFilter.test.tsx
+++ b/src/components/Filters/NumberRangeFilter.test.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { FilterDefs, Filters } from "src/components/Filters";
+import { ProjectFilter } from "src/components/Filters/testDomain";
+import { render, type } from "src/utils/rtl";
+import { numberRangeFilter, NumberRangeFilterValue } from "./NumberRangeFilter";
+
+describe("NumberRangeFilter", () => {
+  it("renders the Number Range Filter in horizontal filters", async () => {
+    // Given we have a Number Range Filter within Filters
+    const r = await render(<TestFilters defs={{ numberRange: numberRangeFilter({ label: "Price" }) }} />);
+
+    // Then the min / max number range filter should be visible
+    expect(r.filter_price_min()).toHaveValue("");
+    expect(r.filter_price_max()).toHaveValue("");
+  });
+
+  it("renders the Number Range Filter in vertical Filters", async () => {
+    // Given we have a Number Range Filter within vertical Filters
+    const r = await render(
+      <TestFilters showVertical={true} defs={{ numberRange: numberRangeFilter({ label: "Price" }) }} />,
+    );
+
+    // Then the min / max number range filter should be visible
+    expect(r.filter_price_min_vertical()).toHaveValue("");
+    expect(r.filter_price_max_vertical()).toHaveValue("");
+  });
+
+  it("should render filter with default values when filter state default is set", async () => {
+    const defaultValue = { min: 10, max: 50 };
+    // Given we have a Number Range Filter with a default value set
+    const r = await render(
+      <TestFilters defaultValue={defaultValue} defs={{ numberRange: numberRangeFilter({ label: "Price" }) }} />,
+    );
+
+    // Then the min / max number range filter should be set with the default values
+    expect(r.filter_price_min()).toHaveValue("10");
+    expect(r.filter_price_max()).toHaveValue("50");
+  });
+
+  it("should set and render the filter range values", async () => {
+    // Given we have a Number Range Filter
+    const r = await render(<TestFilters defs={{ numberRange: numberRangeFilter({ label: "Price" }) }} />);
+
+    // When we set the min / max value
+    type(r.filter_price_min(), "10");
+    type(r.filter_price_max(), "50");
+
+    // Then we expect the min / max filter to be set
+    expect(r.filter_value()).toHaveTextContent(JSON.stringify({ max: 50, min: 10 }));
+  });
+
+  it("should render the formatted range values", async () => {
+    // Given we have a Number Range Filter formatted in cents i.e. numberFieldType is set in cents
+    const r = await render(
+      <TestFilters defs={{ numberRange: numberRangeFilter({ label: "Price", numberFieldType: "cents" }) }} />,
+    );
+
+    // When we set the min / max value
+    type(r.filter_price_min(), "10");
+    type(r.filter_price_max(), "50");
+
+    // Then we expect the min / max filter UI to be formatted
+    expect(r.filter_price_min()).toHaveValue("$10.00");
+    expect(r.filter_price_max()).toHaveValue("$50.00");
+  });
+
+  it("should set the filter range values in cents", async () => {
+    // Given we have a Number Range Filter formatted in cents i.e. numberFieldType is set in cents
+    const r = await render(
+      <TestFilters defs={{ numberRange: numberRangeFilter({ label: "Price", numberFieldType: "cents" }) }} />,
+    );
+
+    // When we set the min / max value
+    type(r.filter_price_min(), "10");
+    type(r.filter_price_max(), "50");
+
+    // And we expect the min / max filter to be set in cents
+    expect(r.filter_value()).toHaveTextContent(JSON.stringify({ max: 5000, min: 1000 }));
+  });
+});
+
+function TestFilters(props: TestFilterProps) {
+  const { defs, showVertical, defaultValue } = props;
+  const [filter, setFilter] = useState<ProjectFilter>(defaultValue ? { numberRange: defaultValue } : {});
+  return (
+    <div>
+      <Filters vertical={!!showVertical} filterDefs={defs} filter={filter} onChange={setFilter} />
+      <div data-testid="filter_value">{JSON.stringify(filter.numberRange)}</div>
+    </div>
+  );
+}
+
+interface TestFilterProps {
+  defs: FilterDefs<ProjectFilter>;
+  showVertical?: boolean;
+  defaultValue?: NumberRangeFilterValue<number>;
+}

--- a/src/components/Filters/NumberRangeFilter.tsx
+++ b/src/components/Filters/NumberRangeFilter.tsx
@@ -1,36 +1,34 @@
-import { Key } from "react";
 import { BaseFilter } from "src/components/Filters/BaseFilter";
 import { Filter } from "src/components/Filters/types";
 import { CompoundField } from "src/components/internal/CompoundField";
 import { Label } from "src/components/Label";
-import { Value } from "src/inputs";
 import { TestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
 import { Css } from "../../Css";
 import { NumberField, NumberFieldType } from "../../inputs/NumberField";
 
-export type NumberRangeFilterProps<V extends Value, DV extends NumberRangeFilterValue<V>> = {
+export type NumberRangeFilterProps<DV extends NumberRangeFilterValue> = {
   label: string;
   numberFieldType?: NumberFieldType;
   defaultValue?: DV;
 };
 
-export type NumberRangeFilterValue<V extends Value> = { min: V; max: V };
+export type NumberRangeFilterValue = { min: number; max: number };
 
-export function numberRangeFilter<V extends Key>(
-  props: NumberRangeFilterProps<V, NumberRangeFilterValue<V>>,
-): (key: string) => Filter<NumberRangeFilterValue<V>> {
+export function numberRangeFilter(
+  props: NumberRangeFilterProps<NumberRangeFilterValue>,
+): (key: string) => Filter<NumberRangeFilterValue> {
   return (key) => new NumberRangeFilter(key, props);
 }
 
-class NumberRangeFilter<V extends Key, DV extends NumberRangeFilterValue<V>>
-  extends BaseFilter<DV, NumberRangeFilterProps<V, DV>>
+class NumberRangeFilter<DV extends NumberRangeFilterValue>
+  extends BaseFilter<DV, NumberRangeFilterProps<DV>>
   implements Filter<DV>
 {
   render(value: DV, setValue: (value: DV | undefined) => void, tid: TestIds, inModal: boolean, vertical: boolean) {
     const { label, numberFieldType } = this.props;
-    const max = (value?.max as number) ?? undefined;
-    const min = (value?.min as number) ?? undefined;
+    const min = value?.min ?? undefined;
+    const max = value?.max ?? undefined;
 
     return (
       <>

--- a/src/components/Filters/NumberRangeFilter.tsx
+++ b/src/components/Filters/NumberRangeFilter.tsx
@@ -49,7 +49,7 @@ class NumberRangeFilter<V extends Key, DV extends NumberRangeFilterValue<V>>
                   const maxValue = max ? { max } : {};
                   setValue(minVal || max ? ({ min: minVal, ...maxValue } as DV) : undefined);
                 }}
-                {...tid[`${defaultTestId(this.label)}_min_vertical`]}
+                {...tid[`${defaultTestId(label)}_min_vertical`]}
               />
             </div>
             <NumberField
@@ -62,7 +62,7 @@ class NumberRangeFilter<V extends Key, DV extends NumberRangeFilterValue<V>>
                 const minValue = min ? { min } : {};
                 setValue(maxVal || min ? ({ max: maxVal, ...minValue } as DV) : undefined);
               }}
-              {...tid[`${defaultTestId(this.label)}_max_vertical`]}
+              {...tid[`${defaultTestId(label)}_max_vertical`]}
             />
           </div>
         )}
@@ -76,28 +76,28 @@ class NumberRangeFilter<V extends Key, DV extends NumberRangeFilterValue<V>>
               inlineLabel
               clearable
               // When in horizontal view, we combine the filter label with the min / max labels as all filter labels are displayed inline
-              label={!inModal ? `${this.label} Min` : "Min"}
+              label={!inModal ? `${label} Min` : "Min"}
               value={min}
               type={numberFieldType}
               onChange={(minVal) => {
                 const maxValue = max ? { max } : {};
                 setValue(minVal || max ? ({ min: minVal, ...maxValue } as DV) : undefined);
               }}
-              {...tid[`${defaultTestId(this.label)}_min`]}
+              {...tid[`${defaultTestId(label)}_min`]}
             />
             <NumberField
               compact
               sizeToContent={!inModal}
               inlineLabel
               clearable
-              label={!inModal ? `${this.label} Max` : "Max"}
+              label={!inModal ? `${label} Max` : "Max"}
               value={max}
               type={numberFieldType}
               onChange={(maxVal) => {
                 const minValue = min ? { min } : {};
                 setValue(maxVal || min ? ({ max: maxVal, ...minValue } as DV) : undefined);
               }}
-              {...tid[`${defaultTestId(this.label)}_max`]}
+              {...tid[`${defaultTestId(label)}_max`]}
             />
           </CompoundField>
         )}

--- a/src/components/Filters/NumberRangeFilter.tsx
+++ b/src/components/Filters/NumberRangeFilter.tsx
@@ -75,7 +75,9 @@ class NumberRangeFilter<V extends Key, DV extends NumberRangeFilterValue<V>>
               sizeToContent={!inModal}
               inlineLabel
               clearable
-              label="Min"
+              // When in horizontal view, we combine the filter label with the min / max labels as they are displayed inline
+              // i.e. "Price Min" / "Price Max"
+              label={!inModal ? `${this.label} Min` : "Min"}
               value={min}
               type={numberFieldType}
               onChange={(minVal) => {
@@ -89,7 +91,7 @@ class NumberRangeFilter<V extends Key, DV extends NumberRangeFilterValue<V>>
               sizeToContent={!inModal}
               inlineLabel
               clearable
-              label="Max"
+              label={!inModal ? `${this.label} Max` : "Max"}
               value={max}
               type={numberFieldType}
               onChange={(maxVal) => {

--- a/src/components/Filters/NumberRangeFilter.tsx
+++ b/src/components/Filters/NumberRangeFilter.tsx
@@ -75,8 +75,7 @@ class NumberRangeFilter<V extends Key, DV extends NumberRangeFilterValue<V>>
               sizeToContent={!inModal}
               inlineLabel
               clearable
-              // When in horizontal view, we combine the filter label with the min / max labels as they are displayed inline
-              // i.e. "Price Min" / "Price Max"
+              // When in horizontal view, we combine the filter label with the min / max labels as all filter labels are displayed inline
               label={!inModal ? `${this.label} Min` : "Min"}
               value={min}
               type={numberFieldType}

--- a/src/components/Filters/NumberRangeFilter.tsx
+++ b/src/components/Filters/NumberRangeFilter.tsx
@@ -1,0 +1,98 @@
+import { Key } from "react";
+import { BaseFilter } from "src/components/Filters/BaseFilter";
+import { Filter } from "src/components/Filters/types";
+import { CompoundField } from "src/components/internal/CompoundField";
+import { Label } from "src/components/Label";
+import { Value } from "src/inputs";
+import { TestIds } from "src/utils";
+import { defaultTestId } from "src/utils/defaultTestId";
+import { Css } from "../../Css";
+import { NumberField, NumberFieldType } from "../../inputs/NumberField";
+
+export type NumberRangeFilterProps<V extends Value, DV extends NumberRangeFilterValue<V>> = {
+  label: string;
+  numberFieldType?: NumberFieldType;
+  defaultValue?: DV;
+};
+
+export type NumberRangeFilterValue<V extends Value> = { min: V; max: V };
+
+export function numberRangeFilter<V extends Key>(
+  props: NumberRangeFilterProps<V, NumberRangeFilterValue<V>>,
+): (key: string) => Filter<NumberRangeFilterValue<V>> {
+  return (key) => new NumberRangeFilter(key, props);
+}
+
+class NumberRangeFilter<V extends Key, DV extends NumberRangeFilterValue<V>>
+  extends BaseFilter<DV, NumberRangeFilterProps<V, DV>>
+  implements Filter<DV>
+{
+  render(value: DV, setValue: (value: DV | undefined) => void, tid: TestIds, inModal: boolean, vertical: boolean) {
+    const { label, numberFieldType } = this.props;
+    const max = (value?.max as number) ?? undefined;
+    const min = (value?.min as number) ?? undefined;
+
+    return (
+      <>
+        {/* In vertical view, we stack the number fields */}
+        {vertical && <div { ...tid }>
+          <Label label={label} />
+          <div css={Css.pb1.$}>
+            <NumberField
+              inlineLabel
+              clearable
+              label="Min"
+              value={min}
+              type={numberFieldType ?? undefined}
+              onChange={(minVal) => {
+                setValue({ min: minVal, max } as DV)
+              }}
+              {...tid[`${defaultTestId(this.label)}_min_vertical`]}
+            />
+          </div>
+          <NumberField
+            inlineLabel
+            clearable
+            label="Max"
+            value={max}
+            type={numberFieldType ?? undefined}
+            onChange={(maxVal) => {
+              setValue({ max: maxVal, min } as DV)
+            }}
+            {...tid[`${defaultTestId(this.label)}_max_vertical`]}
+          />
+        </div>}
+
+        {/* In horizontal / modal view, we wrap the number fields in a compound field */}
+        {!vertical && <CompoundField { ...tid }>
+          <NumberField
+            compact
+            sizeToContent={!inModal}
+            inlineLabel
+            clearable
+            label="Min"
+            value={min}
+            type={numberFieldType ?? undefined}
+            onChange={(minVal) => {
+              setValue({ min: minVal, max } as DV)
+            }}
+            {...tid[`${defaultTestId(this.label)}_min`]}
+          />
+          <NumberField
+            compact
+            sizeToContent={!inModal}
+            inlineLabel
+            clearable
+            label="Max"
+            value={max}
+            type={numberFieldType ?? undefined}
+            onChange={(maxVal) => {
+              setValue({ max: maxVal, min } as DV)
+            }}
+            {...tid[`${defaultTestId(this.label)}_max`]}
+          />
+        </CompoundField>}
+      </>
+    );
+  }
+}

--- a/src/components/Filters/NumberRangeFilter.tsx
+++ b/src/components/Filters/NumberRangeFilter.tsx
@@ -35,63 +35,71 @@ class NumberRangeFilter<V extends Key, DV extends NumberRangeFilterValue<V>>
     return (
       <>
         {/* In vertical view, we stack the number fields */}
-        {vertical && <div { ...tid }>
-          <Label label={label} />
-          <div css={Css.pb1.$}>
+        {vertical && (
+          <div {...tid}>
+            <Label label={label} />
+            <div css={Css.pb1.$}>
+              <NumberField
+                inlineLabel
+                clearable
+                label="Min"
+                value={min}
+                type={numberFieldType}
+                onChange={(minVal) => {
+                  const maxValue = max ? { max } : {};
+                  setValue(minVal || max ? ({ min: minVal, ...maxValue } as DV) : undefined);
+                }}
+                {...tid[`${defaultTestId(this.label)}_min_vertical`]}
+              />
+            </div>
             <NumberField
+              inlineLabel
+              clearable
+              label="Max"
+              value={max}
+              type={numberFieldType}
+              onChange={(maxVal) => {
+                const minValue = min ? { min } : {};
+                setValue(maxVal || min ? ({ max: maxVal, ...minValue } as DV) : undefined);
+              }}
+              {...tid[`${defaultTestId(this.label)}_max_vertical`]}
+            />
+          </div>
+        )}
+
+        {/* In horizontal / modal view, we wrap the number fields in a compound field */}
+        {!vertical && (
+          <CompoundField {...tid}>
+            <NumberField
+              compact
+              sizeToContent={!inModal}
               inlineLabel
               clearable
               label="Min"
               value={min}
-              type={numberFieldType ?? undefined}
+              type={numberFieldType}
               onChange={(minVal) => {
-                setValue({ min: minVal, max } as DV)
+                const maxValue = max ? { max } : {};
+                setValue(minVal || max ? ({ min: minVal, ...maxValue } as DV) : undefined);
               }}
-              {...tid[`${defaultTestId(this.label)}_min_vertical`]}
+              {...tid[`${defaultTestId(this.label)}_min`]}
             />
-          </div>
-          <NumberField
-            inlineLabel
-            clearable
-            label="Max"
-            value={max}
-            type={numberFieldType ?? undefined}
-            onChange={(maxVal) => {
-              setValue({ max: maxVal, min } as DV)
-            }}
-            {...tid[`${defaultTestId(this.label)}_max_vertical`]}
-          />
-        </div>}
-
-        {/* In horizontal / modal view, we wrap the number fields in a compound field */}
-        {!vertical && <CompoundField { ...tid }>
-          <NumberField
-            compact
-            sizeToContent={!inModal}
-            inlineLabel
-            clearable
-            label="Min"
-            value={min}
-            type={numberFieldType ?? undefined}
-            onChange={(minVal) => {
-              setValue({ min: minVal, max } as DV)
-            }}
-            {...tid[`${defaultTestId(this.label)}_min`]}
-          />
-          <NumberField
-            compact
-            sizeToContent={!inModal}
-            inlineLabel
-            clearable
-            label="Max"
-            value={max}
-            type={numberFieldType ?? undefined}
-            onChange={(maxVal) => {
-              setValue({ max: maxVal, min } as DV)
-            }}
-            {...tid[`${defaultTestId(this.label)}_max`]}
-          />
-        </CompoundField>}
+            <NumberField
+              compact
+              sizeToContent={!inModal}
+              inlineLabel
+              clearable
+              label="Max"
+              value={max}
+              type={numberFieldType}
+              onChange={(maxVal) => {
+                const minValue = min ? { min } : {};
+                setValue(maxVal || min ? ({ max: maxVal, ...minValue } as DV) : undefined);
+              }}
+              {...tid[`${defaultTestId(this.label)}_max`]}
+            />
+          </CompoundField>
+        )}
       </>
     );
   }

--- a/src/components/Filters/index.ts
+++ b/src/components/Filters/index.ts
@@ -2,6 +2,7 @@ export { dateFilter } from "src/components/Filters/DateFilter";
 export type { DateFilterValue } from "src/components/Filters/DateFilter";
 export { dateRangeFilter } from "src/components/Filters/DateRangeFilter";
 export type { DateRangeFilterValue } from "src/components/Filters/DateRangeFilter";
+export { numberRangeFilter } from "src/components/Filters/NumberRangeFilter";
 export { multiFilter } from "src/components/Filters/MultiFilter";
 export { singleFilter } from "src/components/Filters/SingleFilter";
 export { booleanFilter } from "./BooleanFilter";

--- a/src/components/Filters/testDomain.ts
+++ b/src/components/Filters/testDomain.ts
@@ -3,6 +3,7 @@ import { dateRangeFilter, DateRangeFilterValue } from "src/components/Filters/Da
 import { multiFilter } from "src/components/Filters/MultiFilter";
 import { singleFilter } from "src/components/Filters/SingleFilter";
 import { FilterDefs } from "src/components/Filters/types";
+import { NumberRangeFilterValue } from "./NumberRangeFilter";
 
 export enum Stage {
   StageOne = "ONE",
@@ -47,6 +48,7 @@ export type ProjectFilter = {
   doNotUse?: boolean | null;
   date?: DateFilterValue<string>;
   dateRange?: DateRangeFilterValue<string>;
+  numberRange?: NumberRangeFilterValue<number>;
 };
 
 export type StageFilter = NonNullable<FilterDefs<ProjectFilter>["stage"]>;

--- a/src/components/Filters/testDomain.ts
+++ b/src/components/Filters/testDomain.ts
@@ -48,7 +48,7 @@ export type ProjectFilter = {
   doNotUse?: boolean | null;
   date?: DateFilterValue<string>;
   dateRange?: DateRangeFilterValue<string>;
-  numberRange?: NumberRangeFilterValue<number>;
+  numberRange?: NumberRangeFilterValue;
 };
 
 export type StageFilter = NonNullable<FilterDefs<ProjectFilter>["stage"]>;

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -105,14 +105,14 @@ export function NumberField(props: NumberFieldProps) {
       type === "percent"
         ? { style: "percent" }
         : type === "basisPoints"
-          ? { style: "percent", minimumFractionDigits: 2 }
-          : type === "cents"
-            ? { style: "currency", currency: "USD", minimumFractionDigits: 2 }
-            : type === "dollars"
-              ? { style: "currency", currency: "USD", minimumFractionDigits: numFractionDigits ?? 2 }
-              : type === "days"
-                ? { style: "unit", unit: "day", unitDisplay: "long", maximumFractionDigits: 0 }
-                : {};
+        ? { style: "percent", minimumFractionDigits: 2 }
+        : type === "cents"
+        ? { style: "currency", currency: "USD", minimumFractionDigits: 2 }
+        : type === "dollars"
+        ? { style: "currency", currency: "USD", minimumFractionDigits: numFractionDigits ?? 2 }
+        : type === "days"
+        ? { style: "unit", unit: "day", unitDisplay: "long", maximumFractionDigits: 0 }
+        : {};
 
     return { ...defaultFormatOptions, ...typeFormat };
   }, [type, numberFormatOptions]);
@@ -179,7 +179,6 @@ export function NumberField(props: NumberFieldProps) {
       labelProps={labelProps}
       label={label}
       required={required}
-      // inputProps={inputProps}
       inputProps={mergeProps(inputProps, {
         size: sizeToContent ? String(inputProps.value ?? "").length || 1 : undefined,
       })}

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -1,6 +1,6 @@
 import { NumberParser } from "@internationalized/number";
 import { ReactNode, useMemo, useRef } from "react";
-import { useLocale, useNumberField } from "react-aria";
+import { mergeProps, useLocale, useNumberField } from "react-aria";
 import { NumberFieldStateOptions, useNumberFieldState } from "react-stately";
 import { resolveTooltip } from "src/components";
 import { usePresentationContext } from "src/components/PresentationContext";
@@ -48,6 +48,8 @@ export interface NumberFieldProps {
   hideErrorMessage?: boolean;
   // Typically used for compact fields in a table. Removes border and uses an box-shadow for focus behavior
   borderless?: boolean;
+  inlineLabel?: boolean;
+  sizeToContent?: boolean;
 }
 
 export function NumberField(props: NumberFieldProps) {
@@ -74,6 +76,7 @@ export function NumberField(props: NumberFieldProps) {
     numberFormatOptions,
     numIntegerDigits,
     useGrouping = true,
+    sizeToContent = false,
     ...otherProps
   } = props;
 
@@ -102,14 +105,14 @@ export function NumberField(props: NumberFieldProps) {
       type === "percent"
         ? { style: "percent" }
         : type === "basisPoints"
-        ? { style: "percent", minimumFractionDigits: 2 }
-        : type === "cents"
-        ? { style: "currency", currency: "USD", minimumFractionDigits: 2 }
-        : type === "dollars"
-        ? { style: "currency", currency: "USD", minimumFractionDigits: numFractionDigits ?? 2 }
-        : type === "days"
-        ? { style: "unit", unit: "day", unitDisplay: "long", maximumFractionDigits: 0 }
-        : {};
+          ? { style: "percent", minimumFractionDigits: 2 }
+          : type === "cents"
+            ? { style: "currency", currency: "USD", minimumFractionDigits: 2 }
+            : type === "dollars"
+              ? { style: "currency", currency: "USD", minimumFractionDigits: numFractionDigits ?? 2 }
+              : type === "days"
+                ? { style: "unit", unit: "day", unitDisplay: "long", maximumFractionDigits: 0 }
+                : {};
 
     return { ...defaultFormatOptions, ...typeFormat };
   }, [type, numberFormatOptions]);
@@ -176,7 +179,10 @@ export function NumberField(props: NumberFieldProps) {
       labelProps={labelProps}
       label={label}
       required={required}
-      inputProps={inputProps}
+      // inputProps={inputProps}
+      inputProps={mergeProps(inputProps, {
+        size: sizeToContent ? String(inputProps.value ?? "").length || 1 : undefined,
+      })}
       // This is called on each DOM change, to push the latest value into the field
       onChange={(rawInputValue) => {
         const parsedValue = numberParser.parse(rawInputValue || "");


### PR DESCRIPTION
Created a new number range filter type that allows users to set `min` and/or `max` number range values.  The new filter is set up to render two separate layouts for vertical or horizontal.

- Created the new `NumberRangeFilter` component
- Created unit tests for new component
- Updated the Filter story to include the new number range filter
- Updated `NumberField` to allow new props - `sizeToContent` & `inlineLabel`

Vertical View:
![Screen Shot 2022-11-11 at 6 16 30 PM](https://user-images.githubusercontent.com/4775570/201449665-908edd06-f628-4b51-9a10-c5419fdf43e9.png)

Horizontal View:
![Screen Shot 2022-11-11 at 6 47 16 PM](https://user-images.githubusercontent.com/4775570/201450864-18db08c0-017e-4894-93a7-39f1643060d6.png)

