### PR TITLE
feat: SuperDrawerHeader

### DIFF
--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -25,6 +25,8 @@ export interface BeamContextState {
   drawerCanCloseChecks: MutableRefObject<CanCloseCheck[]>;
   /** Checks when closing SuperDrawer Details, a double array to keep per-detail lists. */
   drawerCanCloseDetailsChecks: MutableRefObject<CanCloseCheck[][]>;
+  /** The div for SuperDrawerHeader to portal into. */
+  sdHeaderDiv: HTMLDivElement;
 }
 
 /** This is only exported internally, for useModal and useSuperDrawer, it's not a public API. */
@@ -37,6 +39,7 @@ export const BeamContext = createContext<BeamContextState>({
   drawerContentStack: new EmptyRef(),
   drawerCanCloseChecks: new EmptyRef(),
   drawerCanCloseDetailsChecks: new EmptyRef(),
+  sdHeaderDiv: undefined!,
 });
 
 interface BeamProviderProps extends PropsWithChildren<PresentationContextProps> {}
@@ -60,6 +63,7 @@ export function BeamProvider({ children, ...presentationProps }: BeamProviderPro
   const drawerContentStackRef = useRef<ContentStack[]>([]);
   const drawerCanCloseChecks = useRef<CanCloseCheck[]>([]);
   const drawerCanCloseDetailsChecks = useRef<CanCloseCheck[][]>([]);
+  const sdHeaderDiv = useMemo(() => document.createElement("div"), []);
 
   // We essentially expose the refs, but with our own getters/setters so that we can
   // have the setters call `tick` to re-render this Provider
@@ -75,6 +79,7 @@ export function BeamProvider({ children, ...presentationProps }: BeamProviderPro
       modalFooterDiv,
       drawerCanCloseChecks,
       drawerCanCloseDetailsChecks,
+      sdHeaderDiv,
     };
   }, [modalBodyDiv, modalFooterDiv]);
 

--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -26,7 +26,7 @@ export function ButtonGroup(props: ButtonGroupProps) {
   const { buttons, disabled = false, size = "sm" } = props;
   const tid = useTestIds(props, "buttonGroup");
   return (
-    <div css={Css.mPx(4).$} {...tid}>
+    <div {...tid} css={sizeStyles[size]}>
       {buttons.map(({ disabled: buttonDisabled, ...buttonProps }, i) => (
         // Disable the button if the ButtonGroup is disabled or if the current button is disabled.
         <GroupButton key={i} {...buttonProps} disabled={disabled || buttonDisabled} size={size} {...tid} />

--- a/src/components/SuperDrawer/SuperDrawer.stories.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.stories.tsx
@@ -185,8 +185,6 @@ export function OpenWithTitleRightContent() {
           rightContent={<Button label="Manage RFP" onClick={() => {}} />}
         />
       ),
-      // titleLeftContent: <Tag text={"ASSIGNED"} type={"success"} />,
-      // titleRightContent: <Button label="Manage RFP" onClick={() => {}} />,
     });
   }
   useEffect(open, [openInDrawer]);
@@ -210,8 +208,6 @@ export function LongTitle() {
           rightContent={<Button label="Manage RFP" onClick={() => {}} />}
         />
       ),
-      // titleLeftContent: <Tag text={"ASSIGNED"} type={"success"} />,
-      // titleRightContent: <Button label="Manage RFP" onClick={() => {}} />,
     });
   }
   useEffect(open, [openInDrawer]);
