### PR TITLE
chore: lint, vscode fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-  extends: ["react-app", "plugin:storybook/recommended", "@homebound/eslint-config/react"],
+  extends: ["@homebound/eslint-config/react", "plugin:storybook/recommended"],
 };

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["dbaeumer.vscode-eslint"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,6 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "eslint.format.enable": true,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
-  "eslint.alwaysShowStatus": true,
   "[typescript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "eslint.format.enable": true,
+  "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "eslint.alwaysShowStatus": true,
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  }
+}

--- a/src/components/AutoSaveIndicator.test.tsx
+++ b/src/components/AutoSaveIndicator.test.tsx
@@ -19,6 +19,7 @@ describe(AutoSaveIndicator, () => {
 
     const iconElement = r.container.querySelector(`[data-icon=${iconName}]`)!;
     expect(iconElement).toBeInTheDocument();
+    // eslint-disable-next-line jest/no-conditional-expect
     if (helperText) expect(iconElement.nextSibling?.textContent).toMatch(helperText);
   });
 

--- a/src/components/AvatarButton.tsx
+++ b/src/components/AvatarButton.tsx
@@ -1,9 +1,10 @@
 import { AriaButtonProps } from "@react-types/button";
-import { RefObject, useMemo, useRef } from "react";
+import { RefObject, useMemo } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
 import { maybeTooltip, navLink, resolveTooltip } from "src/components";
 import { Avatar, AvatarProps } from "src/components/Avatar";
 import { Css, Palette } from "src/Css";
+import { useGetRef } from "src/hooks/useGetRef";
 import { BeamButtonProps, BeamFocusableProps } from "src/interfaces";
 import { noop } from "src/utils";
 import { getButtonOrLink } from "src/utils/getInteractiveElement";
