### PR TITLE
feat: Add tooltip support to GridTable

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1360,3 +1360,211 @@ export function ExpandableColumnsWithSetTimeout() {
     </div>
   );
 }
+
+type SimpleExpandableRow = ExpandHeader | Header | { id: string; kind: "data"; data: Data };
+export function Tooltips() {
+  const primitiveColumn: GridColumn<SimpleExpandableRow> = {
+    expandableHeader: () => ({
+      content: "Expandable header with tooltip",
+      tooltip: "Tooltip Text for Expandable Header",
+    }),
+    header: () => ({
+      content: "Primitive value - SortHeader with Tooltip",
+      tooltip: "This column demonstrates a tooltip on a cell that renders a primitive value (like a string)",
+    }),
+    data: ({ name, value }, { expanded }) => ({
+      content: expanded ? `Expanded - ${name}` : name,
+      tooltip: "Tooltip text for a primitive value",
+      alignment: value === 1 ? "left" : value === 2 ? "center" : "right",
+    }),
+    w: "300px",
+    expandedWidth: "600px",
+  };
+  const withMarkupColumn: GridColumn<SimpleExpandableRow> = {
+    expandableHeader: () => ({
+      content: "Nothing to expand",
+      tooltip: "This demonstrates a tooltip on an expandable header cell that is not expandable",
+    }),
+    header: () => ({
+      content: () => <div>Cell with markup</div>,
+      tooltip: "This column demonstrates a tooltip on a cell that renders markup",
+    }),
+    data: ({ name, value }) => ({
+      content: () => <div>{name}</div>,
+      tooltip: "Cell tooltip for a value wrapped in markup",
+      alignment: value === 1 ? "left" : value === 2 ? "center" : "right",
+    }),
+    clientSideSort: false,
+    w: "220px",
+  };
+  const buttonColumn: GridColumn<SimpleExpandableRow> = {
+    expandableHeader: emptyCell,
+    header: () => ({
+      content: "As button",
+      tooltip: "This column demonstrates a tooltip on a cell that renders a button element",
+    }),
+    data: ({ value }) => ({
+      content: "Trigger console log" + value,
+      onClick: () => console.log("clicked!"),
+      tooltip: "Cell tooltip for a button cell",
+      alignment: value === 1 ? "left" : value === 2 ? "center" : "right",
+    }),
+    w: "200px",
+  };
+  const linkColumn: GridColumn<SimpleExpandableRow> = {
+    expandableHeader: emptyCell,
+    header: () => ({
+      content: "As link",
+      tooltip: "This column demonstrates a tooltip on a cell that renders a Link component",
+    }),
+    data: ({ value }) => ({
+      content: "Relative link: /",
+      onClick: "/",
+      tooltip: "Cell tooltip for a relative link / React Router Link component",
+      alignment: value === 1 ? "left" : value === 2 ? "center" : "right",
+    }),
+    w: "200px",
+  };
+  const externalLinkColumn: GridColumn<SimpleExpandableRow> = {
+    expandableHeader: emptyCell,
+    header: () => ({
+      content: "As External link",
+      tooltip: "This column demonstrates a tooltip on a cell that renders an anchor element",
+    }),
+    data: ({ value }) => ({
+      content: "homebound.com",
+      onClick: "https://www.homebound.com",
+      tooltip: "Cell tooltip for an external link",
+      alignment: value === 1 ? "left" : value === 2 ? "center" : "right",
+    }),
+    w: "200px",
+  };
+  const truncatedColumn: GridColumn<SimpleExpandableRow> = {
+    expandableHeader: emptyCell,
+    header: () => ({
+      content: "Truncated cells",
+      tooltip: "This column demonstrates a tooltip on a cell where the text should truncate",
+    }),
+    data: ({ name, value }) => ({
+      content: name!.repeat(2),
+      tooltip: "Tooltip for a truncated cell",
+      alignment: value === 1 ? "left" : value === 2 ? "center" : "right",
+    }),
+    w: "200px",
+    clientSideSort: false,
+  };
+
+  const primitiveColumnWoTt: GridColumn<SimpleExpandableRow> = {
+    expandableHeader: "Expandable header with tooltip",
+    header: "Primitive value - SortHeader with Tooltip",
+    data: ({ name, value }, { expanded }) => ({
+      content: expanded ? `Expanded - ${name}` : name,
+      alignment: value === 1 ? "left" : value === 2 ? "center" : "right",
+    }),
+    w: "300px",
+    expandedWidth: "600px",
+  };
+  const withMarkupColumnWoTt: GridColumn<SimpleExpandableRow> = {
+    expandableHeader: "Nothing to expand",
+    header: () => <div>Cell with markup</div>,
+    data: ({ name, value }) => ({
+      content: () => <div>{name}</div>,
+      alignment: value === 1 ? "left" : value === 2 ? "center" : "right",
+    }),
+    clientSideSort: false,
+    w: "220px",
+  };
+  const buttonColumnWoTt: GridColumn<SimpleExpandableRow> = {
+    expandableHeader: emptyCell,
+    header: "As button",
+    data: ({ value }) => ({
+      content: "Trigger console log" + value,
+      onClick: () => console.log("clicked!"),
+      alignment: value === 1 ? "left" : value === 2 ? "center" : "right",
+    }),
+    w: "200px",
+  };
+  const linkColumnWoTt: GridColumn<SimpleExpandableRow> = {
+    expandableHeader: emptyCell,
+    header: "As link",
+    data: ({ value }) => ({
+      content: "Relative link: /",
+      onClick: "/",
+      alignment: value === 1 ? "left" : value === 2 ? "center" : "right",
+    }),
+    w: "200px",
+  };
+  const externalLinkColumnWoTt: GridColumn<SimpleExpandableRow> = {
+    expandableHeader: emptyCell,
+    header: "As External link",
+    data: ({ value }) => ({
+      content: "homebound.com",
+      onClick: "https://www.homebound.com",
+      alignment: value === 1 ? "left" : value === 2 ? "center" : "right",
+    }),
+    w: "200px",
+  };
+  const truncatedColumnWoTt: GridColumn<SimpleExpandableRow> = {
+    expandableHeader: emptyCell,
+    header: "Truncated cells",
+    data: ({ name, value }) => ({
+      content: name!.repeat(2),
+      alignment: value === 1 ? "left" : value === 2 ? "center" : "right",
+    }),
+    w: "200px",
+    clientSideSort: false,
+  };
+
+  return (
+    <div css={Css.bgGray100.p2.$}>
+      <h1 css={Css.xlMd.$}>Fixed Row Height</h1>
+      <GridTable
+        style={{ allWhite: true, rowHeight: "fixed" }}
+        columns={[primitiveColumn, withMarkupColumn, buttonColumn, linkColumn, externalLinkColumn, truncatedColumn]}
+        sorting={{ on: "client", initial: [buttonColumn.id!, "ASC"] }}
+        rows={[
+          { kind: "header", id: "header", data: {} },
+          { kind: "expandableHeader", id: "expandableHeader", data: {} },
+          { kind: "data", id: "1", data: { name: "Tony Stark, Iron Man", value: 1 } },
+          { kind: "data", id: "2", data: { name: "Natasha Romanova, Black Widow", value: 2 } },
+          { kind: "data", id: "3", data: { name: "Thor Odinson, God of Thunder", value: 3 } },
+        ]}
+      />
+      <h1 css={Css.xlMd.mt4.$}>Flexible Row Height</h1>
+      <GridTable
+        style={{ allWhite: true }}
+        columns={[primitiveColumn, withMarkupColumn, buttonColumn, linkColumn, externalLinkColumn, truncatedColumn]}
+        sorting={{ on: "client", initial: [buttonColumn.id!, "ASC"] }}
+        rows={[
+          { kind: "header", id: "header", data: {} },
+          { kind: "expandableHeader", id: "expandableHeader", data: {} },
+          { kind: "data", id: "1", data: { name: "Tony Stark, Iron Man", value: 1 } },
+          { kind: "data", id: "2", data: { name: "Natasha Romanova, Black Widow", value: 2 } },
+          { kind: "data", id: "3", data: { name: "Thor Odinson, God of Thunder", value: 3 } },
+        ]}
+      />
+      <h1 css={Css.xlMd.mt4.$}>
+        Without Tooltips - <span css={Css.base.$}>For visual comparison</span>
+      </h1>
+      <GridTable
+        style={{ allWhite: true }}
+        columns={[
+          primitiveColumnWoTt,
+          withMarkupColumnWoTt,
+          buttonColumnWoTt,
+          linkColumnWoTt,
+          externalLinkColumnWoTt,
+          truncatedColumnWoTt,
+        ]}
+        sorting={{ on: "client", initial: [buttonColumn.id!, "ASC"] }}
+        rows={[
+          { kind: "header", id: "header", data: {} },
+          { kind: "expandableHeader", id: "expandableHeader", data: {} },
+          { kind: "data", id: "1", data: { name: "Tony Stark, Iron Man", value: 1 } },
+          { kind: "data", id: "2", data: { name: "Natasha Romanova, Black Widow", value: 2 } },
+          { kind: "data", id: "3", data: { name: "Thor Odinson, God of Thunder", value: 3 } },
+        ]}
+      />
+    </div>
+  );
+}

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -267,6 +267,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
         const cellClassNames = revealOnRowHover ? revealOnRowHoverClass : undefined;
 
         const cellOnClick = applyCellHighlight ? () => api.setActiveCellId(cellId) : undefined;
