### PR TITLE
fix: Remove wrong width from Static Field div

### DIFF
--- a/src/forms/StaticField.stories.tsx
+++ b/src/forms/StaticField.stories.tsx
@@ -39,3 +39,28 @@ export function StaticField() {
     </FormLines>
   );
 }
+
+export function StaticFieldsGrouped() {
+  return (
+    <div css={Css.w50.$}>
+      <div css={Css.br8.ba.bGray300.bgWhite.$}>
+        <div css={Css.df.gap4.m3.$}>
+          <StaticFieldComponent label="Item code">
+            <div css={Css.dib.red600.$}>1010</div>
+          </StaticFieldComponent>
+          <StaticFieldComponent label="Item description">
+            <div css={Css.nowrap.overflowHidden.add("textOverflow", "ellipsis").w("230px").$}>
+              <div css={Css.dib.$}>intacctVendorName- description</div>
+            </div>
+          </StaticFieldComponent>
+          <StaticFieldComponent label="Posted date">
+            <div css={Css.mla.$}>01/01/18</div>
+          </StaticFieldComponent>
+          <StaticFieldComponent label="Amount">
+            <div css={Css.mla.$}>$100.00</div>
+          </StaticFieldComponent>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/forms/StaticField.tsx
+++ b/src/forms/StaticField.tsx
@@ -1,7 +1,7 @@
 import { useId } from "@react-aria/utils";
 import { ReactNode } from "react";
 import { PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
-import { Css, px } from "src/Css";
+import { Css } from "src/Css";
 import { defaultTestId } from "src/utils/defaultTestId";
 import { useTestIds } from "src/utils/useTestIds";
 
@@ -19,11 +19,11 @@ export function StaticField(props: StaticFieldProps) {
   const tid = useTestIds(props, typeof label === "string" ? defaultTestId(label) : "staticField");
   const id = useId();
   return (
-    <div css={Css.w100.maxw(px(550)).if(labelStyle === "left").df.jcsb.maxw100.$} {...tid.container}>
+    <div css={Css.if(labelStyle === "left").df.jcsb.maxw100.$} {...tid.container}>
       <label css={Css.db.sm.gray700.mbPx(4).$} htmlFor={id} {...tid.label}>
         {label}
       </label>
-      <div id={id} css={Css.smMd.gray900.if(labelStyle === "left").w50.$} {...tid}>
+      <div id={id} css={Css.smMd.gray900.df.aic.if(labelStyle === "left").w50.$} {...tid}>
         {value || children}
       </div>
     </div>


### PR DESCRIPTION
After run Chromic step we could notice a bunch of changes in the PR above, this is because the property `width` set in last commit was wrong.

PR (https://github.com/homebound-team/internal-frontend/pull/3533)

This PR is to remove that and avoid change it in many places.