### PR TITLE
fix: Prevent Avatar from squishing by setting min-width

### DIFF
--- a/src/components/Avatar.stories.tsx
+++ b/src/components/Avatar.stories.tsx
@@ -54,3 +54,19 @@ export function Examples() {
     </div>
   );
 }
+
+export function InFlexChild() {
+  return (
+    <div>
+      <div css={Css.mb2.$}>
+        Demonstrates Avatar will not squish when rendered within a flex child that allows flex-shrink
+      </div>
+      <div css={Css.df.gap2.wPx(250).br8.bgGray200.p1.$}>
+        <div>{"Testing string that will wrap. ".repeat(10)}</div>
+        <div>
+          <Avatar src="captain-marvel.jpg" size="lg" name="Carol Danvers" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -14,7 +14,8 @@ export function Avatar({ src, name, size = "md", showName = false, ...others }: 
   const tid = useTestIds(others, "avatar");
   const px = sizeToPixel[size];
   const [showFallback, setShowFallback] = useState(src === undefined);
-  const styles = Css.br100.wPx(px).hPx(px).overflowHidden.$;
+  // Define min-width as well as width to prevent the image from shrinking when displayed within a flex-child that allows shrinking.
+  const styles = Css.br100.wPx(px).hPx(px).mwPx(px).overflowHidden.$;
 
   const img = showFallback ? (
     <div css={{ ...styles, ...Css[sizeToFallbackTypeScale[size]].bgGray400.gray100.df.aic.jcc.$ }} {...tid}>


### PR DESCRIPTION
Includes storybook example as a regression test.

## Before
<img width="451" alt="Screen Shot 2023-03-21 at 10 16 13 AM" src="https://user-images.githubusercontent.com/1143861/226634802-50b7afc7-b1b0-44a8-b025-ad6aaf905878.png">


## After
<img width="424" alt="Screen Shot 2023-03-21 at 10 17 59 AM" src="https://user-images.githubusercontent.com/1143861/226634817-6faab7b4-66fe-40df-9816-9808955c275b.png">
