### PR TITLE
fix: Add export to Checkbox Filter

### DIFF
--- a/src/components/Filters/index.ts
+++ b/src/components/Filters/index.ts
@@ -6,6 +6,7 @@ export { numberRangeFilter } from "src/components/Filters/NumberRangeFilter";
 export { multiFilter } from "src/components/Filters/MultiFilter";
 export { singleFilter } from "src/components/Filters/SingleFilter";
 export { booleanFilter } from "./BooleanFilter";
+export { checkboxFilter } from "./CheckboxFilter";
 export * from "./FilterModal";
 export * from "./Filters";
 export { toggleFilter } from "./ToggleFilter";


### PR DESCRIPTION
- Accidentally left out the export to use the new `CheckboxFilter`