### PR TITLE
docs: Expand comments for unsetLabel and nothingSelectedText.

### DIFF
--- a/src/inputs/MultiSelectField.tsx
+++ b/src/inputs/MultiSelectField.tsx
@@ -29,33 +29,7 @@ export function MultiSelectField<O, V extends Value>(
   const {
     getOptionValue = (opt: O) => (opt as any).id, // if unset, assume O implements HasId
     getOptionLabel = (opt: O) => (opt as any).name, // if unset, assume O implements HasName
-    options,
-    onSelect,
-    values,
     ...otherProps
   } = props;
-
-  return (
-    <ComboBoxBase
-      multiselect
-      {...otherProps}
-      options={options}
-      getOptionLabel={getOptionLabel}
-      getOptionValue={getOptionValue}
-      values={values}
-      onSelect={(values) => {
-        const [selectedValues, selectedOptions] = options
-          .filter((o) => values.includes(getOptionValue(o)))
-          .reduce(
-            (acc, o) => {
-              acc[0].push(getOptionValue(o));
-              acc[1].push(o);
-              return acc;
-            },
-            [[] as V[], [] as O[]],
-          );
-        onSelect(selectedValues, selectedOptions);
-      }}
-    />
-  );
+  return <ComboBoxBase multiselect getOptionLabel={getOptionLabel} getOptionValue={getOptionValue} {...otherProps} />;
 }

--- a/src/inputs/SelectField.tsx
+++ b/src/inputs/SelectField.tsx
@@ -6,6 +6,11 @@ export interface SelectFieldProps<O, V extends Value>
   extends Omit<ComboBoxBaseProps<O, V>, "values" | "onSelect" | "multiselect"> {
   /** The current value; it can be `undefined`, even if `V` cannot be. */
   value: V | undefined;
+  /**
+   * Called when a value is selected, or `undefined` if `unsetLabel` is being used.
+   *
+   * Ideally callers that didn't pass `unsetLabel` would not have to handle the ` | undefined` here.
+   */
   onSelect: (value: V | undefined, opt: O | undefined) => void;
 }
 
@@ -39,6 +44,7 @@ export function SelectField<O, V extends Value>(
       getOptionValue={getOptionValue}
       values={[value]}
       onSelect={(values, options) => {
+        // If the user used `unsetLabel`, then values will be `[undefined]` and options `[unsetOption]`
         if (values.length > 0 && options.length > 0) {
           const option = options[0];
           onSelect(values[0], option === unsetOption ? undefined : option);

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -37,13 +37,25 @@ export interface ComboBoxBaseProps<O, V extends Value> extends BeamFocusableProp
   onBlur?: () => void;
   onFocus?: () => void;
   sizeToContent?: boolean;
-  /** The text to show when nothing is selected, i.e. could be "All" for filters. */
+  /**
+   * The text to show when nothing is selected, i.e. could be "All" for filters.
+   *
+   * Unlike `unsetLabel`, this does not add an explicit option for the user to select.
+   */
   nothingSelectedText?: string;
   /** When set the SelectField is expected to be put on a darker background */
   contrast?: boolean;
   /** Placeholder content */
   placeholder?: string;
-  /** Only used for Single Select Fields. If set, prepends an option with a `undefined` value at the top of the list */
+  /**
+   * If set, prepends an option with an `undefined` value at the top of the list to allow
+   * unsetting the field.
+   *
+   * Unlike `nothingSelectedText`, which provides the label for empty value state, but doesn't
+   * add an option for the user to explicitly select the empty state.
+   *
+   * Only available for Single Select Fields.
+   */
   unsetLabel?: string;
   hideErrorMessage?: boolean;
 }


### PR DESCRIPTION
Also sneaks in a simplification of MultiSelectField.onSelect.