### PR TITLE
feat: SC: 35536 - Add optional xss for padding on accordion

### DIFF
--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -2,10 +2,12 @@ import { useId, useResizeObserver } from "@react-aria/utils";
 import { Dispatch, ReactNode, SetStateAction, useCallback, useEffect, useRef, useState } from "react";
 import { useFocusRing } from "react-aria";
 import { Icon } from "src/components/Icon";
-import { Css, Padding, Palette, Xss } from "src/Css";
+import { Css, Only, Padding, Palette, Xss } from "src/Css";
 import { useTestIds } from "src/utils";
 
-export interface AccordionProps {
+type AccordionXss = Xss<Padding>;
+
+export interface AccordionProps<X> {
   title: ReactNode;
   children: ReactNode;
   disabled?: boolean;
@@ -23,11 +25,11 @@ export interface AccordionProps {
   setExpandedIndex?: Dispatch<SetStateAction<number | undefined>>;
   /** Used by Accordion list. Sets default padding to 0 for nested accordions */
   omitPadding?: boolean;
-  /** Styles overrides for omit padding */
-  xss?: Xss<Padding>;
+  /** Styles overrides for padding */
+  xss?: X;
 }
 
-export function Accordion(props: AccordionProps) {
+export function Accordion<X extends Only<AccordionXss, X>>(props: AccordionProps<X>) {
   const {
     title,
     children,
@@ -89,7 +91,7 @@ export function Accordion(props: AccordionProps) {
           ...Css.df.jcsb.gap2.aic.w100.p2.baseMd.outline("none").addIn(":hover", Css.bgGray100.$).$,
           ...(disabled && Css.gray500.$),
           ...(isFocusVisible && Css.boxShadow(`inset 0 0 0 2px ${Palette.LightBlue700}`).$),
-          ...(xss && xss),
+          ...xss,
         }}
         onClick={() => {
           setExpanded(!expanded);

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -7,7 +7,7 @@ import { useTestIds } from "src/utils";
 
 type AccordionXss = Xss<Padding>;
 
-export interface AccordionProps<X> {
+export interface AccordionProps<X = AccordionXss> {
   title: ReactNode;
   children: ReactNode;
   disabled?: boolean;

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -2,7 +2,7 @@ import { useId, useResizeObserver } from "@react-aria/utils";
 import { Dispatch, ReactNode, SetStateAction, useCallback, useEffect, useRef, useState } from "react";
 import { useFocusRing } from "react-aria";
 import { Icon } from "src/components/Icon";
-import { Css, Palette } from "src/Css";
+import { Css, Padding, Palette, Xss } from "src/Css";
 import { useTestIds } from "src/utils";
 
 export interface AccordionProps {
@@ -23,6 +23,8 @@ export interface AccordionProps {
   setExpandedIndex?: Dispatch<SetStateAction<number | undefined>>;
   /** Used by Accordion list. Sets default padding to 0 for nested accordions */
   omitPadding?: boolean;
+  /** Styles overrides for omit padding */
+  xss?: Xss<Padding>;
 }
 
 export function Accordion(props: AccordionProps) {
@@ -37,6 +39,7 @@ export function Accordion(props: AccordionProps) {
     index,
     setExpandedIndex,
     omitPadding = false,
+    xss,
   } = props;
   const testIds = useTestIds(props, "accordion");
   const id = useId();
@@ -86,6 +89,7 @@ export function Accordion(props: AccordionProps) {
           ...Css.df.jcsb.gap2.aic.w100.p2.baseMd.outline("none").addIn(":hover", Css.bgGray100.$).$,
           ...(disabled && Css.gray500.$),
           ...(isFocusVisible && Css.boxShadow(`inset 0 0 0 2px ${Palette.LightBlue700}`).$),
+          ...(xss && xss),
         }}
         onClick={() => {
           setExpanded(!expanded);

--- a/src/components/AccordionList.stories.tsx
+++ b/src/components/AccordionList.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from "@storybook/react";
 import { AccordionProps } from "./Accordion";
 import { AccordionList } from "./AccordionList";
+import { Css } from "src/Css";
 
 export default {
   component: AccordionList,
@@ -30,6 +31,7 @@ export function AccordionListWithParentProp() {
   const accordions: AccordionProps[] = [
     {
       title: "First accordion title",
+      xss: Css.pl0.pr0.$,
       children: (
         <table>
           <tbody>


### PR DESCRIPTION
# [SC-35536](https://app.shortcut.com/homebound-team/story/35536/add-omitpadding-to-accordionlist-in-beam-and-update-financials-widget)
* Adds optional `xss` prop in order to have control over changing the padding on the blueprint side