### PR TITLE
feat: TreeSelectField

### DIFF
--- a/src/components/Icon.stories.tsx
+++ b/src/components/Icon.stories.tsx
@@ -82,6 +82,10 @@ export const Icon = (props: IconProps) => {
     "arrowFromLeft",
     "arrowFromRight",
     "arrowFromTop",
+    "triangleLeft",
+    "triangleRight",
+    "triangleUp",
+    "triangleDown",
   ];
   const mediaIcons: IconProps["icon"][] = ["camera", "fileBlank", "folder", "image", "file", "images", "openBook"];
   const miscIcons: IconProps["icon"][] = [

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -294,6 +294,10 @@ export const Icons = {
   arrowRight: (
     <path d="M2.586 13L17.172 13L11.879 18.293L13.293 19.707L21 12L13.293 4.29303L11.879 5.70703L17.172 11L2.586 11L2.586 13Z" />
   ),
+  triangleLeft: <path d="M15 18L9 12L15 6L15 18Z" />,
+  triangleRight: <path d="M9 6L15 12L9 18L9 6Z" />,
+  triangleUp: <path d="M6 15L12 9L18 15L6 15Z" />,
+  triangleDown: <path d="M18 9L12 15L6 9H18Z" />,
   menuClose: (
     <>
       <path d="M8 6H24V8H8V6ZM8 11H24V13H8V11ZM8 16H24V18H8V16Z" />

--- a/src/inputs/CheckboxBase.tsx
+++ b/src/inputs/CheckboxBase.tsx
@@ -46,8 +46,6 @@ export function CheckboxBase(props: CheckboxBaseProps) {
   const { hoverProps, isHovered } = useHover({ isDisabled });
   const tid = useTestIds(props, defaultTestId(label));
 
-  const markIcon = isIndeterminate ? dashSmall : isSelected ? checkmarkSmall : "";
-
   return (
     <label
       css={
@@ -65,22 +63,7 @@ export function CheckboxBase(props: CheckboxBaseProps) {
       <VisuallyHidden>
         <input ref={ref} {...mergeProps(inputProps, focusProps)} {...tid} data-indeterminate={isIndeterminate} />
       </VisuallyHidden>
-      <span
-        {...hoverProps}
-        css={{
-          ...baseStyles,
-          ...(((isSelected && !isDisabled) || isIndeterminate) && filledBoxStyles),
-          ...(((isSelected && !isDisabled) || isIndeterminate) && isHovered && filledBoxHoverStyles),
-          ...(isDisabled && disabledBoxStyles),
-          ...(isDisabled && isSelected && disabledSelectedBoxStyles),
-          ...(isFocusVisible && focusRingStyles),
-          ...(isHovered && hoverBorderStyles),
-          ...markStyles,
-        }}
-        aria-hidden="true"
-      >
-        {markIcon}
-      </span>
+      <StyledCheckbox {...props} isFocusVisible={isFocusVisible} />
       {!checkboxOnly && (
         // Use a mtPx(-2) to better align the label with the checkbox.
         // Not using align-items: center as the checkbox would align with all content below, where we really want it to stay only aligned with the label
@@ -106,6 +89,40 @@ const hoverBorderStyles = Css.bLightBlue900.$;
 const markStyles = { svg: Css.absolute.topPx(-1).leftPx(-1).$ };
 const labelStyles = Css.smMd.$;
 const descStyles = Css.sm.gray700.$;
+
+interface StyledCheckboxProps {
+  isDisabled?: boolean;
+  isIndeterminate?: boolean;
+  isSelected?: boolean;
+  isFocusVisible?: boolean;
+}
+
+export function StyledCheckbox(props: StyledCheckboxProps) {
+  const { isDisabled = false, isIndeterminate = false, isSelected, isFocusVisible } = props;
+  const { hoverProps, isHovered } = useHover({ isDisabled });
+  const markIcon = isIndeterminate ? dashSmall : isSelected ? checkmarkSmall : "";
+  const tid = useTestIds(props);
+  return (
+    <span
+      {...hoverProps}
+      css={{
+        ...baseStyles,
+        ...(((isSelected && !isDisabled) || isIndeterminate) && filledBoxStyles),
+        ...(((isSelected && !isDisabled) || isIndeterminate) && isHovered && filledBoxHoverStyles),
+        ...(isDisabled && disabledBoxStyles),
+        ...(isDisabled && isSelected && disabledSelectedBoxStyles),
+        ...(isFocusVisible && focusRingStyles),
+        ...(isHovered && hoverBorderStyles),
+        ...markStyles,
+      }}
+      aria-hidden="true"
+      data-checked={isSelected ? true : isIndeterminate ? "mixed" : false}
+      {...tid.checkbox}
+    >
+      {markIcon}
+    </span>
+  );
+}
 
 const checkmarkSmall = (
   <svg width="16" height="16">

--- a/src/inputs/TreeSelectField/TreeOption.tsx
+++ b/src/inputs/TreeSelectField/TreeOption.tsx
@@ -23,7 +23,7 @@ export function TreeOption<O>(props: TreeOptionProps<O>) {
   if (!leveledOption) return null;
 
   const [option, level]: [NestedOption<O>, number] = leveledOption;
-  const ref = useRef<HTMLLIElement>(null);
+  const ref = useRef<HTMLElement>(null);
   const { hoverProps, isHovered } = useHover({});
   const tid = useTestIds(props, "treeOption");
 
@@ -36,6 +36,7 @@ export function TreeOption<O>(props: TreeOptionProps<O>) {
   );
 
   // If this item is not selected, then determine if some of its children are selected to show the indeterminate state.
+  // Note: If `isSelected` will be true if all of the children were selected. That auto-parent-selection happens in the `onSelect` callback in TreeSelectField.
   const isIndeterminate = !isSelected && option.children?.some((o) => hasSelectedChildren(o, state, getOptionValue));
 
   const listItemStyles = {
@@ -76,7 +77,7 @@ export function TreeOption<O>(props: TreeOptionProps<O>) {
           )}
         </span>
       )}
-      <span css={Css.df.aic.gap1.h100.fg1.py1.pr2.$} ref={ref as any} {...optionProps}>
+      <span css={Css.df.aic.gap1.h100.fg1.py1.pr2.$} ref={ref} {...optionProps}>
         <StyledCheckbox
           isDisabled={isDisabled}
           isSelected={isSelected}

--- a/src/inputs/TreeSelectField/TreeOption.tsx
+++ b/src/inputs/TreeSelectField/TreeOption.tsx
@@ -1,0 +1,101 @@
+import { Node } from "@react-types/shared";
+import { useRef } from "react";
+import { useHover, useOption } from "react-aria";
+import { ListState } from "react-stately";
+import { Icon } from "src/components";
+import { Css, Palette } from "src/Css";
+import { StyledCheckbox } from "src/inputs/CheckboxBase";
+import { useTreeSelectFieldProvider } from "src/inputs/TreeSelectField/TreeSelectField";
+import { LeveledOption, NestedOption } from "src/inputs/TreeSelectField/utils";
+import { Value, valueToKey } from "src/inputs/Value";
+import { useTestIds } from "src/utils";
+
+interface TreeOptionProps<O> {
+  item: Node<LeveledOption<O>>;
+  state: ListState<O>;
+  contrast?: boolean;
+  allowCollapsing?: boolean;
+}
+/** Represents a single option within a ListBox - used by SelectField, MultiSelectField, and TreeSelectField */
+export function TreeOption<O>(props: TreeOptionProps<O>) {
+  const { item, state, contrast = false, allowCollapsing = true } = props;
+  const leveledOption = item.value;
+  if (!leveledOption) return null;
+
+  const [option, level]: [NestedOption<O>, number] = leveledOption;
+  const ref = useRef<HTMLLIElement>(null);
+  const { hoverProps, isHovered } = useHover({});
+  const tid = useTestIds(props, "treeOption");
+
+  const { collapsedKeys, setCollapsedKeys, getOptionValue } = useTreeSelectFieldProvider<O, Value>();
+
+  const { optionProps, isDisabled, isFocused, isSelected } = useOption(
+    { key: item.key, shouldSelectOnPressUp: true, shouldFocusOnHover: false },
+    state,
+    ref,
+  );
+
+  // If this item is not selected, then determine if some of its children are selected to show the indeterminate state.
+  const isIndeterminate = !isSelected && option.children?.some((o) => hasSelectedChildren(o, state, getOptionValue));
+
+  const listItemStyles = {
+    item: Css.gray900.if(contrast).white.$,
+    hover: Css.bgGray100.if(contrast).bgGray600.$,
+    disabled: Css.cursorNotAllowed.gray400.if(contrast).gray500.$,
+    focus: Css.add("boxShadow", `inset 0 0 0 1px ${!contrast ? Palette.LightBlue700 : Palette.LightBlue500}`).$,
+  };
+
+  return (
+    <li
+      {...hoverProps}
+      css={{
+        ...Css.df.aic.jcsb.gap1.pl2.mh("42px").outline0.cursorPointer.sm.plPx(16 + level * 8).$,
+        ...listItemStyles.item,
+        ...(isHovered && !isDisabled ? listItemStyles.hover : {}),
+        ...(isFocused ? listItemStyles.focus : {}),
+        ...(isDisabled ? listItemStyles.disabled : {}),
+      }}
+    >
+      {allowCollapsing && (
+        <span css={Css.wPx(18).fs0.df.aic.$}>
+          {option.children && option.children?.length > 0 && (
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setCollapsedKeys((prevKeys) =>
+                  collapsedKeys.includes(item.key) ? prevKeys.filter((k) => k !== item.key) : [...prevKeys, item.key],
+                );
+                return false;
+              }}
+              css={Css.br4.hPx(16).wPx(16).bgTransparent.onHover.bgGray300.$}
+              {...tid[`collapseToggle_${item.key}`]}
+            >
+              <Icon icon={collapsedKeys.includes(item.key) ? "triangleRight" : "triangleDown"} inc={2} />
+            </button>
+          )}
+        </span>
+      )}
+      <span css={Css.df.aic.gap1.h100.fg1.py1.pr2.$} ref={ref as any} {...optionProps}>
+        <StyledCheckbox
+          isDisabled={isDisabled}
+          isSelected={isSelected}
+          isIndeterminate={isIndeterminate}
+          {...tid[item.key.toString()]}
+        />
+        <div css={Css.pl1.$}>{item.rendered}</div>
+      </span>
+    </li>
+  );
+}
+
+function hasSelectedChildren<O, V extends Value>(
+  childOption: NestedOption<O>,
+  state: ListState<O>,
+  getOptionValue: (o: O) => V,
+): boolean {
+  if (childOption.children && childOption.children.length > 0) {
+    return childOption.children.some((child) => hasSelectedChildren(child, state, getOptionValue));
+  }
+  return state.selectionManager.isSelected(valueToKey(getOptionValue(childOption)));
+}

--- a/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
@@ -1,0 +1,220 @@
+import { action } from "@storybook/addon-actions";
+import { Meta } from "@storybook/react";
+import { within } from "@storybook/testing-library";
+import { useState } from "react";
+import { Css } from "src/Css";
+import { Value } from "src/inputs/index";
+import { TreeSelectField, TreeSelectFieldProps } from "src/inputs/TreeSelectField/TreeSelectField";
+import { NestedOption } from "src/inputs/TreeSelectField/utils";
+import { HasIdAndName } from "src/types";
+import { zeroTo } from "src/utils/sb";
+
+export default {
+  component: TreeSelectField,
+  title: "Workspace/Inputs/TreeSelectField",
+} as Meta<TreeSelectFieldProps<HasIdAndName, string>>;
+
+function Template(args: TreeSelectFieldProps<HasIdAndName, string>) {
+  const options: NestedOption<HasIdAndName>[] = zeroTo(10).map((dIdx) => ({
+    id: `d:${dIdx}`,
+    name: `Development ${dIdx}`,
+    children: zeroTo(5).map((cIdx) => ({
+      id: `c:${cIdx}:d:${dIdx}`,
+      name: `Cohort ${cIdx}`,
+      children: zeroTo(40).map((pIdx) => ({
+        id: `p:${pIdx}:c:${cIdx}:d:${dIdx}`,
+        name: `Project ${pIdx}`,
+      })),
+    })),
+  }));
+
+  const singleValueId = [options[0]!.children![0]!.children![0].id];
+  const multipleValueIds = [...singleValueId, options[0]!.children![0].children![1].id];
+
+  return (
+    <div css={Css.df.fdc.gap5.p2.if(args.contrast === true).white.bgGray800.$}>
+      <div css={Css.df.fdc.gap3.$}>
+        <TestTreeSelectField
+          {...args}
+          values={["c:1:d:0"]}
+          options={options}
+          placeholder="Select a project"
+          label="Single option selected"
+        />
+
+        <TestTreeSelectField
+          {...args}
+          values={multipleValueIds}
+          options={options}
+          placeholder="Select a project"
+          label="Multiple options selected"
+        />
+
+        <TestTreeSelectField
+          {...args}
+          values={[]}
+          options={options}
+          placeholder="Select a project"
+          label="No options selected"
+        />
+
+        <TestTreeSelectField
+          {...args}
+          disabled="Disabled reason tooltip text"
+          label="Disabled"
+          values={singleValueId}
+          options={options}
+        />
+
+        <TestTreeSelectField
+          {...args}
+          readOnly="Read-only reason tooltip text"
+          label="Read-only"
+          values={singleValueId}
+          options={options}
+        />
+
+        <TestTreeSelectField
+          {...args}
+          label="With error message"
+          values={singleValueId}
+          options={options}
+          errorMsg="This is an error message"
+        />
+
+        <TestTreeSelectField
+          {...args}
+          label="With helper text"
+          values={singleValueId}
+          options={options}
+          helperText="This is the helper text that gives more context to this field"
+        />
+
+        <div css={Css.df.fdc.gap4.$}>
+          <h2 css={Css.lgMd.$}>Other Label Styles</h2>
+          <TestTreeSelectField
+            {...args}
+            values={multipleValueIds}
+            labelStyle="inline"
+            options={options}
+            label="Inline label"
+          />
+
+          <div css={Css.maxwPx(550).$}>
+            <TestTreeSelectField
+              {...args}
+              values={multipleValueIds}
+              labelStyle="left"
+              options={options}
+              label="Left label"
+            />
+          </div>
+
+          <div css={Css.maxwPx(550).$}>
+            <TestTreeSelectField
+              {...args}
+              values={[]}
+              labelStyle="hidden"
+              options={options}
+              label="Hidden label"
+              placeholder="Hidden label"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const Regular = Template.bind({});
+export const Compact = Template.bind({});
+// @ts-ignore
+Compact.args = { compact: true };
+export const Contrast = Template.bind({});
+// @ts-ignore
+Contrast.args = { compact: true, contrast: true };
+
+export function OpenMenu() {
+  const options: NestedOption<HasIdAndName>[] = zeroTo(3).map((dIdx) => ({
+    id: `d:${dIdx}`,
+    name: `Development ${dIdx}`,
+    children: zeroTo(2).map((cIdx) => ({
+      id: `c:${cIdx}:d:${dIdx}`,
+      name: `Cohort ${cIdx}`,
+      children: zeroTo(2).map((pIdx) => ({
+        id: `p:${pIdx}:c:${cIdx}:d:${dIdx}`,
+        name: `Project ${pIdx}`,
+      })),
+    })),
+  }));
+
+  return <TestTreeSelectField values={[]} options={options} label="Nested options" placeholder="Select a project" />;
+}
+OpenMenu.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement);
+  canvas.getByTestId("toggleListBox").click();
+};
+
+export function AsyncOptions() {
+  const options: NestedOption<HasIdAndName>[] = [
+    {
+      id: "baseball",
+      name: "Baseball",
+      children: [
+        { id: "mlb", name: "MLB" },
+        { id: "milb", name: "Minor League Baseball" },
+      ],
+    },
+    {
+      id: "basketball",
+      name: "Basketball",
+      children: [
+        { id: "nba", name: "NBA" },
+        { id: "wnba", name: "WNBA" },
+      ],
+    },
+    {
+      id: "football",
+      name: "Football",
+      children: [
+        { id: "nfl", name: "NFL" },
+        { id: "xfl", name: "XFL" },
+      ],
+    },
+  ];
+  const initialOption = [options[0]];
+
+  return (
+    <TestTreeSelectField
+      values={[]}
+      options={{
+        initial: initialOption,
+        load: async () => {
+          return new Promise((resolve) => {
+            // @ts-ignore - believes `options` should be of type `never[]`
+            setTimeout(() => resolve({ options }), 1500);
+          });
+        },
+      }}
+      label="Favorite League"
+      placeholder="Select a league"
+    />
+  );
+}
+
+function TestTreeSelectField<T extends HasIdAndName, V extends Value>(
+  props: Omit<TreeSelectFieldProps<T, V>, "onSelect" | "getOptionValue" | "getOptionLabel">,
+): JSX.Element {
+  const [selectedOptions, setSelectedOptions] = useState<V[] | undefined>(props.values);
+  return (
+    <TreeSelectField<T, V>
+      {...(props as any)}
+      values={selectedOptions}
+      onSelect={setSelectedOptions}
+      onBlur={action("onBlur")}
+      onFocus={action("onFocus")}
+      getOptionLabel={(o) => o.name}
+      getOptionValue={(o) => o.id}
+    />
+  );
+}

--- a/src/inputs/TreeSelectField/TreeSelectField.test.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.test.tsx
@@ -1,0 +1,378 @@
+import { fireEvent } from "@testing-library/react";
+import { TreeSelectField } from "src/inputs";
+import { NestedOption } from "src/inputs/TreeSelectField/utils";
+import { HasIdAndName } from "src/types";
+import { noop } from "src/utils";
+import { blur, click, focus, render, wait } from "src/utils/rtl";
+
+describe(TreeSelectField, () => {
+  it("renders", async () => {
+    // Given a TreeSelectField
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={[{ id: "1", name: "One" }]}
+        label="Favorite League"
+        placeholder="Select a sport"
+        helperText="Choose any league you like."
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // Then it renders based on the props.
+    expect(r.favoriteLeague()).toHaveAttribute("placeholder", "Select a sport");
+    expect(r.favoriteLeague_label()).toHaveTextContent("Favorite League");
+    expect(r.favoriteLeague_helperText()).toHaveTextContent("Choose any league you like.");
+  });
+
+  it("renders disabled", async () => {
+    // Given a disabled TreeSelectField
+    const r = await render(
+      <TreeSelectField
+        disabled
+        onSelect={noop}
+        options={[{ id: "1", name: "One" }]}
+        label="Favorite League"
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // Then it should be disabled.
+    expect(r.favoriteLeague()).toBeDisabled();
+    // And the expand/collapse button should be disabled.
+    expect(r.toggleListBox()).toBeDisabled();
+  });
+
+  it("renders readonly", async () => {
+    // Given a readonly TreeSelectField
+    const r = await render(
+      <TreeSelectField
+        readOnly
+        onSelect={noop}
+        options={[{ id: "1", name: "One" }]}
+        label="Favorite League"
+        values={["1"]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // Then it should render as just text (no longer an input)
+    expect(r.favoriteLeague()).toHaveTextContent("One");
+  });
+
+  it("triggers onBlur and onFocus callbacks", async () => {
+    // Given a TreeSelectField with `onFocus` and `onBlur` callbacks
+    const onFocus = jest.fn();
+    const onBlur = jest.fn();
+    const r = await render(
+      <TreeSelectField
+        onBlur={onBlur}
+        onFocus={onFocus}
+        onSelect={noop}
+        options={[{ id: "1", name: "One" }]}
+        label="Favorite League"
+        values={["1"]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // When the input is focused
+    focus(r.favoriteLeague);
+    // Then the `onFocus` callback should be called
+    expect(onFocus).toHaveBeenCalledTimes(1);
+    // When the input is blurred
+    blur(r.favoriteLeague);
+    // Then the `onBlur` callback should be called
+    expect(onBlur).toHaveBeenCalledTimes(1);
+  });
+
+  it("can select options", async () => {
+    // Given a TreeSelectField
+    const onSelect = jest.fn();
+    const r = await render(
+      <TreeSelectField
+        onSelect={onSelect}
+        options={getNestedOptions()}
+        label="Favorite League"
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // When selecting a single "leaf" option (no children)
+    click(r.favoriteLeague);
+    click(r.getByRole("option", { name: "NBA" }));
+    click(r.getByRole("option", { name: "NBA" }));
+    // Then only that option is selected
+    const basketballOption = getNestedOptions().find((o) => o.id === "basketball");
+    const nbaOption = basketballOption!.children!.find((o) => o.id === "nba");
+    expect(onSelect).toHaveBeenCalledWith({
+      all: { values: ["nba"], options: [nbaOption] },
+      leaf: { values: ["nba"], options: [nbaOption] },
+      root: { values: ["nba"], options: [nbaOption] },
+    });
+
+    // When selecting a single "parent" option (has children)
+    click(r.getByRole("option", { name: "Basketball" }));
+    // Then all children are selected
+    const wnbaOption = basketballOption!.children!.find((o) => o.id === "wnba");
+    expect(onSelect).toHaveBeenCalledWith({
+      all: { values: ["basketball", "nba", "wnba"], options: [basketballOption, ...basketballOption!.children!] },
+      leaf: { values: ["nba", "wnba"], options: [nbaOption, wnbaOption] },
+      root: { values: ["basketball"], options: [basketballOption] },
+    });
+  });
+
+  it("renders with options to be loaded async", async () => {
+    // Given a TreeSelectField with options to be loaded via a callback
+    const options = getNestedOptions();
+    const initialOption: NestedOption<HasIdAndName>[] = [options[0]];
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={{ initial: initialOption, load: async () => ({ options }) }}
+        label="Favorite League"
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // When opening the options
+    click(r.favoriteLeague);
+    // Then the initial option(s) is visible
+    expect(r.getAllByRole("option")).toHaveLength(3);
+    expect(r.loadingDots()).toBeTruthy();
+    // And when waiting for the promise to resolve
+    await wait();
+
+    // Then expect the rest of the options to be loaded in and the loading state to be removed
+    expect(r.getAllByRole("option")).toHaveLength(9);
+    expect(r.queryByTestId("loadingDots")).toBeFalsy();
+  });
+
+  it("renders with multiple options selected", async () => {
+    // Given a TreeSelectField with a nested options and multiple options selected
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={getNestedOptions()}
+        label="Favorite League"
+        values={["nba", "nfl"]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // Then the selected options are visible
+    expect(r.selectedOptionsCount()).toHaveTextContent("2");
+    expect(r.favoriteLeague()).toHaveValue("");
+
+    // When opening the options
+    click(r.favoriteLeague);
+    // Then the selected options are checked
+    expect(r.getByRole("option", { name: "NBA" })).toHaveAttribute("aria-selected", "true");
+    expect(r.getByRole("option", { name: "NFL" })).toHaveAttribute("aria-selected", "true");
+    // And the parent options checkboxes are in the indeterminate state
+    expect(r.treeOption_basketball_checkbox()).toHaveAttribute("data-checked", "mixed");
+    expect(r.treeOption_football_checkbox()).toHaveAttribute("data-checked", "mixed");
+  });
+
+  it("renders with one option selected", async () => {
+    // Given a TreeSelectField with a nested options and a single option selected
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={getNestedOptions()}
+        label="Favorite League"
+        values={["nba"]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // Then the selected options are visible
+    expect(r.selectedOptionsCount).toNotBeInTheDom();
+    expect(r.favoriteLeague()).toHaveValue("NBA");
+
+    // When opening the options
+    click(r.favoriteLeague);
+    // Then the selected options are checked
+    expect(r.getByRole("option", { name: "NBA" })).toHaveAttribute("aria-selected", "true");
+    // And the parent option's checkbox is in the indeterminate state
+    expect(r.treeOption_basketball_checkbox()).toHaveAttribute("data-checked", "mixed");
+  });
+
+  it("can collapse and expand options", async () => {
+    // Given a TreeSelectField with nested options
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={getNestedOptions()}
+        label="Favorite League"
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // When opening the options
+    click(r.favoriteLeague);
+    // Then the child options are visible
+    expect(r.getByRole("option", { name: "MLB" })).toBeVisible();
+    // And the expand/collapse button has the correct icon
+    expect(r.treeOption_collapseToggle_baseball().firstChild).toHaveAttribute("data-icon", "triangleDown");
+    // When collapsing the parent option
+    click(r.treeOption_collapseToggle_baseball);
+    // Then the child options are no longer visible
+    expect(r.queryByRole("option", { name: "MLB" })).toBeFalsy();
+    // And the expand/collapse button has the correct icon
+    expect(r.treeOption_collapseToggle_baseball().firstChild).toHaveAttribute("data-icon", "triangleRight");
+
+    // When expanding the parent option
+    click(r.treeOption_collapseToggle_baseball);
+    // Then the child options are visible
+    expect(r.getByRole("option", { name: "MLB" })).toBeVisible();
+    // And the expand/collapse button has the correct icon again
+    expect(r.treeOption_collapseToggle_baseball().firstChild).toHaveAttribute("data-icon", "triangleDown");
+  });
+
+  it("can initially render with all options initially collapsed", async () => {
+    // Given a TreeSelectField with nested options
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={getNestedOptions()}
+        label="Favorite League"
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+        defaultCollapsed
+      />,
+    );
+    // When opening the options
+    click(r.favoriteLeague);
+    // Then all top level options are collapsed
+    expect(r.queryAllByRole("option")).toHaveLength(3);
+  });
+
+  it("correctly selects all children if only a parent was passed as a selected value", async () => {
+    // Given a TreeSelectField with nested options
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={getNestedOptions()}
+        label="Favorite League"
+        values={["baseball"]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // When opening the options
+    click(r.favoriteLeague);
+    // Then all children are selected
+    expect(r.getByRole("option", { name: "MLB" })).toHaveAttribute("aria-selected", "true");
+    expect(r.getByRole("option", { name: "Minor League Baseball" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("correctly selects the parent if all children were passed as selected values", async () => {
+    // Given a TreeSelectField with nested options
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={getNestedOptions()}
+        label="Favorite League"
+        values={["mlb", "milb"]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // When opening the options
+    click(r.favoriteLeague);
+    // Then the parent is selected
+    expect(r.getByRole("option", { name: "Baseball" })).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("selects and deselects all children based on parent selection", async () => {
+    // Given a TreeSelectField with nested options
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={getNestedOptions()}
+        label="Favorite League"
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // When opening the options
+    click(r.favoriteLeague);
+    // And selecting the parent option
+    click(r.treeOption_basketball_checkbox());
+    // Then all children are selected
+    expect(r.getByRole("option", { name: "NBA" })).toHaveAttribute("aria-selected", "true");
+    expect(r.getByRole("option", { name: "WNBA" })).toHaveAttribute("aria-selected", "true");
+    // And the parent option's checkbox is in the checked state
+    expect(r.treeOption_basketball_checkbox()).toHaveAttribute("data-checked", "true");
+
+    // When deselecting the parent option
+    click(r.treeOption_basketball_checkbox());
+    // Then all children are deselected
+    expect(r.getByRole("option", { name: "NBA" })).toHaveAttribute("aria-selected", "false");
+    expect(r.getByRole("option", { name: "WNBA" })).toHaveAttribute("aria-selected", "false");
+    // And the parent option's checkbox is in the unchecked state
+    expect(r.treeOption_basketball_checkbox()).toHaveAttribute("data-checked", "false");
+  });
+
+  it("can filter options", async () => {
+    // Given a TreeSelectField with nested options
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={getNestedOptions()}
+        label="Favorite League"
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // When opening the options
+    click(r.favoriteLeague);
+    // Then all options are visible
+    expect(r.queryAllByRole("option")).toHaveLength(9);
+    // And typing in the filter input
+    fireEvent.input(r.favoriteLeague(), { target: { value: "nba" } });
+    expect(r.favoriteLeague()).toHaveValue("nba");
+    // Then only the NBA option is visible
+    expect(r.queryAllByRole("option")).toHaveLength(2);
+    expect(r.getByRole("option", { name: "NBA" })).toBeVisible();
+    expect(r.getByRole("option", { name: "WNBA" })).toBeVisible();
+  });
+});
+
+function getNestedOptions(): NestedOption<HasIdAndName>[] {
+  return [
+    {
+      id: "baseball",
+      name: "Baseball",
+      children: [
+        { id: "mlb", name: "MLB" },
+        { id: "milb", name: "Minor League Baseball" },
+      ],
+    },
+    {
+      id: "basketball",
+      name: "Basketball",
+      children: [
+        { id: "nba", name: "NBA" },
+        { id: "wnba", name: "WNBA" },
+      ],
+    },
+    {
+      id: "football",
+      name: "Football",
+      children: [
+        { id: "nfl", name: "NFL" },
+        { id: "xfl", name: "XFL" },
+      ],
+    },
+  ];
+}

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -40,7 +40,6 @@ export interface TreeSelectFieldProps<O, V extends Value> extends BeamFocusableP
   /** The current value; it can be `undefined`, even if `V` cannot be. */
   values: V[] | undefined;
   onSelect: (options: TreeSelectResponse<O, V>) => void;
-  // disabledOptions?: (V | { value: V; reason: string })[];
   options: NestedOptionsOrLoad<O>;
   /** Whether the field is disabled. If a ReactNode, it's treated as a "disabled reason" that's shown in a tooltip. */
   disabled?: boolean | ReactNode;
@@ -102,7 +101,6 @@ export function TreeSelectField<O, V extends Value>(
         getOptionValue={getOptionValue}
         values={values}
         onSelect={({ all, leaf, root }) => {
-          console.log({ all, leaf, root });
           onSelect({ all, leaf, root });
         }}
       />
@@ -215,7 +213,6 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
   useEffect(() => {
     // Do not run this effect on first render. Otherwise we'd be triggering a re-render on first render.
     if (reactToCollapse.current) {
-      console.log("setting field state based on clappsed keys!", { collapsedKeys });
       setFieldState(({ allOptions, inputValue, ...others }) => ({
         allOptions,
         inputValue,
@@ -278,7 +275,6 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
   // Only on the first open of the listbox, we want to load the options if they haven't been loaded yet.
   const firstOpen = useRef(true);
   function onOpenChange(isOpen: boolean) {
-    if (!isOpen) debugger;
     if (firstOpen.current && isOpen) {
       maybeInitLoad(options, fieldState, setFieldState);
       firstOpen.current = false;
@@ -431,6 +427,7 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
     },
   });
 
+  // Resets the TreeFieldState when the 'blur' event is triggered on the input.
   function resetField() {
     const { inputValue, selectedOptions } = fieldState;
     if (inputValue !== "" || (selectedOptions.length === 1 && inputValue !== getOptionLabel(selectedOptions[0]))) {

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -1,0 +1,540 @@
+import React, {
+  Dispatch,
+  Key,
+  ReactNode,
+  SetStateAction,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useButton, useComboBox, useFilter, useOverlayPosition } from "react-aria";
+import { Item, useComboBoxState, useMultipleSelectionState } from "react-stately";
+import { resolveTooltip } from "src/components";
+import { Popover } from "src/components/internal";
+import { PresentationFieldProps } from "src/components/PresentationContext";
+import { Css, px } from "src/Css";
+import { Value } from "src/inputs/index";
+import { ComboBoxInput } from "src/inputs/internal/ComboBoxInput";
+import { ListBox } from "src/inputs/internal/ListBox";
+import {
+  findOption,
+  flattenOptions,
+  LeveledOption,
+  NestedOption,
+  NestedOptionsOrLoad,
+  TreeFieldState,
+  TreeSelectResponse,
+} from "src/inputs/TreeSelectField/utils";
+import { keyToValue, valueToKey } from "src/inputs/Value";
+import { BeamFocusableProps } from "src/interfaces";
+import { HasIdAndName, Optional } from "src/types";
+
+export interface TreeSelectFieldProps<O, V extends Value> extends BeamFocusableProps, PresentationFieldProps {
+  /** Renders `opt` in the dropdown menu, defaults to the `getOptionLabel` prop. `isUnsetOpt` is only defined for single SelectField */
+  getOptionMenuLabel?: (opt: O, isUnsetOpt?: boolean) => string | ReactNode;
+  getOptionValue: (opt: O) => V;
+  getOptionLabel: (opt: O) => string;
+  /** The current value; it can be `undefined`, even if `V` cannot be. */
+  values: V[] | undefined;
+  onSelect: (options: TreeSelectResponse<O, V>) => void;
+  // disabledOptions?: (V | { value: V; reason: string })[];
+  options: NestedOptionsOrLoad<O>;
+  /** Whether the field is disabled. If a ReactNode, it's treated as a "disabled reason" that's shown in a tooltip. */
+  disabled?: boolean | ReactNode;
+  required?: boolean;
+  errorMsg?: string;
+  helperText?: string | ReactNode;
+  /** Allow placing an icon/decoration within the input field. */
+  fieldDecoration?: (opt: O) => ReactNode;
+  /** Sets the form field label. */
+  label: string;
+  // Whether the field is readOnly. If a ReactNode, it's treated as a "readOnly reason" that's shown in a tooltip.
+  readOnly?: boolean | ReactNode;
+  onBlur?: () => void;
+  onFocus?: () => void;
+  sizeToContent?: boolean;
+  /** The text to show when nothing is selected, i.e. could be "All" for filters. */
+  nothingSelectedText?: string;
+  /** When set the SelectField is expected to be put on a darker background */
+  contrast?: boolean;
+  /** Placeholder content */
+  placeholder?: string;
+  hideErrorMessage?: boolean;
+  /** Whether to have all groups collapsed on initial load. Can also be configured individually, which overrides this behavior.
+   * @default false */
+  defaultCollapsed?: boolean;
+}
+
+export function TreeSelectField<O, V extends Value>(props: TreeSelectFieldProps<O, V>): JSX.Element;
+export function TreeSelectField<O extends HasIdAndName<V>, V extends Value>(
+  props: Optional<TreeSelectFieldProps<O, V>, "getOptionValue" | "getOptionLabel">,
+): JSX.Element;
+export function TreeSelectField<O, V extends Value>(
+  props: Optional<TreeSelectFieldProps<O, V>, "getOptionLabel" | "getOptionValue">,
+): JSX.Element {
+  const {
+    getOptionValue = (opt: O) => (opt as any).id, // if unset, assume O implements HasId
+    getOptionLabel = (opt: O) => (opt as any).name, // if unset, assume O implements HasName
+    options,
+    onSelect,
+    values,
+    defaultCollapsed = false,
+    ...otherProps
+  } = props;
+
+  const [collapsedKeys, setCollapsedKeys] = useState<Key[]>(
+    Array.isArray(options) && defaultCollapsed ? options.map((o) => getOptionValue(o)) : [],
+  );
+  const contextValue = useMemo<CollapsedChildrenState<O, V>>(
+    () => ({ collapsedKeys, setCollapsedKeys, getOptionValue }),
+    [collapsedKeys, setCollapsedKeys],
+  );
+
+  return (
+    <CollapsedContext.Provider value={contextValue}>
+      <TreeSelectFieldBase
+        {...otherProps}
+        options={options}
+        getOptionLabel={getOptionLabel}
+        getOptionValue={getOptionValue}
+        values={values}
+        onSelect={({ all, leaf, root }) => {
+          console.log({ all, leaf, root });
+          onSelect({ all, leaf, root });
+        }}
+      />
+    </CollapsedContext.Provider>
+  );
+}
+
+export function useTreeSelectFieldProvider<O, V extends Value>() {
+  return useContext(CollapsedContext);
+}
+
+interface CollapsedChildrenState<O, V extends Value> {
+  collapsedKeys: Key[];
+  setCollapsedKeys: Dispatch<SetStateAction<Key[]>>;
+  getOptionValue: (opt: O) => V;
+}
+// create the context to hold the collapsed state, default should be false
+export const CollapsedContext = React.createContext<CollapsedChildrenState<any, any>>({
+  collapsedKeys: [],
+  setCollapsedKeys: () => {},
+  getOptionValue: () => ({} as any),
+});
+
+function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, V>) {
+  const {
+    values,
+    options,
+    getOptionValue,
+    getOptionLabel,
+    getOptionMenuLabel = getOptionLabel,
+    disabled,
+    readOnly,
+    labelStyle,
+    borderless,
+    contrast = false,
+    nothingSelectedText = "",
+    onSelect,
+    defaultCollapsed = false,
+    placeholder,
+    ...otherProps
+  } = props;
+
+  const isDisabled = !!disabled;
+  const isReadOnly = !!readOnly;
+  const initialOptions = Array.isArray(options) ? options : options.initial;
+  const { contains } = useFilter({ sensitivity: "base" });
+
+  const { collapsedKeys } = useTreeSelectFieldProvider();
+
+  function levelOptions(o: NestedOption<O>, level: number, filtering?: boolean): LeveledOption<O>[] {
+    // If a user is filtering, then do not provide level to the options as the various paddings may look quite odd.
+    const actualLevel = filtering ? 0 : level;
+    return [
+      [o, actualLevel],
+      ...(o.children?.length && !collapsedKeys.includes(valueToKey(getOptionValue(o)))
+        ? o.children.flatMap((oc: NestedOption<O>) => levelOptions(oc, actualLevel + 1, filtering))
+        : []),
+    ];
+  }
+
+  // Initialize the TreeFieldState
+  const [fieldState, setFieldState] = useState<TreeFieldState<O>>(() => {
+    const filteredOptions = initialOptions.flatMap((o) => levelOptions(o, 0));
+    const selectedOptions: NestedOption<O>[] =
+      values?.flatMap((v) => {
+        const maybeOption = findOption(initialOptions, valueToKey(v), getOptionValue);
+        if (!maybeOption) return [];
+
+        const { option } = maybeOption;
+        // If the selected key has children then all children should also be considered selected.
+        return [option, ...(option.children?.flatMap(flattenOptions) ?? [])];
+      }) ?? [];
+    const selectedKeys = selectedOptions.map((o) => valueToKey(getOptionValue(o)));
+
+    // It is possible that all the children of a parent were considered selected `values`, but the parent wasn't.
+    // In this case, the parent also should be considered a selected option.
+    function areAllChildrenSelected(maybeParent: NestedOption<O>): boolean {
+      const isSelected = selectedKeys.includes(valueToKey(getOptionValue(maybeParent)));
+      // if this key is already selected, then return true
+      if (isSelected) return true;
+
+      // If we do not have children, then return the state of this leaf node.
+      if (!maybeParent.children) return isSelected;
+
+      // If we do have children, then check if all children are selected.
+      // if all are selected, then push this parent to the selectedKeys and selectedOptions
+      const areAllSelected = maybeParent.children.every(areAllChildrenSelected);
+      if (areAllSelected) {
+        selectedKeys.push(valueToKey(getOptionValue(maybeParent)));
+        selectedOptions.push(maybeParent);
+      }
+      return areAllSelected;
+    }
+
+    initialOptions.forEach(areAllChildrenSelected);
+
+    return {
+      selectedKeys,
+      inputValue: selectedOptions.length === 1 ? getOptionLabel(selectedOptions[0]) : "",
+      filteredOptions,
+      selectedOptions,
+      allOptions: initialOptions,
+      optionsLoading: false,
+      allowCollapsing: true,
+    };
+  });
+
+  // React to collapsed keys and update the filtered options
+  const reactToCollapse = useRef(false);
+  useEffect(() => {
+    // Do not run this effect on first render. Otherwise we'd be triggering a re-render on first render.
+    if (reactToCollapse.current) {
+      console.log("setting field state based on clappsed keys!", { collapsedKeys });
+      setFieldState(({ allOptions, inputValue, ...others }) => ({
+        allOptions,
+        inputValue,
+        ...others,
+        filteredOptions: allOptions.flatMap((o) =>
+          levelOptions(o, 0, inputValue.length > 0).filter(([option]) => contains(getOptionLabel(option), inputValue)),
+        ),
+      }));
+    }
+    reactToCollapse.current = true;
+  }, [collapsedKeys]);
+
+  // Update the filtered options when the input value changes
+  const onInputChange = useCallback(
+    (inputValue: string) => {
+      setFieldState((prevState) => {
+        return {
+          ...prevState,
+          inputValue,
+          allowCollapsing: inputValue.length === 0,
+          filteredOptions: prevState.allOptions.flatMap((o) =>
+            levelOptions(o, 0, inputValue.length > 0).filter(([option]) =>
+              contains(getOptionLabel(option), inputValue),
+            ),
+          ),
+        };
+      });
+    },
+    [setFieldState],
+  );
+
+  // Handle loading of the options in the case that they are loaded via a Promise.
+  const maybeInitLoad = useCallback(
+    async (
+      options: NestedOptionsOrLoad<O>,
+      fieldState: TreeFieldState<O>,
+      setFieldState: React.Dispatch<React.SetStateAction<TreeFieldState<O>>>,
+    ) => {
+      if (!Array.isArray(options)) {
+        setFieldState((prevState) => ({ ...prevState, optionsLoading: true }));
+        const loadedOptions = (await options.load()).options;
+        const filteredOptions = loadedOptions.flatMap((o) =>
+          levelOptions(o, 0, fieldState.inputValue.length > 0).filter(([option]) =>
+            contains(getOptionLabel(option), fieldState.inputValue),
+          ),
+        );
+
+        // Ensure the `unset` option is prepended to the top of the list if `unsetLabel` was provided
+        setFieldState((prevState) => ({
+          ...prevState,
+          filteredOptions,
+          allOptions: loadedOptions,
+          optionsLoading: false,
+        }));
+      }
+    },
+    [],
+  );
+
+  // Only on the first open of the listbox, we want to load the options if they haven't been loaded yet.
+  const firstOpen = useRef(true);
+  function onOpenChange(isOpen: boolean) {
+    if (!isOpen) debugger;
+    if (firstOpen.current && isOpen) {
+      maybeInitLoad(options, fieldState, setFieldState);
+      firstOpen.current = false;
+    }
+  }
+
+  // This is _always_ going to appear new. Maybe `useMemo`?
+  const comboBoxProps = {
+    ...otherProps,
+    placeholder: !values || values.length === 0 ? placeholder : "",
+    label: props.label,
+    inputValue: fieldState.inputValue,
+    // where we might want to do flatmap and return diff kind of array (children ? add level prop) inside children callback - can put markup wrapper div adds padding
+    // so we're not doing it multiple places
+    items: fieldState.filteredOptions,
+    isDisabled,
+    isReadOnly,
+    onInputChange,
+    onOpenChange,
+    children: ([item]: LeveledOption<O>) => (
+      // what we're telling it to render. look at padding here - dont have to pass down to tree option - filtered options is where we're flat mapping
+      <Item key={valueToKey(getOptionValue(item))} textValue={getOptionLabel(item)}>
+        {getOptionMenuLabel(item)}
+      </Item>
+    ),
+  };
+
+  const state = useComboBoxState<any>({
+    ...comboBoxProps,
+    allowsEmptyCollection: true,
+  });
+
+  // @ts-ignore - `selectionManager.state` exists, but not according to the types. We are tricking the ComboBox state to support multiple selections.
+  state.selectionManager.state = useMultipleSelectionState({
+    selectionMode: "multiple",
+    selectedKeys: fieldState.selectedKeys,
+    onSelectionChange: (newKeys) => {
+      if (newKeys === "all") {
+        // We do not support an "All" option
+        return;
+      }
+
+      // First figure out which keys changed so we can correctly determine which affiliated options may need to be updated as well.
+      const existingKeys = state.selectionManager.selectedKeys;
+      const addedKeys = new Set([...newKeys].filter((x) => !existingKeys.has(x)));
+      const removedKeys = new Set([...existingKeys].filter((x) => !newKeys.has(x)));
+
+      // Make sure there are changes before we do anything.
+      if (addedKeys.size > 0 || removedKeys.size > 0) {
+        // Quickly return out of this if all selections are removed
+        if (newKeys.size === 0) {
+          setFieldState((prevState) => ({ ...prevState, inputValue: "", selectedKeys: [], selectedOptions: [] }));
+          onSelect({
+            all: { values: [], options: [] },
+            leaf: { values: [], options: [] },
+            root: { values: [], options: [] },
+          });
+          return;
+        }
+
+        // `onSelectionChange` is only ever going to be adding or removing 1 key at a time.
+        // The below logic for adding/removing using a forEach loop is just to make TS happy.
+        // This may look like a lot of logic, but in the execution it will only ever be adding/removing 1 key at a time, so it really isn't as bad as it looks.
+
+        // For added keys, we need to see if any other options should be added as well.
+        [...addedKeys].forEach((key) => {
+          const maybeOption = findOption(fieldState.allOptions, key, getOptionValue);
+          if (!maybeOption) return;
+
+          const { option, parents } = maybeOption;
+
+          // If the newly added option has children, then consider the children to be newly added keys as well.
+          if (option && option.children && option.children.length > 0) {
+            const childrenKeys = option.children.flatMap(flattenOptions).map((o) => valueToKey(getOptionValue(o)));
+            [key, ...childrenKeys].forEach(addedKeys.add, addedKeys);
+          }
+
+          // If this was a child that was selected, then see if every other child is also selected, and if so, consider the parent selected.
+          // Walk up the parents and determine their state.
+          for (const parent of parents.reverse()) {
+            const allChecked = parent.children?.every((child) => {
+              const childKey = valueToKey(getOptionValue(child));
+              return addedKeys.has(childKey) || existingKeys.has(childKey);
+            });
+            if (allChecked) {
+              addedKeys.add(valueToKey(getOptionValue(parent)));
+            }
+          }
+        });
+
+        // For removed keys, we need to also unselect any children and parents of the removed key
+        [...removedKeys].forEach((key) => {
+          // Grab the option and parents of the option that was removed
+          const maybeOption = findOption(fieldState.allOptions, key, getOptionValue);
+          if (!maybeOption) return;
+
+          const { option, parents } = maybeOption;
+
+          // If the option has children, then we need to unselect those children as well
+          if (option.children && option.children.length > 0) {
+            const childrenKeys = option.children.flatMap(flattenOptions).map((o) => valueToKey(getOptionValue(o)));
+            [key, ...childrenKeys].forEach(removedKeys.add, removedKeys);
+          }
+
+          // If the option has parents, then we need to unselect those parents as well
+          if (parents.length > 0) {
+            const parentKeys = parents.map((o) => valueToKey(getOptionValue(o)));
+            [key, ...parentKeys].forEach(removedKeys.add, removedKeys);
+          }
+        });
+
+        // Create the lists to update our TreeState with
+        const selectedKeys = new Set([...existingKeys, ...addedKeys].filter((x) => !removedKeys.has(x)));
+        const selectedOptions = fieldState.allOptions
+          .flatMap(flattenOptions)
+          .filter((o) => selectedKeys.has(valueToKey(getOptionValue(o))));
+
+        // Our `onSelect` callback provides three things:
+        // 1. ALL selected values + options
+        // 2. Only the top level selected values + options
+        // 3. Only the leaf selected values + options
+
+        // For the top level and leaf selections, we need to do some extra work to determine which options are the top level and leaf.
+        function getTopLevelSelections(o: NestedOption<O>): NestedOption<O>[] {
+          // If this element is already selected, return early. Do not bother looking through children.
+          if (selectedKeys.has(valueToKey(getOptionValue(o)))) return [o];
+          // If this element has no children, then look through the children for top level selected options.
+          if (o.children) return [...o.children.flatMap(getTopLevelSelections)];
+          return [];
+        }
+        const rootOptions = fieldState.allOptions.flatMap(getTopLevelSelections);
+        const rootValues = rootOptions.map(getOptionValue);
+
+        // Finally get the list of options that are just the "leaf" options, meaning they have no children.
+        const leafOptions = selectedOptions.filter((o) => !o.children || o.children.length === 0);
+        const leafValues = leafOptions.map(getOptionValue);
+
+        setFieldState((prevState) => ({
+          ...prevState,
+          selectedKeys: [...selectedKeys],
+          selectedOptions,
+        }));
+
+        onSelect({
+          all: { values: [...selectedKeys].map((key) => keyToValue(key)), options: selectedOptions },
+          leaf: { values: leafValues, options: leafOptions },
+          root: { values: rootValues, options: rootOptions },
+        });
+      }
+    },
+  });
+
+  function resetField() {
+    const { inputValue, selectedOptions } = fieldState;
+    if (inputValue !== "" || (selectedOptions.length === 1 && inputValue !== getOptionLabel(selectedOptions[0]))) {
+      setFieldState((prevState) => ({
+        ...prevState,
+        inputValue: selectedOptions.length === 1 ? getOptionLabel(selectedOptions[0]) : "",
+        filteredOptions: initialOptions.flatMap((o) => levelOptions(o, 0)),
+        allowCollapsing: true,
+      }));
+    }
+  }
+
+  const comboBoxRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const inputWrapRef = useRef<HTMLDivElement | null>(null);
+  const listBoxRef = useRef<HTMLDivElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+
+  const {
+    buttonProps: triggerProps,
+    inputProps,
+    listBoxProps,
+    labelProps,
+  } = useComboBox(
+    {
+      ...comboBoxProps,
+      inputRef,
+      buttonRef: triggerRef,
+      listBoxRef,
+      popoverRef,
+    },
+    state,
+  );
+  const { buttonProps } = useButton({ ...triggerProps, isDisabled: isDisabled || isReadOnly }, triggerRef);
+
+  // useOverlayPosition moves the overlay to the top of the DOM to avoid any z-index issues. Uses the `targetRef` to DOM placement
+  const { overlayProps: positionProps } = useOverlayPosition({
+    targetRef: inputWrapRef,
+    overlayRef: popoverRef,
+    scrollRef: listBoxRef,
+    shouldFlip: true,
+    isOpen: state.isOpen,
+    onClose: state.close,
+    placement: "bottom left",
+    offset: borderless ? 8 : 4,
+  });
+
+  positionProps.style = {
+    ...positionProps.style,
+    width: comboBoxRef?.current?.clientWidth,
+    // Ensures the menu never gets too small.
+    minWidth: 200,
+  };
+
+  return (
+    <div css={Css.df.fdc.w100.maxw(px(550)).if(labelStyle === "left").maxw100.$} ref={comboBoxRef}>
+      <ComboBoxInput
+        {...otherProps}
+        labelStyle={labelStyle}
+        buttonProps={buttonProps}
+        buttonRef={triggerRef}
+        inputProps={inputProps}
+        inputRef={inputRef}
+        inputWrapRef={inputWrapRef}
+        listBoxRef={listBoxRef}
+        state={state}
+        labelProps={labelProps}
+        selectedOptions={fieldState.selectedOptions}
+        getOptionValue={getOptionValue}
+        getOptionLabel={getOptionLabel}
+        contrast={contrast}
+        borderless={borderless}
+        tooltip={resolveTooltip(disabled, undefined, readOnly)}
+        resetField={resetField}
+        nothingSelectedText={nothingSelectedText}
+        typeToFilter
+        isTree
+      />
+      {state.isOpen && (
+        <Popover
+          triggerRef={triggerRef}
+          popoverRef={popoverRef}
+          positionProps={positionProps}
+          onClose={() => state.close()}
+          isOpen={state.isOpen}
+          minWidth={200}
+        >
+          <ListBox
+            {...listBoxProps}
+            positionProps={positionProps}
+            state={state}
+            listBoxRef={listBoxRef}
+            selectedOptions={fieldState.selectedOptions}
+            getOptionLabel={getOptionLabel}
+            getOptionValue={(o) => valueToKey(getOptionValue(o))}
+            contrast={contrast}
+            horizontalLayout={labelStyle === "left"}
+            loading={fieldState.optionsLoading}
+            allowCollapsing={fieldState.allowCollapsing}
+            isTree
+          />
+        </Popover>
+      )}
+    </div>
+  );
+}

--- a/src/inputs/TreeSelectField/index.ts
+++ b/src/inputs/TreeSelectField/index.ts
@@ -1,0 +1,2 @@
+export * from "./TreeSelectField";
+export type { NestedOption, NestedOptionsOrLoad } from "./utils";

--- a/src/inputs/TreeSelectField/utils.ts
+++ b/src/inputs/TreeSelectField/utils.ts
@@ -1,0 +1,58 @@
+import { Node } from "@react-types/shared";
+import { Key } from "react";
+import { Value } from "src/inputs/Value";
+
+type FoundOption<O> = { option: NestedOption<O>; parents: NestedOption<O>[] };
+export type NestedOption<O> = O & { children?: NestedOption<O>[] };
+export type NestedOptionsOrLoad<O> =
+  | NestedOption<O>[]
+  | { initial: NestedOption<O>[]; load: () => Promise<{ options: NestedOption<O>[] }> };
+export type LeveledOption<O> = [NestedOption<O>, number];
+
+export type TreeFieldState<O> = {
+  inputValue: string;
+  filteredOptions: LeveledOption<O>[];
+  selectedKeys: Key[];
+  selectedOptions: NestedOption<O>[];
+  allOptions: NestedOption<O>[];
+  optionsLoading: boolean;
+  allowCollapsing: boolean;
+};
+
+export type TreeSelectResponse<O, V extends Value> = {
+  all: { values: V[]; options: O[] };
+  leaf: { values: V[]; options: O[] };
+  root: { values: V[]; options: O[] };
+};
+
+/** Finds an option by Key, and returns it + any parents. */
+export function findOption<O, V extends Value>(
+  options: NestedOption<O>[],
+  key: Key,
+  getOptionValue: (o: O) => V,
+): FoundOption<O> | undefined {
+  // This is technically an array of "maybe FoundRow"
+  const todo: FoundOption<O>[] = options.map((option) => ({ option, parents: [] }));
+  while (todo.length > 0) {
+    const curr = todo.pop()!;
+    if (getOptionValue(curr.option) === key) {
+      return curr;
+    } else if (curr.option.children) {
+      // Search our children and pass along us as the parent
+      todo.push(...curr.option.children.map((option) => ({ option, parents: [...curr.parents, curr.option] })));
+    }
+  }
+  return undefined;
+}
+
+export function flattenOptions<O>(o: NestedOption<O>): NestedOption<O>[] {
+  return [o, ...(o.children?.length ? o.children.flatMap((oc: NestedOption<O>) => flattenOptions(oc)) : [])];
+}
+
+export function isLeveledOption<O>(option: LeveledOption<O> | any): option is LeveledOption<O> {
+  return Array.isArray(option) && option.length === 2 && typeof option[1] === "number";
+}
+
+export function isLeveledNode<O>(node: Node<O> | Node<LeveledOption<O>>): node is Node<LeveledOption<O>> {
+  return isLeveledOption(node.value);
+}

--- a/src/inputs/index.ts
+++ b/src/inputs/index.ts
@@ -17,4 +17,5 @@ export * from "./TextField";
 export type { TextFieldApi } from "./TextField";
 export * from "./ToggleButton";
 export * from "./ToggleChipGroup";
+export * from "./TreeSelectField";
 export type { Value } from "./Value";

--- a/src/inputs/internal/ListBox.tsx
+++ b/src/inputs/internal/ListBox.tsx
@@ -18,6 +18,8 @@ interface ListBoxProps<O, V extends Key> {
   positionProps: React.HTMLAttributes<Element>;
   loading?: boolean | (() => JSX.Element);
   disabledOptionsWithReasons?: Record<string, string | undefined>;
+  isTree?: boolean;
+  allowCollapsing?: boolean;
 }
 
 /** A ListBox is an internal component used by SelectField and MultiSelectField to display the list of options */
@@ -33,6 +35,8 @@ export function ListBox<O, V extends Key>(props: ListBoxProps<O, V>) {
     horizontalLayout = false,
     loading,
     disabledOptionsWithReasons = {},
+    isTree,
+    allowCollapsing,
   } = props;
   const { listBoxProps } = useListBox({ disallowEmptySelection: true, ...props }, state, listBoxRef);
   const positionMaxHeight = positionProps.style?.maxHeight;
@@ -91,7 +95,7 @@ export function ListBox<O, V extends Key>(props: ListBoxProps<O, V>) {
       ref={listBoxRef}
       {...listBoxProps}
     >
-      {isMultiSelect && state.selectionManager.selectedKeys.size > 0 && (
+      {isMultiSelect && !isTree && state.selectionManager.selectedKeys.size > 0 && (
         <ul
           css={Css.listReset.pt2.pl2.pb1.pr1.df.bb.bGray200.add("flexWrap", "wrap").maxh("50%").overflowAuto.$}
           ref={selectedList}
@@ -134,6 +138,8 @@ export function ListBox<O, V extends Key>(props: ListBoxProps<O, V>) {
             scrollOnFocus={(props as any).shouldUseVirtualFocus}
             loading={loading}
             disabledOptionsWithReasons={disabledOptionsWithReasons}
+            isTree={isTree}
+            allowCollapsing={allowCollapsing}
           />
         )}
       </ul>

--- a/src/inputs/internal/Option.tsx
+++ b/src/inputs/internal/Option.tsx
@@ -1,5 +1,5 @@
 import { Node } from "@react-types/shared";
-import { useCallback, useRef } from "react";
+import { useRef } from "react";
 import { mergeProps, useHover, useOption } from "react-aria";
 import { ListState, TreeState } from "react-stately";
 import { maybeTooltip } from "src/components";
@@ -35,38 +35,12 @@ export function Option<O>(props: OptionProps<O>) {
     ref,
   );
 
-  // Additional onKeyDown logic to ensure the  the virtualized list (in <VirtualizedOptions />) scrolls to keep the "focused" option in view
-  const onKeyDown = useCallback(
-    (e: KeyboardEvent) => {
-      if (!scrollToIndex || !(e.key === "ArrowDown" || e.key === "ArrowUp")) {
-        return;
-      }
-
-      const toKey = e.key === "ArrowDown" ? item.nextKey : item.prevKey;
-      if (!toKey) {
-        return;
-      }
-
-      const toItem = state.collection.getItem(toKey);
-      // Only scroll the "options" (`state.collection` is a flat list of sections and items - we want to avoid scrolling to a "section" as it is not shown in the UI)
-      if (
-        toItem &&
-        // Ensure we are only ever scrolling to an "option".
-        (toItem.parentKey === "options" || (!toItem.parentKey && toItem.type === "item")) &&
-        toItem.index !== undefined
-      ) {
-        scrollToIndex(toItem.index);
-      }
-    },
-    [scrollToIndex, state],
-  );
-
   return maybeTooltip({
     title: disabledReason,
     placement: "right",
     children: (
       <li
-        {...mergeProps(optionProps, hoverProps, { onKeyDown })}
+        {...mergeProps(optionProps, hoverProps)}
         ref={ref as any}
         css={{
           ...Css.df.aic.jcsb.py1.px2.mh("42px").outline0.cursorPointer.sm.$,


### PR DESCRIPTION
Creates new TreeSelectField component that allows nested groupings of items within the menu. Handles updating parent and child options selected state based on user input or values defined. Includes logic for lazily loading options.
Supports all existing states as Beam's other fields (disabled, readOnly, etc), as well as variations (compact, label styles, etc).

Adds tests and stories

Future improvements:
- Generate unique keys for each option based on grouping hierarchy
- Create Bound___Field equivalent
- Create Tree filter field for use within Beam filters
- Look at either moving existing TreeFieldState into either the context that currently only supports the collapsed state, or moving everything into a mobx state. Admittedly, this optimization should probably happen sooner than later. But looking to get something out in the meantime.