### PR TITLE
feat: Replace GridTable default styling

### DIFF
--- a/src/components/SuperDrawer/SuperDrawer.stories.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.stories.tsx
@@ -273,7 +273,7 @@ export function TableWithPrevNextAndCloseCheck() {
   // Example of triggering the drawer when clicking on a row
   const rowStyles: RowStyles<Row> = {
     header: {},
-    data: { indent: 2, onClick: openRow },
+    data: { onClick: openRow },
   };
 
   return (
@@ -318,7 +318,7 @@ export function TableWithPrevNext() {
   // Example of triggering the drawer when clicking on a row
   const rowStyles: RowStyles<Row> = {
     header: {},
-    data: { indent: 2, onClick: openRow },
+    data: { onClick: openRow },
   };
 
   return (

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -223,14 +223,6 @@ const rows = makeNestedRows(1);
 const rowsWithHeader: GridDataRow<NestedRow>[] = [simpleHeader, ...rows];
 
 export function NestedRows() {
-  const arrowColumn = actionColumn<NestedRow>({
-    header: (data, { row }) => <CollapseToggle row={row} />,
-    parent: (data, { row }) => <CollapseToggle row={row} />,
-    child: (data, { row }) => <CollapseToggle row={row} />,
-    grandChild: () => "",
-    add: () => "",
-    w: "60px",
-  });
   const nameColumn: GridColumn<NestedRow> = {
     header: () => "Name",
     parent: (row) => ({
@@ -249,7 +241,7 @@ export function NestedRows() {
   };
   return (
     <GridTable
-      columns={[arrowColumn, nameColumn]}
+      columns={[collapseColumn<NestedRow>(), nameColumn]}
       {...{ rows: rowsWithHeader }}
       sorting={{ on: "client", initial: ["c1", "ASC"] }}
     />
@@ -502,7 +494,7 @@ export const AsTableWithRowLink = newStory(
     const valueColumn: GridColumn<Row> = { header: "Value", data: ({ value }) => value };
     const actionColumn: GridColumn<Row> = { header: "Action", data: () => <div>Actions</div> };
     const rowStyles: RowStyles<Row> = {
-      data: { indent: 2, rowLink: () => "http://homebound.com" },
+      data: { rowLink: () => "http://homebound.com" },
       header: {},
     };
     return (

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -207,19 +207,6 @@ describe("GridTable", () => {
     expect(cell(r, 2, 0)).toHaveStyleRule("color", Palette.Red500);
   });
 
-  it("can indent rows", async () => {
-    // Given the data row is indented
-    const rowStyles: RowStyles<Row> = {
-      header: {},
-      data: { indent: 1 },
-    };
-    const r = await render(<GridTable columns={[nameColumn, valueColumn]} rows={rows} rowStyles={rowStyles} />);
-    // Then the data row has the style added
-    expect(cell(r, 1, 0)).toHaveStyleRule("padding-left", "32px");
-    // But the header row does not
-    expect(cell(r, 0, 0)).toHaveStyleRule("padding-left", "8px");
-  });
-
   it("can apply cell-specific styling", async () => {
     // Given a column
     const nameColumn: GridColumn<Row> = {

--- a/src/components/Table/TableStyles.tsx
+++ b/src/components/Table/TableStyles.tsx
@@ -36,10 +36,6 @@ export interface GridStyle {
   firstCellCss?: Properties;
   /** Applied to the last cell of all rows, i.e. for table-wide padding or right-side borders. */
   lastCellCss?: Properties;
-  /** Applied to a cell div when `indent: 1` is used. */
-  indentOneCss?: Properties;
-  /** Applied to a cell div when `indent: 2` is used. */
-  indentTwoCss?: Properties;
   /** Applied if there is a fallback/overflow message showing. */
   firstRowMessageCss?: Properties;
   /** Applied on hover if a row has a rowLink/onClick set. */
@@ -179,8 +175,6 @@ export interface RowStyle<R extends Kinded> {
   cellCss?: Properties | ((row: R) => Properties);
   /** Renders the cell element, i.e. a link to get whole-row links. */
   renderCell?: RenderCellFn<R>;
-  /** Whether the row should be indented (via a style applied to the 1st cell). */
-  indent?: 1 | 2;
   /** Whether the row should be a link. */
   rowLink?: (row: R) => string;
   /** Fired when the row is clicked, similar to rowLink but for actions that aren't 'go to this link'. */

--- a/src/components/Table/TableStyles.tsx
+++ b/src/components/Table/TableStyles.tsx
@@ -1,8 +1,8 @@
 import { ReactNode } from "react";
 import { PresentationContextProps, PresentationFieldProps } from "src/components/PresentationContext";
-import { DiscriminateUnion, GridColumn, GridDataRow, GridTableApi, RenderCellFn } from "src/components/Table/index";
-import { Kinded, RenderAs } from "src/components/Table/types";
-import { Css, Palette, Properties } from "src/Css";
+import { DiscriminateUnion, GridDataRow, GridTableApi, RenderCellFn } from "src/components/Table/index";
+import { Kinded } from "src/components/Table/types";
+import { Css, Palette, Properties, Typography } from "src/Css";
 import { safeKeys } from "src/utils";
 
 /** Completely static look & feel, i.e. nothing that is based on row kinds/content. */
@@ -58,16 +58,24 @@ export interface GridStyle {
 
 // If adding a new `GridStyleDef`, ensure if it added to the `defKeys` in the `resolveStyles` function below
 export interface GridStyleDef {
+  /** Changes the height of the rows when `rowHeight: fixed` to provide more space between rows for input fields. */
   inlineEditing?: boolean;
+  /** Adds styling for grouped rows */
   grouped?: boolean;
+  /** 'fixed' height rows do not allow text to wrap. 'flexible' allows for wrapping. Defaults to `flexible` */
   rowHeight?: "fixed" | "flexible";
   /** Enables cells Highlight and hover */
   cellHighlight?: boolean;
+  /** Applies a white background to the whole table, including header and group rows. */
   allWhite?: boolean;
+  /** Whether to apply a border around the whole table */
   bordered?: boolean;
+  /** Whether to show a hover effect on rows. Defaults to true */
   rowHover?: boolean;
   /** Defines the vertical alignment of the content of the cells for the whole table (not including the 'header' rows). Defaults to `center` */
   vAlign?: "top" | "center" | "bottom";
+  /** Defines the Typography for the table body's cells (not the header). This only applies to rows that are not nested/grouped */
+  cellTypography?: Typography;
 }
 
 // Returns a "blessed" style of GridTable
@@ -82,6 +90,7 @@ function memoizedTableStyles() {
       allWhite = false,
       bordered = false,
       vAlign = "center",
+      cellTypography = "xs" as const,
     } = props;
 
     const key = safeKeys(props)
@@ -123,7 +132,8 @@ function memoizedTableStyles() {
           .py0.boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`)
           .addIn("&:not(:last-of-type)", Css.boxShadow(`inset -1px -1px 0 ${Palette.Gray200}`).$).$,
         cellCss: {
-          ...Css.gray900.xs.bgWhite.ai(alignItems).pxPx(12).boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$,
+          ...Css[cellTypography].gray900.bgWhite.ai(alignItems).pxPx(12).boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`)
+            .$,
           ...(rowHeight === "flexible" ? Css.pyPx(12).$ : Css.nowrap.hPx(inlineEditing ? 48 : 36).$),
           ...(cellHighlight ? { "&:hover": Css.bgGray100.$ } : {}),
           ...(bordered && { "&:first-of-type": Css.bl.bGray200.$, "&:last-of-type": Css.br.bGray200.$ }),
@@ -135,12 +145,13 @@ function memoizedTableStyles() {
           ).$,
           ...(bordered && Css.addIn("& > *", Css.bt.bGray200.$).$),
         },
-        ...(allWhite && {
-          lastRowCss: Css.addIn("& > *:first-of-type", Css.borderRadius("0 0 0 8px").$).addIn(
-            "& > *:last-of-type",
-            Css.borderRadius("0 0 8px 0").$,
-          ).$,
-        }),
+        // Only apply border radius styles to the last row when using the `bordered` style table.
+        lastRowCss: bordered
+          ? Css.addIn("& > *:first-of-type", Css.borderRadius("0 0 0 8px").$).addIn(
+              "& > *:last-of-type",
+              Css.borderRadius("0 0 8px 0").$,
+            ).$
+          : Css.addIn("> *", Css.bsh0.$).$,
         presentationSettings: { borderless: true, typeScale: "xs", wrap: rowHeight === "flexible" },
         levels: grouped ? groupedLevels : defaultLevels,
         rowHoverColor: Palette.LightBlue100,
@@ -177,30 +188,20 @@ export interface RowStyle<R extends Kinded> {
 }
 
 /** Our original table look & feel/style. */
-export const defaultStyle: GridStyle = {
-  rootCss: Css.gray700.$,
-  totalsCellCss: Css.bgWhite.$,
-  betweenRowsCss: Css.bt.bGray400.$,
-  firstNonHeaderRowCss: Css.add({ borderTopStyle: "none" }).$,
-  cellCss: Css.py2.px3.$,
-  firstCellCss: Css.pl1.$,
-  lastCellCss: Css.$,
-  indentOneCss: Css.pl4.$,
-  indentTwoCss: Css.pl7.$,
-  headerCellCss: Css.nowrap.py1.bgGray100.aife.$,
-  firstRowMessageCss: Css.tc.py3.$,
-};
+export const defaultStyle: GridStyle = getTableStyles({});
 
 /** Tightens up the padding of rows, great for rows that have form elements in them. */
 export const condensedStyle: GridStyle = {
-  ...defaultStyle,
-  headerCellCss: Css.bgGray100.tinySb.$,
-  cellCss: Css.aic.sm.py1.px2.$,
-  rootCss: Css.gray700.xs.$,
-  firstRowMessageCss: Css.tc.py2.$,
+  ...getTableStyles({ rowHeight: "fixed" }),
+  firstRowMessageCss: {
+    ...getTableStyles({ rowHeight: "fixed" }).firstRowMessageCss,
+    ...Css.xs.gray900.$,
+  },
 };
 
-/** Renders each row as a card. */
+/** Renders each row as a card.
+ * TODO: Add `cardStyle` option to `getTableStyles` and remove this.
+ * */
 export const cardStyle: GridStyle = {
   ...defaultStyle,
   betweenRowsCss: {},
@@ -218,17 +219,6 @@ export const cardStyle: GridStyle = {
   },
 };
 
-/** GridTable as Table utility to apply <tr> element override styles. */
-export function tableRowStyles(as: RenderAs, column?: GridColumn<any>) {
-  const thWidth = column?.w;
-  return as === "table"
-    ? {
-        ...Css.dtc.$,
-        ...(thWidth ? Css.w(thWidth).$ : {}),
-      }
-    : {};
-}
-
 export function resolveStyles(style: GridStyle | GridStyleDef): GridStyle {
   const defKeysRecord: Record<keyof GridStyleDef, boolean> = {
     inlineEditing: true,
@@ -239,6 +229,7 @@ export function resolveStyles(style: GridStyle | GridStyleDef): GridStyle {
     bordered: true,
     rowHover: true,
     vAlign: true,
+    cellTypography: true,
   };
   const keys = safeKeys(style);
   const defKeys = safeKeys(defKeysRecord);

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -243,8 +243,8 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
         // In practice we've not seen any performance issues with this from our "large but
         // not Google spreadsheets" tables.
         const cellCss = {
-          // Adding display flex so we can align content within the cells
-          ...Css.df.$,
+          // Adding `display: flex` so we can align content within the cells, unless it is displayed as a `table`, then use `table-cell`.
+          ...Css.df.if(as === "table").dtc.$,
           // Apply sticky column/cell styles
           ...maybeStickyColumnStyles,
           // Apply any static/all-cell styling

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -17,7 +17,6 @@ import {
   EXPANDABLE_HEADER,
   getAlignment,
   getFirstOrLastCellCss,
-  getIndentationCss,
   getJustification,
   HEADER,
   isGridCellContent,
@@ -251,9 +250,8 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
           ...style.cellCss,
           // Then override with first/last cell styling
           ...getFirstOrLastCellCss(style, columnIndex, columns),
-          // Then override with per-cell/per-row justification/indentation
+          // Then override with per-cell/per-row justification
           ...justificationCss,
-          ...getIndentationCss(style, rowStyle, columnIndex, maybeContent),
           // Then apply any header-specific override
           ...(isHeader && style.headerCellCss),
           // Then apply any totals-specific override

--- a/src/components/Table/components/cell.tsx
+++ b/src/components/Table/components/cell.tsx
@@ -18,8 +18,6 @@ export type GridCellContent = {
   value?: MaybeFn<number | string | Date | boolean | null | undefined>;
   /** The value to use specifically for sorting (i.e. if `value` is used for filtering); defaults to `value`. */
   sortValue?: MaybeFn<number | string | Date | boolean | null | undefined>;
-  /** Whether to indent the cell. */
-  indent?: 1 | 2;
   colspan?: number;
   typeScale?: Typography;
   /** Allows the cell to stay in place when the user scrolls horizontally, i.e. frozen columns. */

--- a/src/components/Table/components/cell.tsx
+++ b/src/components/Table/components/cell.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import { navLink } from "src/components/CssReset";
 import { GridTableApi } from "src/components/Table/GridTableApi";
-import { RowStyle, tableRowStyles } from "src/components/Table/TableStyles";
+import { RowStyle } from "src/components/Table/TableStyles";
 import { GridCellAlignment, GridColumnWithId, Kinded, MaybeFn, RenderAs } from "src/components/Table/types";
 import { Css, Properties, Typography } from "src/Css";
 
@@ -51,12 +51,7 @@ export const defaultRenderFn: (as: RenderAs) => RenderCellFn<any> =
   (as: RenderAs) => (key, css, content, row, rowStyle, classNames: string | undefined, onClick, tooltip) => {
     const Cell = as === "table" ? "td" : "div";
     return (
-      <Cell
-        key={key}
-        css={{ ...css, ...tableRowStyles(as), ...Css.cursor("default").$ }}
-        className={classNames}
-        onClick={onClick}
-      >
+      <Cell key={key} css={{ ...css, ...Css.cursor("default").$ }} className={classNames} onClick={onClick}>
         {content}
       </Cell>
     );
@@ -70,12 +65,7 @@ export const headerRenderFn: (column: GridColumnWithId<any>, as: RenderAs, colSp
   (column, as, colSpan) => (key, css, content, row, rowStyle, classNames: string | undefined, onClick, tooltip) => {
     const Cell = as === "table" ? "th" : "div";
     return (
-      <Cell
-        key={key}
-        css={{ ...css, ...tableRowStyles(as, column) }}
-        className={classNames}
-        {...(as === "table" && { colSpan })}
-      >
+      <Cell key={key} css={{ ...css }} className={classNames} {...(as === "table" && { colSpan })}>
         {content}
       </Cell>
     );
@@ -87,7 +77,7 @@ export const rowLinkRenderFn: (as: RenderAs) => RenderCellFn<any> =
     const to = rowStyle!.rowLink!(row);
     if (as === "table") {
       return (
-        <td key={key} css={{ ...css, ...tableRowStyles(as) }} className={classNames}>
+        <td key={key} css={{ ...css }} className={classNames}>
           <Link to={to} css={Css.noUnderline.color("unset").db.$} className={navLink}>
             {content}
           </Link>
@@ -114,7 +104,7 @@ export const rowClickRenderFn: (as: RenderAs, api: GridTableApi<any>) => RenderC
     return (
       <Cell
         {...{ key }}
-        css={{ ...css, ...tableRowStyles(as) }}
+        css={{ ...css }}
         className={classNames}
         onClick={(e) => {
           rowStyle!.onClick!(row, api);

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -68,7 +68,7 @@ export type GridColumn<R extends Kinded> = {
   sticky?: "left" | "right";
   /** Prevent column from supporting RowStyle.onClick/rowLink in order to avoid nested interactivity. Defaults to true */
   wrapAction?: false;
-  /** Used as a signal to defer adding the 'indent' styling */
+  /** Used as a signal to defer adding the row's level indentation styling */
   isAction?: true;
   /** Column id that will be used to generate an unique identifier for every row cell */
   id?: string;

--- a/src/components/Table/utils/utils.tsx
+++ b/src/components/Table/utils/utils.tsx
@@ -102,7 +102,7 @@ export function toContent(
         {tooltipEl}
       </>
     );
-  } else if (style.emptyCell && isContentEmpty(content)) {
+  } else if (!isHeader && !isExpandableHeader && style.emptyCell && isContentEmpty(content)) {
     // If the content is empty and the user specified an `emptyCell` node, return that.
     return style.emptyCell;
   }

--- a/src/components/Table/utils/utils.tsx
+++ b/src/components/Table/utils/utils.tsx
@@ -5,7 +5,7 @@ import { ExpandableHeader } from "src/components/Table/components/ExpandableHead
 import { GridDataRow } from "src/components/Table/components/Row";
 import { SortHeader } from "src/components/Table/components/SortHeader";
 import { GridTableApi } from "src/components/Table/GridTableApi";
-import { GridStyle, RowStyle } from "src/components/Table/TableStyles";
+import { GridStyle } from "src/components/Table/TableStyles";
 import { GridCellAlignment, GridColumnWithId, Kinded, RenderAs } from "src/components/Table/types";
 import { Css, Palette, Properties } from "src/Css";
 import { getButtonOrLink } from "src/utils/getInteractiveElement";
@@ -145,22 +145,6 @@ export function applyRowFn<R extends Kinded>(
 export const ASC = "ASC" as const;
 export const DESC = "DESC" as const;
 export const emptyCell: GridCellContent = { content: () => <></>, value: "" };
-
-export function getIndentationCss<R extends Kinded>(
-  style: GridStyle,
-  rowStyle: RowStyle<R> | undefined,
-  columnIndex: number,
-  maybeContent: ReactNode | GridCellContent,
-): Properties {
-  // Look for cell-specific indent or row-specific indent (row-specific is only one the first column)
-  const indent = (isGridCellContent(maybeContent) && maybeContent.indent) || (columnIndex === 0 && rowStyle?.indent);
-  if (typeof indent === "number" && style.levels !== undefined) {
-    throw new Error(
-      "The indent param is deprecated for new beam fixed & flexible styles, use beamNestedFixedStyle or beamNestedFlexibleStyle",
-    );
-  }
-  return indent === 1 ? style.indentOneCss || {} : indent === 2 ? style.indentTwoCss || {} : {};
-}
 
 export function getFirstOrLastCellCss<R extends Kinded>(
   style: GridStyle,


### PR DESCRIPTION
Default and 'condensed' table styles now use the latest patterns.

Includes some various simplifications