### PR TITLE
refactor: Refactor Pagination component

### DIFF
--- a/src/components/Pagination.stories.tsx
+++ b/src/components/Pagination.stories.tsx
@@ -1,7 +1,6 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { noop } from "src/utils";
-import { defaultPage, FormLines, TextField } from "..";
+import { defaultPage, FormLines, StaticField } from "..";
 import { Pagination } from "./Pagination";
 
 export default {
@@ -34,10 +33,10 @@ function RenderPagination({ totalRows }: { totalRows: number }) {
   return (
     <>
       <FormLines labelStyle="left">
-        <TextField label={"Number of items"} readOnly value={String(totalRows)} onChange={noop} />
-        <TextField label={"Current page"} readOnly value={String(settings.pageNumber)} onChange={noop} />
+        <StaticField label="Number of items" value={String(totalRows)} />
+        <StaticField label="Current page" value={String(settings.pageNumber)} />
       </FormLines>
-      <Pagination totalCount={totalRows} setSettings={setSettings} settings={settings} />
+      <Pagination totalCount={totalRows} setPage={setSettings} page={settings} />
     </>
   );
 }

--- a/src/components/Pagination.stories.tsx
+++ b/src/components/Pagination.stories.tsx
@@ -1,11 +1,8 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { noop } from "src/utils";
-import { withBeamDecorator } from "src/utils/sb";
-import { FormLines, TextField } from "..";
-import { PageSettings, Pagination } from "./Pagination";
-
-const initPageSettings = { page: 1, perPage: 100 };
+import { defaultPage, FormLines, TextField } from "..";
+import { Pagination } from "./Pagination";
 
 export default {
   title: "Workspace/Components/Pagination",
@@ -18,34 +15,29 @@ export default {
       url: "https://www.figma.com/file/aWUE4pPeUTgrYZ4vaTYZQU/%E2%9C%A8Beam-Design-System?node-id=3214%3A10519",
     },
   },
-  decorators: [withBeamDecorator],
 } as Meta;
 
 export function WithPages() {
-  return <RenderPagination totalRows={999} label="items" />;
+  return <RenderPagination totalRows={999} />;
 }
 
 export function NoPages() {
-  return <RenderPagination totalRows={0} label="items" />;
+  return <RenderPagination totalRows={0} />;
 }
 
 export function OnlyOnePage() {
   return <RenderPagination totalRows={14} />;
 }
 