@@ -378,15 +374,7 @@ function TestDrawerContent(props: TestDrawerContentProps) {
 
   return (
     <>
-      <SuperDrawerHeader hideControls={hideControls}>
-        <div css={Css.df.jcsb.aic.gap2.$}>
-          <div css={Css.fg1.df.aic.gap2.$}>
-            <h1>{title}</h1>
-            {leftContent}
-          </div>
-          <div css={Css.fs0.$}>{rightContent}</div>
-        </div>
-      </SuperDrawerHeader>
+      <SuperDrawerHeader hideControls={hideControls} title={title} left={leftContent} right={rightContent} />
       <SuperDrawerContent
         actions={
           hasActions
@@ -426,9 +414,7 @@ function TestDetailContent({ book, onPurchase, title }: { book: Book; onPurchase
   const { closeDrawerDetail } = useSuperDrawer();
   return (
     <>
-      <SuperDrawerHeader>
-        <h1>{title}</h1>
-      </SuperDrawerHeader>
+      <SuperDrawerHeader title={title} />
       <SuperDrawerContent
         actions={[
           { label: `Back to "${book.bookTitle}"`, onClick: closeDrawerDetail, variant: "tertiary" },

--- a/src/components/SuperDrawer/SuperDrawer.stories.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { useEffect, useRef } from "react";
+import { ReactNode, useEffect, useRef } from "react";
 import {
   Button,
   GridColumn,
@@ -15,6 +15,7 @@ import {
 } from "src/components";
 import { TestModalContent } from "src/components/Modal/TestModalContent";
 import { useModal } from "src/components/Modal/useModal";
+import { SuperDrawerHeader } from "src/components/SuperDrawer/components/SuperDrawerHeader";
 import { GridDataRow, GridRowLookup } from "src/components/Table";
 import { Css } from "src/Css";
 import { noop } from "src/utils";
@@ -27,11 +28,11 @@ export default {
   title: "Workspace/Components/Super Drawer",
   component: SuperDrawerComponent,
   decorators: [withBeamDecorator, withDimensions()],
-  parameters: { 
+  parameters: {
     design: {
       type: "figma",
       url: "https://www.figma.com/file/aWUE4pPeUTgrYZ4vaTYZQU/%E2%9C%A8Beam-Design-System?node-id=35964%3A102029",
-    }
+    },
   },
 } as Meta;
 
@@ -39,8 +40,7 @@ export function Open() {
   const { openInDrawer, isDrawerOpen } = useSuperDrawer();
   function open() {
     openInDrawer({
-      title: "Drawer Title",
-      content: <TestDrawerContent book={Books[0]} />,
+      content: <TestDrawerContent book={Books[0]} title="Drawer Title" />,
     });
   }
   useEffect(open, [openInDrawer]);
@@ -57,8 +57,7 @@ export function SmallDrawer() {
   const { openInDrawer, isDrawerOpen } = useSuperDrawer();
   function open() {
     openInDrawer({
-      title: "Drawer Title",
-      content: <TestDrawerContent book={Books[0]} />,
+      content: <TestDrawerContent book={Books[0]} title="Drawer Title" />,
       width: SuperDrawerWidth.Small,
     });
   }
@@ -76,8 +75,7 @@ export function OpenWithNoActions() {
   const { openInDrawer } = useSuperDrawer();
   function open() {
     openInDrawer({
-      title: "Drawer Title",
-      content: <TestDrawerContent book={Books[0]} hasActions={false} />,
+      content: <TestDrawerContent book={Books[0]} hasActions={false} title="Drawer Title" />,
     });
   }
   useEffect(open, [openInDrawer]);
@@ -95,8 +93,7 @@ export function CanCloseDrawerChecks() {
 
   function open() {
     openInDrawer({
-      title: "Drawer Title",
-      content: <TestDrawerContent book={Books[0]} hasActions={false} />,
+      content: <TestDrawerContent book={Books[0]} hasActions={false} title="Drawer Title" />,
     });
     // Add two canClose check to show that all checks are ran
     addCanCloseDrawerCheck(() => true);
@@ -121,8 +118,8 @@ export function OpenAtDetail() {
   const { openInDrawer, openDrawerDetail } = useSuperDrawer();
 
   function open() {
-    openInDrawer({ title: "Drawer Title", content: <TestDrawerContent book={Books[0]} /> });
-    openDrawerDetail({ content: <TestDetailContent book={Books[0]} /> });
+    openInDrawer({ content: <TestDrawerContent book={Books[0]} title="Drawer Title" /> });
+    openDrawerDetail({ content: <TestDetailContent book={Books[0]} title="Drawer Title" /> });
   }
   useEffect(open, [openInDrawer, openDrawerDetail]);
   return (
@@ -143,8 +140,8 @@ export function CanCloseDrawerDetailsChecks() {
   const { openInDrawer, openDrawerDetail, addCanCloseDrawerCheck, addCanCloseDrawerDetailCheck } = useSuperDrawer();
 
   function open() {
-    openInDrawer({ title: "Drawer Title", content: <TestDrawerContent book={Books[0]} /> });
-    openDrawerDetail({ content: <TestDetailContent book={Books[0]} /> });
+    openInDrawer({ content: <TestDrawerContent book={Books[0]} title="Drawer Title" /> });
+    openDrawerDetail({ content: <TestDetailContent book={Books[0]} title="Drawer Title" /> });
     // Add failing checks for both drawer and drawer details
     addCanCloseDrawerCheck(() => false);
     addCanCloseDrawerDetailCheck(() => false);
@@ -164,7 +161,7 @@ export function OpenWithModal() {
   const { openInDrawer } = useSuperDrawer();
   const { openModal } = useModal();
   function open() {
-    openInDrawer({ title: "Drawer Title", content: <TestDrawerContent book={Books[0]} /> });
+    openInDrawer({ content: <TestDrawerContent book={Books[0]} title="Drawer Title" /> });
     openModal({ content: <TestModalContent /> });
   }
   useEffect(open, [openInDrawer, openModal]);
@@ -180,10 +177,16 @@ export function OpenWithTitleRightContent() {
   const { openInDrawer } = useSuperDrawer();
   function open() {
     openInDrawer({
-      title: "Title",
-      content: <TestDrawerContent book={Books[0]} />,
-      titleLeftContent: <Tag text={"ASSIGNED"} type={"success"} />,
-      titleRightContent: <Button label="Manage RFP" onClick={() => {}} />,
+      content: (
+        <TestDrawerContent
+          book={Books[0]}
+          title="Title"
+          leftContent={<Tag text={"ASSIGNED"} type={"success"} />}
+          rightContent={<Button label="Manage RFP" onClick={() => {}} />}
+        />
+      ),
+      // titleLeftContent: <Tag text={"ASSIGNED"} type={"success"} />,
+      // titleRightContent: <Button label="Manage RFP" onClick={() => {}} />,
     });
   }
   useEffect(open, [openInDrawer]);
@@ -199,10 +202,16 @@ export function LongTitle() {
   const { openInDrawer } = useSuperDrawer();
   function open() {
     openInDrawer({
-      title: "A very long title that will cause it to wrap. ".repeat(2),
-      content: <TestDrawerContent book={Books[0]} />,
-      titleLeftContent: <Tag text={"ASSIGNED"} type={"success"} />,
-      titleRightContent: <Button label="Manage RFP" onClick={() => {}} />,
+      content: (
+        <TestDrawerContent
+          book={Books[0]}
+          title={"A very long title that will cause it to wrap. ".repeat(2)}
+          leftContent={<Tag text={"ASSIGNED"} type={"success"} />}
+          rightContent={<Button label="Manage RFP" onClick={() => {}} />}
+        />
+      ),
+      // titleLeftContent: <Tag text={"ASSIGNED"} type={"success"} />,
+      // titleRightContent: <Button label="Manage RFP" onClick={() => {}} />,
     });
   }
   useEffect(open, [openInDrawer]);
@@ -254,12 +263,10 @@ export function TableWithPrevNextAndCloseCheck() {
   function openRow(row: GridDataRow<Row>) {
     if (row.kind === "data") {
       const { prev, next } = rowLookup.current!.lookup(row)["data"];
-      console.log("prev = ", prev);
       openInDrawer({
-        title: row.data.bookTitle,
         onPrevClick: prev && (() => openRow(prev)),
         onNextClick: next && (() => openRow(next)),
-        content: <TestDrawerContent book={row.data} />,
+        content: <TestDrawerContent book={row.data} title={row.data.bookTitle} />,
       });
     }
   }
@@ -302,10 +309,9 @@ export function TableWithPrevNext() {
     if (row.kind === "data") {
       const { prev, next } = rowLookup.current!.lookup(row)["data"];
       openInDrawer({
-        title: row.data.bookTitle,
         onPrevClick: prev && (() => openRow(prev)),
         onNextClick: next && (() => openRow(next)),
-        content: <TestDrawerContent book={row.data} />,
+        content: <TestDrawerContent book={row.data} title={row.data.bookTitle} />,
       });
     }
   }
@@ -338,9 +344,7 @@ export function HiddenControls() {
   const { openInDrawer, isDrawerOpen } = useSuperDrawer();
   function open() {
     openInDrawer({
-      title: "Drawer Title",
-      content: <TestDrawerContent book={Books[0]} />,
-      hideControls: true,
+      content: <TestDrawerContent book={Books[0]} title="Drawer Title" hideControls />,
     });
   }
   useEffect(open, [openInDrawer]);
@@ -356,10 +360,15 @@ export function HiddenControls() {
 interface TestDrawerContentProps {
   book: Book;
   hasActions?: boolean;
+  title: string;
+  leftContent?: ReactNode;
+  rightContent?: ReactNode;
+  hideControls?: boolean;
 }
 
 /** Example component to render inside the SuperDrawer */
-function TestDrawerContent({ book, hasActions = true }: TestDrawerContentProps) {
+function TestDrawerContent(props: TestDrawerContentProps) {
+  const { book, hasActions = true, title, leftContent, rightContent, hideControls } = props;
   const { openDrawerDetail, closeDrawer } = useSuperDrawer();
   const { openModal } = useModal();
 
@@ -368,55 +377,70 @@ function TestDrawerContent({ book, hasActions = true }: TestDrawerContentProps) 
   }
 
   return (
-    <SuperDrawerContent
-      actions={
-        hasActions
-          ? [
-              { label: "Close", onClick: () => closeDrawer(), variant: "tertiary" },
-              { label: `Purchase "${book.bookTitle}"`, onClick: handlePurchase },
-            ]
-          : undefined
-      }
-    >
-      <h2 css={Css.xlSb.mb1.$}>{book.bookTitle}</h2>
-      <p css={Css.base.$}>
-        <strong>Description:</strong> {book.bookDescription}
-      </p>
-      <hr css={Css.my1.$} />
-      <div css={Css.df.gap1.aic.$}>
-        <p>
-          <strong>Author:</strong> {book.authorName}
+    <>
+      <SuperDrawerHeader hideControls={hideControls}>
+        <div css={Css.df.jcsb.aic.gap2.$}>
+          <div css={Css.fg1.df.aic.gap2.$}>
+            <h1>{title}</h1>
+            {leftContent}
+          </div>
+          <div css={Css.fs0.$}>{rightContent}</div>
+        </div>
+      </SuperDrawerHeader>
+      <SuperDrawerContent
+        actions={
+          hasActions
+            ? [
+                { label: "Close", onClick: () => closeDrawer(), variant: "tertiary" },
+                { label: `Purchase "${book.bookTitle}"`, onClick: handlePurchase },
+              ]
+            : undefined
+        }
+      >
+        <h2 css={Css.xlSb.mb1.$}>{book.bookTitle}</h2>
+        <p css={Css.base.$}>
+          <strong>Description:</strong> {book.bookDescription}
         </p>
-        <Button
-          variant="tertiary"
-          label={`Learn more about ${book.authorName.split(" ")[0]}`}
-          onClick={() =>
-            openDrawerDetail({
-              title: book.authorName,
-              content: <TestDetailContent book={book} onPurchase={handlePurchase} />,
-            })
-          }
-        />
-      </div>
-    </SuperDrawerContent>
+        <hr css={Css.my1.$} />
+        <div css={Css.df.gap1.aic.$}>
+          <p>
+            <strong>Author:</strong> {book.authorName}
+          </p>
+          <Button
+            variant="tertiary"
+            label={`Learn more about ${book.authorName.split(" ")[0]}`}
+            onClick={() =>
+              openDrawerDetail({
+                content: <TestDetailContent book={book} onPurchase={handlePurchase} title={title} />,
+              })
+            }
+          />
+        </div>
+      </SuperDrawerContent>
+    </>
   );
 }
 
 /** Example component to render inside the SuperDrawer */
-function TestDetailContent({ book, onPurchase }: { book: Book; onPurchase?: () => void }) {
+function TestDetailContent({ book, onPurchase, title }: { book: Book; onPurchase?: () => void; title: string }) {
   const { closeDrawerDetail } = useSuperDrawer();
   return (
-    <SuperDrawerContent
-      actions={[
-        { label: `Back to "${book.bookTitle}"`, onClick: closeDrawerDetail, variant: "tertiary" },
-        { label: `Purchase "${book.bookTitle}"`, onClick: onPurchase ?? noop, disabled: !onPurchase },
-      ]}
-    >
-      <h2 css={Css.xlSb.mb1.$}>{book.authorName}</h2>
-      <p css={Css.base.$}>
-        <strong>Description:</strong> {book.authorDescription}
-      </p>
-    </SuperDrawerContent>
+    <>
+      <SuperDrawerHeader>
+        <h1>{title}</h1>
+      </SuperDrawerHeader>
+      <SuperDrawerContent
+        actions={[
+          { label: `Back to "${book.bookTitle}"`, onClick: closeDrawerDetail, variant: "tertiary" },
+          { label: `Purchase "${book.bookTitle}"`, onClick: onPurchase ?? noop, disabled: !onPurchase },
+        ]}
+      >
+        <h2 css={Css.xlSb.mb1.$}>{book.authorName}</h2>
+        <p css={Css.base.$}>
+          <strong>Description:</strong> {book.authorDescription}
+        </p>
+      </SuperDrawerContent>
+    </>
   );
 }
 
@@ -427,9 +451,7 @@ function TestSimpleModalContent({ book, onPrimaryClick }: { book: Book; onPrimar
     <>
       <ModalHeader>Confirm</ModalHeader>
       <ModalBody>
-        <div css={Css.wPx(500).df.fdc.jcc.aic.tc.$}>
-          <p css={Css.lgSb.$}>Are you sure you want to purchase {book.bookTitle} ?</p>
-        </div>
+        <p>Are you sure you want to purchase {book.bookTitle}?</p>
       </ModalBody>
       <ModalFooter>
         <Button label="Purchase" onClick={onPrimaryClick} />

--- a/src/components/SuperDrawer/components/SuperDrawerHeader.tsx
+++ b/src/components/SuperDrawer/components/SuperDrawerHeader.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react";
+import { ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useBeamContext } from "src/components/BeamContext";
 import { ButtonGroup } from "src/components/ButtonGroup";
@@ -7,11 +7,19 @@ import { Css } from "src/Css";
 import { useTestIds } from "src/utils";
 
 interface SuperDrawerHeaderProps {
+  children: ReactNode;
   hideControls?: boolean;
 }
 
-export function SuperDrawerHeader(props: PropsWithChildren<SuperDrawerHeaderProps>): JSX.Element {
-  const { children, hideControls } = props;
+interface SuperDrawerHeaderStructuredProps {
+  title: string;
+  left?: ReactNode;
+  right?: ReactNode;
+  hideControls?: boolean;
+}
+
+export function SuperDrawerHeader(props: SuperDrawerHeaderProps | SuperDrawerHeaderStructuredProps): JSX.Element {
+  const { hideControls } = props;
   const { sdHeaderDiv, drawerContentStack: contentStack } = useBeamContext();
   const firstContent = contentStack.current[0]?.opts as OpenInDrawerOpts;
   const { onPrevClick, onNextClick } = firstContent ?? {};
@@ -21,7 +29,17 @@ export function SuperDrawerHeader(props: PropsWithChildren<SuperDrawerHeaderProp
 
   return createPortal(
     <div css={Css.df.aic.jcsb.gap3.$} {...tid}>
-      <div css={Css.fg1.$}>{children}</div>
+      {isStructuredProps(props) ? (
+        <div css={Css.df.jcsb.aic.gap2.fg1.$}>
+          <div css={Css.fg1.df.aic.gap2.$}>
+            <h1>{props.title}</h1>
+            {props.left}
+          </div>
+          {props.right && <div css={Css.fs0.$}>{props.right}</div>}
+        </div>
+      ) : (
+        <div css={Css.fg1.$}>{props.children}</div>
+      )}
       {!hideControls && (
         <div css={Css.fs0.if(isDetail).invisible.$}>
           <ButtonGroup
@@ -36,4 +54,10 @@ export function SuperDrawerHeader(props: PropsWithChildren<SuperDrawerHeaderProp
     </div>,
     sdHeaderDiv,
   );
+}
+
+function isStructuredProps(
+  props: SuperDrawerHeaderProps | SuperDrawerHeaderStructuredProps,
+): props is SuperDrawerHeaderStructuredProps {
+  return typeof props === "object" && "title" in props;
 }

--- a/src/components/SuperDrawer/components/SuperDrawerHeader.tsx
+++ b/src/components/SuperDrawer/components/SuperDrawerHeader.tsx
@@ -1,0 +1,39 @@
+import { PropsWithChildren } from "react";
+import { createPortal } from "react-dom";
+import { useBeamContext } from "src/components/BeamContext";
+import { ButtonGroup } from "src/components/ButtonGroup";
+import { OpenInDrawerOpts } from "src/components/SuperDrawer/useSuperDrawer";
+import { Css } from "src/Css";
+import { useTestIds } from "src/utils";
+
+interface SuperDrawerHeaderProps {
+  hideControls?: boolean;
+}
+
+export function SuperDrawerHeader(props: PropsWithChildren<SuperDrawerHeaderProps>): JSX.Element {
+  const { children, hideControls } = props;
+  const { sdHeaderDiv, drawerContentStack: contentStack } = useBeamContext();
+  const firstContent = contentStack.current[0]?.opts as OpenInDrawerOpts;
+  const { onPrevClick, onNextClick } = firstContent ?? {};
+  const currentContent = contentStack.current[contentStack.current.length - 1]?.opts;
+  const isDetail = currentContent !== firstContent;
+  const tid = useTestIds({}, "superDrawerHeader");
+
+  return createPortal(
+    <div css={Css.df.aic.jcsb.gap3.$} {...tid}>
+      <div css={Css.fg1.$}>{children}</div>
+      {!hideControls && (
+        <div css={Css.fs0.if(isDetail).invisible.$}>
+          <ButtonGroup
+            buttons={[
+              { icon: "chevronLeft", onClick: () => onPrevClick && onPrevClick(), disabled: !onPrevClick },
+              { icon: "chevronRight", onClick: () => onNextClick && onNextClick(), disabled: !onNextClick },
+            ]}
+            {...tid.actions}
+          />
+        </div>
+      )}
+    </div>,
+    sdHeaderDiv,
+  );
+}

--- a/src/components/SuperDrawer/index.ts
+++ b/src/components/SuperDrawer/index.ts
@@ -1,4 +1,5 @@
 // These are our public APIs
+export * from "./components/SuperDrawerHeader";
 export * from "./ConfirmCloseModal";
 export * from "./SuperDrawerContent";
 export * from "./useSuperDrawer";

--- a/src/components/SuperDrawer/useSuperDrawer.test.tsx
+++ b/src/components/SuperDrawer/useSuperDrawer.test.tsx
@@ -171,9 +171,7 @@ function TestDrawerContent(props: {
       context.openInDrawer({
         content: (
           <>
-            <SuperDrawerHeader>
-              <h1>Title</h1>
-            </SuperDrawerHeader>
+            <SuperDrawerHeader title="Title" />
             <h2 data-testid="superDrawerContent">SuperDrawer Content</h2>
           </>
         ),

--- a/src/components/SuperDrawer/useSuperDrawer.test.tsx
+++ b/src/components/SuperDrawer/useSuperDrawer.test.tsx
@@ -1,13 +1,15 @@
 import { act, renderHook } from "@testing-library/react-hooks";
 import { ReactElement, useEffect } from "react";
+import { SuperDrawerHeader } from "src/components/SuperDrawer/components/SuperDrawerHeader";
 import { render, withBeamRTL } from "src/utils/rtl";
 import { useBeamContext } from "../BeamContext";
 import { useSuperDrawer } from "./index";
 
 describe("useSuperDrawer", () => {
   it("should allow `new` element to be added", async () => {
-    const { superDrawerContent } = await render(<TestDrawerContent openInDrawer />);
-    expect(superDrawerContent()).toBeTruthy();
+    const r = await render(<TestDrawerContent openInDrawer />);
+    expect(r.superDrawerHeader()).toHaveTextContent("Title");
+    expect(r.superDrawerContent()).toBeTruthy();
   });
 
   it("should not allow `detail` element to be added", async () => {
@@ -17,23 +19,18 @@ describe("useSuperDrawer", () => {
   });
 
   it("should allow `detail` element to be added when as least one `new` element is present", async () => {
-    const { superDrawerDetailContent } = await render(<TestDrawerContent openInDrawer openDrawerDetail />);
-    expect(superDrawerDetailContent()).toBeTruthy();
-  });
-
-  it("should default `detail` element title to previous elements title", async () => {
-    const { superDrawer_title } = await render(<TestDrawerContent openInDrawer openDrawerDetail />);
-    expect(superDrawer_title()).toHaveTextContent("title");
+    const r = await render(<TestDrawerContent openInDrawer openDrawerDetail />);
+    expect(r.superDrawerDetailContent()).toBeTruthy();
   });
 
   it("should show `new` element after calling `closeDrawerDetail()`", async () => {
-    const { superDrawerContent } = await render(<TestDrawerContent openInDrawer openDrawerDetail closeDrawerDetail />);
-    expect(superDrawerContent()).toBeTruthy();
+    const r = await render(<TestDrawerContent openInDrawer openDrawerDetail closeDrawerDetail />);
+    expect(r.superDrawerContent()).toBeTruthy();
   });
 
   it("should reset state when calling `closeDrawer()`", async () => {
-    const { queryByTestId } = await render(<TestDrawerContent openInDrawer openDrawerDetail closeDrawer />);
-    expect(queryByTestId("superDrawer")).toBeFalsy();
+    const r = await render(<TestDrawerContent openInDrawer openDrawerDetail closeDrawer />);
+    expect(r.queryByTestId("superDrawer")).toBeFalsy();
   });
 
   const wrapper = ({ children }: { children: ReactElement }) => withBeamRTL.wrap(children);
@@ -44,7 +41,7 @@ describe("useSuperDrawer", () => {
     // Given the useSuperDrawer hook
     const hook = renderHook(useSuperDrawer, { wrapper }).result.current;
     // And a opened SuperDrawer
-    act(() => hook.openInDrawer({ title: "title", content: "content" }));
+    act(() => hook.openInDrawer({ content: "content" }));
 
     // When adding a canCloseDrawerCheck
     act(() => hook.addCanCloseDrawerCheck(canCloseDrawerCheck));
@@ -75,7 +72,7 @@ describe("useSuperDrawer", () => {
     const hook = renderHook(useSuperDrawer, { wrapper }).result.current;
     // And a opened SuperDrawer with a detail content
     act(() => {
-      hook.openInDrawer({ title: "title", content: "content" });
+      hook.openInDrawer({ content: "content" });
       hook.openDrawerDetail({ content: "detail content" });
     });
 
@@ -95,7 +92,7 @@ describe("useSuperDrawer", () => {
     const beamHook = renderHook(() => useBeamContext(), { wrapper }).result.current;
     // And a opened SuperDrawer with no detail content
     act(() => {
-      superDrawerHook.openInDrawer({ title: "title", content: "content" });
+      superDrawerHook.openInDrawer({ content: "content" });
     });
 
     // When adding a canCloseDrawerDetailCheck
@@ -109,7 +106,7 @@ describe("useSuperDrawer", () => {
     // Given a useSuperDrawer and BeamContext hook
     const hook = renderHook(useSuperDrawer, { wrapper }).result.current;
     // And a opened SuperDrawer
-    act(() => hook.openInDrawer({ title: "title", content: "content" }));
+    act(() => hook.openInDrawer({ content: "content" }));
 
     // When adding a failing canCloseDrawerCheck
     act(() => hook.addCanCloseDrawerCheck(() => false));
@@ -123,7 +120,7 @@ describe("useSuperDrawer", () => {
     const hook = renderHook(useSuperDrawer, { wrapper }).result.current;
     // And a opened SuperDrawer
     act(() => {
-      hook.openInDrawer({ title: "title", content: "content" });
+      hook.openInDrawer({ content: "content" });
       hook.openDrawerDetail({ content: "drawer detail" });
     });
 
@@ -141,7 +138,7 @@ describe("useSuperDrawer", () => {
     const hook = renderHook(useSuperDrawer, { wrapper }).result.current;
 
     // When the drawer is opened and closed
-    act(() => hook.openInDrawer({ title: "title", content: "content", onClose }));
+    act(() => hook.openInDrawer({ content: "content", onClose }));
     act(() => {
       hook.closeDrawer();
     });
@@ -172,8 +169,14 @@ function TestDrawerContent(props: {
   useEffect(() => {
     if (props.openInDrawer) {
       context.openInDrawer({
-        title: "title",
-        content: <h2 data-testid="superDrawerContent">SuperDrawer Content</h2>,
+        content: (
+          <>
+            <SuperDrawerHeader>
+              <h1>Title</h1>
+            </SuperDrawerHeader>
+            <h2 data-testid="superDrawerContent">SuperDrawer Content</h2>
+          </>
+        ),
       });
     }
     if (props.openDrawerDetail) {

--- a/src/components/SuperDrawer/useSuperDrawer.tsx
+++ b/src/components/SuperDrawer/useSuperDrawer.tsx
@@ -6,18 +6,10 @@ import { ConfirmCloseModal } from "./ConfirmCloseModal";
 import { SuperDrawerWidth } from "./utils";
 
 export interface OpenInDrawerOpts {
-  /** Title of the SuperDrawer */
-  title: string;
-  /** Optional content to place left of the prev/next buttons, i.e. a "Manage" link. */
-  titleRightContent?: ReactNode;
-  /** Optional content to place right of the title, i.e. a status badge. */
-  titleLeftContent?: ReactNode;
   /** Invokes left, disabled if undefined. */
   onPrevClick?: () => void;
   /** Invokes right, disabled if undefined. */
   onNextClick?: () => void;
-  /** Hides the pagination controls for `onNextClick` and `onPrevClick` */
-  hideControls?: true;
   /** Adds a callback that is called _after_ close has definitely happened. */
   onClose?: () => void;
   content: ReactNode;
@@ -26,8 +18,6 @@ export interface OpenInDrawerOpts {
 }
 
 export interface OpenDetailOpts {
-  /** Title of the SuperDrawer for this detail page (replaces the original title). */
-  title?: string;
   content: ReactNode;
 }
 

--- a/src/forms/SuperDrawerApp.stories.tsx
+++ b/src/forms/SuperDrawerApp.stories.tsx
@@ -2,6 +2,7 @@ import { useFormState } from "@homebound/form-state";
 import { Meta } from "@storybook/react";
 import { useEffect } from "react";
 import { Button, SuperDrawerContent, useSuperDrawer } from "src/components";
+import { SuperDrawerHeader } from "src/components/SuperDrawer/components/SuperDrawerHeader";
 import { Css } from "src/Css";
 import { withBeamDecorator, withDimensions } from "src/utils/sb";
 import { BoundDateField } from "./BoundDateField";
@@ -29,7 +30,6 @@ export function SuperDrawerApp() {
 
   function openSuperDrawer() {
     openInDrawer({
-      title: "Create Author",
       content: <SuperDrawerForm />,
     });
   }
@@ -63,6 +63,9 @@ function SuperDrawerForm() {
         },
       ]}
     >
+      <SuperDrawerHeader>
+        <h1>Create Author</h1>
+      </SuperDrawerHeader>
       <fieldset>
         <legend css={Css.xl.mb2.$}>Author</legend>
         <BoundTextField field={formState.firstName} />

--- a/src/inputs/Examples.stories.tsx
+++ b/src/inputs/Examples.stories.tsx
@@ -2,6 +2,7 @@ import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
 import { useEffect } from "react";
 import { SuperDrawerContent, useSuperDrawer } from "src/components";
+import { SuperDrawerHeader } from "src/components/SuperDrawer/components/SuperDrawerHeader";
 import { Css } from "src/Css";
 import { noop } from "src/utils";
 import { withBeamDecorator } from "src/utils/sb";
@@ -18,7 +19,7 @@ export function SuperDrawerWithForm() {
   const { openInDrawer } = useSuperDrawer();
 
   useEffect(() => {
-    openInDrawer({ title: "5304.01 - Counters", content: <DrawerWithInputs /> });
+    openInDrawer({ content: <DrawerWithInputs /> });
   }, [openInDrawer]);
 
   return null;
@@ -32,6 +33,9 @@ function DrawerWithInputs() {
         { label: "Save", onClick: noop },
       ]}
     >
+      <SuperDrawerHeader>
+        <h1>5304.01 - Counters</h1>
+      </SuperDrawerHeader>
       <form css={{ ...Css.df.fdc.gap5.$, fieldset: Css.df.fdc.gap2.$, legend: Css.baseMd.mb2.$ }}>
         <fieldset>
           <legend>Details</legend>


### PR DESCRIPTION
Introduces the SuperDrawerHeader component. This component portals itself into the header of the SuperDrawer. Follows the existing pattern of our Modals.

This is a fairly large breaking change as we have completely changed how to define the header of the SuperDrawer. It removes all title/header configuration properties from the openInDrawer method.