### PR TITLE
fix: Set width on Static Field when label style is LEFT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@homebound/beam",
-  "version": "2.253.0",
+  "version": "2.254.0",
   "author": "Homebound",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/forms/StaticField.test.tsx
+++ b/src/forms/StaticField.test.tsx
@@ -18,5 +18,6 @@ describe("StaticField", () => {
     expect(r.foo_container()).toHaveStyleRule("display", "flex");
     expect(r.foo_container()).toHaveStyleRule("justify-content", "space-between");
     expect(r.foo_container()).toHaveStyleRule("max-width", "100%");
+    expect(r.foo()).toHaveStyleRule("width", "50%");
   });
 });

--- a/src/forms/StaticField.tsx
+++ b/src/forms/StaticField.tsx
@@ -22,7 +22,7 @@ export function StaticField(props: StaticFieldProps) {
       <label css={Css.db.sm.gray700.mbPx(4).$} htmlFor={id} {...tid.label}>
         {label}
       </label>
-      <div id={id} css={Css.smMd.gray900.$} {...tid}>
+      <div id={id} css={Css.smMd.gray900.if(labelStyle === "left").w50.$} {...tid}>
         {value || children}
       </div>
     </div>


### PR DESCRIPTION
Fix to https://github.com/homebound-team/beam/pull/824