### PR TITLE
fix: support precise year selection

### DIFF
--- a/src/components/internal/DatePicker/DatePicker.stories.tsx
+++ b/src/components/internal/DatePicker/DatePicker.stories.tsx
@@ -18,3 +18,29 @@ export function Default() {
   const [date, setDate] = useState(jan1);
   return <DatePicker value={date} onSelect={setDate} dottedDays={[jan1, jan2, jan29]} disabledDays={[jan10]} />;
 }
+
+export function Skip() {
+  const [date, setDate] = useState(jan1);
+  return (
+    <DatePicker
+      value={date}
+      onSelect={setDate}
+      dottedDays={[jan1, jan2, jan29]}
+      disabledDays={[jan10]}
+      yearPicker={"skip"}
+    />
+  );
+}
+
+export function Precise() {
+  const [date, setDate] = useState(jan1);
+  return (
+    <DatePicker
+      value={date}
+      onSelect={setDate}
+      dottedDays={[jan1, jan2, jan29]}
+      disabledDays={[jan10]}
+      yearPicker={"precise"}
+    />
+  );
+}

--- a/src/components/internal/DatePicker/DatePicker.tsx
+++ b/src/components/internal/DatePicker/DatePicker.tsx
@@ -1,26 +1,34 @@
 import { DayPicker, Matcher } from "react-day-picker";
 import { Day } from "src/components/internal/DatePicker/Day";
-import { Header } from "src/components/internal/DatePicker/Header";
+import { Header, PreciseDateHeader, YearSkipHeader } from "src/components/internal/DatePicker/Header";
 import { WeekHeader } from "src/components/internal/DatePicker/WeekHeader";
 import { Css } from "src/Css";
 import { useTestIds } from "src/utils";
 import "./DatePicker.css";
