### PR TITLE
feat: (SC-25686) Hack Day - new label property to CollapseToggle #715

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1138,6 +1138,43 @@ export function ToggleCustomCollapse() {
   );
 }
 
+export function ToggleCustomCollapseLabeled() {
+  const collapseCol = collapseColumn<Row | ChildRow>({
+    data: () => emptyCell,
+  });
+
+  const nameCol: GridColumn<Row | ChildRow> = {
+    header: "Name",
+    data: ({ name }, { row }) => <CollapseToggle label={name} compact row={row} />,
+    child: ({ name }) => ({ content: name }),
+    mw: "160px",
+  };
+
+  return (
+    <>
+      <GridTable
+        columns={[collapseCol, nameCol]}
+        style={{ rowHeight: "fixed" }}
+        rows={[
+          simpleHeader,
+          {
+            id: "p1",
+            kind: "data",
+            data: { name: "Parent", value: 1 },
+            children: [
+              {
+                id: "c1",
+                kind: "child",
+                data: { name: "Child" },
+              },
+            ],
+          },
+        ]}
+      />
+    </>
+  );
+}
+
 type ExpandHeader = { id: "expandableHeader"; kind: "expandableHeader" };
 type Header = { id: "header"; kind: "header" };
 type ExpandableData = {

--- a/src/components/Table/components/CollapseToggle.test.tsx
+++ b/src/components/Table/components/CollapseToggle.test.tsx
@@ -46,4 +46,16 @@ describe("CollapseToggle", () => {
     `);
     expect(r.firstElement.firstElementChild).toBeNull();
   });
+
+  it("should render a labeled collapse", async () => {
+    const rowState = new TableState();
+    const r = await render(
+      <TableStateContext.Provider value={{ tableState: rowState }}>
+        <CollapseToggle label="customLabel" row={{ id: "r:1", kind: "otherKind", data: {}, children: [{} as any] }} />
+      </TableStateContext.Provider>,
+    );
+
+    expect(r.firstElement.firstElementChild).toBeInTheDocument();
+    expect(r.getByText("customLabel")).toBeInTheDocument();
+  });
 });

--- a/src/components/Table/components/CollapseToggle.test.tsx
+++ b/src/components/Table/components/CollapseToggle.test.tsx
@@ -48,14 +48,18 @@ describe("CollapseToggle", () => {
   });
 
   it("should render a labeled collapse", async () => {
+    // Given a table state
     const rowState = new TableState();
+    // When render it with a collapse toggle
     const r = await render(
       <TableStateContext.Provider value={{ tableState: rowState }}>
         <CollapseToggle label="customLabel" row={{ id: "r:1", kind: "otherKind", data: {}, children: [{} as any] }} />
       </TableStateContext.Provider>,
     );
 
+    // Then the element should be in the document
     expect(r.firstElement.firstElementChild).toBeInTheDocument();
+    // And the custom label should be displayed
     expect(r.getByText("customLabel")).toBeInTheDocument();
   });
 });

--- a/src/components/Table/components/CollapseToggle.tsx
+++ b/src/components/Table/components/CollapseToggle.tsx
@@ -1,14 +1,16 @@
 import { useContext } from "react";
 import { GridDataRow, IconButton, IconButtonProps, TableStateContext } from "src/components/index";
+import { Css } from "src/Css";
 import { useComputed } from "src/hooks";
 
 export interface GridTableCollapseToggleProps extends Pick<IconButtonProps, "compact"> {
   row: GridDataRow<any>;
+  label?: string;
 }
 
 /** Provides a chevron icons to collapse/un-collapse for parent/child tables. */
 export function CollapseToggle(props: GridTableCollapseToggleProps) {
-  const { row, compact } = props;
+  const { row, compact, label } = props;
   const { tableState } = useContext(TableStateContext);
 
   const isCollapsed = useComputed(() => tableState.isCollapsed(row.id), [tableState]);
@@ -21,11 +23,16 @@ export function CollapseToggle(props: GridTableCollapseToggleProps) {
     return null;
   }
 
+  const onClickToggleCollapsed = () => tableState.toggleCollapsed(row.id);
+
   return (
-    <IconButton
-      onClick={() => tableState.toggleCollapsed(row.id)}
-      icon={isHeader ? headerIconKey : iconKey}
-      compact={compact}
-    />
+    <>
+      {label ? (
+        <span css={Css.cursorPointer.$} onClick={onClickToggleCollapsed}>
+          {label}
+        </span>
+      ) : null}
+      <IconButton onClick={onClickToggleCollapsed} icon={isHeader ? headerIconKey : iconKey} compact={compact} />
+    </>
   );
 }


### PR DESCRIPTION
[Hack Day Ticket](https://app.shortcut.com/homebound-team/story/25686/add-label-property-to-collapsetoggle-beam-component)

- Added a new label property to CollapseToggle component which includes a new clickable text to the collapse icon. 

![ezgif-5-0b6e8626c8](https://user-images.githubusercontent.com/108748822/202768088-8c5f42c7-9b75-403d-ab58-a5f01074f51e.gif)

