### PR TITLE
fix: Strip colons from default test ids.

### DIFF
--- a/src/hooks/useComputed.ts
+++ b/src/hooks/useComputed.ts
@@ -51,7 +51,13 @@ export function useComputed<T>(fn: (prev: T | undefined) => T, deps: readonly an
       // Only trigger a re-render if this is not the 1st autorun. Note
       // that if deps has changed, we're inherently in a re-render so also
       // don't need to trigger an additional re-render.
-      if (hasRan) setTick((tick) => tick + 1);
+      if (hasRan) {
+        // This can cause 'Cannot update a component while rendering a different component'
+        // if one component (the mutator) is updating observable from directly
+        // within it's render method. Usually this is rare and can be avoided by
+        // only updating observables from within useEffect.
+        setTick((tick) => tick + 1);
+      }
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);

--- a/src/utils/defaultTestId.test.ts
+++ b/src/utils/defaultTestId.test.ts
@@ -1,0 +1,7 @@
+import { defaultTestId } from "src";
+
+describe("defaultTestId", () => {
+  it("strips underscore", () => {
+    expect(defaultTestId("rpo:4")).toEqual("rpo4");
+  });
+});

--- a/src/utils/defaultTestId.ts
+++ b/src/utils/defaultTestId.ts
@@ -5,8 +5,12 @@ import { camelCase } from "change-case";
  * returns `homeownerContract`.
  *
  * This is useful for our (non-bound) form fields that will probably have a label,
- * but may not have an data-testid set by the encompassing page.
+ * but may not have a `data-testid` set by the encompassing page.
+ *
+ * (Bound form fields typically set their test id from their form-state field's key.)
  */
 export function defaultTestId(label: string): string {
-  return camelCase(label);
+  // Strip `m:4` to `m4` to prevent it from becoming `m_4` which our rtl-utils assumes
+  // means "the 4th element with a data-testid value of 'm'".
+  return camelCase(label.replace(":", ""));
 }


### PR DESCRIPTION
Going to wait to merge this after the bump-react PRs land to avoid conflicts.