+
+export type YearPicker = "default" | "skip" | "precise";
 
 export interface DatePickerProps {
   value?: Date;
   onSelect: (value: Date) => void;
   disabledDays?: Matcher | Matcher[];
   dottedDays?: Matcher[];
+  yearPicker?: YearPicker;
 }
 
 export function DatePicker(props: DatePickerProps) {
-  const { value, onSelect, disabledDays, dottedDays } = props;
+  const { value, onSelect, disabledDays, dottedDays, yearPicker = "default" } = props;
   const tid = useTestIds(props, "datePicker");
 
   return (
     <div css={Css.dib.bgWhite.xs.$} {...tid}>
       <DayPicker
-        components={{ Caption: Header, Head: WeekHeader, Day }}
+        components={{
+          Caption:
+            (yearPicker === "skip" && YearSkipHeader) || (yearPicker === "precise" && PreciseDateHeader) || Header,
+          Head: WeekHeader,
+          Day,
+        }}
         // DatePicker only allows for a single date to be `selected` (per our props) though DayPicker expects an array of dates
         selected={value ? [value] : []}
         defaultMonth={value ?? new Date()}

--- a/src/components/internal/DatePicker/DateRangePicker.tsx
+++ b/src/components/internal/DatePicker/DateRangePicker.tsx
@@ -1,10 +1,11 @@
 import { DayPicker, Matcher } from "react-day-picker";
 import { Day } from "src/components/internal/DatePicker/Day";
-import { Header, YearSkipHeader } from "src/components/internal/DatePicker/Header";
+import { Header, PreciseDateHeader, YearSkipHeader } from "src/components/internal/DatePicker/Header";
 import { WeekHeader } from "src/components/internal/DatePicker/WeekHeader";
 import { Css } from "src/Css";
 import { DateRange } from "src/types";
 import { useTestIds } from "src/utils";
+import { YearPicker } from "./DatePicker";
 import "./DatePicker.css";
 
 export interface DateRangePickerProps {
@@ -12,11 +13,11 @@ export interface DateRangePickerProps {
   onSelect: (range: DateRange | undefined) => void;
   disabledDays?: Matcher | Matcher[];
   dottedDays?: Matcher[];
-  useYearPicker?: boolean;
+  yearPicker?: YearPicker;
 }
 
 export function DateRangePicker(props: DateRangePickerProps) {
-  const { range, onSelect, disabledDays, dottedDays, useYearPicker } = props;
+  const { range, onSelect, disabledDays, dottedDays, yearPicker = "default" } = props;
   const tid = useTestIds(props, "datePicker");
 
   return (
@@ -24,7 +25,12 @@ export function DateRangePicker(props: DateRangePickerProps) {
       <DayPicker
         mode="range"
         selected={range}
-        components={{ Caption: useYearPicker ? YearSkipHeader : Header, Head: WeekHeader, Day }}
+        components={{
+          Caption:
+            (yearPicker === "skip" && YearSkipHeader) || (yearPicker === "precise" && PreciseDateHeader) || Header,
+          Head: WeekHeader,
+          Day,
+        }}
         defaultMonth={range?.to ?? new Date()}
         onSelect={(selection, day, activeModifiers) => {
           // Disallow returning disabled dates.

--- a/src/components/internal/DatePicker/Header.tsx
+++ b/src/components/internal/DatePicker/Header.tsx
@@ -1,7 +1,9 @@
 import { addMonths, addYears, format } from "date-fns";
+import { useMemo } from "react";
 import { CaptionProps, useNavigation } from "react-day-picker";
 import { IconButton } from "src/components/IconButton";
 import { Css, Palette } from "src/Css";
+import { SelectField } from "src/inputs";
 
 export function Header(props: CaptionProps) {
   const { displayMonth } = props;
@@ -34,6 +36,60 @@ export function YearSkipHeader(props: CaptionProps) {
         <IconButton color={Palette.Gray700} icon="chevronLeft" onClick={() => goToMonth(addYears(displayMonth, -1))} />
         <h1 css={Css.base.$}>{format(displayMonth, "yyyy")}</h1>
         <IconButton color={Palette.Gray700} icon="chevronRight" onClick={() => goToMonth(addYears(displayMonth, 1))} />
+      </div>
+    </div>
+  );
+}
+
+type Option = {
+  label: string;
+  value: number;
+};
+
+export function PreciseDateHeader(props: CaptionProps) {
+  const { displayMonth } = props;
+  const { goToMonth } = useNavigation();
+  const currentYear = new Date().getFullYear();
+
+  const months: Option[] = useMemo(
+    () =>
+      new Array(12).fill(0).map((_, i) => ({
+        label: format(new Date(2021, i), "MMMM"),
+        value: i,
+      })),
+    [],
+  );
+
+  const years: Option[] = useMemo(
+    () =>
+      new Array(100).fill(0).map((_, i) => ({
+        label: (currentYear - i).toString(),
+        value: currentYear - i,
+      })),
+    [currentYear],
+  );
+
+  return (
+    <div css={Css.df.jcsb.aic.hPx(32).maxwPx(224).gap1.$}>
+      <SelectField
+        options={months}
+        label=""
+        getOptionLabel={(option) => option.label}
+        getOptionValue={(option) => option.value}
+        value={displayMonth.getMonth()}
+        onSelect={(month) => goToMonth(new Date(displayMonth.getFullYear(), month!))}
+        compact
+      />
+      <div css={Css.wPx(150).$}>
+        <SelectField
+          options={years}
+          label=""
+          getOptionLabel={(option) => option.label}
+          getOptionValue={(option) => option.value}
+          value={displayMonth.getFullYear()}
+          onSelect={(year) => goToMonth(new Date(year!, displayMonth.getMonth()))}
+          compact
+        />
       </div>
     </div>
   );

--- a/src/inputs/DateFields/DateFieldBase.tsx
+++ b/src/inputs/DateFields/DateFieldBase.tsx
@@ -3,7 +3,7 @@ import { useButton, useOverlayPosition, useOverlayTrigger, useTextField } from "
 import { isDateRange, Matcher } from "react-day-picker";
 import { useOverlayTriggerState } from "react-stately";
 import { Icon, IconButton, resolveTooltip } from "src/components";
-import { DatePicker, DateRangePicker, Popover } from "src/components/internal";
+import { DatePicker, DateRangePicker, Popover, YearPicker } from "src/components/internal";
 import { DatePickerOverlay } from "src/components/internal/DatePicker/DatePickerOverlay";
 import { Css, Palette, Properties } from "src/Css";
 import {
@@ -51,6 +51,7 @@ export interface DateFieldBaseProps
   mode: DateFieldMode;
   /** Range filters should only allow a full DateRange or nothing */
   isRangeFilterField?: boolean;
+  yearPicker?: YearPicker;
 }
 
 export interface DateSingleFieldBaseProps extends DateFieldBaseProps {
@@ -86,6 +87,7 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
     defaultOpen,
     mode,
     isRangeFilterField = false,
+    yearPicker = "default",
     ...others
   } = props;
 
@@ -333,7 +335,8 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
                   setInputValue(formatDateRange(dr, dateFormats.short) ?? "");
                   onChange(dr);
                 }}
-                useYearPicker={isRangeFilterField}
+                // Allow the year picker to be overridden by the `yearPicker` prop, otherwise default to "skip" for range filters
+                yearPicker={yearPicker || (isRangeFilterField && "skip")}
                 {...tid.datePicker}
               />
             ) : (
@@ -345,6 +348,7 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
                   onChange(d);
                   state.close();
                 }}
+                yearPicker={yearPicker}
                 {...tid.datePicker}
               />
             )}


### PR DESCRIPTION
I think this should already exist in beam, is pretty bad UX having to click a 100 times to get to the desired year.

I added this custom header to the `DatePicker` and `DateRangePicker`, open to design feedback 🙂.

![image](https://user-images.githubusercontent.com/35903168/220224050-244a4745-64d7-4a75-9c08-3f2e33efe1d1.png)
