### PR TITLE
feat(button-group): allow JSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@homebound/beam",
-  "version": "2.282.0",
+  "version": "2.283.0",
   "author": "Homebound",
   "license": "MIT",
   "main": "dist/index.js",

--- a/src/components/ButtonGroup.test.tsx
+++ b/src/components/ButtonGroup.test.tsx
@@ -1,5 +1,6 @@
 import { ButtonGroup, ButtonGroupButton } from "src/components/ButtonGroup";
 import { click, render } from "src/utils/rtl";
+import { Css } from "..";
 
 describe("ButtonGroup", () => {
   it("renders and fires callbacks", async () => {
@@ -56,5 +57,10 @@ describe("ButtonGroup", () => {
     expect(r.buttonGroup_first().closest("[data-testid='tooltip']")).toHaveAttribute("title", "Tooltip");
     expect(r.buttonGroup_last()).not.toBeDisabled();
     expect(r.buttonGroup_last().closest("[data-testid='tooltip']")).toHaveAttribute("title", "Other Tooltip");
+  });
+
+  it("can render jsx", async () => {
+    const r = await render(<ButtonGroup buttons={[{ text: <div css={Css.red500.$}>Hello World</div> }]} />);
+    expect(r.getByText("Hello World")).toHaveStyleRule("color", Css.red500.$.color);
   });
 });

--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useRef } from "react";
+import { ReactNode, useRef } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
 import { Icon, IconProps } from "src/components/Icon";
 import { maybeTooltip, resolveTooltip } from "src/components/Tooltip";
@@ -17,7 +17,7 @@ export type ButtonGroupButton = {
   icon?: IconProps["icon"];
   iconColor?: IconProps["color"];
   iconInc?: IconProps["inc"];
-  text?: React.ReactNode;
+  text?: ReactNode;
   onClick?: VoidFunction;
   /** Disables the button. Pass a ReactNode to disable the button and show a tooltip */
   disabled?: boolean | ReactNode;

--- a/src/components/ButtonGroup.tsx
+++ b/src/components/ButtonGroup.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useRef } from "react";
+import React, { ReactNode, useRef } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
 import { Icon, IconProps } from "src/components/Icon";
 import { maybeTooltip, resolveTooltip } from "src/components/Tooltip";
@@ -17,7 +17,7 @@ export type ButtonGroupButton = {
   icon?: IconProps["icon"];
   iconColor?: IconProps["color"];
   iconInc?: IconProps["inc"];
-  text?: string;
+  text?: React.ReactNode;
   onClick?: VoidFunction;
   /** Disables the button. Pass a ReactNode to disable the button and show a tooltip */
   disabled?: boolean | ReactNode;
@@ -73,7 +73,7 @@ function GroupButton(props: GroupButtonProps) {
               ...(isPressed ? pressedStyles : isHovered ? hoverStyles : {}),
               ...(icon ? iconStyles[size] : {}),
             }}
-            {...tid[defaultTestId(text ?? icon ?? "button")]}
+            {...tid[defaultTestId((typeof text === "string" && text) || icon || "button")]}
           >
             {icon && (
               <Icon xss={Css.if(!!text).mrPx(4).$} icon={icon} color={disabled ? undefined : iconColor} inc={iconInc} />


### PR DESCRIPTION
The text on this already gets rendered as a ReactNode `<button>{text}</button>`, but the Typing is only allowing Strings through. So let _me_ use what _Beam_ is already doing. 

Specifically, I need to be able to make `Reject` Red:

<img width="298" alt="image" src="https://github.com/homebound-team/beam/assets/20718430/c7441a24-2d08-4c87-9a3a-6448527d7359">

Previously I needed to color the icons (#874)

<img width="340" alt="image" src="https://github.com/homebound-team/beam/assets/20718430/de31b408-18e1-4784-9546-bb10a48dbd7a">

Both of these would've been solvable if the Type was being exposed in the same way it's being used.