### PR TITLE
fix: Properly use initial option for SelectField when lazy load options

### DIFF
--- a/src/inputs/SelectField.stories.tsx
+++ b/src/inputs/SelectField.stories.tsx
@@ -227,23 +227,45 @@ const loadTestOptions: TestOption[] = zeroTo(1000).map((i) => ({ id: String(i), 
 export function PerfTest() {
   const [selectedValue, setSelectedValue] = useState<string | undefined>(loadTestOptions[2].id);
   return (
-    <SelectField
-      label="Project"
-      value={selectedValue}
-      onSelect={setSelectedValue}
-      errorMsg={selectedValue !== undefined ? "" : "Select an option. Plus more error text to force it to wrap."}
-      options={{
-        initial: [loadTestOptions[2]],
-        load: async () => {
-          return new Promise((resolve) => {
-            // @ts-ignore - believes `options` should be of type `never[]`
-            setTimeout(() => resolve({ options: loadTestOptions }), 1500);
-          });
-        },
-      }}
-      onBlur={action("onBlur")}
-      onFocus={action("onFocus")}
-    />
+    <>
+      <SelectField
+        label="Project"
+        value={selectedValue}
+        onSelect={setSelectedValue}
+        unsetLabel="-"
+        // errorMsg={selectedValue !== undefined ? "" : "Select an option. Plus more error text to force it to wrap."}
+        options={{
+          initial: [loadTestOptions.find((o) => o.id === selectedValue)!],
+          load: async () => {
+            return new Promise((resolve) => {
+              // @ts-ignore - believes `options` should be of type `never[]`
+              setTimeout(() => resolve({ options: loadTestOptions }), 1500);
+            });
+          },
+        }}
+        onBlur={action("onBlur")}
+        onFocus={action("onFocus")}
+      />
+      <div>second</div>
+      <SelectField
+        label="Project"
+        unsetLabel="-"
+        value={selectedValue}
+        onSelect={setSelectedValue}
+        // errorMsg={selectedValue !== undefined ? "" : "Select an option. Plus more error text to force it to wrap."}
+        options={{
+          initial: [loadTestOptions.find((o) => o.id === selectedValue)!],
+          load: async () => {
+            return new Promise((resolve) => {
+              // @ts-ignore - believes `options` should be of type `never[]`
+              setTimeout(() => resolve({ options: loadTestOptions }), 1500);
+            });
+          },
+        }}
+        onBlur={action("onBlur")}
+        onFocus={action("onFocus")}
+      />
+    </>
   );
 }
 PerfTest.parameters = { chromatic: { disableSnapshot: true } };


### PR DESCRIPTION
This PR fixes a problem when a SelectField have a initial value (as object) and that selected option are not on the options list (because it's not loaded yet).

### Issue video demo
https://user-images.githubusercontent.com/108748822/234427111-b13a59f7-a368-47e8-adda-684d211f381b.mov

### After changes (working)
https://user-images.githubusercontent.com/108748822/234427754-4eada42e-ccbf-4bd3-9175-994d3d9aa6d7.mov