+        const tooltip = isGridCellContent(maybeContent) ? maybeContent.tooltip : undefined;
 
         const renderFn: RenderCellFn<any> =
           (rowStyle?.renderCell || rowStyle?.rowLink) && wrapAction
@@ -277,7 +278,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
             ? rowClickRenderFn(as, api)
             : defaultRenderFn(as);
 
-        return renderFn(columnIndex, cellCss, content, row, rowStyle, cellClassNames, cellOnClick);
+        return renderFn(columnIndex, cellCss, content, row, rowStyle, cellClassNames, cellOnClick, tooltip);
       })}
     </RowTag>
   );

--- a/src/components/Table/components/cell.tsx
+++ b/src/components/Table/components/cell.tsx
@@ -4,6 +4,7 @@ import { navLink } from "src/components/CssReset";
 import { GridTableApi } from "src/components/Table/GridTableApi";
 import { RowStyle, tableRowStyles } from "src/components/Table/TableStyles";
 import { GridCellAlignment, GridColumnWithId, Kinded, MaybeFn, RenderAs } from "src/components/Table/types";
+import { maybeTooltip } from "src/components/Tooltip";
 import { Css, Properties, Typography } from "src/Css";
 
 /**
@@ -30,6 +31,8 @@ export type GridCellContent = {
   css?: Properties;
   /** Allows cell to reveal content when the user hovers over a row. Content must be wrapped in an element in order to be hidden. IE <div>{value}</div>*/
   revealOnRowHover?: true;
