### PR TITLE
feat: Add icon for denoting tooltips in table cells

### DIFF
--- a/src/components/Table/components/ExpandableHeader.tsx
+++ b/src/components/Table/components/ExpandableHeader.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from "react";
+import { ReactNode, useContext, useState } from "react";
 import { Icon } from "src/components/Icon";
 import { GridColumnWithId, Kinded, RenderAs } from "src/components/Table/types";
 import { TableStateContext } from "src/components/Table/utils/TableState";
@@ -13,10 +13,11 @@ interface ExpandableHeaderProps<R extends Kinded> {
   column: GridColumnWithId<R>;
   minStickyLeftOffset: number;
   as: RenderAs;
+  tooltipEl?: ReactNode;
 }
 
 export function ExpandableHeader<R extends Kinded>(props: ExpandableHeaderProps<R>) {
-  const { title, column, minStickyLeftOffset, as } = props;
+  const { title, column, minStickyLeftOffset, as, tooltipEl } = props;
   const { tableState } = useContext(TableStateContext);
   const expandedColumnIds = useComputed(() => tableState.expandedColumnIds, [tableState]);
   const isExpanded = expandedColumnIds.includes(column.id);
@@ -44,15 +45,17 @@ export function ExpandableHeader<R extends Kinded>(props: ExpandableHeaderProps<
     >
       <span
         css={
-          Css.tl.lineClamp2
+          Css.df.aic
             .if(applyStickyStyles)
             .sticky.leftPx(minStickyLeftOffset + 12)
             .pr2.mr2.bgWhite.z(zIndices.expandableHeaderTitle)
             .if(isHovered).bgGray100.$
         }
       >
-        {title}
+        <span css={Css.tl.lineClamp2.$}>{title}</span>
+        {tooltipEl}
       </span>
+
       <span css={Css.if(applyStickyStyles).sticky.rightPx(12).z(zIndices.expandableHeaderIcon).$}>
         {isLoading ? <Loader size="xs" /> : <Icon icon={isExpanded ? "chevronLeft" : "chevronRight"} inc={2} />}
       </span>

--- a/src/components/Table/components/SortHeader.tsx
+++ b/src/components/Table/components/SortHeader.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useContext } from "react";
+import { ReactNode, useCallback, useContext } from "react";
 import { Icon } from "src/components/Icon";
 import { TableStateContext } from "src/components/Table/utils/TableState";
 import { Css, Palette, Properties } from "src/Css";
@@ -10,6 +10,7 @@ interface SortHeaderProps {
   xss?: Properties;
   iconOnLeft?: boolean;
   sortKey: string;
+  tooltipEl?: ReactNode;
 }
 
 /**
@@ -24,7 +25,7 @@ interface SortHeaderProps {
  *   current sort state + `toggleSort` function
  */
 export function SortHeader(props: SortHeaderProps) {
-  const { content, xss, iconOnLeft = false, sortKey } = props;
+  const { content, xss, iconOnLeft = false, sortKey, tooltipEl } = props;
   const { isHovered, hoverProps } = useHover({});
   const { tableState } = useContext(TableStateContext);
   const current = useComputed(() => tableState.sortState?.current, [tableState]);
@@ -53,6 +54,7 @@ export function SortHeader(props: SortHeaderProps) {
     <div {...tid} css={{ ...Css.df.aic.h100.cursorPointer.selectNone.$, ...xss }} {...hoverProps} onClick={toggleSort}>
       {iconOnLeft && icon}
       <span css={Css.lineClamp2.$}>{content}</span>
+      {tooltipEl}
       {!iconOnLeft && icon}
     </div>
   );

--- a/src/components/Table/components/cell.tsx
+++ b/src/components/Table/components/cell.tsx
@@ -4,7 +4,6 @@ import { navLink } from "src/components/CssReset";
 import { GridTableApi } from "src/components/Table/GridTableApi";
 import { RowStyle, tableRowStyles } from "src/components/Table/TableStyles";
 import { GridCellAlignment, GridColumnWithId, Kinded, MaybeFn, RenderAs } from "src/components/Table/types";
-import { maybeTooltip } from "src/components/Tooltip";
 import { Css, Properties, Typography } from "src/Css";
 
 /**
@@ -53,7 +52,7 @@ export const defaultRenderFn: (as: RenderAs) => RenderCellFn<any> =
     const Cell = as === "table" ? "td" : "div";
     return (
       <Cell key={key} css={{ ...css, ...tableRowStyles(as) }} className={classNames} onClick={onClick}>
-        {maybeTooltip({ title: tooltip, placement: "top", children: content })}
+        {content}
       </Cell>
     );
   };
@@ -72,7 +71,7 @@ export const headerRenderFn: (column: GridColumnWithId<any>, as: RenderAs, colSp
         className={classNames}
         {...(as === "table" && { colSpan })}
       >
-        {maybeTooltip({ title: tooltip, placement: "top", children: content })}
+        {content}
       </Cell>
     );
   };
@@ -84,32 +83,22 @@ export const rowLinkRenderFn: (as: RenderAs) => RenderCellFn<any> =
     if (as === "table") {
       return (
         <td key={key} css={{ ...css, ...tableRowStyles(as) }} className={classNames}>
-          {maybeTooltip({
-            title: tooltip,
-            placement: "top",
-            children: (
-              <Link to={to} css={Css.noUnderline.color("unset").db.$} className={navLink}>
-                {content}
-              </Link>
-            ),
-          })}
+          <Link to={to} css={Css.noUnderline.color("unset").db.$} className={navLink}>
+            {content}
+          </Link>
         </td>
       );
     }
-    return maybeTooltip({
-      title: tooltip,
-      placement: "top",
-      children: (
-        <Link
-          key={key}
-          to={to}
-          css={{ ...Css.noUnderline.color("unset").$, ...css }}
-          className={`${navLink} ${classNames}`}
-        >
-          {content}
-        </Link>
-      ),
-    });
+    return (
+      <Link
+        key={key}
+        to={to}
+        css={{ ...Css.noUnderline.color("unset").$, ...css }}
+        className={`${navLink} ${classNames}`}
+      >
+        {content}
+      </Link>
+    );
   };
 
 /** Renders a cell that will fire the RowStyle.onClick. */
@@ -127,7 +116,7 @@ export const rowClickRenderFn: (as: RenderAs, api: GridTableApi<any>) => RenderC
           onClick && onClick();
         }}
       >
