### PR TITLE
feat: ButtonGroup 'xs' size

### DIFF
--- a/src/components/ButtonGroup.stories.tsx
+++ b/src/components/ButtonGroup.stories.tsx
@@ -18,16 +18,23 @@ export function ButtonGroups() {
     <div css={Css.df.fdc.gap2.$}>
       <div>
         <h2>Icon Only</h2>
+        <ButtonGroup size="xs" buttons={[{ icon: "chevronLeft" }, { icon: "plus" }, { icon: "chevronRight" }]} />
         <ButtonGroup buttons={[{ icon: "chevronLeft" }, { icon: "plus" }, { icon: "chevronRight" }]} />
         <ButtonGroup size="md" buttons={[{ icon: "chevronLeft" }, { icon: "plus" }, { icon: "chevronRight" }]} />
       </div>
       <div>
         <h2>Basic</h2>
+        <ButtonGroup size="xs" buttons={[{ text: "Leading" }, { text: "Middle" }, { text: "Trailing" }]} />
         <ButtonGroup buttons={[{ text: "Leading" }, { text: "Middle" }, { text: "Trailing" }]} />
         <ButtonGroup size="md" buttons={[{ text: "Leading" }, { text: "Middle" }, { text: "Trailing" }]} />
       </div>
       <div>
         <h2>Active</h2>
+
+        <ButtonGroup
+          size="xs"
+          buttons={[{ text: "Leading", active: true }, { text: "Middle" }, { text: "Trailing" }]}
+        />
         <ButtonGroup buttons={[{ text: "Leading", active: true }, { text: "Middle" }, { text: "Trailing" }]} />
         <ButtonGroup
           size="md"
@@ -36,6 +43,7 @@ export function ButtonGroups() {
       </div>
       <div>
         <h2>Disabled</h2>
+        <ButtonGroup size="xs" disabled buttons={[{ text: "Leading" }, { text: "Middle" }, { text: "Trailing" }]} />
         <ButtonGroup disabled buttons={[{ text: "Leading" }, { text: "Middle" }, { text: "Trailing" }]} />
         <ButtonGroup size="md" disabled buttons={[{ text: "Leading" }, { text: "Middle" }, { text: "Trailing" }]} />
       </div>

--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -99,13 +99,15 @@ function getButtonStyles() {
 }
 
 const sizeStyles: Record<ButtonGroupSize, {}> = {
+  xs: Css.hPx(28).$,
   sm: Css.hPx(32).$,
   md: Css.hPx(40).$,
 };
 
 const iconStyles: Record<ButtonGroupSize, {}> = {
+  xs: Css.pxPx(2).$,
   sm: Css.pxPx(4).$,
   md: Css.px1.$,
 };
 
-type ButtonGroupSize = "sm" | "md";
+type ButtonGroupSize = "xs" | "sm" | "md";


### PR DESCRIPTION
In Blueprint, the Schedules page was reaching into the component to make the button group smaller. This caused problems when changing the markup of the ButtonGroup component. Instead of trying to rework those styles reaching into Beam, we are not supporting a smaller size.