-function RenderPagination({ totalRows, label }: { totalRows: number; label?: string }) {
-  const [settings, setSettings] = useState<PageSettings>({
-    page: initPageSettings.page,
-    perPage: initPageSettings.perPage,
-  });
-
+function RenderPagination({ totalRows }: { totalRows: number }) {
+  const [settings, setSettings] = useState(defaultPage);
   return (
     <>
       <FormLines labelStyle="left">
         <TextField label={"Number of items"} readOnly value={String(totalRows)} onChange={noop} />
-        <TextField label={"Current page"} readOnly value={String(settings.page)} onChange={noop} />
+        <TextField label={"Current page"} readOnly value={String(settings.pageNumber)} onChange={noop} />
       </FormLines>
-      <Pagination totalCount={totalRows} label={label ?? "items"} setSettings={setSettings} settings={settings} />
+      <Pagination totalCount={totalRows} setSettings={setSettings} settings={settings} />
     </>
   );
 }

--- a/src/components/Pagination.stories.tsx
+++ b/src/components/Pagination.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { defaultPage, FormLines, StaticField } from "..";
+import { FormLines, StaticField } from "..";
 import { Pagination } from "./Pagination";
 
 export default {
@@ -29,7 +29,7 @@ export function OnlyOnePage() {
 }
 
 function RenderPagination({ totalRows }: { totalRows: number }) {
-  const page = useState(defaultPage);
+  const page = useState({ pageNumber: 1, pageSize: 100 });
   return (
     <>
       <FormLines labelStyle="left">

--- a/src/components/Pagination.stories.tsx
+++ b/src/components/Pagination.stories.tsx
@@ -29,14 +29,14 @@ export function OnlyOnePage() {
 }
 
 function RenderPagination({ totalRows }: { totalRows: number }) {
-  const [settings, setSettings] = useState(defaultPage);
+  const page = useState(defaultPage);
   return (
     <>
       <FormLines labelStyle="left">
         <StaticField label="Number of items" value={String(totalRows)} />
-        <StaticField label="Current page" value={String(settings.pageNumber)} />
+        <StaticField label="Current page" value={String(page[0].pageNumber)} />
       </FormLines>
-      <Pagination totalCount={totalRows} setPage={setSettings} page={settings} />
+      <Pagination totalCount={totalRows} page={page} />
     </>
   );
 }

--- a/src/components/Pagination.test.tsx
+++ b/src/components/Pagination.test.tsx
@@ -27,6 +27,18 @@ describe("Pagination", () => {
     expect(setSettings).toHaveBeenCalledWith({ pageNumber: 2, pageSize: 50 });
   });
 
+  it("fires setSettings with offset/limit if used", async () => {
+    // Given a pagination component on page 1 and per page 50
+    const setSettings = jest.fn();
+    const page = [{ offset: 0, limit: 50 }, setSettings] as const;
+    const r = await render(<Pagination totalCount={100} page={page} />);
+    // When click to go to the next page
+    click(r.pagination_nextIcon);
+    // Then setSettings is called
+    expect(setSettings).toHaveBeenCalledTimes(1);
+    expect(setSettings).toHaveBeenCalledWith({ offset: 50, limit: 50 });
+  });
+
   it("fires setSettings on select pageSize option", async () => {
     // Given a pagination component on page 1 and per page 50
     const setSettings = jest.fn();

--- a/src/components/Pagination.test.tsx
+++ b/src/components/Pagination.test.tsx
@@ -6,12 +6,12 @@ const init: PageSettings = { pageNumber: 1, pageSize: 100 };
 
 describe("Pagination", () => {
   it("can have a data-testid", async () => {
-    const r = await render(<Pagination totalCount={10} setSettings={noop} settings={init} data-testid="pag" />);
+    const r = await render(<Pagination totalCount={10} setPage={noop} page={init} data-testid="pag" />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("pag");
   });
 
   it("defaults data-testid to pagination", async () => {
-    const r = await render(<Pagination totalCount={10} setSettings={noop} settings={init} />);
+    const r = await render(<Pagination totalCount={10} setPage={noop} page={init} />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("pagination");
   });
 
@@ -19,7 +19,7 @@ describe("Pagination", () => {
     // Given a pagination component on page 1 and per page 50
     const setSettings = jest.fn();
     const r = await render(
-      <Pagination totalCount={100} setSettings={setSettings} settings={{ pageNumber: 1, pageSize: 50 }} />,
+      <Pagination totalCount={100} setPage={setSettings} page={{ pageNumber: 1, pageSize: 50 }} />,
     );
     // When click to go to the next page
     click(r.pagination_nextIcon);
@@ -32,7 +32,7 @@ describe("Pagination", () => {
     // Given a pagination component on page 1 and per page 50
     const setSettings = jest.fn();
     const r = await render(
-      <Pagination totalCount={10} setSettings={setSettings} settings={{ pageNumber: 1, pageSize: 100 }} />,
+      <Pagination totalCount={10} setPage={setSettings} page={{ pageNumber: 1, pageSize: 100 }} />,
     );
     // Then pageSize field have value of 100
     expect(r.pagination_pageSize()).toHaveValue("100");
@@ -47,45 +47,35 @@ describe("Pagination", () => {
 
   it("cannot navigate to previous page when are in the first page", async () => {
     // Given a render pagination on page 1
-    const r = await render(
-      <Pagination totalCount={10} setSettings={jest.fn} settings={{ pageNumber: 1, pageSize: 50 }} />,
-    );
+    const r = await render(<Pagination totalCount={10} setPage={jest.fn} page={{ pageNumber: 1, pageSize: 50 }} />);
     // Then previous page button is disabled
     expect(r.pagination_previousIcon()).toBeDisabled();
   });
 
   it("cannot navigate to next page when current page is minor than total count / per page", async () => {
     // Given a render pagination on page 1
-    const r = await render(
-      <Pagination totalCount={999} setSettings={jest.fn} settings={{ pageNumber: 5, pageSize: 200 }} />,
-    );
+    const r = await render(<Pagination totalCount={999} setPage={jest.fn} page={{ pageNumber: 5, pageSize: 200 }} />);
     // Then next page button is disabled
     expect(r.pagination_nextIcon()).toBeDisabled();
   });
 
   it("can navigate to next page when current page is greater than total count / per page", async () => {
     // Given a render pagination on page 1
-    const r = await render(
-      <Pagination totalCount={999} setSettings={jest.fn} settings={{ pageNumber: 4, pageSize: 200 }} />,
-    );
+    const r = await render(<Pagination totalCount={999} setPage={jest.fn} page={{ pageNumber: 4, pageSize: 200 }} />);
     // Then next page button is not disabled
     expect(r.pagination_nextIcon()).not.toBeDisabled();
   });
 
   it("shows detailed navigation page info", async () => {
     // Given a render pagination of 999 lines on page 4
-    const r = await render(
-      <Pagination totalCount={999} setSettings={jest.fn} settings={{ pageNumber: 4, pageSize: 200 }} />,
-    );
+    const r = await render(<Pagination totalCount={999} setPage={jest.fn} page={{ pageNumber: 4, pageSize: 200 }} />);
     // Then show the information about what is paginated
     expect(r.pagination_pageInfoLabel()).toHaveTextContent("601 - 800 of 999"); // we're showing 601-800 from 999 items
   });
 
   it("shows detailed navigation page info on last page", async () => {
     // Given a render pagination of 999 lines on last page
-    const r = await render(
-      <Pagination totalCount={999} setSettings={jest.fn} settings={{ pageNumber: 5, pageSize: 200 }} />,
-    );
+    const r = await render(<Pagination totalCount={999} setPage={jest.fn} page={{ pageNumber: 5, pageSize: 200 }} />);
     // Then show the information about what is paginated
     expect(r.pagination_pageInfoLabel()).toHaveTextContent("801 - 999 of 999");
   });

--- a/src/components/Pagination.test.tsx
+++ b/src/components/Pagination.test.tsx
@@ -1,19 +1,17 @@
 import { noop } from "src/utils";
 import { click, render } from "src/utils/rtl";
-import { pageOptions, Pagination, toFirstAndOffset } from "./Pagination";
+import { pageOptions, PageSettings, Pagination, toFirstAndOffset } from "./Pagination";
 
-const initPageSettings = { page: 1, perPage: 100 };
+const init: PageSettings = { pageNumber: 1, pageSize: 100 };
 
 describe("Pagination", () => {
   it("can have a data-testid", async () => {
-    const r = await render(
-      <Pagination totalCount={10} label="" setSettings={noop} settings={initPageSettings} data-testid="pag" />,
-    );
+    const r = await render(<Pagination totalCount={10} setSettings={noop} settings={init} data-testid="pag" />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("pag");
   });
 
   it("defaults data-testid to pagination", async () => {
-    const r = await render(<Pagination totalCount={10} label="" setSettings={noop} settings={initPageSettings} />);
+    const r = await render(<Pagination totalCount={10} setSettings={noop} settings={init} />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("pagination");
   });
 
@@ -21,36 +19,36 @@ describe("Pagination", () => {
     // Given a pagination component on page 1 and per page 50
     const setSettings = jest.fn();
     const r = await render(
-      <Pagination totalCount={100} label="" setSettings={setSettings} settings={{ page: 1, perPage: 50 }} />,
+      <Pagination totalCount={100} setSettings={setSettings} settings={{ pageNumber: 1, pageSize: 50 }} />,
     );
     // When click to go to the next page
     click(r.pagination_nextIcon);
     // Then setSettings is called
     expect(setSettings).toHaveBeenCalledTimes(1);
-    expect(setSettings).toHaveBeenCalledWith({ page: 2, perPage: 50 });
+    expect(setSettings).toHaveBeenCalledWith({ pageNumber: 2, pageSize: 50 });
   });
 
-  it("fires setSettings on select perPage option", async () => {
+  it("fires setSettings on select pageSize option", async () => {
     // Given a pagination component on page 1 and per page 50
     const setSettings = jest.fn();
     const r = await render(
-      <Pagination totalCount={10} label="" setSettings={setSettings} settings={{ page: 1, perPage: 50 }} />,
+      <Pagination totalCount={10} setSettings={setSettings} settings={{ pageNumber: 1, pageSize: 100 }} />,
     );
-    // Then perPage field have value of 50
-    expect(r.pagination_perPage()).toHaveValue("50");
+    // Then pageSize field have value of 100
+    expect(r.pagination_pageSize()).toHaveValue("100");
     // When click it
-    click(r.pagination_perPage);
+    click(r.pagination_pageSize);
     // And select option 100
-    click(r.getByRole("option", { name: "100" }));
+    click(r.getByRole("option", { name: "500" }));
     // Then setSettings is called
     expect(setSettings).toHaveBeenCalledTimes(1);
-    expect(setSettings).toHaveBeenCalledWith({ page: 1, perPage: 100 });
+    expect(setSettings).toHaveBeenCalledWith({ pageNumber: 1, pageSize: 500 });
   });
 
   it("cannot navigate to previous page when are in the first page", async () => {
     // Given a render pagination on page 1
     const r = await render(
-      <Pagination totalCount={10} label="" setSettings={jest.fn} settings={{ page: 1, perPage: 50 }} />,
+      <Pagination totalCount={10} setSettings={jest.fn} settings={{ pageNumber: 1, pageSize: 50 }} />,
     );
     // Then previous page button is disabled
     expect(r.pagination_previousIcon()).toBeDisabled();
@@ -59,7 +57,7 @@ describe("Pagination", () => {
   it("cannot navigate to next page when current page is minor than total count / per page", async () => {
     // Given a render pagination on page 1
     const r = await render(
-      <Pagination totalCount={999} label="" setSettings={jest.fn} settings={{ page: 5, perPage: 200 }} />,
+      <Pagination totalCount={999} setSettings={jest.fn} settings={{ pageNumber: 5, pageSize: 200 }} />,
     );
     // Then next page button is disabled
     expect(r.pagination_nextIcon()).toBeDisabled();
@@ -68,7 +66,7 @@ describe("Pagination", () => {
   it("can navigate to next page when current page is greater than total count / per page", async () => {
     // Given a render pagination on page 1
     const r = await render(
-      <Pagination totalCount={999} label="" setSettings={jest.fn} settings={{ page: 4, perPage: 200 }} />,
+      <Pagination totalCount={999} setSettings={jest.fn} settings={{ pageNumber: 4, pageSize: 200 }} />,
     );
     // Then next page button is not disabled
     expect(r.pagination_nextIcon()).not.toBeDisabled();
@@ -77,34 +75,38 @@ describe("Pagination", () => {
   it("shows detailed navigation page info", async () => {
     // Given a render pagination of 999 lines on page 4
     const r = await render(
-      <Pagination totalCount={999} label="items" setSettings={jest.fn} settings={{ page: 4, perPage: 200 }} />,
+      <Pagination totalCount={999} setSettings={jest.fn} settings={{ pageNumber: 4, pageSize: 200 }} />,
     );
     // Then show the information about what is paginated
-    expect(r.pagination_pageInfoLabel()).toHaveTextContent("601 - 800 of 999 items"); // we're showing 601-800 from 999 items
+    expect(r.pagination_pageInfoLabel()).toHaveTextContent("601 - 800 of 999"); // we're showing 601-800 from 999 items
   });
 
   it("shows detailed navigation page info on last page", async () => {
     // Given a render pagination of 999 lines on last page
     const r = await render(
-      <Pagination totalCount={999} label="" setSettings={jest.fn} settings={{ page: 5, perPage: 200 }} />,
+      <Pagination totalCount={999} setSettings={jest.fn} settings={{ pageNumber: 5, pageSize: 200 }} />,
     );
     // Then show the information about what is paginated
-    expect(r.pagination_pageInfoLabel()).toHaveTextContent("801 of 999"); // we're showing 801 of 999 items
+    expect(r.pagination_pageInfoLabel()).toHaveTextContent("801 - 999 of 999");
   });
 
   describe("pageOptions", () => {
     it("returns page options", () => {
-      const expected = [50, 100, 150, 200, 250].map((n) => ({ id: n, name: String(n) }));
+      const expected = [100, 500, 1000].map((n) => ({ id: n, name: String(n) }));
       expect(pageOptions).toEqual(expected);
     });
   });
 
   describe("toFirstAndOffset", () => {
     it("returns offset 0 on first page", () => {
-      expect(toFirstAndOffset(initPageSettings.page, initPageSettings.perPage)).toEqual({ first: 100, offset: 0 });
+      expect(toFirstAndOffset(init.pageNumber, init.pageSize)).toEqual({
+        first: 100,
+        offset: 0,
+      });
     });
+
     it("returns 100 offset on page 2", () => {
-      expect(toFirstAndOffset(initPageSettings.page + 1, initPageSettings.perPage)).toEqual({
+      expect(toFirstAndOffset(init.pageNumber + 1, init.pageSize)).toEqual({
         first: 100,
         offset: 100,
       });

--- a/src/components/Pagination.test.tsx
+++ b/src/components/Pagination.test.tsx
@@ -1,6 +1,6 @@
 import { noop } from "src/utils";
 import { click, render } from "src/utils/rtl";
-import { pageOptions, PageSettings, Pagination, toFirstAndOffset } from "./Pagination";
+import { pageOptions, PageSettings, Pagination, toLimitAndOffset } from "./Pagination";
 
 const init: PageSettings = { pageNumber: 1, pageSize: 100 };
 
@@ -90,17 +90,17 @@ describe("Pagination", () => {
     });
   });
 
-  describe("toFirstAndOffset", () => {
+  describe("toLimitAndOffset", () => {
     it("returns offset 0 on first page", () => {
-      expect(toFirstAndOffset(init.pageNumber, init.pageSize)).toEqual({
-        first: 100,
+      expect(toLimitAndOffset({ pageNumber: 1, pageSize: 100 })).toEqual({
+        limit: 100,
         offset: 0,
       });
     });
 
     it("returns 100 offset on page 2", () => {
-      expect(toFirstAndOffset(init.pageNumber + 1, init.pageSize)).toEqual({
-        first: 100,
+      expect(toLimitAndOffset({ pageNumber: 2, pageSize: 100 })).toEqual({
+        limit: 100,
         offset: 100,
       });
     });

--- a/src/components/Pagination.test.tsx
+++ b/src/components/Pagination.test.tsx
@@ -6,21 +6,20 @@ const init: PageSettings = { pageNumber: 1, pageSize: 100 };
 
 describe("Pagination", () => {
   it("can have a data-testid", async () => {
-    const r = await render(<Pagination totalCount={10} setPage={noop} page={init} data-testid="pag" />);
+    const r = await render(<Pagination totalCount={10} page={[init, noop]} data-testid="pag" />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("pag");
   });
 
   it("defaults data-testid to pagination", async () => {
-    const r = await render(<Pagination totalCount={10} setPage={noop} page={init} />);
+    const r = await render(<Pagination totalCount={10} page={[init, noop]} />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("pagination");
   });
 
   it("fires setSettings method on click next icon", async () => {
     // Given a pagination component on page 1 and per page 50
     const setSettings = jest.fn();
-    const r = await render(
-      <Pagination totalCount={100} setPage={setSettings} page={{ pageNumber: 1, pageSize: 50 }} />,
-    );
+    const page = [{ pageNumber: 1, pageSize: 50 }, setSettings] as const;
+    const r = await render(<Pagination totalCount={100} page={page} />);
     // When click to go to the next page
     click(r.pagination_nextIcon);
     // Then setSettings is called
@@ -31,9 +30,8 @@ describe("Pagination", () => {
   it("fires setSettings on select pageSize option", async () => {
     // Given a pagination component on page 1 and per page 50
     const setSettings = jest.fn();
-    const r = await render(
-      <Pagination totalCount={10} setPage={setSettings} page={{ pageNumber: 1, pageSize: 100 }} />,
-    );
+    const page = [{ pageNumber: 1, pageSize: 100 }, setSettings] as const;
+    const r = await render(<Pagination page={page} totalCount={10} />);
     // Then pageSize field have value of 100
     expect(r.pagination_pageSize()).toHaveValue("100");
     // When click it
@@ -47,35 +45,40 @@ describe("Pagination", () => {
 
   it("cannot navigate to previous page when are in the first page", async () => {
     // Given a render pagination on page 1
-    const r = await render(<Pagination totalCount={10} setPage={jest.fn} page={{ pageNumber: 1, pageSize: 50 }} />);
+    const page = [{ pageNumber: 1, pageSize: 50 }, jest.fn] as const;
+    const r = await render(<Pagination totalCount={10} page={page} />);
     // Then previous page button is disabled
     expect(r.pagination_previousIcon()).toBeDisabled();
   });
 
   it("cannot navigate to next page when current page is minor than total count / per page", async () => {
-    // Given a render pagination on page 1
-    const r = await render(<Pagination totalCount={999} setPage={jest.fn} page={{ pageNumber: 5, pageSize: 200 }} />);
+    // Given a render pagination on page 5 of 5 pages
+    const page = [{ pageNumber: 5, pageSize: 200 }, jest.fn] as const;
+    const r = await render(<Pagination totalCount={999} page={page} />);
     // Then next page button is disabled
     expect(r.pagination_nextIcon()).toBeDisabled();
   });
 
   it("can navigate to next page when current page is greater than total count / per page", async () => {
-    // Given a render pagination on page 1
-    const r = await render(<Pagination totalCount={999} setPage={jest.fn} page={{ pageNumber: 4, pageSize: 200 }} />);
+    // Given a render pagination on page 4 of 5 pages
+    const page = [{ pageNumber: 4, pageSize: 200 }, jest.fn] as const;
+    const r = await render(<Pagination totalCount={999} page={page} />);
     // Then next page button is not disabled
     expect(r.pagination_nextIcon()).not.toBeDisabled();
   });
 
   it("shows detailed navigation page info", async () => {
     // Given a render pagination of 999 lines on page 4
-    const r = await render(<Pagination totalCount={999} setPage={jest.fn} page={{ pageNumber: 4, pageSize: 200 }} />);
+    const page = [{ pageNumber: 4, pageSize: 200 }, jest.fn] as const;
+    const r = await render(<Pagination totalCount={999} page={page} />);
     // Then show the information about what is paginated
     expect(r.pagination_pageInfoLabel()).toHaveTextContent("601 - 800 of 999"); // we're showing 601-800 from 999 items
   });
 
   it("shows detailed navigation page info on last page", async () => {
     // Given a render pagination of 999 lines on last page
-    const r = await render(<Pagination totalCount={999} setPage={jest.fn} page={{ pageNumber: 5, pageSize: 200 }} />);
+    const page = [{ pageNumber: 5, pageSize: 200 }, jest.fn] as const;
+    const r = await render(<Pagination totalCount={999} page={page} />);
     // Then show the information about what is paginated
     expect(r.pagination_pageInfoLabel()).toHaveTextContent("801 - 999 of 999");
   });

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,27 +1,31 @@
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch } from "react";
 import { IconButton } from "src/components";
 import { Css, Palette } from "src/Css";
 import { SelectField } from "src/inputs";
 import { useTestIds } from "src/utils";
 
-export type PageSettings = {
-  pageNumber: number;
-  pageSize: number;
-};
+/**
+ * Page settings, either a pageNumber+pageSize or offset+limit.
+ *
+ * This component is implemented in terms of "page number + page size",
+ * but our backend wants offset+limit, so we accept both and translate.
+ */
+export type PageSettings = PageNumberAndSize | OffsetAndLimit;
+export type PageNumberAndSize = { pageNumber: number; pageSize: number };
+export type OffsetAndLimit = { offset: number; limit: number };
 
-export const defaultPage: PageSettings = { pageNumber: 1, pageSize: 100 };
+// Use OffsetAndLimit as our default b/c that's what backend filters expect
+export const defaultPage: OffsetAndLimit = { offset: 0, limit: 100 };
 
 interface PaginationProps {
-  page: readonly [PageSettings, Dispatch<SetStateAction<PageSettings>>];
+  page: readonly [PageNumberAndSize, Dispatch<PageNumberAndSize>] | readonly [OffsetAndLimit, Dispatch<OffsetAndLimit>];
   totalCount: number;
 }
 
 export function Pagination(props: PaginationProps) {
-  const {
-    page: [page, setPage],
-    totalCount,
-  } = props;
-  const { pageSize, pageNumber } = page;
+  const { totalCount } = props;
+  const [page, setPage] = props.page;
+  const { pageSize, pageNumber } = toPageNumberSize(page);
 
   const hasPrevPage = pageNumber > 1;
   const hasNextPage = pageNumber < totalCount / pageSize;
@@ -30,6 +34,15 @@ export function Pagination(props: PaginationProps) {
   const last = Math.min(pageSize * pageNumber, totalCount);
   // Don't both with `0 - 0 of 0`
   const showLast = totalCount > 0;
+
+  // Convert the new page back to whatever format the caller wants
+  function set(newPage: PageNumberAndSize): void {
+    if ("pageNumber" in props.page[0]) {
+      setPage(newPage as any);
+    } else {
+      setPage(toLimitAndOffset(newPage) as any);
+    }
+  }
 
   const tid = useTestIds(props, "pagination");
   return (
@@ -44,9 +57,7 @@ export function Pagination(props: PaginationProps) {
           labelStyle="hidden"
           options={pageOptions}
           value={pageSize}
-          onSelect={(val) => {
-            setPage({ pageNumber: 1, pageSize: val! });
-          }}
+          onSelect={(val) => set({ pageNumber: 1, pageSize: val! })}
           {...tid.pageSize}
         />
       </div>
@@ -57,14 +68,14 @@ export function Pagination(props: PaginationProps) {
         <IconButton
           icon="chevronLeft"
           color={hasPrevPage ? Palette.LightBlue700 : Palette.Gray200}
-          onClick={() => setPage({ pageNumber: page.pageNumber - 1, pageSize })}
+          onClick={() => set({ pageNumber: pageNumber - 1, pageSize })}
           disabled={!hasPrevPage}
           {...tid.previousIcon}
         />
         <IconButton
           icon="chevronRight"
           color={hasNextPage ? Palette.LightBlue700 : Palette.Gray200}
-          onClick={() => setPage({ pageNumber: page.pageNumber + 1, pageSize })}
+          onClick={() => set({ pageNumber: pageNumber + 1, pageSize })}
           disabled={!hasNextPage}
           {...tid.nextIcon}
         />
@@ -73,13 +84,24 @@ export function Pagination(props: PaginationProps) {
   );
 }
 
-export function toLimitAndOffset(page: PageSettings) {
-  return {
-    // E.g. on first page the offset is 0, second page the offset is 100, then 200, etc.
-    offset: (page.pageNumber - 1) * page.pageSize,
-    limit: page.pageSize,
-  };
+export function toLimitAndOffset(page: PageSettings): OffsetAndLimit {
+  return "limit" in page
+    ? page
+    : {
+        // E.g. on first page the offset is 0, second page the offset is 100, then 200, etc.
+        offset: (page.pageNumber - 1) * page.pageSize,
+        limit: page.pageSize,
+      };
 }
 
-// Make a list of 100/500/1000 page sizes for the user to chose
+export function toPageNumberSize(page: PageSettings): PageNumberAndSize {
+  return "pageNumber" in page
+    ? page
+    : {
+        pageNumber: Math.floor(page.offset / page.limit) + 1,
+        pageSize: page.limit,
+      };
+}
+
+// Make a list of 100/500/1000 for the user to choose
 export const pageOptions = [100, 500, 1000].map((num) => ({ id: num, name: String(num) }));

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -12,13 +12,15 @@ export type PageSettings = {
 export const defaultPage: PageSettings = { pageNumber: 1, pageSize: 100 };
 
 interface PaginationProps {
-  page: PageSettings;
-  setPage: Dispatch<SetStateAction<PageSettings>>;
+  page: readonly [PageSettings, Dispatch<SetStateAction<PageSettings>>];
   totalCount: number;
 }
 
 export function Pagination(props: PaginationProps) {
-  const { page, setPage, totalCount } = props;
+  const {
+    page: [page, setPage],
+    totalCount,
+  } = props;
   const { pageSize, pageNumber } = page;
 
   const hasPrevPage = pageNumber > 1;

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -12,14 +12,14 @@ export type PageSettings = {
 export const defaultPage: PageSettings = { pageNumber: 1, pageSize: 100 };
 
 interface PaginationProps {
-  settings: PageSettings;
-  setSettings: Dispatch<SetStateAction<PageSettings>>;
+  page: PageSettings;
+  setPage: Dispatch<SetStateAction<PageSettings>>;
   totalCount: number;
 }
 
 export function Pagination(props: PaginationProps) {
-  const { settings, totalCount, setSettings } = props;
-  const { pageSize, pageNumber } = settings;
+  const { page, setPage, totalCount } = props;
+  const { pageSize, pageNumber } = page;
 
   const hasPrevPage = pageNumber > 1;
   const hasNextPage = pageNumber < totalCount / pageSize;
@@ -43,7 +43,7 @@ export function Pagination(props: PaginationProps) {
           options={pageOptions}
           value={pageSize}
           onSelect={(val) => {
-            setSettings({ pageNumber: 1, pageSize: val! });
+            setPage({ pageNumber: 1, pageSize: val! });
           }}
           {...tid.pageSize}
         />
@@ -55,14 +55,14 @@ export function Pagination(props: PaginationProps) {
         <IconButton
           icon="chevronLeft"
           color={hasPrevPage ? Palette.LightBlue700 : Palette.Gray200}
-          onClick={() => setSettings({ pageNumber: settings.pageNumber - 1, pageSize })}
+          onClick={() => setPage({ pageNumber: page.pageNumber - 1, pageSize })}
           disabled={!hasPrevPage}
           {...tid.previousIcon}
         />
         <IconButton
           icon="chevronRight"
           color={hasNextPage ? Palette.LightBlue700 : Palette.Gray200}
-          onClick={() => setSettings({ pageNumber: settings.pageNumber + 1, pageSize })}
+          onClick={() => setPage({ pageNumber: page.pageNumber + 1, pageSize })}
           disabled={!hasNextPage}
           {...tid.nextIcon}
         />

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -32,7 +32,7 @@ export function Pagination(props: PaginationProps) {
   // Create the `1 - 100 of 1000` or `0 of 0`
   const first = pageSize * (pageNumber - 1) + (totalCount ? 1 : 0);
   const last = Math.min(pageSize * pageNumber, totalCount);
-  // Don't both with `0 - 0 of 0`
+  // When no rows, show '0 of 0' instead of '0 - 0 of 0'
   const showLast = totalCount > 0;
 
   // Convert the new page back to whatever format the caller wants

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -73,11 +73,11 @@ export function Pagination(props: PaginationProps) {
   );
 }
 
-export function toFirstAndOffset(pageNumber: number, pageSize: number) {
+export function toLimitAndOffset(page: PageSettings) {
   return {
-    first: pageSize,
     // E.g. on first page the offset is 0, second page the offset is 100, then 200, etc.
-    offset: (pageNumber - 1) * pageSize,
+    offset: (page.pageNumber - 1) * page.pageSize,
+    limit: page.pageSize,
   };
 }
 


### PR DESCRIPTION
Most of my hackday was BE paging, but this changes some of the FE, specifically:

* Combines the previous `settings` and `setSettings` props into a single `page` tuple
* Supports both `pageNumber`+`pageSize` as well as `offset`+`limit`, based on caller pref
* Defaults to `offset`+`limit` since that is what our BE filters want
* Reduces # of page size options, plus makes each increment larger/further away from each other
* Removes the `label` prop as unnecessary
* Fixes some boundary cases in the "x - y of z" on the last page of data / only a single page of data