-        {maybeTooltip({ title: tooltip, placement: "top", children: content })}
+        {content}
       </Cell>
     );
   };

--- a/src/components/Table/utils/utils.tsx
+++ b/src/components/Table/utils/utils.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import { Icon } from "src/components/Icon";
 import { GridCellContent } from "src/components/Table/components/cell";
 import { ExpandableHeader } from "src/components/Table/components/ExpandableHeader";
 import { GridDataRow } from "src/components/Table/components/Row";
@@ -6,7 +7,7 @@ import { SortHeader } from "src/components/Table/components/SortHeader";
 import { GridTableApi } from "src/components/Table/GridTableApi";
 import { GridStyle, RowStyle } from "src/components/Table/TableStyles";
 import { GridCellAlignment, GridColumnWithId, Kinded, RenderAs } from "src/components/Table/types";
-import { Css, Properties } from "src/Css";
+import { Css, Palette, Properties } from "src/Css";
 import { getButtonOrLink } from "src/utils/getInteractiveElement";
 
 /** If a column def return just string text for a given row, apply some default styling. */
@@ -41,6 +42,12 @@ export function toContent(
       "GridTables with as=virtual & sortable columns should use functions that return JSX, instead of JSX",
     );
   }
+  const tooltip = isGridCellContent(maybeContent) ? maybeContent.tooltip : undefined;
+  const tooltipEl = tooltip ? (
+    <span css={Css.fs0.mlPx(4).$}>
+      <Icon icon="infoCircle" tooltip={tooltip} inc={2} color={Palette.Gray600} />
+    </span>
+  ) : null;
 
   content =
     isGridCellContent(maybeContent) && !!maybeContent.onClick
@@ -55,31 +62,56 @@ export function toContent(
         content={content}
         iconOnLeft={alignment === "right"}
         sortKey={column.serverSideSortKey ?? column.id}
+        tooltipEl={tooltipEl}
       />
     );
   } else if (content && typeof content === "string" && isExpandableHeader && isExpandable) {
-    return <ExpandableHeader title={content} column={column} minStickyLeftOffset={minStickyLeftOffset} as={as} />;
+    return (
+      <ExpandableHeader
+        title={content}
+        column={column}
+        minStickyLeftOffset={minStickyLeftOffset}
+        as={as}
+        tooltipEl={tooltipEl}
+      />
+    );
   } else if (content && typeof content === "string" && isExpandableHeader) {
-    return <span css={Css.lineClamp2.$}>{content}</span>;
+    return (
+      <>
+        <span css={Css.lineClamp2.$}>{content}</span>
+        {tooltipEl}
+      </>
+    );
   } else if (!isContentEmpty(content) && isHeader && typeof content === "string") {
     return (
-      <span css={Css.lineClamp2.$} title={content}>
-        {content}
-      </span>
+      <>
+        <span css={Css.lineClamp2.$} title={content}>
+          {content}
+        </span>
+        {tooltipEl}
+      </>
     );
   } else if (!isHeader && content && style?.presentationSettings?.wrap === false && typeof content === "string") {
     // In order to truncate the text properly, then we need to wrap it in another element
     // as our cell element is a flex container, which don't allow for applying truncation styles directly on it.
     return (
-      <span css={Css.truncate.mw0.$} title={content}>
-        {content}
-      </span>
+      <>
+        <span css={Css.truncate.mw0.$} title={content}>
+          {content}
+        </span>
+        {tooltipEl}
+      </>
     );
   } else if (style.emptyCell && isContentEmpty(content)) {
     // If the content is empty and the user specified an `emptyCell` node, return that.
     return style.emptyCell;
   }
-  return content;
+  return (
+    <>
+      {content}
+      {tooltipEl}
+    </>
+  );
 }
 
 export function isGridCellContent(content: ReactNode | GridCellContent): content is GridCellContent {


### PR DESCRIPTION
When using the `tooltip` property on `GridCellContent`, the 'infoCircle' icon will be displayed as the tooltip trigger/target. This makes it more discoverable when tooltips are added to our table cells.