### PR TITLE
chore: Rename internal components

### DIFF
--- a/src/components/Filters/MultiFilter.tsx
+++ b/src/components/Filters/MultiFilter.tsx
@@ -1,7 +1,7 @@
 import { Key } from "react";
 import { BaseFilter } from "src/components/Filters/BaseFilter";
 import { Filter } from "src/components/Filters/types";
-import { disabledOptionToKeyedTuple } from "src/inputs/internal/SelectFieldBase";
+import { disabledOptionToKeyedTuple } from "src/inputs/internal/ComboBoxBase";
 import { MultiSelectField, MultiSelectFieldProps } from "src/inputs/MultiSelectField";
 import { ToggleChipGroup } from "src/inputs/ToggleChipGroup";
 import { Value } from "src/inputs/Value";

--- a/src/inputs/MultiLineSelectField.tsx
+++ b/src/inputs/MultiLineSelectField.tsx
@@ -2,12 +2,11 @@ import { useState } from "react";
 import { Button } from "src/components/Button";
 import { Label } from "src/components/Label";
 import { SelectField, Value } from "src/inputs";
-import { BeamSelectFieldBaseProps } from "src/inputs/internal/SelectFieldBase";
+import { ComboBoxBaseProps } from "src/inputs/internal/ComboBoxBase";
 import { Optional } from "src/types";
 import { Css, useTestIds } from "..";
 
-export interface MultiLineSelectFieldProps<O, V extends Value>
-  extends Exclude<BeamSelectFieldBaseProps<O, V>, "unsetLabel"> {
+export interface MultiLineSelectFieldProps<O, V extends Value> extends Exclude<ComboBoxBaseProps<O, V>, "unsetLabel"> {
   values: V[];
   options: O[];
   getOptionValue: (opt: O) => V;

--- a/src/inputs/MultiSelectField.tsx
+++ b/src/inputs/MultiSelectField.tsx
@@ -1,10 +1,9 @@
 import { ReactNode } from "react";
 import { Value } from "src/inputs";
-import { BeamSelectFieldBaseProps, SelectFieldBase } from "src/inputs/internal/SelectFieldBase";
+import { ComboBoxBase, ComboBoxBaseProps } from "src/inputs/internal/ComboBoxBase";
 import { HasIdAndName, Optional } from "src/types";
 
-export interface MultiSelectFieldProps<O, V extends Value>
-  extends Exclude<BeamSelectFieldBaseProps<O, V>, "unsetLabel"> {
+export interface MultiSelectFieldProps<O, V extends Value> extends Exclude<ComboBoxBaseProps<O, V>, "unsetLabel"> {
   /** Renders `opt` in the dropdown menu, defaults to the `getOptionLabel` prop. */
   getOptionMenuLabel?: (opt: O) => string | ReactNode;
   getOptionValue: (opt: O) => V;
@@ -37,7 +36,7 @@ export function MultiSelectField<O, V extends Value>(
   } = props;
 
   return (
-    <SelectFieldBase
+    <ComboBoxBase
       multiselect
       {...otherProps}
       options={options}

--- a/src/inputs/SelectField.tsx
+++ b/src/inputs/SelectField.tsx
@@ -1,9 +1,8 @@
 import { Value } from "src/inputs";
-import { BeamSelectFieldBaseProps, SelectFieldBase, unsetOption } from "src/inputs/internal/SelectFieldBase";
+import { ComboBoxBase, ComboBoxBaseProps, unsetOption } from "src/inputs/internal/ComboBoxBase";
 import { HasIdAndName, Optional } from "src/types";
 
-export interface SelectFieldProps<O, V extends Value>
-  extends Omit<BeamSelectFieldBaseProps<O, V>, "values" | "onSelect"> {
+export interface SelectFieldProps<O, V extends Value> extends Omit<ComboBoxBaseProps<O, V>, "values" | "onSelect"> {
   /** The current value; it can be `undefined`, even if `V` cannot be. */
   value: V | undefined;
   onSelect: (value: V | undefined, opt: O | undefined) => void;
@@ -32,7 +31,7 @@ export function SelectField<O, V extends Value>(
   } = props;
 
   return (
-    <SelectFieldBase
+    <ComboBoxBase
       {...otherProps}
       options={options}
       getOptionLabel={getOptionLabel}

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -6,13 +6,13 @@ import { resolveTooltip } from "src/components";
 import { Popover } from "src/components/internal";
 import { PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
 import { Css, px } from "src/Css";
+import { ComboBoxInput } from "src/inputs/internal/ComboBoxInput";
 import { ListBox } from "src/inputs/internal/ListBox";
-import { SelectFieldInput } from "src/inputs/internal/SelectFieldInput";
 import { keyToValue, Value, valueToKey } from "src/inputs/Value";
 import { BeamFocusableProps } from "src/interfaces";
 import { areArraysEqual } from "src/utils";
 
-export interface BeamSelectFieldBaseProps<O, V extends Value> extends BeamFocusableProps, PresentationFieldProps {
+export interface ComboBoxBaseProps<O, V extends Value> extends BeamFocusableProps, PresentationFieldProps {
   /** Renders `opt` in the dropdown menu, defaults to the `getOptionLabel` prop. `isUnsetOpt` is only defined for single SelectField */
   getOptionMenuLabel?: (opt: O, isUnsetOpt?: boolean) => string | ReactNode;
   getOptionValue: (opt: O) => V;
@@ -57,7 +57,7 @@ export interface BeamSelectFieldBaseProps<O, V extends Value> extends BeamFocusa
  * Note that the `V extends Key` constraint come from react-aria,
  * and so we cannot easily change them.
  */
-export function SelectFieldBase<O, V extends Value>(props: BeamSelectFieldBaseProps<O, V>): JSX.Element {
+export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>): JSX.Element {
   const { fieldProps } = usePresentationContext();
   const {
     disabled,
@@ -360,7 +360,7 @@ export function SelectFieldBase<O, V extends Value>(props: BeamSelectFieldBasePr
 
   return (
     <div css={Css.df.fdc.w100.maxw(px(550)).if(labelStyle === "left").maxw100.$} ref={comboBoxRef}>
-      <SelectFieldInput
+      <ComboBoxInput
         {...otherProps}
         buttonProps={buttonProps}
         buttonRef={triggerRef}

--- a/src/inputs/internal/ComboBoxInput.tsx
+++ b/src/inputs/internal/ComboBoxInput.tsx
@@ -34,7 +34,7 @@ interface SelectFieldInputProps<O, V extends Value> extends PresentationFieldPro
   hideErrorMessage?: boolean;
 }
 
-export function SelectFieldInput<O, V extends Value>(props: SelectFieldInputProps<O, V>) {
+export function ComboBoxInput<O, V extends Value>(props: SelectFieldInputProps<O, V>) {
   const {
     inputProps,
     buttonProps,


### PR DESCRIPTION
Rename the internal component SelectFieldBase and SelectFieldInput to ComboBoxBase and ComboBoxInput in preparation for creating a SelectField without the "type to filter". This will make distinguishing between the internal components easier as one will use React-Aria's 'useComboBox' (existing) and 'useSelect'. 

For extra context, the eventual state is that when using the 'SelectField' component that has fewer than X options, then a user will get the SelectField vs the ComboBox, as the type to filter will be unnecessary. We had said always supplying the "type to filter" wouldn't hurt, but that has become untrue with users on iPads. Currently when a user opens up a SelectField, then the input is immediately focused, triggering the iPad's keyboard, and then limiting the amount of space there is to view the ~5-10 options (i.e. Status fields). Supporting a SelectField that doesn't include the type to filter would greatly improve the user experience in these situations