### PR TITLE
feat: add `tableSnapshot` helper

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -12,7 +12,7 @@ import { emptyCell, matchesFilter } from "src/components/Table/utils/utils";
 import { Css, Palette } from "src/Css";
 import { useComputed } from "src/hooks";
 import { Checkbox, TextField } from "src/inputs";
-import { cell, cellAnd, cellOf, click, render, row, type, wait, withRouter } from "src/utils/rtl";
+import { cell, cellAnd, cellOf, click, render, row, tableSnapshot, type, wait, withRouter } from "src/utils/rtl";
 
 // Most of our tests use this simple Row and 2 columns
 type Data = { name: string; value: number | undefined | null };
@@ -2806,6 +2806,30 @@ describe("GridTable", () => {
       // Then the `columnA` remains collapsed
       expect(row(r, 1).childNodes).toHaveLength(2);
     });
+  });
+
+  it("can be tested with a human readable inlineSnapshot using tableSnapshot()", async () => {
+    // Given a table with simple data
+    const r = await render(
+      <GridTable
+        columns={[nameColumn, valueColumn]}
+        sorting={{ on: "client" }}
+        rows={[
+          simpleHeader,
+          { kind: "data", id: "1", data: { name: "Row 1", value: 200 } },
+          { kind: "data", id: "2", data: { name: "Row 2", value: 300 } },
+          { kind: "data", id: "3", data: { name: "Row 3", value: 1000 } },
+        ]}
+      />,
+    );
+
+    // Then a text snapshot should be generated when using `tableSnapshot`
+    expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+      "Name | Value
+      Row 1 | 200
+      Row 2 | 300
+      Row 3 | 1000"
+    `);
   });
 });
 

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -2792,12 +2792,28 @@ describe("GridTable", () => {
 
       // Then the column is initially expanded (1 column + 1 expanded column)
       expect(row(r, 1).childNodes).toHaveLength(2);
+      expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+        "
+        | Client name |
+        | First name  | Last name |
+        | ----------- | --------- |
+        | Brandon     | Dow       |
+        "
+      `);
 
       //  When clicking to collapse `columnA`
       click(r.expandableColumn);
 
       // Then the column is collapsed
       expect(row(r, 1).childNodes).toHaveLength(1);
+      expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+              "
+              | Client name |
+              | Full name   |
+              | ----------- |
+              | Brandon Dow |
+              "
+          `);
 
       // And when then triggering new `columnB` to be introduced
       api.current?.setVisibleColumns(api.current.getVisibleColumnIds().concat("columnB"));
@@ -2805,6 +2821,14 @@ describe("GridTable", () => {
 
       // Then the `columnA` remains collapsed
       expect(row(r, 1).childNodes).toHaveLength(2);
+      expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+        "
+        | Client name | Age |
+        | Full name   |     |
+        | ----------- | --- |
+        | Brandon Dow | 36  |
+        "
+      `);
     });
   });
 
