### PR TITLE
feat: HackDay: Add xs loader; Button allow change icons on async

### DIFF
--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
 import { capitalCase } from "change-case";
-import { Button, ButtonSize, ButtonVariant } from "src";
+import { Button, ButtonSize, ButtonVariant, Icon, Loader } from "src";
 import { Css } from "src/Css";
 import { withRouter } from "src/utils/sb";
 
@@ -151,10 +151,31 @@ export function ButtonWithTooltip() {
 }
 
 export function AsyncButton() {
+  const ea = <Icon icon={"cloudUpload"} />;
+  const eaInFlight = <Loader size="xs" />;
+  const label = "Upload";
+  const labelInFlight = "Uploading";
+  const icon = "archive";
+  const iconInFlight = "sunny";
+
   return (
-    <div>
-      <h2>Clicking the button will disable it for 2 seconds (while async request is in progress)</h2>
-      <Button label="Upload" onClick={async () => await new Promise((resolve) => setTimeout(resolve, 2000))} />
-    </div>
+    <>
+      <div>
+        <h2>Clicking the button will disable it for 2 seconds (while async request is in progress)</h2>
+        <Button label="Upload" onClick={async () => await new Promise((resolve) => setTimeout(resolve, 2000))} />
+      </div>
+      <div css={Css.mt4.$}>
+        <h2>Additional Props may be passed in to further customize in flight look</h2>
+        <Button
+          label={label}
+          endAdornment={ea}
+          icon={icon}
+          inFlightEndAdornment={eaInFlight}
+          inFlightIcon={iconInFlight}
+          inFlightLabel={labelInFlight}
+          onClick={async () => await new Promise((resolve) => setTimeout(resolve, 2000))}
+        />
+      </div>
+    </>
   );
 }

--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
 import { capitalCase } from "change-case";
-import { Button, ButtonSize, ButtonVariant, Icon, Loader } from "src";
+import { Button, ButtonSize, ButtonVariant, Icon } from "src";
 import { Css } from "src/Css";
 import { withRouter } from "src/utils/sb";
 
@@ -151,31 +151,41 @@ export function ButtonWithTooltip() {
 }
 
 export function AsyncButton() {
-  const ea = <Icon icon={"cloudUpload"} />;
-  const eaInFlight = <Loader size="xs" />;
-  const label = "Upload";
-  const labelInFlight = "Uploading";
-  const icon = "archive";
-  const iconInFlight = "sunny";
-
   return (
     <>
       <div>
-        <h2>Clicking the button will disable it for 2 seconds (while async request is in progress)</h2>
+        <h2>
+          Clicking the button will disable it for 2 seconds (while async request is in progress) and show a loading icon
+        </h2>
         <Button label="Upload" onClick={async () => await new Promise((resolve) => setTimeout(resolve, 2000))} />
       </div>
       <div css={Css.mt4.$}>
-        <h2>Additional Props may be passed in to further customize in flight look</h2>
+        <h2>An Inflight label may be provided. End adornments are replaced with spinner</h2>
         <Button
-          label={label}
-          endAdornment={ea}
-          icon={icon}
-          inFlightEndAdornment={eaInFlight}
-          inFlightIcon={iconInFlight}
-          inFlightLabel={labelInFlight}
+          label="Upload"
+          endAdornment={<Icon icon={"cloudUpload"} />}
+          icon="templates"
+          labelInFlight="Uploading"
           onClick={async () => await new Promise((resolve) => setTimeout(resolve, 2000))}
         />
       </div>
     </>
   );
 }
+export function ConstrastAsyncButton() {
+  return (
+    <div css={Css.white.$}>
+      <h2 css={Css.mb2.$}>Contrast is also passed to spinner</h2>
+      <Button
+        label="Upload"
+        endAdornment={<Icon icon={"cloudUpload"} />}
+        icon="templates"
+        labelInFlight="Uploading"
+        onClick={async () => await new Promise((resolve) => setTimeout(resolve, 2000))}
+        contrast
+      />
+    </div>
+  );
+}
+
+ConstrastAsyncButton.parameters = { backgrounds: { default: "dark" } };

--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -98,11 +98,11 @@ describe("Button", () => {
     expect(onError).toBeCalledWith("Promise error");
   });
 