+  /** Tooltip to add to a cell. **Only Works on Headers** */
+  tooltip?: ReactNode;
 };
 
 /** Allows rendering a specific cell. */
@@ -41,15 +44,16 @@ export type RenderCellFn<R extends Kinded> = (
   rowStyle: RowStyle<R> | undefined,
   classNames: string | undefined,
   onClick: VoidFunction | undefined,
+  tooltip: ReactNode | undefined,
 ) => ReactNode;
 
 /** Renders our default cell element, i.e. if no row links and no custom renderCell are used. */
 export const defaultRenderFn: (as: RenderAs) => RenderCellFn<any> =
-  (as: RenderAs) => (key, css, content, row, rowStyle, classNames: string | undefined, onClick) => {
+  (as: RenderAs) => (key, css, content, row, rowStyle, classNames: string | undefined, onClick, tooltip) => {
     const Cell = as === "table" ? "td" : "div";
     return (
       <Cell key={key} css={{ ...css, ...tableRowStyles(as) }} className={classNames} onClick={onClick}>
-        {content}
+        {maybeTooltip({ title: tooltip, placement: "top", children: content })}
       </Cell>
     );
   };
@@ -59,7 +63,7 @@ export const defaultRenderFn: (as: RenderAs) => RenderCellFn<any> =
  * Used for the Header, Totals, and Expanded Header row's cells.
  * */
 export const headerRenderFn: (column: GridColumnWithId<any>, as: RenderAs, colSpan: number) => RenderCellFn<any> =
-  (column, as, colSpan) => (key, css, content, row, rowStyle, classNames: string | undefined) => {
+  (column, as, colSpan) => (key, css, content, row, rowStyle, classNames: string | undefined, onClick, tooltip) => {
     const Cell = as === "table" ? "th" : "div";
     return (
       <Cell
@@ -68,43 +72,53 @@ export const headerRenderFn: (column: GridColumnWithId<any>, as: RenderAs, colSp
         className={classNames}
         {...(as === "table" && { colSpan })}
       >
-        {content}
+        {maybeTooltip({ title: tooltip, placement: "top", children: content })}
       </Cell>
     );
   };
 
 /** Renders a cell element when a row link is in play. */
 export const rowLinkRenderFn: (as: RenderAs) => RenderCellFn<any> =
-  (as: RenderAs) => (key, css, content, row, rowStyle, classNames: string | undefined) => {
+  (as: RenderAs) => (key, css, content, row, rowStyle, classNames: string | undefined, onClick, tooltip) => {
     const to = rowStyle!.rowLink!(row);
     if (as === "table") {
       return (
         <td key={key} css={{ ...css, ...tableRowStyles(as) }} className={classNames}>
-          <Link to={to} css={Css.noUnderline.color("unset").db.$} className={navLink}>
-            {content}
-          </Link>
+          {maybeTooltip({
+            title: tooltip,
+            placement: "top",
+            children: (
+              <Link to={to} css={Css.noUnderline.color("unset").db.$} className={navLink}>
+                {content}
+              </Link>
+            ),
+          })}
         </td>
       );
     }
-    return (
-      <Link
-        key={key}
-        to={to}
-        css={{ ...Css.noUnderline.color("unset").$, ...css }}
-        className={`${navLink} ${classNames}`}
-      >
-        {content}
-      </Link>
-    );
+    return maybeTooltip({
+      title: tooltip,
+      placement: "top",
+      children: (
+        <Link
+          key={key}
+          to={to}
+          css={{ ...Css.noUnderline.color("unset").$, ...css }}
+          className={`${navLink} ${classNames}`}
+        >
+          {content}
+        </Link>
+      ),
+    });
   };
 
 /** Renders a cell that will fire the RowStyle.onClick. */
 export const rowClickRenderFn: (as: RenderAs, api: GridTableApi<any>) => RenderCellFn<any> =
   (as: RenderAs, api: GridTableApi<any>) =>
-  (key, css, content, row, rowStyle, classNames: string | undefined, onClick) => {
-    const Row = as === "table" ? "tr" : "div";
+  (key, css, content, row, rowStyle, classNames: string | undefined, onClick, tooltip) => {
+    const Cell = as === "table" ? "td" : "div";
     return (
-      <Row
+      <Cell
         {...{ key }}
         css={{ ...css, ...tableRowStyles(as) }}
         className={classNames}
@@ -113,7 +127,7 @@ export const rowClickRenderFn: (as: RenderAs, api: GridTableApi<any>) => RenderC
           onClick && onClick();
         }}
       >
-        {content}
-      </Row>
+        {maybeTooltip({ title: tooltip, placement: "top", children: content })}
+      </Cell>
     );
   };


### PR DESCRIPTION
Updated the Tooltip component's wrapping element to use 'display: contents;'. This allows for styles to flow through the element like it wasn't there, such as flex item positioning.