@@ -2817,7 +2841,7 @@ describe("GridTable", () => {
         rows={[
           simpleHeader,
           { kind: "data", id: "1", data: { name: "Row 1", value: 200 } },
-          { kind: "data", id: "2", data: { name: "Row 2", value: 300 } },
+          { kind: "data", id: "2", data: { name: "Row 2 with a longer name", value: 300 } },
           { kind: "data", id: "3", data: { name: "Row 3", value: 1000 } },
         ]}
       />,
@@ -2825,10 +2849,13 @@ describe("GridTable", () => {
 
     // Then a text snapshot should be generated when using `tableSnapshot`
     expect(tableSnapshot(r)).toMatchInlineSnapshot(`
-      "Name | Value
-      Row 1 | 200
-      Row 2 | 300
-      Row 3 | 1000"
+      "
+      | Name                     | Value |
+      | ------------------------ | ----- |
+      | Row 1                    | 200   |
+      | Row 2 with a longer name | 300   |
+      | Row 3                    | 1000  |
+      "
     `);
   });
 });

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -2807,13 +2807,13 @@ describe("GridTable", () => {
       // Then the column is collapsed
       expect(row(r, 1).childNodes).toHaveLength(1);
       expect(tableSnapshot(r)).toMatchInlineSnapshot(`
-              "
-              | Client name |
-              | Full name   |
-              | ----------- |
-              | Brandon Dow |
-              "
-          `);
+        "
+        | Client name |
+        | Full name   |
+        | ----------- |
+        | Brandon Dow |
+        "
+      `);
 
       // And when then triggering new `columnB` to be introduced
       api.current?.setVisibleColumns(api.current.getVisibleColumnIds().concat("columnB"));

--- a/src/utils/rtl.tsx
+++ b/src/utils/rtl.tsx
@@ -100,13 +100,72 @@ export function rowAnd(r: RenderResult, rowNum: number, testId: string): HTMLEle
 export function tableSnapshot(r: RenderResult): string {
   const tableEl = r.getByTestId("gridTable");
   const dataRows = Array.from(tableEl.querySelectorAll("[data-gridrow]"));
+  const hasExpandableHeader = !!tableEl.querySelector(`[data-testid="expandableColumn"]`);
 
-  return dataRows
-    .map((row) => {
-      const cellTextContent = Array.from(row.childNodes).map((cell) => cell.textContent);
-      return cellTextContent.join(" | ");
-    })
-    .join("\n");
+  const tableDataAsStrings = dataRows.map((row) => {
+    return Array.from(row.childNodes).map(getTextFromTableCellNode);
+  });
+
+  return toMarkupTableString({ tableRows: tableDataAsStrings, hasExpandableHeader });
+}
+
+function toMarkupTableString({
+  tableRows,
+  hasExpandableHeader,
+}: {
+  tableRows: (string | null)[][];
+  hasExpandableHeader: boolean;
+}) {
+  // Find the largest width of each column to set a consistent width for each row
+  const columnWidths = tableRows.reduce((acc, row) => {
+    row.forEach((cell, columnIndex) => {
+      const cellWidth = cell?.length ?? 0;
+      const currentMaxWidth = acc.get(columnIndex) ?? 0;
+      if (cellWidth > currentMaxWidth || !currentMaxWidth) acc.set(columnIndex, cellWidth);
+    });
+
+    return acc;
+  }, new Map<number, number>());
+
+  const wrapTableRowEnds = (str: string) => `| ${str} |`;
+
+  const rowsWithPaddingAndDividers = tableRows.map((tableCells) => {
+    const formattedRow = tableCells
+      .map((cell, columnIndex) => {
+        const cellWidth = columnWidths.get(columnIndex) ?? 0;
+        return cell?.padEnd(cellWidth, " ") || "";
+      })
+      .join(" | ");
+    return wrapTableRowEnds(formattedRow);
+  });
+
+  const headerDivider = Array.from(columnWidths.values())
+    .map((width) => "-".repeat(width) ?? "")
+    .join(" | ");
+
+  const headerDividerRowNumber = hasExpandableHeader ? 2 : 1;
+  rowsWithPaddingAndDividers.splice(headerDividerRowNumber, 0, wrapTableRowEnds(headerDivider));
+
+  // Pad a newline on top and bottom for cleaner diffs
+  return `\n${rowsWithPaddingAndDividers.join("\n")}\n`;
+}
+
+/** Prefer showing a `value` from a mocked input vs. the combined text content from an inputs markup */
+function getTextFromTableCellNode(node: ChildNode) {
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    const element = node as HTMLElement;
+
+    const maybeInput = element.getElementsByTagName("input")[0];
+    if (maybeInput) return maybeInput.value;
+
+    const maybeTextarea = element.getElementsByTagName("textarea")[0];
+    if (maybeTextarea) return maybeTextarea.value;
+
+    const maybeSelect = element.getElementsByTagName("select")[0];
+    if (maybeSelect) return maybeSelect.value;
+  }
+
+  return node.textContent;
 }
 
 /** RTL wrapper for Beam's SuperDrawer/Modal context. */

--- a/src/utils/rtl.tsx
+++ b/src/utils/rtl.tsx
@@ -89,13 +89,17 @@ export function rowAnd(r: RenderResult, rowNum: number, testId: string): HTMLEle
   return e.querySelector(`[data-testid="${testId}"]`) || fail(`Element not found ${prettyDOM(e)}`);
 }
 
-/** Intended to be used to generate a human-readable text representation of a GridTable
- * * Example Use: `expect(tableSnapshot(r)).toMatchInlineSnapshot(`
-      "Name | Value
-      Row 1 | 200
-      Row 2 | 300
-      Row 3 | 1000"
-    `)`
+/** Intended to be used to generate a human-readable text 
+ * representation of a GridTable using the markdown table syntax.
+ * * Example Use: expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+      "
+      | Name                     | Value |
+      | ------------------------ | ----- |
+      | Row 1                    | 200   |
+      | Row 2 with a longer name | 300   |
+      | Row 3                    | 1000  |
+      "
+    `);
  * */
 export function tableSnapshot(r: RenderResult): string {
   const tableEl = r.getByTestId("gridTable");

--- a/src/utils/rtl.tsx
+++ b/src/utils/rtl.tsx
@@ -89,6 +89,26 @@ export function rowAnd(r: RenderResult, rowNum: number, testId: string): HTMLEle
   return e.querySelector(`[data-testid="${testId}"]`) || fail(`Element not found ${prettyDOM(e)}`);
 }
 
+/** Intended to be used to generate a human-readable text representation of a GridTable
+ * * Example Use: `expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+      "Name | Value
+      Row 1 | 200
+      Row 2 | 300
+      Row 3 | 1000"
+    `)`
+ * */
+export function tableSnapshot(r: RenderResult): string {
+  const tableEl = r.getByTestId("gridTable");
+  const dataRows = Array.from(tableEl.querySelectorAll("[data-gridrow]"));
+
+  return dataRows
+    .map((row) => {
+      const cellTextContent = Array.from(row.childNodes).map((cell) => cell.textContent);
+      return cellTextContent.join(" | ");
+    })
+    .join("\n");
+}
+
 /** RTL wrapper for Beam's SuperDrawer/Modal context. */
 export const withBeamRTL: Wrapper = {
   wrap: (c) => <BeamProvider>{c}</BeamProvider>,


### PR DESCRIPTION
Generates a human-readable string representation of a table for easy matching using `toMatchInlineSnapshot`
```ts
    expect(tableSnapshot(r)).toMatchInlineSnapshot(`
      "
      | Name                     | Value |
      | ------------------------ | ----- |
      | Row 1                    | 200   |
      | Row 2 with a longer name | 300   |
      | Row 3                    | 1000  |
      "
    `);
```

**Example from lot sequence sheet:**
```ts
      expect(tableSnapshot(r)).toMatchInlineSnapshot(`
        "
        |     |          |                  |          | Plot information  | Exterior options | Floor plan options | Add-ons          | Interior options   |               |
        |     | Address  | Construction RTS | Delivery | Plan              | Spec level       | Sellable SF        | Net Buildable SF | Gross Buildable SF | Permitable SF | Bedrooms | Full baths | Half baths | Elevation   | Exterior scheme |                     |      |      |  |
        | --- | -------- | ---------------- | -------- | ----------------- | ---------------- | ------------------ | ---------------- | ------------------ | ------------- | -------- | ---------- | ---------- | ----------- | --------------- | ------------------- | ---- | ---- |  |
        |     | Cohort 1 |                  |          |                   |                  |                    |                  |                    |               |          |            |            |             |                 |                     |      |      |
        | New | street1  | 01/01/18         | 01/02/18 | Ready Plan 1 (RH) | Base             | 149                | 100              | 100                | 100           | 3        | 2          | 1          | Elevation 1 | Palette 1       | fpo1fpo2fpo3+1 more | aoo1 | iso1 |  |
        "
      `);
```

**Example from a project schedule table:**
```ts
    expect(tableSnapshot(r)).toMatchInlineSnapshot(`
      "
      |  | Task                | Start    | End      | Duration | Duration Variance | Predecessor | Successor | Status      | Assignee | Trade Partner | Resources | Phase                       | SubPhase                     | Files | Actions |
      |  | ------------------- | -------- | -------- | -------- | ----------------- | ----------- | --------- | ----------- | -------- | ------------- | --------- | --------------------------- | ---------------------------- | ----- | ------- |
      |  | Schedule Phase 1    | 01/01/18 | 01/10/18 | 8 days   |                   |             |           | 25%         |          |               |           |                             |                              |       |         |
      |  | Schedule SubPhase 1 | 01/01/18 | 01/02/18 | 1 day    |                   |             |           | 33%         |          |               |           |                             |                              |       |         |
      |  | Schedule SubPhase 2 | 01/01/18 | 01/02/18 | 1 day    |                   |             |           | 0%          |          |               |           |                             |                              |       |         |
      |  | 1Task 2             | 01/01/18 | 01/02/18 | 1 day    |                   | 1 +3 more   | 1 +4 more | IN_PROGRESS | User #2  | ABC Builders  | false     | Schedule PhaseGlobalPhase 1 | Schedule Sub Phase+ SubPhase |       | 2       |
      |  | Schedule Phase 2    | 01/01/18 | 01/02/18 | 1 day    |                   |             |           | 0%          |          |               |           |                             |                              |       |         |
      |  | Schedule SubPhase 3 | 01/01/18 | 01/02/18 | 1 day    |                   |             |           | 0%          |          |               |           |                             |                              |       |         |
      |  | Schedule SubPhase 4 | 01/01/18 | 01/02/18 | 1 day    |                   |             |           | 0%          |          |               |           |                             |                              |       |         |
      |  | Schedule Phase 3    |          |          |          |                   |             |           | 0%          |          |               |           |                             |                              |       |         |
      "
    `);
```

**Potential Improvements:**

- Config to ignore header row(s)
- Config to ignore columns
- Config to print text content differently for `input` types values (such as including labels)