### PR TITLE
feat: Pass 'close' method to ButtonModal content

### DIFF
--- a/src/components/ButtonModal.test.tsx
+++ b/src/components/ButtonModal.test.tsx
@@ -4,19 +4,31 @@ import { ButtonModal } from "./ButtonModal";
 describe("ButtonModal", () => {
   it("can open a ButtonModal", async () => {
     // Given a ButtonModal
-    const r = await render(<TestButtonModal />);
+    const r = await render(
+      <ButtonModal trigger={{ label: "Menu trigger" }} content={"Lorum Ipsum"} title={"Modal Title"} />,
+    );
     // When opening the ButtonModal
     click(r.menuTrigger);
     // Then expect Button Modal title and content to be rendered
     expect(r.popup_title).toBeTruthy();
     expect(r.popup_content).toBeTruthy();
   });
-});
 
-function TestButtonModal() {
-  return (
-    <>
-      <ButtonModal trigger={{ label: "Menu trigger" }} content={"Lorum Ipsum"} title={"Modal Title"} />
-    </>
-  );
-}
+  it("can be closed via the close prop to contextual modal", async () => {
+    // Given the ButtonModal where the content prop is a function that accepts the `close` property and passes it to the resulting component
+    function TestModal({ close }: { close: () => void }) {
+      return <button onClick={close} data-testid="close" />;
+    }
+    const r = await render(
+      <ButtonModal trigger={{ label: "Trigger" }} content={(close) => <TestModal close={close} />} />,
+    );
+
+    // When opening the modal
+    click(r.trigger);
+    // And clicking the close button within the modal content
+    click(r.close);
+
+    // Then the modal should now be closed.
+    expect(r.popup).toNotBeInTheDom();
+  });
+});

--- a/src/components/ButtonModal.tsx
+++ b/src/components/ButtonModal.tsx
@@ -11,8 +11,9 @@ import { useTestIds } from "src/utils";
 import { ButtonVariant } from "./Button";
 import { ContextualModal } from "./internal/ContextualModal";
 
-export interface ButtonModalProps extends Pick<OverlayTriggerProps, "trigger" | "placement" | "disabled" | "tooltip" | "showActiveBorder"> {
-  content: ReactNode;
+export interface ButtonModalProps
+  extends Pick<OverlayTriggerProps, "trigger" | "placement" | "disabled" | "tooltip" | "showActiveBorder"> {
+  content: ReactNode | ((close: () => void) => ReactNode);
   title?: string;
   variant?: ButtonVariant;
   storybookDefaultOpen?: boolean;
@@ -31,7 +32,7 @@ export function ButtonModal(props: ButtonModalProps) {
 
   return (
     <OverlayTrigger {...props} menuTriggerProps={menuTriggerProps} state={state} buttonRef={buttonRef} {...tid}>
-      <ContextualModal content={content} title={title} />
+      <ContextualModal content={content} title={title} close={state.close} />
     </OverlayTrigger>
   );
 }

--- a/src/components/internal/ContextualModal.stories.tsx
+++ b/src/components/internal/ContextualModal.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta } from "@storybook/react";
+import { noop } from "src/utils";
 import { withDimensions } from "src/utils/sb";
 import { ContextualModal } from "./ContextualModal";
 
@@ -12,14 +13,14 @@ export default {
     design: {
       type: "figma",
       url: "https://www.figma.com/file/aWUE4pPeUTgrYZ4vaTYZQU/%E2%9C%A8Beam-Design-System?node-id=32720%3A99727",
-    }
+    },
   },
 } as Meta;
 
 export function BasicContextualModal() {
-  return <ContextualModal content="Hello" />;
+  return <ContextualModal content="Hello" close={noop} />;
 }
 
 export function BasicContextualModalWithTitle() {
-  return <ContextualModal content="Hello" title="Modal title" />;
+  return <ContextualModal content="Hello" title="Modal title" close={noop} />;
 }

--- a/src/components/internal/ContextualModal.tsx
+++ b/src/components/internal/ContextualModal.tsx
@@ -6,20 +6,21 @@ import { useTestIds } from "src/utils";
 export interface ContextualModalProps {
   content: ReactNode;
   title?: string;
+  close: () => void;
 }
 
 export function ContextualModal(props: ContextualModalProps) {
-  const { content, title } = props;
+  const { content, title, close } = props;
   const tid = useTestIds(props, "popup");
   return (
     <FocusScope restoreFocus autoFocus>
-      <div css={Css.p3.df.fdc.gap3.bgWhite.bshModal.br4.maxh("inherit").overflowAuto.$}>
+      <div css={Css.p3.df.fdc.gap3.bgWhite.bshModal.br4.maxh("inherit").overflowAuto.$} {...tid}>
         {title && (
           <div css={Css.lg.tc.$} {...tid.title}>
             {title}
           </div>
         )}
-        <div {...tid.content}>{content}</div>
+        <div {...tid.content}>{typeof content === "function" ? content(close) : content}</div>
       </div>
     </FocusScope>
   );

--- a/src/components/internal/OverlayTrigger.tsx
+++ b/src/components/internal/OverlayTrigger.tsx
@@ -50,7 +50,7 @@ export function OverlayTrigger(props: OverlayTriggerProps) {
     children,
     variant,
     hideEndAdornment,
-    showActiveBorder = false
+    showActiveBorder = false,
   } = props;
   const popoverRef = useRef(null);
   const { overlayProps: positionProps } = useOverlayPosition({


### PR DESCRIPTION
Allows for the ButtonModal's content to provide its own closing actions