### PR TITLE
fix(grid-table-expanded-cols): persist between rerenders

### DIFF
--- a/src/components/Table/utils/TableState.test.ts
+++ b/src/components/Table/utils/TableState.test.ts
@@ -2,6 +2,22 @@ import { deriveSortState, TableState } from "src/components/Table/utils/TableSta
 import { ASC, DESC } from "src/components/Table/utils/utils";
 
 describe(TableState, () => {
+  it("preserves expanded state", () => {
+    // Given some column definitions and initial state
+    const state = new TableState();
+    const columns = [{ id: "one" }, { id: "two" }];
+    state.setColumns(columns, undefined);
+
+    // When we toggle a column
+    state.toggleExpandedColumn("one");
+    expect(state.expandedColumnIds).toEqual(["one"]);
+    // And setColumns gets called again (perhaps as the result of an updated createColumns() result)
+    state.setColumns([...columns], undefined);
+
+    // Then expect our expanded column to still be expanded
+    expect(state.expandedColumnIds).toEqual(["one"]);
+  });
+
   describe(deriveSortState, () => {
     it("can derive the next sort state when current state is undefined", () => {
       expect(deriveSortState({}, "2", undefined)).toEqual({ current: { columnId: "2", direction: ASC } });

--- a/src/components/Table/utils/TableState.ts
+++ b/src/components/Table/utils/TableState.ts
@@ -212,12 +212,13 @@ export class TableState {
   }
 
   setColumns(columns: GridColumnWithId<any>[], visibleColumnsStorageKey: string | undefined): void {
+    const isInitial = !this.columns || this.columns.length === 0;
     if (columns !== this.columns) {
       this.columns = columns;
       this.visibleColumnsStorageKey = visibleColumnsStorageKey ?? camelCase(columns.map((c) => c.id).join());
       this.visibleColumns.replace(readOrSetLocalVisibleColumnState(columns, this.visibleColumnsStorageKey));
       const expandedColumnIds = columns.filter((c) => c.initExpanded).map((c) => c.id);
-      this.expandedColumns.replace(expandedColumnIds);
+      if (isInitial) this.expandedColumns.replace(expandedColumnIds);
     }
   }
 


### PR DESCRIPTION
For Bulk Template Management, whenever we touch a cell (delete, save) and trigger a new `createColumns()` call, that trickles through GridTable and TableApi and resets/collapses any expanded columns we had.

By the nature of our table, users will be updating items across the row in quick succession, so having to re-expand a column each time they touch it or its children will get tedious.

Commenting out 220/221 appears to fix it but would likely break the initExpanded feature. So I've scoped it to only run when initially setting the columns. This likely means that if a developer is _toggling_ `initExpanded` in _their_ createColumns for some reason, that likely won't have any effect. 