### PR TITLE
feat: add disabled flag and tooltip to radio group field options (sc-25841)

### DIFF
--- a/src/inputs/RadioGroupField.stories.tsx
+++ b/src/inputs/RadioGroupField.stories.tsx
@@ -245,7 +245,7 @@ export function Disabled() {
         value={"a"}
         onChange={() => {}}
         options={[
-          { label: "Asiago", value: "a", disabled: true, disabledTooltip: "This option is disabled by some reason" },
+          { label: "Asiago", value: "a", disabled: "This option is disabled by some reason" },
           { label: "Burratta", value: "b" },
           { label: "Camembert", value: "c", disabled: true },
           {

--- a/src/inputs/RadioGroupField.stories.tsx
+++ b/src/inputs/RadioGroupField.stories.tsx
@@ -218,25 +218,47 @@ export function LabelsAndDescriptions() {
 
 export function Disabled() {
   return (
-    <RadioGroupField
-      label={"Favorite cheese"}
-      value={"a"}
-      onChange={() => {}}
-      disabled={true}
-      options={[
-        { label: "Asiago", value: "a" },
-        { label: "Burratta", value: "b" },
-        { label: "Camembert", value: "c" },
-        {
-          label: "Roquefort",
-          description:
-            "Roquefort is a sheep milk cheese from Southern France, and is one of the world's best known blue cheeses.",
-          value: "d",
-        },
-      ]}
-      onBlur={action("onBlur")}
-      onFocus={action("onFocus")}
-    />
+    <FormLines width="sm">
+      <p css={Css.mb1.$}>All options disabled</p>
+      <RadioGroupField
+        label={"Favorite cheese"}
+        value={"a"}
+        onChange={() => {}}
+        disabled={true}
+        options={[
+          { label: "Asiago", value: "a" },
+          { label: "Burratta", value: "b" },
+          { label: "Camembert", value: "c" },
+          {
+            label: "Roquefort",
+            description:
+              "Roquefort is a sheep milk cheese from Southern France, and is one of the world's best known blue cheeses.",
+            value: "d",
+          },
+        ]}
+        onBlur={action("onBlur")}
+        onFocus={action("onFocus")}
+      />
+      <p css={Css.mb1.$}>Only a few options disabled, with a tooltip</p>
+      <RadioGroupField
+        label={"Favorite cheese"}
+        value={"a"}
+        onChange={() => {}}
+        options={[
+          { label: "Asiago", value: "a", disabled: true, disabledTooltip: "This option is disabled by some reason" },
+          { label: "Burratta", value: "b" },
+          { label: "Camembert", value: "c", disabled: true },
+          {
+            label: "Roquefort",
+            description:
+              "Roquefort is a sheep milk cheese from Southern France, and is one of the world's best known blue cheeses.",
+            value: "d",
+          },
+        ]}
+        onBlur={action("onBlur")}
+        onFocus={action("onFocus")}
+      />
+    </FormLines>
   );
 }
 

--- a/src/inputs/RadioGroupField.test.tsx
+++ b/src/inputs/RadioGroupField.test.tsx
@@ -16,4 +16,37 @@ describe("RadioGroupField", () => {
     );
     click(r.favoriteCheese_a);
   });
+
+  it("should disable only first option", async () => {
+    const r = await render(
+      <RadioGroupField
+        label={"Favorite cheese"}
+        value="a"
+        onChange={() => {}}
+        options={[
+          { value: "a", label: "Asiago", disabled: true },
+          { value: "b", label: "Burratta" },
+        ]}
+      />,
+    );
+    const radioInput = r.container.querySelector(`[data-testid="favoriteCheese_a"]`)!;
+    expect(radioInput).toBeDisabled();
+  });
+
+  it("should disable first option and have a tooltip", async () => {
+    const r = await render(
+      <RadioGroupField
+        label={"Favorite cheese"}
+        value="a"
+        onChange={() => {}}
+        options={[
+          { value: "a", label: "Asiago", disabled: "some reason" },
+          { value: "b", label: "Burratta" },
+        ]}
+      />,
+    );
+    const tooltip = r.container.querySelector(`[data-testid="tooltip"]`)!;
+    expect(tooltip).toBeInTheDocument();
+    expect(tooltip).toHaveAttribute("title", "some reason");
+  });
 });

--- a/src/inputs/RadioGroupField.tsx
+++ b/src/inputs/RadioGroupField.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useMemo, useRef } from "react";
 import { useFocusRing, useHover, useRadio, useRadioGroup } from "react-aria";
 import { RadioGroupState, useRadioGroupState } from "react-stately";
+import { maybeTooltip } from "src/components";
 import { HelperText } from "src/components/HelperText";
 import { Label } from "src/components/Label";
 import { PresentationFieldProps } from "src/components/PresentationContext";
@@ -19,6 +20,10 @@ export interface RadioFieldOption<K extends string> {
   description?: string | (() => ReactNode);
   /** The undisplayed value, i.e. an id of some sort. */
   value: K;
+  /** Disable only specific options */
+  disabled?: boolean;
+  /** Optional message for the reason the option is disabled */
+  disabledTooltip?: string;
 }
 
 export interface RadioGroupFieldProps<K extends string> extends Pick<PresentationFieldProps, "labelStyle"> {
@@ -70,16 +75,22 @@ export function RadioGroupField<K extends string>(props: RadioGroupFieldProps<K>
     <div css={Css.df.fdc.gap1.aifs.if(labelStyle === "left").fdr.gap2.jcsb.$}>
       <Label label={label} {...labelProps} {...tid.label} hidden={labelStyle === "hidden"} />
       <div {...radioGroupProps}>
-        {options.map((option) => (
-          <Radio
-            key={option.value}
-            parentId={name}
-            option={option}
-            state={state}
-            {...otherProps}
-            {...tid[option.value]}
-          />
-        ))}
+        {options.map((option) =>
+          maybeTooltip({
+            title: option.disabledTooltip,
+            placement: "bottom",
+            children: (
+              <Radio
+                key={option.value}
+                parentId={name}
+                option={option}
+                state={{ ...state, isDisabled: state.isDisabled || !!option.disabled }}
+                {...otherProps}
+                {...tid[option.value]}
+              />
+            ),
+          }),
+        )}
         {errorMsg && <ErrorMessage errorMsg={errorMsg} {...tid.errorMsg} />}
         {helperText && <HelperText helperText={helperText} />}
       </div>

--- a/src/inputs/RadioGroupField.tsx
+++ b/src/inputs/RadioGroupField.tsx
@@ -1,7 +1,7 @@
-import { ReactNode, useMemo, useRef } from "react";
+import { Fragment, ReactNode, useMemo, useRef } from "react";
 import { useFocusRing, useHover, useRadio, useRadioGroup } from "react-aria";
 import { RadioGroupState, useRadioGroupState } from "react-stately";
-import { maybeTooltip } from "src/components";
+import { maybeTooltip, resolveTooltip } from "src/components";
 import { HelperText } from "src/components/HelperText";
 import { Label } from "src/components/Label";
 import { PresentationFieldProps } from "src/components/PresentationContext";
@@ -21,9 +21,9 @@ export interface RadioFieldOption<K extends string> {
   /** The undisplayed value, i.e. an id of some sort. */
   value: K;
   /** Disable only specific options */
-  disabled?: boolean;
+  disabled?: boolean | ReactNode;
   /** Optional message for the reason the option is disabled */
-  disabledTooltip?: string;
+  // disabledTooltip?: string;
 }
 
 export interface RadioGroupFieldProps<K extends string> extends Pick<PresentationFieldProps, "labelStyle"> {
@@ -75,22 +75,26 @@ export function RadioGroupField<K extends string>(props: RadioGroupFieldProps<K>
     <div css={Css.df.fdc.gap1.aifs.if(labelStyle === "left").fdr.gap2.jcsb.$}>
       <Label label={label} {...labelProps} {...tid.label} hidden={labelStyle === "hidden"} />
       <div {...radioGroupProps}>
-        {options.map((option) =>
-          maybeTooltip({
-            title: option.disabledTooltip,
-            placement: "bottom",
-            children: (
-              <Radio
-                key={option.value}
-                parentId={name}
-                option={option}
-                state={{ ...state, isDisabled: state.isDisabled || !!option.disabled }}
-                {...otherProps}
-                {...tid[option.value]}
-              />
-            ),
-          }),
-        )}
+        {options.map((option) => {
+          const isDisabled = state.isDisabled || !!option.disabled;
+          return (
+            <Fragment key={option.value}>
+              {maybeTooltip({
+                title: resolveTooltip(option.disabled),
+                placement: "bottom",
+                children: (
+                  <Radio
+                    parentId={name}
+                    option={option}
+                    state={{ ...state, isDisabled }}
+                    {...otherProps}
+                    {...tid[option.value]}
+                  />
+                ),
+              })}
+            </Fragment>
+          );
+        })}
         {errorMsg && <ErrorMessage errorMsg={errorMsg} {...tid.errorMsg} />}
         {helperText && <HelperText helperText={helperText} />}
       </div>

--- a/src/inputs/RadioGroupField.tsx
+++ b/src/inputs/RadioGroupField.tsx
@@ -20,10 +20,8 @@ export interface RadioFieldOption<K extends string> {
   description?: string | (() => ReactNode);
   /** The undisplayed value, i.e. an id of some sort. */
   value: K;
-  /** Disable only specific options */
+  /** Disable only specific option, with an optional reason */
   disabled?: boolean | ReactNode;
-  /** Optional message for the reason the option is disabled */
-  // disabledTooltip?: string;
 }
 
 export interface RadioGroupFieldProps<K extends string> extends Pick<PresentationFieldProps, "labelStyle"> {


### PR DESCRIPTION
<img width="335" alt="image" src="https://user-images.githubusercontent.com/13225733/213335630-519c6bb3-f4c9-4943-aaa4-efc473c95ee1.png">

Changes in RadioGroupField include:

- add optional `disabled` attribute to `RadioFieldOption`
- add optional `disabledTooltip` attribute to `RadioFieldOption`