### PR TITLE
fix: dropdown label value defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "chromatic": "chromatic --project-token=074248da7284 --exit-once-uploaded --only-changed",
     "copy": "npx copyfiles -u 1 \"./src/**/*.css\" \"./dist/\"",
     "copy-to-internal-frontend": "cp -r dist/* ~/homebound/internal-frontend/node_modules/@homebound/beam/dist/",
-    "format": "prettier --loglevel warn --write \"**/*.{ts,tsx,css,md,mdx}\""
+    "format": "prettier --loglevel warn --write \"**/*.{ts,tsx,css,md,mdx}\"",
+    "type-check": "ttsc --noEmit"
   },
   "dependencies": {
     "@homebound/form-state": "^2.15.3",

--- a/src/components/Filters/SingleFilter.tsx
+++ b/src/components/Filters/SingleFilter.tsx
@@ -1,6 +1,7 @@
 import { Key } from "react";
 import { BaseFilter } from "src/components/Filters/BaseFilter";
 import { Filter } from "src/components/Filters/types";
+import { defaultGetOptionLabel, defaultGetOptionValue } from "src/inputs/internal/SelectFieldBase";
 import { SelectField, SelectFieldProps } from "src/inputs/SelectField";
 import { Value } from "src/inputs/Value";
 import { TestIds } from "src/utils/useTestIds";
@@ -25,7 +26,14 @@ class SingleFilter<O, V extends Key> extends BaseFilter<V, SingleFilterProps<O, 
     inModal: boolean,
     vertical: boolean,
   ) {
-    const { label, defaultValue, options: maybeOptions, getOptionLabel, getOptionValue, ...props } = this.props;
+    const {
+      label,
+      defaultValue,
+      options: maybeOptions,
+      getOptionLabel = defaultGetOptionLabel,
+      getOptionValue = defaultGetOptionValue,
+      ...props
+    } = this.props;
 
     const options = Array.isArray(maybeOptions)
       ? [allOption as O, ...maybeOptions]
@@ -35,8 +43,8 @@ class SingleFilter<O, V extends Key> extends BaseFilter<V, SingleFilterProps<O, 
       <SelectField<O, V>
         {...props}
         options={options}
-        getOptionValue={(o) => (o === allOption ? (undefined as any as V) : getOptionValue(o))}
-        getOptionLabel={(o) => (o === allOption ? "All" : getOptionLabel(o))}
+        getOptionValue={(o) => (o === allOption ? (undefined as any as V) : getOptionValue(o as any))}
+        getOptionLabel={(o) => (o === allOption ? "All" : getOptionLabel(o as any))}
         compact={!vertical}
         value={value}
         label={this.label}

--- a/src/inputs/internal/SelectFieldBase.tsx
+++ b/src/inputs/internal/SelectFieldBase.tsx
@@ -487,5 +487,5 @@ export const defaultGetOptionLabel = (o: InferrableOptionLabel): string =>
   o?.name ||
   o?.value ||
   (() => {
-    throw new Error("Unable to determine option label. Please provide a custom getOptionValue function");
+    throw new Error("Unable to determine option label. Please provide a custom getOptionLabel function");
   })();

--- a/src/inputs/internal/SelectFieldBase.tsx
+++ b/src/inputs/internal/SelectFieldBase.tsx
@@ -15,7 +15,9 @@ import { areArraysEqual } from "src/utils";
 export interface BeamSelectFieldBaseProps<O, V extends Value> extends BeamFocusableProps, PresentationFieldProps {
   /** Renders `opt` in the dropdown menu, defaults to the `getOptionLabel` prop. `isUnsetOpt` is only defined for single SelectField */
   getOptionMenuLabel?: (opt: O, isUnsetOpt?: boolean) => string | ReactNode;
+  /** Defaults to `id ?? value` */
   getOptionValue?: (opt: O) => V;
+  /** Defaults to `displayName || label || name || value` */
   getOptionLabel?: (opt: O) => string;
   /** The current value; it can be `undefined`, even if `V` cannot be. */
   values: V[] | undefined;
@@ -481,8 +483,8 @@ type InferrableOptionLabel = AtLeastOne<{
 }>;
 export const defaultGetOptionLabel = (o: InferrableOptionLabel): string =>
   o?.displayName ||
-  o?.name ||
   o?.label ||
+  o?.name ||
   o?.value ||
   (() => {
     throw new Error("Unable to determine option label. Please provide a custom getOptionValue function");


### PR DESCRIPTION
In BluePrint I find that this is very tedious...

```jsx
<SelectField
  options={options}
  getOptionValue={(o) => o.id}
  getOptionLabel={(o) => o.name}
/>
```

...given that it's `id/value` or `displayName/label/name/value` seemingly 95% of the time. So, let's make getOptionValue/Label optional and try to infer, while still easily letting developers override or provide missing behavior when necessary.

Also, I tried to type-guard this (like if you pass in `{ code: string; id: string }[]` it'd tell you getOptionLabel is required), but our abundant use of Interfaces over Types makes that a significant lift. Interfaces may only extend other Interfaces with statically-known types, so a key that's _conditionally_ required or optional breaks extensions and a few overloads. 