### PR TITLE
fix: ScrollableContent bgColor bug fix

### DIFF
--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -173,7 +173,7 @@ function HistoryExample() {
     <>
       <div css={Css.lgSb.$}>History</div>
       <p>Demonstrates not utilizing ScrollableContent component. Expect this section of the layout to scroll</p>
-      <ul css={Css.df.fdc.gap2.$}>
+      <ul css={Css.df.fdc.gap2.mb0.pb1.$}>
         {zeroTo(20).map((i) => (
           <li key={i}>History Item {i + 1}</li>
         ))}

--- a/src/components/Layout/ScrollableContent.tsx
+++ b/src/components/Layout/ScrollableContent.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, ReactPortal, useEffect } from "react";
 import { createPortal } from "react-dom";
-import { scrollContainerBottomPadding, useScrollableParent } from "src/components/Layout/ScrollableParent";
+import { useScrollableParent } from "src/components/Layout/ScrollableParent";
 import { Css, Palette } from "src/Css";
 
 interface ScrollableContentProps {
@@ -49,3 +49,6 @@ export function ScrollableContent(props: ScrollableContentProps): ReactPortal | 
     scrollableEl,
   );
 }
+
+// Styles to wrap around the scrollable content in order to give padding beneath the content within the scrollable container.
+const scrollContainerBottomPadding = Css.addIn("&:after", Css.contentEmpty.db.h2.$).$;

--- a/src/components/Layout/ScrollableParent.tsx
+++ b/src/components/Layout/ScrollableParent.tsx
@@ -61,7 +61,7 @@ export function ScrollableParent(props: PropsWithChildren<ScrollableParentContex
   const scrollableEl = useMemo(() => {
     const el = document.createElement("div");
     // Ensure this wrapping div takes up the full height of its container
-    el.style.height = "100%";
+    el.style.flexGrow = "1";
     return el;
   }, []);
   const [, setTick] = useState(0);
@@ -85,16 +85,9 @@ export function ScrollableParent(props: PropsWithChildren<ScrollableParentContex
        * Otherwise, the flex-item's min-height/width is based on the content of the flex-item, which maybe overflow the container.
        * See https://stackoverflow.com/questions/42130384/why-should-i-specify-height-0-even-if-i-specified-flex-basis-0-in-css3-flexbox */}
       <Tag css={{ ...Css.mh0.mw0.fg1.df.fdc.$, ...otherXss }}>
-        <div
-          css={{
-            ...Css.pl(context.pl).pr(context.pr).$,
-            ...(!hasScrollableContent ? { ...Css.overflowAuto.h100.$, ...scrollContainerBottomPadding } : undefined),
-          }}
-        >
-          {children}
-        </div>
+        <div css={Css.pl(context.pl).pr(context.pr).if(!hasScrollableContent).overflowAuto.h100.$}>{children}</div>
         {/* Set fg1 to take up the remaining space in the viewport.*/}
-        <div css={Css.fg1.overflowAuto.$} ref={scrollableRef} />
+        <div css={Css.fg1.overflowAuto.df.fdc.$} ref={scrollableRef} />
       </Tag>
     </ScrollableParentContext.Provider>
   );
@@ -103,6 +96,3 @@ export function ScrollableParent(props: PropsWithChildren<ScrollableParentContex
 export function useScrollableParent() {
   return useContext(ScrollableParentContext);
 }
-
-// Styles to wrap around the scrollable content in order to give padding beneath the content within the scrollable container.
-export const scrollContainerBottomPadding = Css.addIn("&:after", Css.contentEmpty.db.h2.$).$;


### PR DESCRIPTION
Previously setting the bgColor on ScrollableContent was only displaying the background color at 'height: 100%', which applied to only what was in view on the screen. Once the user scrolled, then you could see the background was not under all of the content. Switching to use flex-box and a flexGrow: 1 to have the ScrollableContent's element to extend the full height of the content within.

Additionally removing the bottom padding when using the fallback when ScrollableContent is not used. This is because of issues it causes with setting background colors elsewhere (like on tabs), but then the background is no applied to the ScrollableParent, so the extra padding would not include a background color, and would look weird. It would also be something not easily addressed by the consuming app, so just removing it in favor of requesting implementations to use ScrollableContent.