### PR TITLE
feat: Allow parent rows to be selected independent of child row selections

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -2538,6 +2538,59 @@ describe("GridTable", () => {
       // Then the visible column session storage is defined using the `visibleColumnsStorageKey` prop
       expect(sessionStorage.setItem).toHaveBeenLastCalledWith("testStorageKey", '["name"]');
     });
+
+    it("respects setting inferSelectState to false", async () => {
+      // Given nested rows
+      const rows: GridDataRow<NestedRow>[] = [
+        simpleHeader,
+        {
+          // With one grand parent that sets `inferSelectedState: false`
+          ...{ kind: "parent", id: "p1", inferSelectedState: false, data: { name: "parent 1" } },
+          children: [
+            {
+              ...{ kind: "child", id: "p1c1", data: { name: "child 1" } },
+              children: [
+                { kind: "grandChild", id: "p1c1gc1", data: { name: "grandChild p1c1gc1" } },
+                { kind: "grandChild", id: "p1c1gc2", data: { name: "grandChild p1c1gc2" } },
+              ],
+            },
+          ],
+        },
+      ];
+      const api: MutableRefObject<GridTableApi<NestedRow> | undefined> = { current: undefined };
+      const r = await render(<TestFilterAndSelect api={api} rows={rows} />);
+
+      // When selecting a grand child of the grand parent that sets `inferSelectedState: false`
+      click(cellAnd(r, 3, 1, "select"));
+
+      // Then the header row should be indeterminate
+      expect(cellAnd(r, 0, 1, "select")).toBePartiallyChecked();
+      // And the grand parent row to not be checked.
+      expect(cellAnd(r, 1, 1, "select")).not.toBeChecked();
+      // And the parent row should show indeterminate,
+      expect(cellAnd(r, 2, 1, "select")).toBePartiallyChecked();
+      expect(api.current!.getSelectedRowIds()).toEqual(["p1c1gc1"]);
+
+      // When selecting the grand parent
+      click(cellAnd(r, 1, 1, "select"));
+
+      // Then all rows should be considered selected
+      expect(cellAnd(r, 0, 1, "select")).toBeChecked();
+      expect(cellAnd(r, 1, 1, "select")).toBeChecked();
+      expect(cellAnd(r, 2, 1, "select")).toBeChecked();
+      expect(api.current!.getSelectedRowIds()).toEqual(["p1", "p1c1", "p1c1gc2", "p1c1gc1"]);
+
+      // When unselecting a single grand child
+      click(cellAnd(r, 3, 1, "select"));
+
+      // Then the header row should return to indeterminate
+      expect(cellAnd(r, 0, 1, "select")).toBePartiallyChecked();
+      // And the grand parent row to remain checked.
+      expect(cellAnd(r, 1, 1, "select")).toBeChecked();
+      // And the parent row should return to indeterminate,
+      expect(cellAnd(r, 2, 1, "select")).toBePartiallyChecked();
+      expect(api.current!.getSelectedRowIds()).toEqual(["p1", "p1c1gc2"]);
+    });
   });
 });
 

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -334,4 +334,6 @@ export type GridDataRow<R extends Kinded> = {
   initSelected?: boolean;
   /** Whether row can be selected */
   selectable?: false;
+  /** Whether this row should infer its selected state based on its children's selected state */
+  inferSelectedState?: false;
 } & IfAny<R, {}, DiscriminateUnion<R, "kind", R["kind"]>>;


### PR DESCRIPTION
When adding `GridDataRow.inferSelectedState: false` to a row, then it will no longer derived its selected state based on the state of its children rows. Instead the row must be selected specifically (or via its own parent) in order for it to be considered selected. This also removes the ability for the row to show in the 'indeterminate' state