### PR TITLE
feat: add the functionality of the initSelected of children rows on init load

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1163,19 +1163,17 @@ export function SelectableRows() {
 }
 
 export function SelectableChildrenRows() {
-  type HeaderRow = { kind: "header"; id: string; data: undefined };
-  type ParentRow = { kind: "parent"; id: string; data: { name: string } };
-  type ChildRow = { kind: "child"; id: string; data: { name: string } };
-  type GrandChildRow = { kind: "grandChild"; id: string; data: { name: string } };
-  type Row = HeaderRow | ParentRow | ChildRow | GrandChildRow;
+  type ParentRow = { kind: "parent"; id: string; data: string };
+  type ChildRow = { kind: "child"; id: string; data: string };
+  type GrandChildRow = { kind: "grandChild"; id: string; data: string };
+  type Row = ParentRow | ChildRow | GrandChildRow;
 
   const selectCol = selectColumn<Row>();
 
   const nameCol: GridColumn<Row> = {
-    header: "Name",
-    parent: ({ name }) => name,
-    child: ({ name }) => name,
-    grandChild: ({ name }) => name,
+    parent: (name) => name,
+    child: (name) => name,
+    grandChild: (name) => name,
     mw: "160px",
   };
 
@@ -1183,31 +1181,26 @@ export function SelectableChildrenRows() {
     <>
       <GridTable
         columns={[collapseColumn<Row>(), selectCol, nameCol]}
-        style={{ rowHeight: "fixed" }}
         rows={
           [
             simpleHeader,
             {
               kind: "parent",
               id: "1",
-              data: { name: "Howard Stark" },
+              data: "Howard Stark",
               initSelected: true,
               inferSelectedState: false,
               children: [
                 {
                   kind: "child" as const,
                   id: "2",
-                  data: {
-                    name: "Tony Stark",
-                  },
+                  data: "Tony Stark",
                   initSelected: false,
                   children: [
                     {
                       kind: "grandChild" as const,
                       id: "5",
-                      data: {
-                        name: "Morgan Stark",
-                      },
+                      data: "Morgan Stark",
                       initSelected: true,
                     },
                   ],
@@ -1217,32 +1210,14 @@ export function SelectableChildrenRows() {
             {
               kind: "parent",
               id: "3",
-              data: { name: "Odin" },
+              data: "Odin",
               initSelected: false,
               inferSelectedState: false,
               children: [
                 {
                   kind: "child" as const,
                   id: "4",
-                  data: {
-                    name: "Thor",
-                  },
-                  initSelected: true,
-                },
-                {
-                  kind: "child" as const,
-                  id: "6",
-                  data: {
-                    name: "Hela",
-                  },
-                  initSelected: true,
-                },
-                {
-                  kind: "child" as const,
-                  id: "7",
-                  data: {
-                    name: "Loki",
-                  },
+                  data: "Thor",
                   initSelected: true,
                 },
               ],

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1162,6 +1162,85 @@ export function SelectableRows() {
   );
 }
 
+export function SelectableChildrenRows() {
+  type HeaderRow = { kind: "header"; id: string; data: undefined };
+  type ParentRow = { kind: "parent"; id: string; data: { name: string } };
+  type ChildRow = { kind: "child"; id: string; data: { name: string } };
+  type GrandChildRow = { kind: "grandChild"; id: string; data: { name: string } };
+  type Row = HeaderRow | ParentRow | ChildRow | GrandChildRow;
+
+  const selectCol = selectColumn<Row>();
+
+  const nameCol: GridColumn<Row> = {
+    header: "Name",
+    parent: ({ name }) => name,
+    child: ({ name }) => name,
+    grandChild: ({ name }) => name,
+    mw: "160px",
+  };
+
+  return (
+    <>
+      <GridTable
+        columns={[collapseColumn<Row>(), selectCol, nameCol]}
+        style={{ rowHeight: "fixed" }}
+        rows={
+          [
+            simpleHeader,
+            {
+              kind: "parent",
+              id: "1",
+              data: { name: "Howard Stark" },
+              initCollapsed: false,
+              initSelected: true,
+              inferSelectedState: false,
+              children: [
+                {
+                  kind: "child" as const,
+                  id: "2",
+                  data: {
+                    name: "Tony Stark",
+                  },
+                  initSelected: false,
+                  pin: "first",
+                  children: [
+                    {
+                      kind: "grandChild" as const,
+                      id: "5",
+                      data: {
+                        name: "Morgan Stark",
+                      },
+                      initSelected: true,
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              kind: "parent",
+              id: "3",
+              data: { name: "Odin" },
+              initCollapsed: false,
+              initSelected: false,
+              inferSelectedState: false,
+              children: [
+                {
+                  kind: "child" as const,
+                  id: "4",
+                  data: {
+                    name: "Thor",
+                  },
+                  initSelected: true,
+                },
+              ],
+            },
+          ] as GridDataRow<Row>[]
+        }
+      />
+    </>
+  );
+}
+
 export function RevealOnRowHover() {
   const nameColumn: GridColumn<Row> = {
     header: "Name",

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1191,7 +1191,6 @@ export function SelectableChildrenRows() {
               kind: "parent",
               id: "1",
               data: { name: "Howard Stark" },
-              initCollapsed: false,
               initSelected: true,
               inferSelectedState: false,
               children: [
@@ -1202,7 +1201,6 @@ export function SelectableChildrenRows() {
                     name: "Tony Stark",
                   },
                   initSelected: false,
-                  pin: "first",
                   children: [
                     {
                       kind: "grandChild" as const,
@@ -1220,7 +1218,6 @@ export function SelectableChildrenRows() {
               kind: "parent",
               id: "3",
               data: { name: "Odin" },
-              initCollapsed: false,
               initSelected: false,
               inferSelectedState: false,
               children: [
@@ -1229,6 +1226,22 @@ export function SelectableChildrenRows() {
                   id: "4",
                   data: {
                     name: "Thor",
+                  },
+                  initSelected: true,
+                },
+                {
+                  kind: "child" as const,
+                  id: "6",
+                  data: {
+                    name: "Hela",
+                  },
+                  initSelected: true,
+                },
+                {
+                  kind: "child" as const,
+                  id: "7",
+                  data: {
+                    name: "Loki",
                   },
                   initSelected: true,
                 },

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -2422,18 +2422,16 @@ describe("GridTable", () => {
   });
 
   it("can render with rows with initSelected defined include the children rows", async () => {
-    type HeaderRow = { kind: "header"; id: string; data: undefined };
-    type ParentRow = { kind: "parent"; id: string; data: { name: string } };
-    type ChildRow = { kind: "child"; id: string; data: { name: string } };
-    type GrandChildRow = { kind: "grandChild"; id: string; data: { name: string } };
-    type Row = HeaderRow | ParentRow | ChildRow | GrandChildRow;
+    type ParentRow = { kind: "parent"; id: string; data: string };
+    type ChildRow = { kind: "child"; id: string; data: string };
+    type GrandChildRow = { kind: "grandChild"; id: string; data: string };
+    type Row = ParentRow | ChildRow | GrandChildRow;
 
     const selectCol = selectColumn<Row>();
     const nameCol: GridColumn<Row> = {
-      header: "Name",
-      parent: ({ name }) => name,
-      child: ({ name }) => name,
-      grandChild: ({ name }) => name,
+      parent: (name) => name,
+      child: (name) => name,
+      grandChild: (name) => name,
       mw: "160px",
     };
 
@@ -2443,24 +2441,19 @@ describe("GridTable", () => {
       {
         kind: "parent",
         id: "1",
-        data: { name: "Howard Stark" },
+        data: "Howard Stark",
         initSelected: true,
-        inferSelectedState: false,
         children: [
           {
             kind: "child" as const,
             id: "2",
-            data: {
-              name: "Tony Stark",
-            },
+            data: "Tony Stark",
             initSelected: false,
             children: [
               {
                 kind: "grandChild" as const,
                 id: "5",
-                data: {
-                  name: "Morgan Stark",
-                },
+                data: "Morgan Stark",
                 initSelected: true,
               },
             ],
@@ -2470,32 +2463,13 @@ describe("GridTable", () => {
       {
         kind: "parent",
         id: "3",
-        data: { name: "Odin" },
+        data: "Odin",
         initSelected: false,
-        inferSelectedState: false,
         children: [
           {
             kind: "child" as const,
             id: "4",
-            data: {
-              name: "Thor",
-            },
-            initSelected: true,
-          },
-          {
-            kind: "child" as const,
-            id: "6",
-            data: {
-              name: "Hela",
-            },
-            initSelected: true,
-          },
-          {
-            kind: "child" as const,
-            id: "7",
-            data: {
-              name: "Loki",
-            },
+            data: "Thor",
             initSelected: true,
           },
         ],
@@ -2515,15 +2489,13 @@ describe("GridTable", () => {
 
     expect(tableSnapshot(r)).toMatchInlineSnapshot(`
       "
-      | on | Name         |
+      | on |              |
       | -- | ------------ |
       | on | Howard Stark |
       | on | Tony Stark   |
       | on | Morgan Stark |
       | on | Odin         |
       | on | Thor         |
-      | on | Hela         |
-      | on | Loki         |
       "
     `);
 
@@ -2543,14 +2515,8 @@ describe("GridTable", () => {
     expect(cell(r, 5, 1)).toHaveTextContent("Thor");
     expect(cellAnd(r, 5, 0, "select")).toBeChecked();
 
-    expect(cell(r, 6, 1)).toHaveTextContent("Hela");
-    expect(cellAnd(r, 6, 0, "select")).toBeChecked();
-
-    expect(cell(r, 7, 1)).toHaveTextContent("Loki");
-    expect(cellAnd(r, 7, 0, "select")).toBeChecked();
-
     // And they can no longer be fetched by the api
-    expect(api.current!.getSelectedRowIds()).toEqual(["7", "6", "4", "1", "5"]);
+    expect(api.current!.getSelectedRowIds()).toEqual(["4", "1", "5"]);
   });
 
   describe("expandable columns", () => {

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -2442,6 +2442,7 @@ describe("GridTable", () => {
         kind: "parent",
         id: "1",
         data: "Howard Stark",
+        inferSelectedState: false,
         initSelected: true,
         children: [
           {
@@ -2464,6 +2465,7 @@ describe("GridTable", () => {
         kind: "parent",
         id: "3",
         data: "Odin",
+        inferSelectedState: false,
         initSelected: false,
         children: [
           {

--- a/src/components/Table/utils/TableState.ts
+++ b/src/components/Table/utils/TableState.ts
@@ -105,8 +105,8 @@ export class TableState {
   }
 
   loadSelected(rows: GridDataRow<any>[]): void {
-    const childRows = rows.flatMap((r) => (r.children ? flattenRows(r.children) : []));
-    const selectedRows = [...rows, ...childRows].filter((row) => row.initSelected);
+    const allRows = flattenRows(rows);
+    const selectedRows = allRows.filter((row) => row.initSelected);
     // Initialize with selected rows as defined
     const map = new Map<string, SelectedState>();
     selectedRows.forEach((row) => {

--- a/src/components/Table/utils/TableState.ts
+++ b/src/components/Table/utils/TableState.ts
@@ -105,7 +105,8 @@ export class TableState {
   }
 
   loadSelected(rows: GridDataRow<any>[]): void {
-    const selectedRows = rows.filter((row) => row.initSelected);
+    const childRows = rows.flatMap((r) => (r.children ? flattenRows(r.children) : []));
+    const selectedRows = [...rows, ...childRows].filter((row) => row.initSelected);
     // Initialize with selected rows as defined
     const map = new Map<string, SelectedState>();
     selectedRows.forEach((row) => {


### PR DESCRIPTION
I need to that `initSelected` on rows works on children

https://60466f7d43c37c0021788867-xuabsrkbed.chromatic.com/?path=/story/components-table-gridtable--selectable-children-rows