### PR TITLE
fix: [sc-27302] Multiselect filter correctly disables chips in modal;

### DIFF
--- a/src/components/Filters/MultiFilter.stories.tsx
+++ b/src/components/Filters/MultiFilter.stories.tsx
@@ -10,6 +10,11 @@ export default {
 } as Meta;
 
 export function MultiFilterInPage() {
+  const filter = stageFilter("stage");
+  return filter.render(undefined, () => {}, {}, false, false);
+}
+
+export function MultiFilterWithDisabledOptionsInPage() {
   const filter = stageFilterDisabledOptions("stage");
   return (
     <>

--- a/src/components/Filters/MultiFilter.stories.tsx
+++ b/src/components/Filters/MultiFilter.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react";
-import { stageFilter } from "src/components/Filters/testDomain";
+import { stageFilter, stageFilterDisabledOptions } from "src/components/Filters/testDomain";
 import { Filters, multiFilter } from "src/components/index";
 import { HasIdAndName } from "src/types";
 
@@ -10,13 +10,28 @@ export default {
 } as Meta;
 
 export function MultiFilterInPage() {
-  const filter = stageFilter("stage");
-  return filter.render(undefined, () => {}, {}, false, false);
+  const filter = stageFilterDisabledOptions("stage");
+  return (
+    <>
+      <div>Supports disabled options with or without tooltip reason.</div>
+      {filter.render(undefined, () => {}, {}, false, false)}
+    </>
+  );
 }
 
 export function MultiFilterInModal() {
   const filter = stageFilter("stage");
   return filter.render(undefined, () => {}, {}, true, false);
+}
+
+export function MultiFilterWithDisabledOptionsInModal() {
+  const filter = stageFilterDisabledOptions("stage");
+  return (
+    <>
+      <div>Supports disabled options with or without tooltip reason.</div>
+      {filter.render(undefined, () => {}, {}, true, false)}
+    </>
+  );
 }
 
 export function MultiFilterVertical() {

--- a/src/components/Filters/MultiFilter.tsx
+++ b/src/components/Filters/MultiFilter.tsx
@@ -1,6 +1,7 @@
 import { Key } from "react";
 import { BaseFilter } from "src/components/Filters/BaseFilter";
 import { Filter } from "src/components/Filters/types";
+import { disabledOptionToKeyedTuple } from "src/inputs/internal/SelectFieldBase";
 import { MultiSelectField, MultiSelectFieldProps } from "src/inputs/MultiSelectField";
 import { ToggleChipGroup } from "src/inputs/ToggleChipGroup";
 import { Value } from "src/inputs/Value";
@@ -28,13 +29,23 @@ class MultiFilter<O, V extends Value> extends BaseFilter<V[], MultiFilterProps<O
     vertical: boolean,
   ): JSX.Element {
     if (inModal && this.props.options.length > 0 && this.props.options.length <= 8) {
+      const { disabledOptions } = this.props;
+      const disabledOptionsWithReasons = Object.fromEntries(disabledOptions?.map(disabledOptionToKeyedTuple) ?? []);
+      const disabledKeys = Object.keys(disabledOptionsWithReasons);
       return (
         <ToggleChipGroup
           label={this.label}
-          options={this.props.options.map((o: O) => ({
-            label: this.props.getOptionLabel(o),
-            value: this.props.getOptionValue(o) as string,
-          }))}
+          options={this.props.options.map((o: O) => {
+            const value = this.props.getOptionValue(o);
+            const isDisabled = value && disabledKeys.includes(value.toString());
+            const disabledReason = isDisabled ? disabledOptionsWithReasons[value.toString()] : undefined;
+            return {
+              label: this.props.getOptionLabel(o),
+              value: value as string,
+              isDisabled,
+              disabledReason,
+            };
+          })}
           onChange={(values) => {
             setValue(values.length === 0 ? undefined : (values as V[]));
           }}

--- a/src/components/Filters/MultiFilter.tsx
+++ b/src/components/Filters/MultiFilter.tsx
@@ -37,13 +37,12 @@ class MultiFilter<O, V extends Value> extends BaseFilter<V[], MultiFilterProps<O
           label={this.label}
           options={this.props.options.map((o: O) => {
             const value = this.props.getOptionValue(o);
-            const isDisabled = value && disabledKeys.includes(value.toString());
-            const disabledReason = isDisabled ? disabledOptionsWithReasons[value.toString()] : undefined;
+            const disabled = value && disabledKeys.includes(value.toString());
+            const disabledReason = disabled ? disabledOptionsWithReasons[value.toString()] : undefined;
             return {
               label: this.props.getOptionLabel(o),
               value: value as string,
-              isDisabled,
-              disabledReason,
+              disabled: disabledReason ?? disabled,
             };
           })}
           onChange={(values) => {

--- a/src/components/Filters/testDomain.ts
+++ b/src/components/Filters/testDomain.ts
@@ -69,6 +69,13 @@ export const stageFilter: StageFilter = multiFilter({
   getOptionLabel: (s) => s.name,
 });
 
+export const stageFilterDisabledOptions: StageFilter = multiFilter({
+  options: stageOptions,
+  getOptionValue: (s) => s.code,
+  getOptionLabel: (s) => s.name,
+  disabledOptions: [{ value: Stage.StageOne, reason: "I have a reason to be disabled." }, Stage.StageTwo],
+});
+
 export const stageSingleFilter: StageSingleFilter = singleFilter({
   options: stageOptions,
   getOptionValue: (s) => s.code,

--- a/src/inputs/ToggleChipGroup.test.tsx
+++ b/src/inputs/ToggleChipGroup.test.tsx
@@ -14,4 +14,20 @@ describe("ToggleGroupChip", () => {
     expect(r.market_m1()).toHaveAttribute("data-selected", "false");
     expect(r.market_m2()).toHaveAttribute("data-selected", "true");
   });
+
+  it("supports disabled options with tooltips", async () => {
+    const options = [
+      { label: "Bahamas", value: "m:1" },
+      { label: "Southern California", value: "m:2", isDisabled: true, disabledReason: undefined },
+      { label: "Northern California", value: "m:3", isDisabled: true, disabledReason: "No data" },
+    ];
+    const r = await render(
+      <ToggleChipGroup label="Market" options={options} values={["m:2"]} onChange={() => {}} data-testid="market" />,
+    );
+
+    expect(r.market_m2()).toHaveAttribute("data-disabled", "true");
+
+    expect(r.market_m3()).toHaveAttribute("data-disabled", "true");
+    expect(r.getByTestId("tooltip")).toHaveAttribute("title", "No data");
+  });
 });

--- a/src/inputs/ToggleChipGroup.test.tsx
+++ b/src/inputs/ToggleChipGroup.test.tsx
@@ -18,8 +18,8 @@ describe("ToggleGroupChip", () => {
   it("supports disabled options with tooltips", async () => {
     const options = [
       { label: "Bahamas", value: "m:1" },
-      { label: "Southern California", value: "m:2", isDisabled: true, disabledReason: undefined },
-      { label: "Northern California", value: "m:3", isDisabled: true, disabledReason: "No data" },
+      { label: "Southern California", value: "m:2", disabled: true },
+      { label: "Northern California", value: "m:3", disabled: "No data" },
     ];
     const r = await render(
       <ToggleChipGroup label="Market" options={options} values={["m:2"]} onChange={() => {}} data-testid="market" />,

--- a/src/inputs/ToggleChipGroup.tsx
+++ b/src/inputs/ToggleChipGroup.tsx
@@ -1,7 +1,7 @@
-import { useRef } from "react";
+import { ReactNode, useRef } from "react";
 import { useCheckboxGroup, useCheckboxGroupItem, useFocusRing, VisuallyHidden } from "react-aria";
 import { CheckboxGroupState, useCheckboxGroupState } from "react-stately";
-import { maybeTooltip } from "src/components";
+import { maybeTooltip, resolveTooltip } from "src/components";
 import { Label } from "src/components/Label";
 import { Css } from "src/Css";
 import { useTestIds } from "src/utils/useTestIds";
@@ -9,8 +9,12 @@ import { useTestIds } from "src/utils/useTestIds";
 type ToggleChipItemProps = {
   label: string;
   value: string;
-  isDisabled?: boolean;
-  disabledReason?: string;
+  /**
+   * Whether the interactive element is disabled.
+   *
+   * If a ReactNode, it's treated as a "disabled reason" that's shown in a tooltip.
+   */
+  disabled?: boolean | ReactNode;
 };
 
 export interface ToggleChipGroupProps {
@@ -38,8 +42,7 @@ export function ToggleChipGroup(props: ToggleChipGroupProps) {
             groupState={state}
             selected={state.value.includes(o.value)}
             label={o.label}
-            isDisabled={o.isDisabled}
-            disabledReason={o.disabledReason}
+            disabled={o.disabled}
             {...tid[o.value]}
           />
         ))}
@@ -53,18 +56,24 @@ interface ToggleChipProps {
   value: string;
   groupState: CheckboxGroupState;
   selected: boolean;
-  isDisabled?: boolean;
-  disabledReason?: string;
+  /**
+   * Whether the interactive element is disabled.
+   *
+   * If a ReactNode, it's treated as a "disabled reason" that's shown in a tooltip.
+   */
+  disabled?: boolean | ReactNode;
 }
 
 function ToggleChip(props: ToggleChipProps) {
-  const { label, value, groupState, selected: isSelected, isDisabled = false, disabledReason, ...others } = props;
+  const { label, value, groupState, selected: isSelected, disabled = false, ...others } = props;
+  const isDisabled = !!disabled;
   const ref = useRef(null);
   const { inputProps } = useCheckboxGroupItem({ value, "aria-label": label, isDisabled }, groupState, ref);
   const { isFocusVisible, focusProps } = useFocusRing();
+  const tooltip = resolveTooltip(disabled);
 
   return maybeTooltip({
-    title: disabledReason,
+    title: tooltip,
     placement: "top",
     children: (
       <label
@@ -73,9 +82,9 @@ function ToggleChip(props: ToggleChipProps) {
           ...(isSelected
             ? {
                 ...Css.white.bgLightBlue700.$,
-                ":hover:not(:isDisabled)": Css.bgLightBlue800.$,
+                ":hover:not([data-disabled='true'])": Css.bgLightBlue800.$,
               }
-            : { ":hover:not(:isDisabled)": Css.bgGray300.$ }),
+            : { ":hover:not([data-disabled='true'])": Css.bgGray300.$ }),
           ...(isFocusVisible ? Css.bshFocus.$ : {}),
         }}
         data-selected={isSelected}

--- a/src/inputs/internal/SelectFieldBase.tsx
+++ b/src/inputs/internal/SelectFieldBase.tsx
@@ -446,7 +446,7 @@ function getOptionsWithUnset<O>(unsetLabel: string, options: O[]): O[] {
 
 export const unsetOption = {};
 
-function disabledOptionToKeyedTuple(
+export function disabledOptionToKeyedTuple(
   disabledOption: Value | { value: Value; reason: string },
 ): [React.Key, string | undefined] {
   if (typeof disabledOption === "object" && disabledOption !== null) {


### PR DESCRIPTION
Multiselect filter will now correctly disable options when rendered as a ToggleChipGroup.