### PR TITLE
fix: [sc-26428] Expose numberFormatOptions prop in NumberRangeFilter;

### DIFF
--- a/src/components/Filters/NumberRangeFilter.tsx
+++ b/src/components/Filters/NumberRangeFilter.tsx
@@ -11,6 +11,8 @@ export type NumberRangeFilterProps<DV extends NumberRangeFilterValue> = {
   label: string;
   numberFieldType?: NumberFieldType;
   defaultValue?: DV;
+  // Support edge cases. Overrides numberFieldType
+  numberFormatOptions?: Intl.NumberFormatOptions;
 };
 
 export type NumberRangeFilterValue = { min: number; max: number };
@@ -26,7 +28,7 @@ class NumberRangeFilter<DV extends NumberRangeFilterValue>
   implements Filter<DV>
 {
   render(value: DV, setValue: (value: DV | undefined) => void, tid: TestIds, inModal: boolean, vertical: boolean) {
-    const { label, numberFieldType } = this.props;
+    const { label, numberFieldType, numberFormatOptions } = this.props;
     const min = value?.min ?? undefined;
     const max = value?.max ?? undefined;
 
@@ -43,6 +45,7 @@ class NumberRangeFilter<DV extends NumberRangeFilterValue>
                 label="Min"
                 value={min}
                 type={numberFieldType}
+                numberFormatOptions={numberFormatOptions}
                 onChange={(minVal) => {
                   const maxValue = max ? { max } : {};
                   setValue(minVal || max ? ({ min: minVal, ...maxValue } as DV) : undefined);
@@ -56,6 +59,7 @@ class NumberRangeFilter<DV extends NumberRangeFilterValue>
               label="Max"
               value={max}
               type={numberFieldType}
+              numberFormatOptions={numberFormatOptions}
               onChange={(maxVal) => {
                 const minValue = min ? { min } : {};
                 setValue(maxVal || min ? ({ max: maxVal, ...minValue } as DV) : undefined);
@@ -77,6 +81,7 @@ class NumberRangeFilter<DV extends NumberRangeFilterValue>
               label={!inModal ? `${label} Min` : "Min"}
               value={min}
               type={numberFieldType}
+              numberFormatOptions={numberFormatOptions}
               onChange={(minVal) => {
                 const maxValue = max ? { max } : {};
                 setValue(minVal || max ? ({ min: minVal, ...maxValue } as DV) : undefined);
@@ -91,6 +96,7 @@ class NumberRangeFilter<DV extends NumberRangeFilterValue>
               label={!inModal ? `${label} Max` : "Max"}
               value={max}
               type={numberFieldType}
+              numberFormatOptions={numberFormatOptions}
               onChange={(maxVal) => {
                 const minValue = min ? { min } : {};
                 setValue(maxVal || min ? ({ max: maxVal, ...minValue } as DV) : undefined);


### PR DESCRIPTION
Story details: https://app.shortcut.com/homebound-team/story/26428


<img width="944" alt="Screenshot 2023-01-03 at 4 50 48 PM" src="https://user-images.githubusercontent.com/108819408/210458892-cb3d20b7-6b77-4be8-876d-b1e68dec3ae9.png">

We're using numberRangeFilter for a year value and dont need the formatting. This is a quicker fix than updating the DatePicker to have a year-only option  and bubbling that up to be useable by a DateRangeFilter component