### PR TITLE
fix: Fix console error 'Unknown event handler property 'onPress'

### DIFF
--- a/src/inputs/DateFields/DateFieldBase.tsx
+++ b/src/inputs/DateFields/DateFieldBase.tsx
@@ -296,7 +296,7 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
         helperText={helperText}
         required={required}
         labelProps={labelProps}
-        inputProps={{ ...triggerProps, ...inputProps, size: inputSize }}
+        inputProps={{ ...inputProps, size: inputSize }}
         inputRef={inputRef}
         inputWrapRef={inputWrapRef}
         inlineLabel={inlineLabel}


### PR DESCRIPTION
DateField should not be passing `triggerProps` to the TextFieldBase's `inputProps` property. This caused the 'Unknown event handler property `onPress`'