### PR TITLE
feat: SC-22120 Init active row

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1138,6 +1138,47 @@ export function ToggleCustomCollapse() {
   );
 }
 
+export function InitActiveRow() {
+  const nameColumn: GridColumn<RowWithTotals> = {
+    header: "Name",
+    totals: "Totals",
+    data: ({ name }) => name,
+  };
+  const valueColumn: GridColumn<RowWithTotals> = {
+    header: "Value",
+    totals: ({ value }) => value,
+    data: ({ value }) => value,
+  };
+  const actionColumn: GridColumn<RowWithTotals> = { header: "Actions", totals: "", data: "Actions"};
+  const rows: GridDataRow<RowWithTotals>[] = useMemo(
+    () => [
+      { kind: "totals", id: "totals", data: { value: 100 } },
+      simpleHeader,
+      ...zeroTo(15).map((i) => ({ kind: "data" as const, id: String(i), data: { name: `Name ${i}`, value: i } })),
+    ],
+    [],
+  );
+
+  const api = useGridTableApi<RowWithTotals>();
+  return (
+    <div css={Css.wPx(500).hPx(500).$}>
+      <GridTable
+        columns={[
+          nameColumn,
+          valueColumn,
+          actionColumn,
+        ]}
+        stickyHeader
+        rows={rows}
+        as="virtual"
+        api={api}
+        initActiveRow={true}
+        activeRowId="data_10"
+      />
+    </div>
+  );
+}
+
 type ExpandHeader = { id: "expandableHeader"; kind: "expandableHeader" };
 type Header = { id: "header"; kind: "header" };
 type ExpandableData = {

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -157,6 +157,8 @@ export interface GridTableProps<R extends Kinded, X> {
    * This is beneficial when looking at the same table, but of a different subject (i.e. Project A's PreCon Schedule vs Project A's Construction schedule)
    */
   visibleColumnsStorageKey?: string;
+  /** Scroll to active row if it set as true */
+  initActiveRow?: boolean;
 }
 
 /**
@@ -196,6 +198,7 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = {}
     activeRowId,
     activeCellId,
     visibleColumnsStorageKey,
+    initActiveRow,
   } = props;
 
   const columnsWithIds = useMemo(() => assignDefaultColumnIds(_columns), [_columns]);
@@ -347,6 +350,13 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = {}
 
     return [headerRows, visibleDataRows, totalsRows, expandableHeaderRows, filteredRowIds];
   }, [as, api, filter, maybeSorted, columns, style, rowStyles, sortOn, columnSizes, collapsedIds, getCount]);
+
+  // Scroll to index of activeRowId if initActiveRow is set
+  if(initActiveRow && activeRowId){
+    const index = visibleDataRows.map((row)=> row[0]).findIndex(row => row.id === activeRowId.split("_")[1]);
+    if(index > 0)
+      api.scrollToIndex(index);
+  }
 
   // Once our header rows are created we can organize them in expected order.
   const tableHeadRows = totalsRows.concat(expandableHeaderRows).concat(headerRows);


### PR DESCRIPTION
[SC-22120](https://app.shortcut.com/homebound-team/story/22120/maintain-schedule-view-after-refreshing)

**Description**
In order to maintain the scroll position of the table when the page is refreshing, add a initActiveRow prop to GridTable to scroll to index of active row is it is set

