### PR TITLE
fix: OverlayTrigger to pass onClick value

### DIFF
--- a/src/components/internal/OverlayTrigger.tsx
+++ b/src/components/internal/OverlayTrigger.tsx
@@ -91,7 +91,7 @@ export function OverlayTrigger(props: OverlayTriggerProps) {
           endAdornment={!hideEndAdornment ? <Icon icon={state.isOpen ? "chevronUp" : "chevronDown"} /> : null}
           disabled={disabled}
           tooltip={tooltip}
-          onClick={noop}
+          onClick={menuTriggerProps.onPress ?? noop}
           forceFocusStyles={showActiveBorder && state.isOpen}
           {...tid}
         />
@@ -113,7 +113,7 @@ export function OverlayTrigger(props: OverlayTriggerProps) {
           {...tid}
           disabled={disabled}
           tooltip={tooltip}
-          onClick={noop}
+          onClick={menuTriggerProps.onPress ?? noop}
           forceFocusStyles={showActiveBorder && state.isOpen}
         />
       ) : (
@@ -124,7 +124,7 @@ export function OverlayTrigger(props: OverlayTriggerProps) {
           {...tid}
           disabled={disabled}
           tooltip={tooltip}
-          onClick={noop}
+          onClick={menuTriggerProps.onPress ?? noop}
           forceFocusStyles={showActiveBorder && state.isOpen}
         />
       )}


### PR DESCRIPTION
It was discovered that on iOS that the OverlayTrigger was not invoking the menu to open. This appeared to be due to passing 'noop' to the trigger element's onClick property. For whatever reason on non-mobile browsers this appeared to still work find. The 'menuTriggerProps.onPress' was still be fired as expected. Though, it was not being fired on iOS. This update passes the 'menuTriggerProps.onPress' as the 'onClick' property of the trigger elements where needed.

Not 100% sure how to go about adding a regression test at the moment, but figured we can get this fix out in the meantime.