-  it("changes button label, adornment, and icon if present while onClick is in flight and reverts it after a successful promise", async () => {
+  it("changes button label if present while async onClick is in flight and reverts it after a successful promise", async () => {
     const r = await render(
       <Button
         label="Button"
-        inFlightLabel="Watch The Button Fly"
+        labelInFlight="Watch The Button Fly"
         onClick={async () => new Promise((resolve) => resolve())}
       />,
     );

--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -97,4 +97,24 @@ describe("Button", () => {
     expect(r.button()).not.toBeDisabled();
     expect(onError).toBeCalledWith("Promise error");
   });
+
+  it("changes button label, adornment, and icon if present while onClick is in flight and reverts it after a successful promise", async () => {
+    const r = await render(
+      <Button
+        label="Button"
+        inFlightLabel="Watch The Button Fly"
+        onClick={async () => new Promise((resolve) => resolve())}
+      />,
+    );
+    expect(r.button()).toHaveTextContent("Button");
+
+    click(r.button, { allowAsync: true });
+    expect(r.button()).toBeDisabled();
+    expect(r.button()).toHaveTextContent("Watch The Button Fly");
+
+    await wait();
+
+    expect(r.button()).not.toBeDisabled();
+    expect(r.button()).toHaveTextContent("Button");
+  });
 });

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -23,6 +23,11 @@ export interface ButtonProps extends BeamButtonProps, BeamFocusableProps {
   /** Denotes if this button is used to download a resource. Uses the anchor tag with the `download` attribute */
   download?: boolean;
   contrast?: boolean;
+
+  // Additional icon and text to further customize buttons whyle async request is in progress.
+  inFlightEndAdornment?: ReactNode;
+  inFlightIcon?: IconProps["icon"] | null;
+  inFlightLabel?: string;
 }
 
 export function Button(props: ButtonProps) {
@@ -36,6 +41,9 @@ export function Button(props: ButtonProps) {
     download,
     contrast = false,
     forceFocusStyles = false,
+    inFlightEndAdornment,
+    inFlightIcon,
+    inFlightLabel,
     ...otherProps
   } = props;
   const asLink = typeof onPress === "string";
@@ -79,9 +87,11 @@ export function Button(props: ButtonProps) {
 
   const buttonContent = (
     <>
-      {icon && <Icon xss={iconStyles[size]} icon={icon} />}
-      {label}
-      {endAdornment && <span css={Css.ml1.$}>{endAdornment}</span>}
+      {icon && <Icon xss={iconStyles[size]} icon={inFlightIcon && asyncInProgress ? inFlightIcon : icon} />}
+      {inFlightLabel && asyncInProgress ? inFlightLabel : label}
+      {endAdornment && (
+        <span css={Css.ml1.$}>{inFlightEndAdornment && asyncInProgress ? inFlightEndAdornment : endAdornment}</span>
+      )}
     </>
   );
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -89,8 +89,8 @@ export function Button(props: ButtonProps) {
     <>
       {icon && <Icon xss={iconStyles[size]} icon={inFlightIcon && asyncInProgress ? inFlightIcon : icon} />}
       {inFlightLabel && asyncInProgress ? inFlightLabel : label}
-      {endAdornment && (
-        <span css={Css.ml1.$}>{inFlightEndAdornment && asyncInProgress ? inFlightEndAdornment : endAdornment}</span>
+      {(endAdornment || asyncInProgress) && (
+        <span css={Css.ml1.$}>{asyncInProgress ? inFlightEndAdornment : endAdornment}</span>
       )}
     </>
   );

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,7 +1,7 @@
 import { AriaButtonProps } from "@react-types/button";
 import { ButtonHTMLAttributes, ReactNode, RefObject, useMemo, useRef, useState } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
-import { Icon, IconProps, maybeTooltip, navLink, resolveTooltip } from "src/components";
+import { Icon, IconProps, Loader, maybeTooltip, navLink, resolveTooltip } from "src/components";
 import { Css, Palette } from "src/Css";
 import { BeamButtonProps, BeamFocusableProps } from "src/interfaces";
 import { isAbsoluteUrl, isPromise, noop } from "src/utils";
@@ -24,10 +24,8 @@ export interface ButtonProps extends BeamButtonProps, BeamFocusableProps {
   download?: boolean;
   contrast?: boolean;
 
-  // Additional icon and text to further customize buttons whyle async request is in progress.
-  inFlightEndAdornment?: ReactNode;
-  inFlightIcon?: IconProps["icon"] | null;
-  inFlightLabel?: string;
+  /** Additional text to further customize button during an async request is in progress. */
+  labelInFlight?: string;
 }
 
 export function Button(props: ButtonProps) {
@@ -41,9 +39,7 @@ export function Button(props: ButtonProps) {
     download,
     contrast = false,
     forceFocusStyles = false,
-    inFlightEndAdornment,
-    inFlightIcon,
-    inFlightLabel,
+    labelInFlight,
     ...otherProps
   } = props;
   const asLink = typeof onPress === "string";
@@ -87,10 +83,10 @@ export function Button(props: ButtonProps) {
 
   const buttonContent = (
     <>
-      {icon && <Icon xss={iconStyles[size]} icon={inFlightIcon && asyncInProgress ? inFlightIcon : icon} />}
-      {inFlightLabel && asyncInProgress ? inFlightLabel : label}
+      {icon && <Icon xss={iconStyles[size]} icon={icon} />}
+      {labelInFlight && asyncInProgress ? labelInFlight : label}
       {(endAdornment || asyncInProgress) && (
-        <span css={Css.ml1.$}>{asyncInProgress ? inFlightEndAdornment : endAdornment}</span>
+        <span css={Css.ml1.$}>{asyncInProgress ? <Loader size={"xs"} contrast={contrast} /> : endAdornment}</span>
       )}
     </>
   );

--- a/src/components/Loader.stories.tsx
+++ b/src/components/Loader.stories.tsx
@@ -9,6 +9,7 @@ export default {
 function Loaders(contrast: boolean = false) {
   return (
     <div css={Css.df.fdc.gap3.$}>
+      <Loader contrast={contrast} size="xs" />
       <Loader contrast={contrast} size="sm" />
       <Loader contrast={contrast} size="md" />
       <Loader contrast={contrast} />

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,7 +1,7 @@
 import { Css, Palette } from "src/Css";
 
 interface LoaderProps {
-  size?: "sm" | "md" | "lg";
+  size?: "xs" | "sm" | "md" | "lg";
   contrast?: boolean;
 }
 
@@ -30,8 +30,9 @@ export function Loader({ size = "lg", contrast = false }: LoaderProps) {
   );
 }
 
-type LoaderSize = "sm" | "md" | "lg";
+type LoaderSize = "xs" | "sm" | "md" | "lg";
 const sizeToPixels: Record<LoaderSize, [number, number]> = {
+  xs: [16, 2],
   sm: [32, 4],
   md: [64, 8],
   lg: [96, 12],


### PR DESCRIPTION
[SC-25242](https://app.shortcut.com/homebound-team/story/25242/fe-beam)

Spending Hackday updating some libraries and doing cleanup for Underwriting app. 

The async button changes felt like a natural progression since we're automatically disabling it in flight already.