### PR TITLE
feat: Chips/Chip xss and compact prop

### DIFF
--- a/src/components/Chip.stories.tsx
+++ b/src/components/Chip.stories.tsx
@@ -29,11 +29,12 @@ export function DefaultChip() {
 export function ColoredChips() {
   return (
     <div>
-      <div css={Css.df.gap1.wPx(500).$}>
+      <div css={Css.df.gap1.wPx(550).$}>
         <Chip text="default" />
         <Chip text="caution" type={ChipTypes.caution} />
         <Chip text="warning" type={ChipTypes.warning} />
         <Chip text="success" type={ChipTypes.success} />
+        <Chip text="info" type={ChipTypes.info} />
         <Chip text="light" type={ChipTypes.light} />
         <Chip text="darkMode" type={ChipTypes.darkMode} />
         <Chip text="dark" type={ChipTypes.dark} />

--- a/src/components/Chip.stories.tsx
+++ b/src/components/Chip.stories.tsx
@@ -45,3 +45,7 @@ export function ColoredChips() {
 export function ChipWithCustomTitle() {
   return <Chip text="Chip text content, hover me" title="Chip has a custom title, different than the content" />;
 }
+
+export function ChipWithCustomColor() {
+  return <Chip text="Chip with custom color" xss={Css.bgLightBlue100.$} />;
+}

--- a/src/components/Chip.test.tsx
+++ b/src/components/Chip.test.tsx
@@ -23,4 +23,9 @@ describe("Chip", () => {
     expect(r.chip().textContent).toBe("Chip text content");
     expect(r.tooltip()).toHaveAttribute("title", "title is different");
   });
+
+  it("can set background color and color with xss prop", async () => {
+    const r = await render(<Chip text="Chip" xss={Css.lightBlue100.bgLightBlue100.$} />);
+    expect(r.chip()).toHaveStyle(`background: ${Css.lightBlue100.bgLightBlue100.$}`);
+  });
 });

--- a/src/components/Chip.test.tsx
+++ b/src/components/Chip.test.tsx
@@ -26,6 +26,6 @@ describe("Chip", () => {
 
   it("can set background color and color with xss prop", async () => {
     const r = await render(<Chip text="Chip" xss={Css.lightBlue100.bgLightBlue100.$} />);
-    expect(r.chip()).toHaveStyle(`background: ${Css.lightBlue100.bgLightBlue100.$}`);
+    expect(r.chip()).toHaveStyle(Css.lightBlue100.bgLightBlue100.$);
   });
 });

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -4,7 +4,7 @@ import { maybeTooltip } from "src/components/Tooltip";
 import { Css, Margin, Only, Properties, Xss } from "src/Css";
 import { useTestIds } from "src/utils/useTestIds";
 
-type ChipType = "caution" | "warning" | "success" | "light" | "dark" | "neutral" | "darkMode";
+export type ChipType = "caution" | "warning" | "success" | "light" | "dark" | "neutral" | "darkMode";
 
 // exporting for using in type prop as constant - this could be moved and become a global list for colors
 export const ChipTypes: Record<ChipType, ChipType> = {

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -26,7 +26,10 @@ export interface ChipProps<X> {
 }
 
 /** Kinda like a chip, but read-only, so no `onClick` or `hover`. */
-export function Chip<X extends Only<Xss<Margin>, X>>({ type = ChipTypes.neutral, ...props }: ChipProps<X>) {
+export function Chip<X extends Only<Xss<Margin | "color" | "backgroundColor">, X>>({
+  type = ChipTypes.neutral,
+  ...props
+}: ChipProps<X>) {
   const { fieldProps } = usePresentationContext();
   const { text, title, xss = {}, compact = fieldProps?.compact } = props;
   const tid = useTestIds(props, "chip");

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -4,7 +4,7 @@ import { maybeTooltip } from "src/components/Tooltip";
 import { Css, Margin, Only, Properties, Xss } from "src/Css";
 import { useTestIds } from "src/utils/useTestIds";
 
-export type ChipType = "caution" | "warning" | "success" | "light" | "dark" | "neutral" | "darkMode";
+export type ChipType = "caution" | "warning" | "success" | "light" | "dark" | "neutral" | "darkMode" | "info";
 
 // exporting for using in type prop as constant - this could be moved and become a global list for colors
 export const ChipTypes: Record<ChipType, ChipType> = {
@@ -15,6 +15,7 @@ export const ChipTypes: Record<ChipType, ChipType> = {
   dark: "dark",
   neutral: "neutral",
   darkMode: "darkMode",
+  info: "info",
 };
 
 export interface ChipProps<X> {
@@ -60,4 +61,5 @@ const typeStyles: Record<ChipType, Properties> = {
   dark: Css.bgGray900.white.$,
   neutral: Css.bgGray200.$,
   darkMode: Css.bgGray700.white.$,
+  info: Css.bgLightBlue100.$,
 };

--- a/src/components/Chips.stories.tsx
+++ b/src/components/Chips.stories.tsx
@@ -44,3 +44,19 @@ export function ChipsWithCustomTitles() {
   ];
   return <Chips values={customChips} />;
 }
+
+export function ChipsWithCompactVariant() {
+  return (
+    <>
+      <h1 css={Css.mt3.$}>Chips with compact variant</h1>
+      <div css={Css.wPx(300).ba.$}>
+        <Chips values={["First Last", "Second Last", "Third Last", "Fourth Last"]} compact />
+      </div>
+
+      <h1 css={Css.mt3.$}>Chips without compact</h1>
+      <div css={Css.wPx(300).ba.$}>
+        <Chips values={["First Last", "Second Last", "Third Last", "Fourth Last"]} />
+      </div>
+    </>
+  );
+}

--- a/src/components/Chips.test.tsx
+++ b/src/components/Chips.test.tsx
@@ -1,0 +1,23 @@
+import { render } from "src/utils/rtl";
+import { Chips } from "./Chips";
+
+describe("Chips", () => {
+  const values = [
+    { text: "123", title: "tooltip" },
+    { text: "abc", title: "" },
+  ];
+  it("renders", async () => {
+    const r = await render(<Chips values={values} />);
+    expect(r.chip_0().textContent).toBe("123");
+    expect(r.chip_1().textContent).toBe("abc");
+    expect(r.tooltip()).toHaveAttribute("title", "tooltip");
+  });
+
+  it("can set compact to change size to xs", async () => {
+    const r = await render(<Chips values={values} compact />);
+    expect(r.chip_0())
+      .toHaveStyleRule("font-size", "12px")
+      .toHaveStyleRule("font-weight", "400")
+      .toHaveStyleRule("line-height", "16px");
+  });
+});

--- a/src/components/Chips.tsx
+++ b/src/components/Chips.tsx
@@ -12,12 +12,13 @@ export interface ChipValue {
 export interface ChipsProps<X> {
   values: string[] | ChipValue[];
   xss?: X;
+  compact?: boolean;
 }
 
 /** Renders a list of `Chip`s, with wrapping & appropriate margin between each `Chip`. */
 export function Chips<X extends Only<ChipsXss, X>>(props: ChipsProps<X>) {
   const { wrap } = usePresentationContext();
-  const { values, xss = {} } = props;
+  const { values, compact, xss = {} } = props;
   return (
     <div
       css={{
@@ -28,7 +29,7 @@ export function Chips<X extends Only<ChipsXss, X>>(props: ChipsProps<X>) {
     >
       {values.map((value, i) => {
         const { text, title } = (value.hasOwnProperty("text") ? value : { text: value }) as ChipValue;
-        return <Chip key={i} text={text} title={title} />;
+        return <Chip key={i} text={text} title={title} compact={compact} />;
       })}
     </div>
   );


### PR DESCRIPTION
[SC-35341](https://app.shortcut.com/homebound-team/story/35341/beam-chips-grouped-and-chip-style-improvements)

1. Add "color" | "backgroundColor" to Chip (singular) XSS
2. Add compact prop to change Chips (group) size
3. New "info" type to ChipTypes

![Screen Shot 2023-05-26 at 2 55 52 PM](https://github.com/homebound-team/beam/assets/43801393/3dffe357-c004-4acc-8490-51e8f09480a0)

![Screen Shot 2023-05-26 at 3 01 29 PM](https://github.com/homebound-team/beam/assets/43801393/a951a3ef-1c50-4a1a-a5ab-0a44048be3be)


![Screen Shot 2023-05-30 at 11 45 54 AM](https://github.com/homebound-team/beam/assets/43801393/9e89021c-9e3e-4da2-9d6d-747d9dc7e5f6)
