### PR TITLE
fix: Fix styling of button group when using tooltips

### DIFF
--- a/src/components/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup.stories.tsx
@@ -44,6 +44,7 @@ export function ButtonGroups() {
         <ButtonGroup
           buttons={[
             { text: "Leading", tooltip: "Active Tooltip" },
+            { text: "Middle" },
             { text: "Trailing", disabled: "Disabled Reason" },
           ]}
         />

--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -29,7 +29,7 @@ export function ButtonGroup(props: ButtonGroupProps) {
   const { buttons, disabled = false, size = "sm" } = props;
   const tid = useTestIds(props, "buttonGroup");
   return (
-    <div {...tid} css={{ ...Css.df.$, ...sizeStyles[size] }}>
+    <div {...tid} css={Css.df.add(sizeStyles[size]).$}>
       {buttons.map(({ disabled: buttonDisabled, ...buttonProps }, i) => (
         // Disable the button if the ButtonGroup is disabled or if the current button is disabled.
         <GroupButton key={i} {...buttonProps} disabled={disabled || buttonDisabled} size={size} {...tid} />

--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -63,9 +63,8 @@ function GroupButton(props: GroupButtonProps) {
             {...focusProps}
             {...hoverProps}
             css={{
-              ...Css.buttonBase.px2.br0.$,
+              ...Css.buttonBase.px2.br0.h100.$,
               "&:disabled": Css.gray400.cursorNotAllowed.bGray300.$,
-              ...sizeStyles[size],
               ...(isFocusVisible ? defaultFocusRingStyles : {}),
               ...(active ? activeStyles : {}),
               ...(isPressed ? pressedStyles : isHovered ? hoverStyles : {}),

--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -29,7 +29,7 @@ export function ButtonGroup(props: ButtonGroupProps) {
   const { buttons, disabled = false, size = "sm" } = props;
   const tid = useTestIds(props, "buttonGroup");
   return (
-    <div {...tid} css={sizeStyles[size]}>
+    <div {...tid} css={{ ...Css.df.$, ...sizeStyles[size] }}>
       {buttons.map(({ disabled: buttonDisabled, ...buttonProps }, i) => (
         // Disable the button if the ButtonGroup is disabled or if the current button is disabled.
         <GroupButton key={i} {...buttonProps} disabled={disabled || buttonDisabled} size={size} {...tid} />
@@ -51,31 +51,35 @@ function GroupButton(props: GroupButtonProps) {
   const { hoverProps, isHovered } = useHover(ariaProps);
   const tid = useTestIds(props);
 
-  return maybeTooltip({
-    title: resolveTooltip(disabled, tooltip),
-    placement: "top",
-    children: (
-      <button
-        ref={ref}
-        {...buttonProps}
-        {...focusProps}
-        {...hoverProps}
-        css={{
-          ...Css.buttonBase.$,
-          ...getButtonStyles(),
-          ...sizeStyles[size],
-          ...(isFocusVisible ? defaultFocusRingStyles : {}),
-          ...(active ? activeStyles : {}),
-          ...(isPressed ? pressedStyles : isHovered ? hoverStyles : {}),
-          ...(icon ? iconStyles[size] : {}),
-        }}
-        {...tid[defaultTestId(text ?? icon ?? "button")]}
-      >
-        {icon && <Icon icon={icon} />}
-        {text}
-      </button>
-    ),
-  });
+  return (
+    <span css={getButtonStyles()}>
+      {maybeTooltip({
+        title: resolveTooltip(disabled, tooltip),
+        placement: "top",
+        children: (
+          <button
+            ref={ref}
+            {...buttonProps}
+            {...focusProps}
+            {...hoverProps}
+            css={{
+              ...Css.buttonBase.px2.br0.$,
+              "&:disabled": Css.gray400.cursorNotAllowed.bGray300.$,
+              ...sizeStyles[size],
+              ...(isFocusVisible ? defaultFocusRingStyles : {}),
+              ...(active ? activeStyles : {}),
+              ...(isPressed ? pressedStyles : isHovered ? hoverStyles : {}),
+              ...(icon ? iconStyles[size] : {}),
+            }}
+            {...tid[defaultTestId(text ?? icon ?? "button")]}
+          >
+            {icon && <Icon icon={icon} />}
+            {text}
+          </button>
+        ),
+      })}
+    </span>
+  );
 }
 
 const pressedStyles = Css.bgGray200.$;
@@ -85,8 +89,7 @@ const defaultFocusRingStyles = Css.relative.z2.bshFocus.$;
 
 function getButtonStyles() {
   return {
-    ...Css.z1.px2.bgWhite.bGray300.bw1.ba.gray900.br0.$,
-    "&:disabled": Css.gray400.cursorNotAllowed.bGray300.$,
+    ...Css.z1.bgWhite.bGray300.bw1.ba.gray900.br0.overflowHidden.$,
     // Our first button should have a rounded left border
     "&:first-of-type": Css.add("borderRadius", "4px 0 0 4px").$,
     // Our last button should have a rounded right border


### PR DESCRIPTION
## Before
<img width="208" alt="Screen Shot 2022-12-02 at 1 18 09 PM" src="https://user-images.githubusercontent.com/1143861/205359646-5856f630-4f47-4d2f-b2cb-510fc3599316.png">

## After
<img width="269" alt="Screen Shot 2022-12-02 at 1 18 18 PM" src="https://user-images.githubusercontent.com/1143861/205359625-c7e6306e-2c7a-4394-b4f3-b7b5ce442888.png">
