### PR TITLE
feat: allow to always show helper text

### DIFF
--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -48,7 +48,7 @@ export interface NumberFieldProps extends Pick<PresentationFieldProps, "labelSty
   // Typically used for compact fields in a table. Removes border and uses an box-shadow for focus behavior
   borderless?: boolean;
   sizeToContent?: boolean;
-  // If set, the helper text will always be shown
+  // If set, the helper text will always be shown (usually we hide the helper text if read only)
   alwaysShowHelperText?: boolean;
 }
 

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -48,6 +48,8 @@ export interface NumberFieldProps extends Pick<PresentationFieldProps, "labelSty
   // Typically used for compact fields in a table. Removes border and uses an box-shadow for focus behavior
   borderless?: boolean;
   sizeToContent?: boolean;
+  // If set, the helper text will always be shown
+  alwaysShowHelperText?: boolean;
 }
 
 export function NumberField(props: NumberFieldProps) {

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -54,6 +54,7 @@ export interface TextFieldBaseProps<X>
   textAreaMinHeight?: number;
   tooltip?: ReactNode;
   hideErrorMessage?: boolean;
+  alwaysShowHelperText?: boolean;
 }
 
 // Used by both TextField and TextArea
@@ -86,6 +87,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
     visuallyDisabled = fieldProps?.visuallyDisabled ?? true,
     errorInTooltip = fieldProps?.errorInTooltip ?? false,
     hideErrorMessage = false,
+    alwaysShowHelperText = false,
   } = props;
 
   const typeScale = fieldProps?.typeScale ?? (inputProps.readOnly && labelStyle !== "hidden" ? "smMd" : "sm");
@@ -269,22 +271,26 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
             </div>
           ),
         })}
-        {/* Compound fields will handle their own error and helper text. Do not show error or helper text when 'readOnly' or disabled */}
-        {labelStyle !== "left" && !compound && !inputProps.disabled && !inputProps.readOnly && (
-          <>
-            {errorMsg && !errorInTooltip && (
-              <ErrorMessage id={errorMessageId} errorMsg={errorMsg} hidden={hideErrorMessage} {...tid.errorMsg} />
-            )}
-            {helperText && <HelperText helperText={helperText} {...tid.helperText} />}
-          </>
-        )}
+        {/* Compound fields will handle their own error and helper text.
+          * Do not show error or helper text when 'readOnly' or disabled
+          except if alwaysShowHelperText is provided */}
+        {labelStyle !== "left" &&
+          (alwaysShowHelperText || (!compound && !inputProps.disabled && !inputProps.readOnly)) && (
+            <>
+              {errorMsg && !errorInTooltip && (
+                <ErrorMessage id={errorMessageId} errorMsg={errorMsg} hidden={hideErrorMessage} {...tid.errorMsg} />
+              )}
+              {helperText && <HelperText helperText={helperText} {...tid.helperText} />}
+            </>
+          )}
       </div>
       {/* Error message and helper text for "left" labelStyle */}
       {labelStyle === "left" &&
-        !compound &&
-        !inputProps.disabled &&
-        !inputProps.readOnly &&
-        ((errorMsg && !errorInTooltip) || helperText) && (
+        (alwaysShowHelperText ||
+          (!compound &&
+            !inputProps.disabled &&
+            !inputProps.readOnly &&
+            ((errorMsg && !errorInTooltip) || helperText))) && (
           // Reduces the margin between the error/helper text and input field
           <div css={Css.mtPx(-8).$}>
             {errorMsg && !errorInTooltip && (

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -54,6 +54,7 @@ export interface TextFieldBaseProps<X>
   textAreaMinHeight?: number;
   tooltip?: ReactNode;
   hideErrorMessage?: boolean;
+  // If set, the helper text will always be shown (usually we hide the helper text if read only)
   alwaysShowHelperText?: boolean;
 }
 


### PR DESCRIPTION
Allow number field to always show the helper text if the prop `alwaysShowHelperText` is passed.