### PR TITLE
fix: Avoid inheriting line-height in ButtonGroup

### DIFF
--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -29,7 +29,8 @@ export function ButtonGroup(props: ButtonGroupProps) {
   const { buttons, disabled = false, size = "sm" } = props;
   const tid = useTestIds(props, "buttonGroup");
   return (
-    <div {...tid} css={Css.df.add(sizeStyles[size]).$}>
+    // Adding `line-height: 0` prevent inheriting line-heights that might throw off sizing within the button group.
+    <div {...tid} css={Css.df.lh(0).add(sizeStyles[size]).$}>
       {buttons.map(({ disabled: buttonDisabled, ...buttonProps }, i) => (
         // Disable the button if the ButtonGroup is disabled or if the current button is disabled.
         <GroupButton key={i} {...buttonProps} disabled={disabled || buttonDisabled} size={size} {...tid} />


### PR DESCRIPTION
In the below examples, the line-height is being inherited from the ModalHeader component, causing `<span/>` elements that wrap each button to be taller than they should.

#### Before
<img width="815" alt="Screen Shot 2022-12-06 at 8 28 19 PM" src="https://user-images.githubusercontent.com/1143861/206065356-240c9537-18dd-44b2-9aae-d278dbccd098.png">

#### After
<img width="803" alt="Screen Shot 2022-12-06 at 8 28 43 PM" src="https://user-images.githubusercontent.com/1143861/206065339-f53b6f7f-ce08-4a98-85c8-e844068c7073.png">
