### PR TITLE
feat: support wrap text on table using select field

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -30,6 +30,7 @@ import {
 } from "src/components/index";
 import { Css, Palette } from "src/Css";
 import { useComputed } from "src/hooks";
+import { SelectField } from "src/inputs";
 import { NumberField } from "src/inputs/NumberField";
 import { noop } from "src/utils";
 import { newStory, withRouter, zeroTo } from "src/utils/sb";
@@ -601,6 +602,52 @@ export function WrappedHeaders() {
           kind: "data",
           id: "4",
           data: { name: "Baz", role: "Contractor", date: "04/21/21", priceInCents: 12_365_00 },
+        },
+      ]}
+    />
+  );
+}
+
+export function WrappedCells() {
+  const leftAlignedColumn = column<Row2>({
+    header: "Basic field header",
+    data: ({ name }) => ({ content: <div>{name}</div>, sortValue: name }),
+    w: "150px",
+  });
+  const centerAlignedColumn = actionColumn<Row2>({
+    header: "Readonly select field header",
+    data: ({ role }) => (
+      <SelectField label="role" value={role} onSelect={noop} options={[{ id: role, name: role }]} readOnly />
+    ),
+    w: "150px",
+  });
+
+  return (
+    <GridTable<Row2>
+      columns={[leftAlignedColumn, centerAlignedColumn]}
+      sorting={{ on: "client", initial: undefined }}
+      style={{ rowHeight: "flexible" }}
+      rows={[
+        simpleHeader,
+        {
+          kind: "data",
+          id: "1",
+          data: {
+            name: "Very long long name here",
+            role: "Something you can wrap",
+            date: "11/29/85",
+            priceInCents: 113_00,
+          },
+        },
+        {
+          kind: "data",
+          id: "3",
+          data: {
+            name: "Another very long long name here",
+            role: "A very long text herea very long text here",
+            date: "11/08/18",
+            priceInCents: 80_65,
+          },
         },
       ]}
     />

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -11,7 +11,8 @@ import { TableStateContext } from "src/components/Table/utils/TableState";
 import { emptyCell, matchesFilter } from "src/components/Table/utils/utils";
 import { Css, Palette } from "src/Css";
 import { useComputed } from "src/hooks";
-import { Checkbox, TextField } from "src/inputs";
+import { Checkbox, SelectField, TextField } from "src/inputs";
+import { noop } from "src/utils";
 import { cell, cellAnd, cellOf, click, render, row, tableSnapshot, type, wait, withRouter } from "src/utils/rtl";
 
 // Most of our tests use this simple Row and 2 columns
@@ -135,6 +136,36 @@ describe("GridTable", () => {
     const r = await render(<GridTable columns={[valueColumn]} rows={rows} />);
     expect(cell(r, 1, 0)).toHaveTextContent("1");
     expect(cell(r, 2, 0)).toHaveTextContent("2");
+  });
+
+  it("wraps readonly select field", async () => {
+    // Given a column with a select field
+    const longText = "Something very long that have to wrap here";
+    const selectColumn: GridColumn<Row> = {
+      header: "Select",
+      w: "150px",
+      data: (row) => ({
+        content: (
+          <SelectField
+            label="field"
+            getOptionLabel={(r) => r.name}
+            getOptionValue={(r) => r.id}
+            value={row.value}
+            onSelect={noop}
+            options={[{ id: row.value, name: row.name }]}
+            readOnly
+          />
+        ),
+      }),
+    };
+    const rows: GridDataRow<Row>[] = [simpleHeader, { kind: "data", id: "1", data: { name: longText, value: 1 } }];
+    // And it's rendered with row height flexible
+    const r = await render(<GridTable style={{ rowHeight: "flexible" }} columns={[selectColumn]} rows={rows} />);
+
+    // Then field do not have any Css.truncate styles
+    expect(r.field()).not.toHaveStyleRule("white-space", "nowrap");
+    expect(r.field()).not.toHaveStyleRule("overflow", "hidden");
+    expect(r.field()).not.toHaveStyleRule("textOverflow", "ellipsis");
   });
 
   it("can have per-row styles", async () => {

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -60,7 +60,7 @@ export interface TextFieldBaseProps<X>
 
 // Used by both TextField and TextArea
 export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldBaseProps<X>) {
-  const { fieldProps } = usePresentationContext();
+  const { fieldProps, wrap = false } = usePresentationContext();
   const {
     label,
     required,
@@ -194,7 +194,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
               css={{
                 // Use input wrapper to get common styles, but then we need to override some
                 ...fieldStyles.inputWrapperReadOnly,
-                ...(multiline ? Css.fdc.aifs.gap2.$ : Css.truncate.$),
+                ...(multiline ? Css.fdc.aifs.gap2.$ : Css.if(wrap === false).truncate.$),
                 ...xss,
               }}
               data-readonly="true"


### PR DESCRIPTION
# SC-31248

Updated `TextFieldBase` to use wrap PresentationContext property to prevent truncate the field.

