### PR TITLE
fix: Various minor style fixes

### DIFF
--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -24,6 +24,8 @@ export interface IconButtonProps extends BeamButtonProps, BeamFocusableProps {
   contrast?: boolean;
   /** Denotes if this button is used to download a resource. Uses the anchor tag with the `download` attribute */
   download?: boolean;
+  /** Provides label for screen readers - Will become a required soon */
+  label?: string;
 }
 
 export function IconButton(props: IconButtonProps) {
@@ -42,6 +44,7 @@ export function IconButton(props: IconButtonProps) {
     contrast = false,
     download = false,
     forceFocusStyles = false,
+    label,
   } = props;
   const isDisabled = !!disabled;
   const ariaProps = { onPress, isDisabled, autoFocus, ...menuTriggerProps };
@@ -78,6 +81,7 @@ export function IconButton(props: IconButtonProps) {
     className: typeof onPress === "string" ? navLink : undefined,
     ref: ref as any,
     css: styles,
+    "aria-label": label,
   };
   const buttonContent = (
     <Icon icon={icon} color={color || (isDisabled ? Palette.Gray400 : iconColor)} inc={compact ? 2 : inc} />

--- a/src/components/internal/MenuItem.tsx
+++ b/src/components/internal/MenuItem.tsx
@@ -70,11 +70,12 @@ export function MenuItemImpl(props: MenuItemProps) {
       {...hoverProps}
       ref={ref}
       css={{
-        ...Css.df.aic.py1.px2.cursorPointer.outline0.mh("42px").$,
+        ...Css.df.aic.py1.px2.cursorPointer.outline0.mh("42px").sm.$,
         ...(!isDisabled && isHovered ? (contrast ? Css.bgGray800.$ : Css.bgGray100.$) : {}),
         ...(isFocused ? Css.add("boxShadow", `inset 0 0 0 1px ${Palette.LightBlue700}`).$ : {}),
         ...(isDisabled ? Css.gray500.cursorNotAllowed.$ : {}),
         ...(destructive ? Css.red600.$ : {}),
+        ...(isSelected ? Css.fw5.$ : {}),
       }}
       {...tid[defaultTestId(menuItem.label)]}
     >
@@ -159,7 +160,7 @@ function maybeWrapInLink(
   }
 
   return isAbsoluteUrl(onClick) ? (
-    <a href={onClick} target="_blank" rel="noopener noreferrer" className="navLink" css={Css.df.jcsb.w100.$}>
+    <a href={onClick} target="_blank" rel="noopener noreferrer" className="navLink" css={Css.df.aic.jcsb.w100.$}>
       {content}
       <span css={Css.fs0.ml2.$}>
         <Icon icon="linkExternal" />

--- a/src/components/internal/MenuSection.tsx
+++ b/src/components/internal/MenuSection.tsx
@@ -23,7 +23,7 @@ export function MenuSectionImpl(props: MenuSectionProps) {
   return (
     <>
       {isPersistentSection && <li {...separatorProps} css={Css.bt.bGray200.$} />}
-      <li {...itemProps} css={Css.if(!isPersistentSection).overflowAuto.if(contrast).white.$}>
+      <li {...itemProps} css={Css.gray900.if(!isPersistentSection).overflowAuto.if(contrast).white.$}>
         <ul css={Css.listReset.$} {...groupProps} {...tid[isPersistentSection ? "persistentItems" : "menuItems"]}>
           {[...section.childNodes].map((item) => (
             <MenuItemImpl key={item.key} item={item} state={state} onClose={onClose} contrast={contrast} {...tid} />

--- a/src/components/internal/OverlayTrigger.tsx
+++ b/src/components/internal/OverlayTrigger.tsx
@@ -80,7 +80,8 @@ export function OverlayTrigger(props: OverlayTriggerProps) {
   );
 
   return (
-    <div css={Css.relative.dib.$}>
+    // Add `line-height: 0` to prevent the Icon button and Avatar buttons from inheriting the line-height, causing them to be taller than they should.
+    <div css={Css.dib.add("lineHeight", 0).$}>
       {isTextButton(trigger) ? (
         <Button
           variant={variant ? variant : "secondary"}


### PR DESCRIPTION
Prevent Icon and Avatar buttons from adding more height than necessary. Define color for non-contrast menu items (inherited via MenuSection styles) Add 'align-items: center' for MenuItems wrapped in links Add 'label' prop for IconButton for accessibility purposes