### PR TITLE
fix: Add zIndex to ScrollShadows

### DIFF
--- a/src/components/ScrollShadows.tsx
+++ b/src/components/ScrollShadows.tsx
@@ -26,6 +26,7 @@ export function ScrollShadows(props: ScrollShadowsProps) {
   const [showEndShadow, setShowEndShadow] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
+  // The shadow styles will rarely every change. Memoize them to avoid recomputing them when we don't have to.
   const [startShadowStyles, endShadowStyles] = useMemo(() => {
     const transparentBgColor = bgColor.replace(/,1\)$/, ",0)");
     const commonStyles = Css.absolute.z3.$;


### PR DESCRIPTION
Refactors styles in hopes of not regenerating them every time the state changes / component re-renders