@@ -28,8 +29,7 @@ export function AvatarButton(props: AvatarButtonProps) {
   } = props;
   const isDisabled = !!disabled;
   const ariaProps = { onPress, isDisabled, autoFocus, ...menuTriggerProps };
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const ref = buttonRef || useRef(null);
+  const ref = useGetRef(buttonRef);
   const { buttonProps, isPressed } = useButton(
     {
       ...ariaProps,

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,8 +1,9 @@
 import { AriaButtonProps } from "@react-types/button";
-import { ButtonHTMLAttributes, ReactNode, RefObject, useMemo, useRef, useState } from "react";
+import { ButtonHTMLAttributes, ReactNode, RefObject, useMemo, useState } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
 import { Icon, IconProps, Loader, maybeTooltip, navLink, resolveTooltip } from "src/components";
 import { Css, Palette, Properties } from "src/Css";
+import { useGetRef } from "src/hooks/useGetRef";
 import { BeamButtonProps, BeamFocusableProps } from "src/interfaces";
 import { isAbsoluteUrl, isPromise, noop } from "src/utils";
 import { getButtonOrLink } from "src/utils/getInteractiveElement";
@@ -56,7 +57,7 @@ export function Button(props: ButtonProps) {
     size = "sm",
     buttonRef,
   } = ariaProps;
-  const ref = buttonRef || useRef(null);
+  const ref = useGetRef(buttonRef);
   const tid = useTestIds(props, labelOr(ariaProps, "button"));
   const { buttonProps, isPressed } = useButton(
     {

--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -2,7 +2,7 @@ import { ReactNode, useRef } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
 import { Icon, IconProps } from "src/components/Icon";
 import { maybeTooltip, resolveTooltip } from "src/components/Tooltip";
-import { Css } from "src/Css";
+import { Css, Properties } from "src/Css";
 import { useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
 
@@ -30,7 +30,7 @@ export function ButtonGroup(props: ButtonGroupProps) {
   const tid = useTestIds(props, "buttonGroup");
   return (
     // Adding `line-height: 0` prevent inheriting line-heights that might throw off sizing within the button group.
-    <div {...tid} css={Css.df.lh(0).add(sizeStyles[size]).$}>
+    <div {...tid} css={Css.df.lh(0).add({ ...sizeStyles[size] }).$}>
       {buttons.map(({ disabled: buttonDisabled, ...buttonProps }, i) => (
         // Disable the button if the ButtonGroup is disabled or if the current button is disabled.
         <GroupButton key={i} {...buttonProps} disabled={disabled || buttonDisabled} size={size} {...tid} />
@@ -99,13 +99,13 @@ function getButtonStyles() {
   };
 }
 
-const sizeStyles: Record<ButtonGroupSize, {}> = {
+const sizeStyles: Record<ButtonGroupSize, Properties> = {
   xs: Css.hPx(28).$,
   sm: Css.hPx(32).$,
   md: Css.hPx(40).$,
 };
 
-const iconStyles: Record<ButtonGroupSize, {}> = {
+const iconStyles: Record<ButtonGroupSize, Properties> = {
   xs: Css.pxPx(2).$,
   sm: Css.pxPx(4).$,
   md: Css.px1.$,

--- a/src/components/Filters/Filters.test.tsx
+++ b/src/components/Filters/Filters.test.tsx
@@ -7,7 +7,7 @@ describe("Filters", () => {
     type StageFilter = FilterDefs<ProjectFilter>["stage"];
     // type StageFilter = FilterDef<Stage[]>;
     // Then we can assign multiFilter to it
-    let f: StageFilter = multiFilter({
+    const f: StageFilter = multiFilter({
       options: [Stage.StageOne, Stage.StageTwo],
       getOptionValue: (s) => s,
       getOptionLabel: () => "name",
@@ -20,7 +20,7 @@ describe("Filters", () => {
     type StageFilter = FilterDefs<ProjectFilter>["stageSingle"];
     // type StageFilter = FilterDef<Stage>;
     // Then we can assign singleFilter to it
-    let f: StageFilter = singleFilter({
+    const f: StageFilter = singleFilter({
       options: [Stage.StageOne, Stage.StageTwo],
       getOptionValue: (s) => s,
       getOptionLabel: (s) => "name",
@@ -33,7 +33,7 @@ describe("Filters", () => {
     type FavoriteFilter = FilterDefs<ProjectFilter>["favorite"];
     // type StageFilter = FilterDef<Stage>;
     // Then we can assign singleFilter to it
-    let f: FavoriteFilter = booleanFilter({
+    const f: FavoriteFilter = booleanFilter({
       options: [
         [undefined, "All"],
         [true, "Favorited"],

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,8 +1,9 @@
 import { AriaButtonProps } from "@react-types/button";
-import { RefObject, useMemo, useRef } from "react";
+import { RefObject, useMemo } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
 import { Icon, IconProps, maybeTooltip, navLink, resolveTooltip } from "src/components";
 import { Css, Palette } from "src/Css";
+import { useGetRef } from "src/hooks/useGetRef";
 import { BeamButtonProps, BeamFocusableProps } from "src/interfaces";
 import { noop } from "src/utils";
 import { getButtonOrLink } from "src/utils/getInteractiveElement";
@@ -45,7 +46,7 @@ export function IconButton(props: IconButtonProps) {
   const isDisabled = !!disabled;
   const ariaProps = { onPress, isDisabled, autoFocus, ...menuTriggerProps };
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const ref = buttonRef || useRef(null);
+  const ref = useGetRef(buttonRef);
   const { buttonProps } = useButton(
     {
       ...ariaProps,

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -45,7 +45,6 @@ export function IconButton(props: IconButtonProps) {
   } = props;
   const isDisabled = !!disabled;
   const ariaProps = { onPress, isDisabled, autoFocus, ...menuTriggerProps };
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const ref = useGetRef(buttonRef);
   const { buttonProps } = useButton(
     {

--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { PropsWithChildren, ReactNode, useMemo, useState } from "react";
+import { ReactNode, useMemo, useState } from "react";
 import { IconButton } from "src/components/IconButton";
 import { TabsWithContent, TabWithContent } from "src/components/Tabs";
 import { Css, Palette } from "src/Css";
@@ -16,6 +16,7 @@ import {
   SimpleHeaderAndData,
 } from "src/index";
 import { NumberField } from "src/inputs/NumberField";
+import { ChildrenOnly } from "src/types";
 import { withBeamDecorator, withDimensions, withRouter, zeroTo } from "src/utils/sb";
 
 export default {
@@ -266,7 +267,7 @@ function VirutalizedPage() {
   );
 }
 
-function TestLayout({ children }: PropsWithChildren<{}>) {
+function TestLayout({ children }: ChildrenOnly) {
   return (
     <PreventBrowserScroll>
       <TestTopNav />
@@ -275,7 +276,7 @@ function TestLayout({ children }: PropsWithChildren<{}>) {
   );
 }
 
-function TestProjectLayout({ children }: PropsWithChildren<{}>) {
+function TestProjectLayout({ children }: ChildrenOnly) {
   return (
     <PreventBrowserScroll>
       <TestTopNav />

--- a/src/components/Layout/PreventBrowserScroll.tsx
+++ b/src/components/Layout/PreventBrowserScroll.tsx
@@ -1,8 +1,8 @@
-import { PropsWithChildren } from "react";
 import { Css } from "src/Css";
+import { ChildrenOnly } from "src/types";
 
 /** Intended to wrap the whole application to prevent the browser's native scrolling behavior while also taking the full height of the viewport */
-export function PreventBrowserScroll({ children }: PropsWithChildren<{}>) {
+export function PreventBrowserScroll({ children }: ChildrenOnly) {
   return (
     // Take over the full viewport and hide any overflown content.
     <div css={Css.overflowHidden.vh100.$}>

--- a/src/components/Layout/RightPaneLayout/RightPaneContext.tsx
+++ b/src/components/Layout/RightPaneLayout/RightPaneContext.tsx
@@ -8,7 +8,7 @@ export type RightPaneLayoutContextProps = {
   openInPane: (opts: OpenRightPaneOpts) => void;
   closePane: () => void;
   clearPane: () => void;
-  isRightPaneOpen: Boolean;
+  isRightPaneOpen: boolean;
   rightPaneContent: ReactNode;
 };
 
@@ -23,7 +23,7 @@ export const RightPaneContext = React.createContext<RightPaneLayoutContextProps>
 export function RightPaneProvider({ children }: { children: ReactNode }) {
   // Note: separating the pane content from isOpen state to prevent animating when updating content.
   const [rightPaneContent, setRightPaneContent] = useState<ReactNode>(undefined);
-  const [isRightPaneOpen, setIsRightPaneOpen] = useState<Boolean>(false);
+  const [isRightPaneOpen, setIsRightPaneOpen] = useState<boolean>(false);
 
   const openInPane = useCallback(
     (opts: OpenRightPaneOpts) => {

--- a/src/components/Layout/RightPaneLayout/RightPaneLayout.stories.tsx
+++ b/src/components/Layout/RightPaneLayout/RightPaneLayout.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta } from "@storybook/react";
-import { PropsWithChildren, useMemo } from "react";
+import { useMemo } from "react";
+import { ChildrenOnly } from "src/types";
 import { withBeamDecorator, zeroTo } from "src/utils/sb";
 import { Css } from "../../../Css";
 import { Button } from "../../Button";
@@ -67,7 +68,7 @@ function ExamplePageComponent() {
   );
 }
 
-function TestProjectLayout({ children }: PropsWithChildren<{}>) {
+function TestProjectLayout({ children }: ChildrenOnly) {
   return (
     <PreventBrowserScroll>
       <div css={Css.df.h100.overflowHidden.$}>

--- a/src/components/NavLink.stories.tsx
+++ b/src/components/NavLink.stories.tsx
@@ -37,7 +37,7 @@ export function BaseStates() {
   return (
     <div css={Css.df.gap2.$}>
       <div css={Css.df.fdc.gap2.p1.$}>
-        <a {...args} css={sideNavStyles.baseStyles}>
+        <a {...args} css={{ ...sideNavStyles.baseStyles }}>
           {getChildren("Side nav default")}
         </a>
         <a {...args} css={{ ...sideNavStyles.baseStyles, ...sideNavStyles.hoverStyles }}>
@@ -57,7 +57,7 @@ export function BaseStates() {
         </a>
       </div>
       <div css={Css.df.fdc.gap2.bgGray900.p1.br12.$}>
-        <a {...args} css={sideContrastNavStyles.baseStyles}>
+        <a {...args} css={{ ...sideContrastNavStyles.baseStyles }}>
           {getChildren("Side contrast nav default")}
         </a>
         <a {...args} css={{ ...sideContrastNavStyles.baseStyles, ...sideContrastNavStyles.hoverStyles }}>
@@ -77,7 +77,7 @@ export function BaseStates() {
         </a>
       </div>
       <div css={Css.df.fdc.gap2.p1.$}>
-        <a {...args} css={globalNavStyles.baseStyles}>
+        <a {...args} css={{ ...globalNavStyles.baseStyles }}>
           {getChildren("Global nav default")}
         </a>
         <a {...args} css={{ ...globalNavStyles.baseStyles, ...globalNavStyles.hoverStyles }}>

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -3,7 +3,7 @@ import { mergeProps, useButton, useFocusRing, useHover } from "react-aria";
 import { Link } from "react-router-dom";
 import type { IconKey } from "src/components";
 import { navLink } from "src/components";
-import { Css } from "src/Css";
+import { Css, Properties } from "src/Css";
 import { BeamFocusableProps } from "src/interfaces";
 import { isAbsoluteUrl } from "src/utils";
 import { Icon } from "./Icon";
@@ -87,11 +87,16 @@ export function getNavLinkStyles(variant: NavLinkVariant, contrast: boolean) {
 
 const baseStyles = Css.df.aic.hPx(32).pyPx(6).px1.br4.smMd.outline0.$;
 
-const navLinkVariantStyles: (
-  contrast: boolean,
-) => Record<
+const navLinkVariantStyles: (contrast: boolean) => Record<
   NavLinkVariant,
-  { baseStyles: {}; hoverStyles: {}; disabledStyles: {}; focusRingStyles: {}; activeStyles: {}; pressedStyles: {} }
+  {
+    baseStyles: Properties;
+    hoverStyles: Properties;
+    disabledStyles: Properties;
+    focusRingStyles: Properties;
+    activeStyles: Properties;
+    pressedStyles: Properties;
+  }
 > = (contrast) => ({
   side: {
     baseStyles: { ...baseStyles, ...Css.gray700.if(contrast).gray600.$ },

--- a/src/components/Snackbar/SnackbarContext.tsx
+++ b/src/components/Snackbar/SnackbarContext.tsx
@@ -1,5 +1,6 @@
-import React, { createContext, PropsWithChildren, useContext, useMemo, useState } from "react";
+import React, { createContext, useContext, useMemo, useState } from "react";
 import { SnackbarNoticeProps } from "src/components/Snackbar/SnackbarNotice";
+import { ChildrenOnly } from "src/types";
 import { Offset, Snackbar } from "./Snackbar";
 
 export type SnackbarContextProps = {
@@ -9,7 +10,7 @@ export type SnackbarContextProps = {
 
 export const SnackbarContext = createContext<SnackbarContextProps>({ setNotices: () => {}, setOffset: () => {} });
 
-export function SnackbarProvider(props: PropsWithChildren<{}>) {
+export function SnackbarProvider(props: ChildrenOnly) {
   const [notices, setNotices] = useState<SnackbarNoticeProps[]>([]);
   const [offset, setOffset] = useState<Offset>({});
   const contextValue = useMemo(() => ({ setNotices, setOffset }), []);

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1002,7 +1002,6 @@ export function PrimaryColumnSorting() {
     clientSideSort: false,
   };
 
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const [filter, setFilter] = useState<string | undefined>();
   return (
     <div>

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -889,7 +889,7 @@ describe("GridTable", () => {
       );
     });
 
-    it("as=virtual accepts percentages ", () => {
+    it("as=virtual accepts percentages", () => {
       expect(calcColumnSizes([{ w: "10%" }, { w: 2 }] as any, undefined, undefined, []).join(" ")).toEqual(
         "10% ((100% - 10% - 0px) * (2 / 2))",
       );
@@ -2072,7 +2072,7 @@ describe("GridTable", () => {
     await render(<GridTable rows={[row1]} columns={columns} />);
   });
 
-  it("provides a per-row render count ", async () => {
+  it("provides a per-row render count", async () => {
     const [header, row1, row2] = rows;
     const columns = [nameColumn];
 

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -175,7 +175,7 @@ export interface GridTableProps<R extends Kinded, X> {
  * row `kind` along with the data rows. (Admittedly, out of pragmatism, we do apply some
  * special styling to the row that uses `kind: "header"`.)
  */
-export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = {}>(props: GridTableProps<R, X>) {
+export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = any>(props: GridTableProps<R, X>) {
   const {
     id = "gridTable",
     as = "div",

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -29,6 +29,7 @@ import {
 } from "src/components/Table/utils/utils";
 import { Css, Palette } from "src/Css";
 import { useComputed } from "src/hooks";
+import { AnyObject } from "src/types";
 import { shallowEqual } from "src/utils/shallowEqual";
 
 interface RowProps<R extends Kinded> {
@@ -334,4 +335,4 @@ export type GridDataRow<R extends Kinded> = {
   initSelected?: boolean;
   /** Whether row can be selected */
   selectable?: false;
-} & IfAny<R, {}, DiscriminateUnion<R, "kind", R["kind"]>>;
+} & IfAny<R, AnyObject, DiscriminateUnion<R, "kind", R["kind"]>>;

--- a/src/components/Table/components/cell.tsx
+++ b/src/components/Table/components/cell.tsx
@@ -25,7 +25,7 @@ export type GridCellContent = {
   /** Allows the cell to stay in place when the user scrolls horizontally, i.e. frozen columns. */
   sticky?: "left" | "right";
   /** If provided, content of the cell will be wrapped within a <button /> or <a /> tag depending on if the value is a function or a string. */
-  onClick?: () => {} | string;
+  onClick?: VoidFunction | string;
   /** Custom css to apply directly to this cell, i.e. cell-specific borders. */
   css?: Properties;
   /** Allows cell to reveal content when the user hovers over a row. Content must be wrapped in an element in order to be hidden. IE <div>{value}</div>*/
@@ -40,7 +40,7 @@ export type RenderCellFn<R extends Kinded> = (
   row: R,
   rowStyle: RowStyle<R> | undefined,
   classNames: string | undefined,
-  onClick: (() => void) | undefined,
+  onClick: VoidFunction | undefined,
 ) => ReactNode;
 
 /** Renders our default cell element, i.e. if no row links and no custom renderCell are used. */

--- a/src/components/Table/utils/GridRowLookup.test.ts
+++ b/src/components/Table/utils/GridRowLookup.test.ts
@@ -5,9 +5,9 @@ import { getKinds } from "src/components/Table/utils/GridRowLookup";
 describe("GridRowLookup", () => {
   it("ignores action columns when calling 'getKinds'", () => {
     type Row =
-      | { kind: "header"; id: "header"; data: {} }
-      | { kind: "group"; id: "group"; data: {} }
-      | { kind: "data"; id: string; data: {} };
+      | { kind: "header"; id: "header"; data: unknown }
+      | { kind: "group"; id: "group"; data: unknown }
+      | { kind: "data"; id: string; data: unknown };
 
     const columns: GridColumn<Row>[] = [
       collapseColumn(),

--- a/src/components/Table/utils/columns.tsx
+++ b/src/components/Table/utils/columns.tsx
@@ -142,7 +142,7 @@ export function calcColumnSizes(
     return `((100% - ${claimedPercentages}% - ${claimedPixels}px) * (${myFr} / ${totalFr}))`;
   }
 
-  let sizes = columns.map(({ id, expandedWidth, w: _w }) => {
+  const sizes = columns.map(({ id, expandedWidth, w: _w }) => {
     const w = expandedColumnIds.includes(id) && expandedWidth !== undefined ? expandedWidth : _w;
 
     if (typeof w === "undefined") {

--- a/src/components/Table/utils/utils.tsx
+++ b/src/components/Table/utils/utils.tsx
@@ -197,7 +197,7 @@ export function maybeApplyFunction<T>(
 }
 
 export function matchesFilter(maybeContent: ReactNode | GridCellContent, filter: string): boolean {
-  let value = filterValue(maybeContent);
+  const value = filterValue(maybeContent);
   if (typeof value === "string") {
     return value.toLowerCase().includes(filter.toLowerCase());
   } else if (typeof value === "number") {

--- a/src/components/Tabs.test.tsx
+++ b/src/components/Tabs.test.tsx
@@ -91,7 +91,7 @@ describe("TabsWithContent", () => {
     expect(r.tab_panel().textContent).toBe("Tab 1 Content");
   });
 
-  it("shows all the tabs if 'alwaysShowAllTabs' is defined, but only a single tab is enabled ", async () => {
+  it("shows all the tabs if 'alwaysShowAllTabs' is defined, but only a single tab is enabled", async () => {
     // Given only the 1st tab is enabled
     const testTabs: TabWithContent<TabValue>[] = [
       { name: "Tab 1", value: "tab1", render: () => <TestTabContent content="Tab 1 Content" /> },
@@ -179,12 +179,12 @@ describe("TabsWithContent", () => {
       },
     ];
     const r = await render(<TabsWithContent tabs={testTabs} />, router);
-    //Then expect the first tab to have captured the param
+    // Then expect the first tab to have captured the param
     expect(r.ceId().textContent).toBe("ce:1");
 
     // When clicking the second tab
     click(r.tabs_tabB);
-    //Then expect the second tab to have captured both params
+    // Then expect the second tab to have captured both params
     expect(r.ceId().textContent).toBe("ce:2");
     expect(r.celiId().textContent).toBe("celi:2");
   });

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,3 +1,4 @@
+import { InterpolationWithTheme } from "@emotion/core";
 import { camelCase } from "change-case";
 import { HTMLAttributes, KeyboardEvent, ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { mergeProps, useFocusRing, useHover } from "react-aria";
@@ -7,6 +8,7 @@ import type { IconKey } from "src/components";
 import { FullBleed } from "src/components";
 import { Css, Margin, Only, Padding, Xss } from "src/Css";
 import { BeamFocusableProps } from "src/interfaces";
+import { AnyObject } from "src/types";
 import { useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
 import { Icon } from "./Icon";
@@ -88,7 +90,7 @@ export function TabsWithContent<V extends string, X extends Only<TabsContentXss,
 }
 
 export function TabContent<V extends string>(
-  props: Omit<RequiredRenderTabs<V, {}>, "onChange"> | RequiredRenderRouteTabs<V, {}>,
+  props: Omit<RequiredRenderTabs<V, AnyObject>, "onChange"> | RequiredRenderRouteTabs<V, AnyObject>,
 ) {
   const tid = useTestIds(props, "tab");
   const { tabs, contentXss = {} } = props;
@@ -110,7 +112,7 @@ export function TabContent<V extends string>(
         role="tabpanel"
         tabIndex={0}
         {...tid.panel}
-        css={contentXss}
+        css={contentXss as InterpolationWithTheme<any>}
       >
         {isRouteTab(selectedTab) ? <Route path={selectedTab.path} render={selectedTab.render} /> : selectedTab.render()}
       </div>
@@ -119,7 +121,7 @@ export function TabContent<V extends string>(
 }
 
 /** The top list of tabs. */
-export function Tabs<V extends string>(props: TabsProps<V, {}> | RouteTabsProps<V, {}>) {
+export function Tabs<V extends string>(props: TabsProps<V, AnyObject> | RouteTabsProps<V, AnyObject>) {
   const { ariaLabel, tabs, includeBottomBorder, right, ...others } = props;
   const location = useLocation();
   const selected = isRouteTabs(props)
@@ -299,6 +301,6 @@ function uniqueTabValue(tab: Tab<any> | RouteTab<any>) {
 }
 
 // Determines whether we should hide the Tab panel. Returns true if there is only one enabled tab and `alwaysShowAllTabs` is falsey.
-function hideTabs(props: Omit<TabsProps<any, {}>, "onChange"> | RouteTabsProps<any, {}>) {
+function hideTabs(props: Omit<TabsProps<any, AnyObject>, "onChange"> | RouteTabsProps<any, AnyObject>) {
   return props.alwaysShowAllTabs ? false : (props.tabs as any[]).filter((t) => !t.disabled).length === 1;
 }

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,5 +1,5 @@
 import { Icon, IconKey } from "src/components/Icon";
-import { Css, Palette } from "src/Css";
+import { Css, Palette, Properties } from "src/Css";
 import { useTestIds } from "src/utils";
 import { IconButton } from "../IconButton";
 import { useToastContext } from "./ToastContext";
@@ -38,7 +38,7 @@ const typeToIcon: Record<ToastTypes, IconKey> = {
   error: "xCircle",
 };
 
-const variantStyles: Record<ToastTypes, {}> = {
+const variantStyles: Record<ToastTypes, Properties> = {
   success: Css.bgGreen100.gray900.$,
   info: Css.bgLightBlue100.gray900.$,
   warning: Css.bgYellow200.gray900.$,

--- a/src/components/Toast/ToastContext.tsx
+++ b/src/components/Toast/ToastContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, PropsWithChildren, ReactNode, useContext, useMemo, useState } from "react";
+import React, { createContext, ReactNode, useContext, useMemo, useState } from "react";
 import { ToastTypes } from "./Toast";
 
 export interface ToastNoticeProps {
@@ -18,7 +18,7 @@ export const ToastContext = createContext<ToastContextProps>({
   notice: undefined,
 });
 
-export function ToastProvider(props: PropsWithChildren<{}>) {
+export function ToastProvider(props: { children: ReactNode }) {
   const [notice, setNotice] = useState<ToastNoticeProps>();
   const contextValue = useMemo(() => ({ setNotice, notice }), [setNotice, notice]);
   return <ToastContext.Provider value={contextValue}>{props.children}</ToastContext.Provider>;

--- a/src/components/internal/Popover.tsx
+++ b/src/components/internal/Popover.tsx
@@ -28,7 +28,7 @@ export function Popover(props: PopoverProps) {
         if (triggerRef.current?.contains(e)) {
           return true;
         }
-        //Do not close the Popover if the user is interacting with a tribute menu, dialog or alert on top of it, otherwise close it.
+        // Do not close the Popover if the user is interacting with a tribute menu, dialog or alert on top of it, otherwise close it.
         return !(e.closest(".tribute-container") || e.closest("[role='dialog']") || e.closest("[role='alert']"));
       },
       ...others,

--- a/src/forms/BoundTextField.test.tsx
+++ b/src/forms/BoundTextField.test.tsx
@@ -19,13 +19,6 @@ describe("BoundTextField", () => {
     expect(firstName_errorMsg()).toHaveTextContent("Required");
   });
 
-  it("shows an error message", async () => {
-    const author = createObjectState(formConfig, {});
-    author.touched = true;
-    const { firstName_errorMsg } = await render(<BoundTextField field={author.firstName} />);
-    expect(firstName_errorMsg()).toHaveTextContent("Required");
-  });
-
   it("can blur onEnter and call onEnter callback", async () => {
     const autoSave = jest.fn();
     const onEnter = jest.fn();

--- a/src/hooks/useGetRef.ts
+++ b/src/hooks/useGetRef.ts
@@ -1,0 +1,6 @@
+import { MutableRefObject, RefObject, useRef } from "react";
+
+export const useGetRef = <T extends HTMLElement>(maybeRef: RefObject<T> | undefined): MutableRefObject<T | null> => {
+  const newRef = useRef(null);
+  return maybeRef || newRef;
+};

--- a/src/hooks/useGetRef.ts
+++ b/src/hooks/useGetRef.ts
@@ -1,5 +1,9 @@
 import { MutableRefObject, RefObject, useRef } from "react";
 
+/**
+ * Replaces code like `const ref = passedRef || useRef(null)` which was triggering rules-of-hooks violations. Used
+ * to sometimes accept a caller's ref, or if they did not pass one, use an internal one anyway.
+ */
 export const useGetRef = <T extends HTMLElement>(maybeRef: RefObject<T> | undefined): MutableRefObject<T | null> => {
   const newRef = useRef(null);
   return maybeRef || newRef;

--- a/src/inputs/DateFields/DateFieldBase.tsx
+++ b/src/inputs/DateFields/DateFieldBase.tsx
@@ -215,8 +215,8 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
         (isRangeMode ? formatDateRange(props.value, dateFormat) : formatDate(props.value, dateFormat)) ?? "",
       );
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     // We don't want to update the internal `wipValue` or `inputValue` back to `value` just because focus state changes or the overlay opens
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, dateFormat]);
 
   // Create a type safe `onChange` to handle both Single and Range date fields.

--- a/src/inputs/DateFields/DateFieldBase.tsx
+++ b/src/inputs/DateFields/DateFieldBase.tsx
@@ -5,7 +5,7 @@ import { useOverlayTriggerState } from "react-stately";
 import { Icon, IconButton, resolveTooltip } from "src/components";
 import { DatePicker, DateRangePicker, Popover } from "src/components/internal";
 import { DatePickerOverlay } from "src/components/internal/DatePicker/DatePickerOverlay";
-import { Css, Palette } from "src/Css";
+import { Css, Palette, Properties } from "src/Css";
 import {
   DateFieldMode,
   dateFormats,
@@ -22,7 +22,7 @@ import { maybeCall, useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
 
 export interface DateFieldBaseProps
-  extends Pick<TextFieldBaseProps<{}>, "borderless" | "visuallyDisabled" | "labelStyle" | "compact"> {
+  extends Pick<TextFieldBaseProps<Properties>, "borderless" | "visuallyDisabled" | "labelStyle" | "compact"> {
   label: string;
   /** Called when the component loses focus */
   onBlur?: () => void;

--- a/src/inputs/DateFields/utils.ts
+++ b/src/inputs/DateFields/utils.ts
@@ -59,7 +59,7 @@ function parseDateString(str: string, format: string): Date | undefined {
   }
   const month = parseInt(split[0], 10) - 1;
   const day = parseInt(split[1], 10);
-  let year = parseInt(split[2], 10);
+  const year = parseInt(split[2], 10);
   // This is also ~verbatim copy/pasted from react-day-picker
   if (
     isNaN(year) ||

--- a/src/inputs/MultiLineSelectField.stories.tsx
+++ b/src/inputs/MultiLineSelectField.stories.tsx
@@ -1,6 +1,5 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import type { IconKey } from "src/components";
 import { Css } from "src/Css";
 import { MultiLineSelectField, Value } from "src/inputs";
 import { FormLines } from "..";
@@ -32,19 +31,36 @@ export function MultiLineSelectFields() {
       <div css={Css.df.fdc.gap2.$}>
         <h1 css={Css.lg.$}>Regular</h1>
         <FormLines width="md">
-          <MultiLineSelectField label="Favorite Shapes" values={values} options={options} onSelect={(val) => setValues(val)} />
+          <MultiLineSelectField
+            label="Favorite Shapes"
+            values={values}
+            options={options}
+            onSelect={(val) => setValues(val)}
+          />
         </FormLines>
       </div>
       <div css={Css.df.fdc.gap2.$}>
         <h1 css={Css.lg.$}>With a hidden label</h1>
         <FormLines width="md">
-          <MultiLineSelectField label="Favorite Shapes" labelStyle="hidden" values={values} options={options} onSelect={(val) => setValues(val)} />
+          <MultiLineSelectField
+            label="Favorite Shapes"
+            labelStyle="hidden"
+            values={values}
+            options={options}
+            onSelect={(val) => setValues(val)}
+          />
         </FormLines>
       </div>
       <div css={Css.df.fdc.gap2.$}>
         <h1 css={Css.lg.$}>With a horizontal layout</h1>
         <FormLines width="md">
-          <MultiLineSelectField label="Favorite Shapes" labelStyle="left" values={values} options={options} onSelect={(val) => setValues(val)} />
+          <MultiLineSelectField
+            label="Favorite Shapes"
+            labelStyle="left"
+            values={values}
+            options={options}
+            onSelect={(val) => setValues(val)}
+          />
         </FormLines>
       </div>
     </div>

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -7,7 +7,6 @@ import React, {
   MutableRefObject,
   ReactNode,
   TextareaHTMLAttributes,
-  useRef,
   useState,
 } from "react";
 import { chain, mergeProps, useFocusWithin, useHover } from "react-aria";
@@ -17,6 +16,7 @@ import { InlineLabel, Label } from "src/components/Label";
 import { usePresentationContext } from "src/components/PresentationContext";
 import { Css, Only, Palette, px } from "src/Css";
 import { getLabelSuffix } from "src/forms/labelUtils";
+import { useGetRef } from "src/hooks/useGetRef";
 import { ErrorMessage } from "src/inputs/ErrorMessage";
 import { BeamTextFieldProps, TextFieldInternalProps, TextFieldXss } from "src/interfaces";
 import { defaultTestId } from "src/utils/defaultTestId";
@@ -98,7 +98,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
   const [isFocused, setIsFocused] = useState(false);
   const { hoverProps, isHovered } = useHover({});
   const { focusWithinProps } = useFocusWithin({ onFocusWithinChange: setIsFocused });
-  const fieldRef = inputRef ?? useRef();
+  const fieldRef = useGetRef(inputRef);
 
   const maybeSmaller = compound ? 2 : 0;
   const fieldHeight = 40;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 // Import and re-export DateRange type so other apps do not need a direct dependency on react-day-picker
+import React from "react";
 import { DateRange as _DateRange } from "react-day-picker";
 export type { _DateRange as DateRange };
 
@@ -9,3 +10,5 @@ export type CanCloseCheck = { check: CheckFn; discardText?: string; continueText
 export function assertNever(x: never): never {
   throw new Error("Unexpected object: " + x);
 }
+export type AnyObject = Record<string, unknown>;
+export type ChildrenOnly = { children: React.ReactNode };

--- a/src/utils/sb.tsx
+++ b/src/utils/sb.tsx
@@ -1,7 +1,7 @@
 import { DecoratorFn } from "@storybook/react";
 import { ReactNode } from "react";
 import { BeamProvider } from "src/components";
-import { Css } from "src/Css";
+import { Css, Properties } from "src/Css";
 import { withRouter as rtlWithRouter } from "src/utils/rtl";
 
 export function withRouter(url?: string, path?: string): DecoratorFn {
@@ -51,7 +51,7 @@ export const withBeamDecorator = (Story: () => JSX.Element) => (
  * Used to help Chromatic properly render positioned `fixed` components.
  */
 export const withDimensions =
-  (width: number | string = "100vw", height: number | string = "100vh", xss?: {}) =>
+  (width: number | string = "100vw", height: number | string = "100vh", xss?: Properties) =>
   (Story: () => JSX.Element) =>
     (
       <div css={{ ...Css.w(width).h(height).$, ...xss }}>


### PR DESCRIPTION
VSCode users weren't getting any linting or autoformatting help from ESLint because its setup & installation was incomplete. This finishes that installation as well as resolves some blocking lint errors:

1. most notably the invalid `{}` type which exposes a [huge type-safety hole](https://github.com/typescript-eslint/typescript-eslint/issues/2063#issuecomment-675156492) and should not be used. 
1. some rule-of-hooks violations where hooks were being conditionally called 
1. other --fix'able violations