### PR TITLE
style: SC-26626 add darkMode type to chip styles

### DIFF
--- a/src/components/Chip.stories.tsx
+++ b/src/components/Chip.stories.tsx
@@ -35,6 +35,7 @@ export function ColoredChips() {
         <Chip text="warning" type={ChipTypes.warning} />
         <Chip text="success" type={ChipTypes.success} />
         <Chip text="light" type={ChipTypes.light} />
+        <Chip text="darkMode" type={ChipTypes.darkMode} />
         <Chip text="dark" type={ChipTypes.dark} />
       </div>
     </div>

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -4,7 +4,7 @@ import { maybeTooltip } from "src/components/Tooltip";
 import { Css, Margin, Only, Properties, Xss } from "src/Css";
 import { useTestIds } from "src/utils/useTestIds";
 
-type ChipType = "caution" | "warning" | "success" | "light" | "dark" | "neutral";
+type ChipType = "caution" | "warning" | "success" | "light" | "dark" | "neutral" | "darkMode";
 
 // exporting for using in type prop as constant - this could be moved and become a global list for colors
 export const ChipTypes: Record<ChipType, ChipType> = {
@@ -14,6 +14,7 @@ export const ChipTypes: Record<ChipType, ChipType> = {
   light: "light",
   dark: "dark",
   neutral: "neutral",
+  darkMode: "darkMode",
 };
 
 export interface ChipProps<X> {
@@ -55,4 +56,5 @@ const typeStyles: Record<ChipType, Properties> = {
   light: Css.bgWhite.$,
   dark: Css.bgGray900.white.$,
   neutral: Css.bgGray200.$,
+  darkMode: Css.bgGray700.white.$,
 };


### PR DESCRIPTION
We need to add a new type style for Chip
As per as conversation with Radhi, the name should be `darkMode`

Figma: https://www.figma.com/file/anwOr1tvzTrXObf3vh2QfX/22-Q3-%F0%9F%9B%A0-Item-Catalog?node-id=5403%3A90038&t=ZUXMT7oeBzScF23w-0

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/102976231/221699974-c6dd148f-8b21-49f4-ab3e-dfc2d4834452.png">
