### PR TITLE
feat: Add secondary borderless button variant

### DIFF
--- a/src/components/Button.stories.mdx
+++ b/src/components/Button.stories.mdx
@@ -45,7 +45,7 @@ export const Template = (args) => {
       <Button variant="tertiaryDanger" label="Delete" />
       <Button variant="danger" label="Delete" />
       <Button variant="text" label="Edit" />
-      <Button variant="secondaryBorderless" label="Text" />
+      <Button variant="secondaryText" label="Text" />
     </div>
   </Story>
 </Canvas>

--- a/src/components/Button.stories.mdx
+++ b/src/components/Button.stories.mdx
@@ -34,7 +34,7 @@ export const Template = (args) => {
 
 # Variant
 
-#### There are 6 different variants for a Button.
+#### There are 7 different variants for a Button.
 
 <Canvas>
   <Story name="Variant">
@@ -45,6 +45,7 @@ export const Template = (args) => {
       <Button variant="tertiaryDanger" label="Delete" />
       <Button variant="danger" label="Delete" />
       <Button variant="text" label="Edit" />
+      <Button variant="secondaryBorderless" label="Text" />
     </div>
   </Story>
 </Canvas>

--- a/src/components/Button.stories.mdx
+++ b/src/components/Button.stories.mdx
@@ -45,7 +45,7 @@ export const Template = (args) => {
       <Button variant="tertiaryDanger" label="Delete" />
       <Button variant="danger" label="Delete" />
       <Button variant="text" label="Edit" />
-      <Button variant="secondaryText" label="Text" />
+      <Button variant="textSecondary" label="Text" />
     </div>
   </Story>
 </Canvas>

--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -16,7 +16,7 @@ export default {
 } as Meta;
 
 const sizes: ButtonSize[] = ["sm", "md", "lg"];
-const variants: ButtonVariant[] = ["primary", "secondary", "tertiary", "tertiaryDanger", "danger", "secondaryText"];
+const variants: ButtonVariant[] = ["primary", "secondary", "tertiary", "tertiaryDanger", "danger", "textSecondary"];
 
 export function ButtonVariations({ contrast = false }: { contrast?: boolean }) {
   return (

--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -16,14 +16,7 @@ export default {
 } as Meta;
 
 const sizes: ButtonSize[] = ["sm", "md", "lg"];
-const variants: ButtonVariant[] = [
-  "primary",
-  "secondary",
-  "tertiary",
-  "tertiaryDanger",
-  "danger",
-  "secondaryBorderless",
-];
+const variants: ButtonVariant[] = ["primary", "secondary", "tertiary", "tertiaryDanger", "danger", "secondaryText"];
 
 export function ButtonVariations({ contrast = false }: { contrast?: boolean }) {
   return (

--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -16,7 +16,14 @@ export default {
 } as Meta;
 
 const sizes: ButtonSize[] = ["sm", "md", "lg"];
-const variants: ButtonVariant[] = ["primary", "secondary", "tertiary", "tertiaryDanger", "danger"];
+const variants: ButtonVariant[] = [
+  "primary",
+  "secondary",
+  "tertiary",
+  "tertiaryDanger",
+  "danger",
+  "secondaryBorderless",
+];
 
 export function ButtonVariations({ contrast = false }: { contrast?: boolean }) {
   return (

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -189,7 +189,7 @@ const variantStyles: (contrast: boolean) => Record<
     disabledStyles: Css.lightBlue300.if(contrast).lightBlue700.$,
     focusStyles: Css.bshFocus.if(contrast).boxShadow(`0 0 0 2px ${Palette.White}`).$,
   },
-  secondaryBorderless: {
+  secondaryText: {
     baseStyles: Css.gray900.add("fontSize", "inherit").$,
     hoverStyles: Css.bgGray100.$,
     pressedStyles: Css.gray900.$,
@@ -218,4 +218,4 @@ export type ButtonVariant =
   | "tertiaryDanger"
   | "danger"
   | "text"
-  | "secondaryBorderless";
+  | "secondaryText";

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -189,6 +189,13 @@ const variantStyles: (contrast: boolean) => Record<
     disabledStyles: Css.lightBlue300.if(contrast).lightBlue700.$,
     focusStyles: Css.bshFocus.if(contrast).boxShadow(`0 0 0 2px ${Palette.White}`).$,
   },
+  secondaryBorderless: {
+    baseStyles: Css.gray900.add("fontSize", "inherit").$,
+    hoverStyles: Css.bgGray100.$,
+    pressedStyles: Css.gray900.$,
+    disabledStyles: Css.bgWhite.gray400.$,
+    focusStyles: Css.gray900.$,
+  },
 });
 
 const sizeStyles: Record<ButtonSize, Properties> = {
@@ -204,4 +211,11 @@ const iconStyles: Record<ButtonSize, IconProps["xss"]> = {
 };
 
 export type ButtonSize = "sm" | "md" | "lg";
-export type ButtonVariant = "primary" | "secondary" | "tertiary" | "tertiaryDanger" | "danger" | "text";
+export type ButtonVariant =
+  | "primary"
+  | "secondary"
+  | "tertiary"
+  | "tertiaryDanger"
+  | "danger"
+  | "text"
+  | "secondaryBorderless";

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -189,7 +189,8 @@ const variantStyles: (contrast: boolean) => Record<
     disabledStyles: Css.lightBlue300.if(contrast).lightBlue700.$,
     focusStyles: Css.bshFocus.if(contrast).boxShadow(`0 0 0 2px ${Palette.White}`).$,
   },
-  secondaryText: {
+  // Todo: handle contrast variant
+  textSecondary: {
     baseStyles: Css.gray900.add("fontSize", "inherit").$,
     hoverStyles: Css.bgGray100.$,
     pressedStyles: Css.gray900.$,
@@ -218,4 +219,4 @@ export type ButtonVariant =
   | "tertiaryDanger"
   | "danger"
   | "text"
-  | "secondaryText";
+  | "textSecondary";

--- a/src/components/ButtonModal.stories.tsx
+++ b/src/components/ButtonModal.stories.tsx
@@ -91,3 +91,17 @@ export function ButtonModalWithChipAndTooltip() {
     />
   );
 }
+
+export function ButtonModalWithSecondaryBorderless() {
+  return (
+    <ButtonModal
+      storybookDefaultOpen
+      title={"Modal Title"}
+      content={
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ipsum purus, bibendum sit amet vulputate eget, porta semper ligula."
+      }
+      trigger={{ label: "Button Modal trigger" }}
+      variant={"secondaryBorderless"}
+    />
+  );
+}

--- a/src/components/ButtonModal.stories.tsx
+++ b/src/components/ButtonModal.stories.tsx
@@ -92,7 +92,7 @@ export function ButtonModalWithChipAndTooltip() {
   );
 }
 
-export function ButtonModalWithSecondaryBorderless() {
+export function ButtonModalWithSecondaryText() {
   return (
     <ButtonModal
       storybookDefaultOpen
@@ -101,7 +101,7 @@ export function ButtonModalWithSecondaryBorderless() {
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ipsum purus, bibendum sit amet vulputate eget, porta semper ligula."
       }
       trigger={{ label: "Button Modal trigger" }}
-      variant={"secondaryBorderless"}
+      variant={"secondaryText"}
     />
   );
 }

--- a/src/components/ButtonModal.stories.tsx
+++ b/src/components/ButtonModal.stories.tsx
@@ -92,7 +92,7 @@ export function ButtonModalWithChipAndTooltip() {
   );
 }
 
-export function ButtonModalWithSecondaryText() {
+export function ButtonModalWithTextSecondary() {
   return (
     <ButtonModal
       storybookDefaultOpen
@@ -101,7 +101,11 @@ export function ButtonModalWithSecondaryText() {
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam ipsum purus, bibendum sit amet vulputate eget, porta semper ligula."
       }
       trigger={{ label: "Button Modal trigger" }}
-      variant={"secondaryText"}
+      variant={"textSecondary"}
     />
   );
 }
+// disable chromatic snapshot for this story
+ButtonModalWithTextSecondary.parameters = {
+  chromatic: { disableSnapshot: true },
+};


### PR DESCRIPTION
[SC-32614](https://app.shortcut.com/homebound-team/story/32614/add-new-button-variant-to-beam-s-button-modal)

* Add new `secondaryBorderless` variant to Button
![Screen Shot 2023-04-13 at 11 09 06 AM](https://user-images.githubusercontent.com/86630863/231823866-b012bd14-47da-4acc-832a-a9ef9d140f79.png)
