### PR TITLE
feat: support for label style on StaticField

### DIFF
--- a/src/forms/StaticField.stories.tsx
+++ b/src/forms/StaticField.stories.tsx
@@ -13,7 +13,7 @@ export default {
 export function StaticField() {
   return (
     <FormLines>
-      <StaticFieldComponent label="First" value="Bob" />
+      <StaticFieldComponent label="Above" value="Bob" />
       <FieldGroup widths={["100px", "100px", "200px"]}>
         <StaticFieldComponent label="First" value="Bob" />
         <StaticFieldComponent label="First" value="Bob" />
@@ -33,6 +33,9 @@ export function StaticField() {
       <StaticFieldComponent label="First">
         <Chips values={["First", "Last"]} />
       </StaticFieldComponent>
+      <div css={Css.w25.$}>
+        <StaticFieldComponent label="Left" value="Bob" labelStyle="left" />
+      </div>
     </FormLines>
   );
 }

--- a/src/forms/StaticField.test.tsx
+++ b/src/forms/StaticField.test.tsx
@@ -11,4 +11,12 @@ describe("StaticField", () => {
     const r = await render(<StaticField label="Foo" value="Bar" data-testid="zaz" />);
     expect(r.zaz()).toHaveTextContent("Bar");
   });
+
+  it("supports label style left", async () => {
+    const r = await render(<StaticField label="Foo" labelStyle="left" value="Bar" />);
+    expect(r.foo()).toHaveTextContent("Bar");
+    expect(r.foo_container()).toHaveStyleRule("display", "flex");
+    expect(r.foo_container()).toHaveStyleRule("justify-content", "space-between");
+    expect(r.foo_container()).toHaveStyleRule("max-width", "100%");
+  });
 });

--- a/src/forms/StaticField.tsx
+++ b/src/forms/StaticField.tsx
@@ -1,6 +1,6 @@
 import { useId } from "@react-aria/utils";
 import { ReactNode } from "react";
-import { PresentationFieldProps } from "src/components/PresentationContext";
+import { PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
 import { Css, px } from "src/Css";
 import { defaultTestId } from "src/utils/defaultTestId";
 import { useTestIds } from "src/utils/useTestIds";
@@ -13,7 +13,8 @@ interface StaticFieldProps {
 }
 
 export function StaticField(props: StaticFieldProps) {
-  const { label, labelStyle = "above", value, children } = props;
+  const { fieldProps } = usePresentationContext();
+  const { label, labelStyle = fieldProps?.labelStyle ?? "above", value, children } = props;
   const tid = useTestIds(props, typeof label === "string" ? defaultTestId(label) : "staticField");
   const id = useId();
   return (

--- a/src/forms/StaticField.tsx
+++ b/src/forms/StaticField.tsx
@@ -1,6 +1,7 @@
 import { useId } from "@react-aria/utils";
 import { ReactNode } from "react";
-import { Css } from "src/Css";
+import { PresentationFieldProps } from "src/components/PresentationContext";
+import { Css, px } from "src/Css";
 import { defaultTestId } from "src/utils/defaultTestId";
 import { useTestIds } from "src/utils/useTestIds";
 
@@ -8,18 +9,19 @@ interface StaticFieldProps {
   label: ReactNode;
   value?: string;
   children?: ReactNode;
+  labelStyle?: PresentationFieldProps["labelStyle"];
 }
 
 export function StaticField(props: StaticFieldProps) {
-  const { label, value, children } = props;
+  const { label, labelStyle = "above", value, children } = props;
   const tid = useTestIds(props, typeof label === "string" ? defaultTestId(label) : "staticField");
   const id = useId();
   return (
-    <div>
+    <div css={Css.w100.maxw(px(550)).if(labelStyle === "left").df.jcsb.maxw100.$} {...tid.container}>
       <label css={Css.db.sm.gray700.mbPx(4).$} htmlFor={id} {...tid.label}>
         {label}
       </label>
-      <div id={id} css={Css.smMd.gray900.df.aic.$} {...tid}>
+      <div id={id} css={Css.smMd.gray900.$} {...tid}>
         {value || children}
       </div>
     </div>


### PR DESCRIPTION
## SC-30546

- Add support for `labelStyle` prop

### Example
<img width="366" alt="image" src="https://user-images.githubusercontent.com/108748822/224157248-97a80d0b-a993-4e72-a868-203026822976.png">

Discussion: https://github.com/homebound-team/internal-frontend/pull/3533#discussion_r1131495964