### PR TITLE
feat: On MenuItem, react-router NavLink was changed to BEAM NavLink

### DIFF
--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -25,7 +25,7 @@ export interface NavLinkProps extends BeamFocusableProps {
   buttonRef?: RefObject<HTMLElement>;
 }
 
-type NavLinkVariant = "side" | "global" | "normal";
+type NavLinkVariant = "side" | "global";
 
 export function NavLink(props: NavLinkProps) {
   const {
@@ -84,7 +84,7 @@ export function getNavLinkStyles(variant: NavLinkVariant, contrast: boolean) {
   return navLinkVariantStyles(contrast)[variant];
 }
 
-const baseStyles = Css.df.aic.hPx(32).pyPx(6).br4.smMd.outline0.$;
+const baseStyles = Css.df.aic.hPx(32).pyPx(6).px1.br4.smMd.outline0.$;
 
 const navLinkVariantStyles: (contrast: boolean) => Record<
   NavLinkVariant,
@@ -98,7 +98,7 @@ const navLinkVariantStyles: (contrast: boolean) => Record<
   }
 > = (contrast) => ({
   side: {
-    baseStyles: { ...baseStyles, ...Css.gray700.if(contrast).gray600.px1.$ },
+    baseStyles: { ...baseStyles, ...Css.gray700.if(contrast).gray600.$ },
     activeStyles: Css.lightBlue700.bgLightBlue50.if(contrast).white.bgGray700.$,
     disabledStyles: Css.gray400.cursorNotAllowed.if(contrast).gray800.$,
     focusRingStyles: Css.bgLightBlue50.bshFocus.if(contrast).bgGray700.white.$,
@@ -106,7 +106,7 @@ const navLinkVariantStyles: (contrast: boolean) => Record<
     pressedStyles: Css.gray700.bgGray200.if(contrast).bgGray200.gray800.$,
   },
   global: {
-    baseStyles: { ...baseStyles, ...Css.add("width", "max-content").gray500.px1.$ },
+    baseStyles: { ...baseStyles, ...Css.add("width", "max-content").gray500.$ },
     activeStyles: Css.white.bgGray900.$,
     disabledStyles: Css.gray400.cursorNotAllowed.$,
     focusRingStyles: Css.gray500.bgGray900.add(
@@ -116,12 +116,4 @@ const navLinkVariantStyles: (contrast: boolean) => Record<
     hoverStyles: Css.gray500.bgGray900.$,
     pressedStyles: Css.gray500.bgGray700.$,
   },
-  normal: {
-    baseStyles: { ...baseStyles, ...Css.gray700.if(contrast).gray600.$ },
-    activeStyles: Css.lightBlue700.bgLightBlue50.if(contrast).white.bgGray700.$,
-    disabledStyles: Css.gray400.cursorNotAllowed.if(contrast).gray800.$,
-    focusRingStyles: Css.bgLightBlue50.bshFocus.if(contrast).bgGray700.white.$,
-    hoverStyles: Css.gray700.bgGray100.if(contrast).bgGray800.gray600.$,
-    pressedStyles: Css.gray700.bgGray200.if(contrast).bgGray200.gray800.$,
-  }
 });

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -25,7 +25,7 @@ export interface NavLinkProps extends BeamFocusableProps {
   buttonRef?: RefObject<HTMLElement>;
 }
 
-type NavLinkVariant = "side" | "global";
+type NavLinkVariant = "side" | "global" | "normal";
 
 export function NavLink(props: NavLinkProps) {
   const {
@@ -84,7 +84,7 @@ export function getNavLinkStyles(variant: NavLinkVariant, contrast: boolean) {
   return navLinkVariantStyles(contrast)[variant];
 }
 
-const baseStyles = Css.df.aic.hPx(32).pyPx(6).px1.br4.smMd.outline0.$;
+const baseStyles = Css.df.aic.hPx(32).pyPx(6).br4.smMd.outline0.$;
 
 const navLinkVariantStyles: (contrast: boolean) => Record<
   NavLinkVariant,
@@ -98,7 +98,7 @@ const navLinkVariantStyles: (contrast: boolean) => Record<
   }
 > = (contrast) => ({
   side: {
-    baseStyles: { ...baseStyles, ...Css.gray700.if(contrast).gray600.$ },
+    baseStyles: { ...baseStyles, ...Css.gray700.if(contrast).gray600.px1.$ },
     activeStyles: Css.lightBlue700.bgLightBlue50.if(contrast).white.bgGray700.$,
     disabledStyles: Css.gray400.cursorNotAllowed.if(contrast).gray800.$,
     focusRingStyles: Css.bgLightBlue50.bshFocus.if(contrast).bgGray700.white.$,
@@ -106,7 +106,7 @@ const navLinkVariantStyles: (contrast: boolean) => Record<
     pressedStyles: Css.gray700.bgGray200.if(contrast).bgGray200.gray800.$,
   },
   global: {
-    baseStyles: { ...baseStyles, ...Css.add("width", "max-content").gray500.$ },
+    baseStyles: { ...baseStyles, ...Css.add("width", "max-content").gray500.px1.$ },
     activeStyles: Css.white.bgGray900.$,
     disabledStyles: Css.gray400.cursorNotAllowed.$,
     focusRingStyles: Css.gray500.bgGray900.add(
@@ -116,4 +116,12 @@ const navLinkVariantStyles: (contrast: boolean) => Record<
     hoverStyles: Css.gray500.bgGray900.$,
     pressedStyles: Css.gray500.bgGray700.$,
   },
+  normal: {
+    baseStyles: { ...baseStyles, ...Css.gray700.if(contrast).gray600.$ },
+    activeStyles: Css.lightBlue700.bgLightBlue50.if(contrast).white.bgGray700.$,
+    disabledStyles: Css.gray400.cursorNotAllowed.if(contrast).gray800.$,
+    focusRingStyles: Css.bgLightBlue50.bshFocus.if(contrast).bgGray700.white.$,
+    hoverStyles: Css.gray700.bgGray100.if(contrast).bgGray800.gray600.$,
+    pressedStyles: Css.gray700.bgGray200.if(contrast).bgGray200.gray800.$,
+  }
 });

--- a/src/components/internal/Menu.stories.tsx
+++ b/src/components/internal/Menu.stories.tsx
@@ -3,12 +3,12 @@ import { useState } from "react";
 import { ButtonMenu } from "src/components/ButtonMenu";
 import { Menu } from "src/components/internal/Menu";
 import { noop } from "src/utils";
-import { withDimensions } from "src/utils/sb";
+import { withDimensions, withRouter } from "src/utils/sb";
 
 export default {
   component: Menu,
   title: "Workspace/Components/Menu",
-  decorators: [withDimensions()],
+  decorators: [withDimensions(), withRouter()],
   parameters: {
     design: {
       type: "figma",
@@ -17,14 +17,15 @@ export default {
   },
 } as Meta;
 
+
 export function BasicMenuItems() {
   return (
     <ButtonMenu
       defaultOpen
       trigger={{ label: "Menu Trigger" }}
       items={[
-        { label: "Menu item 1", onClick: noop },
-        { label: "Menu item 2", onClick: noop },
+        { label: "Menu item 1", onClick: "/"},
+        { label: "Menu item 2", onClick: "https://google.com" },
         { label: "Menu item 3", onClick: noop, disabled: true },
         { label: "Menu item 4", onClick: noop },
         { label: "Destructive menu item", onClick: noop, destructive: true },

--- a/src/components/internal/MenuItem.tsx
+++ b/src/components/internal/MenuItem.tsx
@@ -10,7 +10,7 @@ import { maybeTooltip, resolveTooltip } from "src/components/Tooltip";
 import { Css, Palette } from "src/Css";
 import { isAbsoluteUrl, useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
-import { NavLink } from "../NavLink";
+import { Link } from "react-router-dom";
 
 interface MenuItemProps {
   item: Node<MenuItem>;
@@ -167,7 +167,7 @@ function maybeWrapInLink(
       </span>
     </a>
   ) : (
-    <NavLink href={onClick} label={content.toString()} variant="normal"/>
+    <Link className="navLink" to={onClick}>{content}</Link>
   );
 }
 

--- a/src/components/internal/MenuItem.tsx
+++ b/src/components/internal/MenuItem.tsx
@@ -2,7 +2,6 @@ import { Node } from "@react-types/shared";
 import { useRef } from "react";
 import { useHover, useMenuItem } from "react-aria";
 import { useHistory } from "react-router";
-import { NavLink } from "react-router-dom";
 import { TreeState } from "react-stately";
 import { Avatar } from "src/components/Avatar";
 import { IconMenuItemType, ImageMenuItemType, MenuItem } from "src/components/ButtonMenu";
@@ -11,6 +10,7 @@ import { maybeTooltip, resolveTooltip } from "src/components/Tooltip";
 import { Css, Palette } from "src/Css";
 import { isAbsoluteUrl, useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
+import { NavLink } from "../NavLink";
 
 interface MenuItemProps {
   item: Node<MenuItem>;
@@ -167,9 +167,7 @@ function maybeWrapInLink(
       </span>
     </a>
   ) : (
-    <NavLink to={onClick} className="navLink">
-      {content}
-    </NavLink>
+    <NavLink href={onClick} label={content.toString()} variant="normal"/>
   );
 }
 


### PR DESCRIPTION
Context of the change [SC-34164](https://app.shortcut.com/homebound-team/story/34164/cmd-click-on-menu-items-under-libraries-does-not-open-pages-in-a-new-tab), after that, I made some changes
- Replace react-router-dom <NavLink with  react-router-dom <Link `<a role="button"`, that is the reason of the issue (I searched and only this component was using this version)
- Update the storybook to show all the variations on a menuItems

Please see the video [DEMO BUG/FIX](https://www.awesomescreenshot.com/video/17326734?key=5de1eb65374829ac52f8debc163c7dbc)

[Menu Storybook](https://60466f7d43c37c0021788867-rmtwfusvhr.chromatic.com/?path=/story/workspace-components-menu--basic-menu-items)

![Screen Shot 2023-05-11 at 16 39 28](https://github.com/homebound-team/beam/assets/106679157/3d263137-d658-4f5c-a305-6ec618ac7f4f)



