### PR TITLE
fix: use nothingSelectedText on MultiSelectField

### DIFF
--- a/src/components/Filters/MultiFilter.tsx
+++ b/src/components/Filters/MultiFilter.tsx
@@ -55,7 +55,7 @@ class MultiFilter<O, V extends Value> extends BaseFilter<V[], MultiFilterProps<O
       );
     }
 
-    const { defaultValue, ...props } = this.props;
+    const { defaultValue, nothingSelectedText, ...props } = this.props;
     return (
       <MultiSelectField<O, V>
         {...props}
@@ -67,7 +67,7 @@ class MultiFilter<O, V extends Value> extends BaseFilter<V[], MultiFilterProps<O
         onSelect={(values) => {
           setValue(values.length === 0 ? undefined : values);
         }}
-        nothingSelectedText="All"
+        nothingSelectedText={nothingSelectedText ?? "All"}
         {...this.testId(tid)}
       />
     );


### PR DESCRIPTION
BulkTemplateManagement asks people to select filters first, before loading any data. It's disjoint for the filter to say "All" when Nothing is selected or loaded, and `multiFilter({})` is ignoring nothingSelectedText. 