### PR TITLE
feat: Disable type to filter for single SelectFields with 10 or fewer options

### DIFF
--- a/src/inputs/SelectField.test.tsx
+++ b/src/inputs/SelectField.test.tsx
@@ -3,7 +3,9 @@ import { fireEvent } from "@testing-library/react";
 import { useState } from "react";
 import { SelectField, SelectFieldProps, Value } from "src/inputs";
 import { HasIdAndName, Optional } from "src/types";
+import { noop } from "src/utils";
 import { blur, click, focus, render, wait } from "src/utils/rtl";
+import { zeroTo } from "src/utils/sb";
 
 describe("SelectFieldTest", () => {
   it("can set a value", async () => {
@@ -368,6 +370,31 @@ describe("SelectFieldTest", () => {
 
     // Then `onSelect` is triggered with `undefined`
     expect(onSelect.mock.calls[2][0]).toBe(undefined);
+  });
+
+  it("renders the input as read only with 10 or fewer options, otherwise it is editable", async () => {
+    const r = await render(
+      <>
+        <SelectField
+          label="Fewer options"
+          onSelect={noop}
+          options={zeroTo(10).map((idx) => ({ id: `opt:${idx}`, name: `Option ${idx}` }))}
+          value={undefined}
+          getOptionLabel={(o) => o.name}
+          getOptionValue={(o) => o.id}
+        />
+        <SelectField
+          label="More options"
+          onSelect={noop}
+          options={zeroTo(11).map((idx) => ({ id: `opt:${idx}`, name: `Option ${idx}` }))}
+          value={undefined}
+          getOptionLabel={(o) => o.name}
+          getOptionValue={(o) => o.id}
+        />
+      </>,
+    );
+    expect(r.fewerOptions()).toHaveAttribute("readonly");
+    expect(r.moreOptions()).not.toHaveAttribute("readonly");
   });
 
   // Used to validate the `unset` option can be applied to non-`HasIdAndName` options

--- a/src/inputs/SelectField.tsx
+++ b/src/inputs/SelectField.tsx
@@ -2,7 +2,8 @@ import { Value } from "src/inputs";
 import { ComboBoxBase, ComboBoxBaseProps, unsetOption } from "src/inputs/internal/ComboBoxBase";
 import { HasIdAndName, Optional } from "src/types";
 
-export interface SelectFieldProps<O, V extends Value> extends Omit<ComboBoxBaseProps<O, V>, "values" | "onSelect"> {
+export interface SelectFieldProps<O, V extends Value>
+  extends Omit<ComboBoxBaseProps<O, V>, "values" | "onSelect" | "multiselect"> {
   /** The current value; it can be `undefined`, even if `V` cannot be. */
   value: V | undefined;
   onSelect: (value: V | undefined, opt: O | undefined) => void;

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -56,6 +56,10 @@ export interface TextFieldBaseProps<X>
   hideErrorMessage?: boolean;
   // If set, the helper text will always be shown (usually we hide the helper text if read only)
   alwaysShowHelperText?: boolean;
+  /** Used by ComboBoxInput to decide whether we should allow the user to type to filter the options.
+   * This is admittedly a hack, as we really should not use a TextField at all in this instance. How we're currently implementing breaks all sorts of accessibility best practices.
+   * But for now it is the quickest way to get the desired behavior. Will updating to use a proper select field at another point. */
+  typeToFilter?: boolean;
 }
 
 // Used by both TextField and TextArea
@@ -89,6 +93,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
     errorInTooltip = fieldProps?.errorInTooltip ?? false,
     hideErrorMessage = false,
     alwaysShowHelperText = false,
+    typeToFilter = true,
   } = props;
 
   const typeScale = fieldProps?.typeScale ?? (inputProps.readOnly && labelStyle !== "hidden" ? "smMd" : "sm");
@@ -166,7 +171,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
   }
 
   const onFocusChained = chain((e: FocusEvent<HTMLInputElement> | FocusEvent<HTMLTextAreaElement>) => {
-    e.target.select();
+    typeToFilter && e.target.select();
   }, onFocus);
 
   const showFocus = (isFocused && !inputProps.readOnly) || forceFocus;
@@ -243,6 +248,8 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
                 {...(errorMsg ? { "aria-errormessage": errorMessageId } : {})}
                 ref={fieldRef as any}
                 rows={multiline ? 1 : undefined}
+                // Make the input field readOnly if the field explicitly sets it to `true`, otherwise base it on whether we should allow `typeToFilter`
+                readOnly={inputProps.readOnly || typeToFilter === false}
                 css={{
                   ...fieldStyles.input,
                   ...(inputProps.disabled ? fieldStyles.disabled : {}),

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -49,7 +49,7 @@ export interface ComboBoxBaseProps<O, V extends Value> extends BeamFocusableProp
 }
 
 /**
- * Provides a non-native select/dropdown widget.
+ * Provides a non-native select/dropdown widget that allows the user to type to filter the options.
  *
  * The `O` type is a list of options to show, the `V` is the primitive value of a
  * given `O` (i.e. it's id) that you want to use as the current/selected value.
@@ -377,6 +377,8 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
         borderless={borderless}
         tooltip={resolveTooltip(disabled, undefined, readOnly)}
         resetField={resetField}
+        // If there are 10 or fewer options and it is not the multiselect, then we disable the typeahead filter for a better UX.
+        typeToFilter={!(!multiselect && Array.isArray(options) && options.length <= 10)}
       />
       {state.isOpen && (
         <Popover
@@ -414,7 +416,7 @@ type FieldState<O> = {
   allOptions: O[];
   optionsLoading: boolean;
 };
-type OptionsOrLoad<O> = O[] | { initial: O[]; load: () => Promise<{ options: O[] }> };
+export type OptionsOrLoad<O> = O[] | { initial: O[]; load: () => Promise<{ options: O[] }> };
 type UnsetOption = { id: undefined; name: string };
 
 function getInputValue<O>(

--- a/src/inputs/internal/ComboBoxInput.tsx
+++ b/src/inputs/internal/ComboBoxInput.tsx
@@ -32,6 +32,7 @@ interface SelectFieldInputProps<O, V extends Value> extends PresentationFieldPro
   tooltip?: ReactNode;
   resetField: VoidFunction;
   hideErrorMessage?: boolean;
+  typeToFilter: boolean;
 }
 
 export function ComboBoxInput<O, V extends Value>(props: SelectFieldInputProps<O, V>) {


### PR DESCRIPTION
This provides a better UX for users using iPads where the virtual keyboard gets in the way and is unnecessary for select fields with few options.