### PR TITLE
feat: SC-34857: Table component now considers hidden rows as selected

### DIFF
--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -3,7 +3,6 @@ import { VirtuosoHandle } from "react-virtuoso";
 import { GridDataRow } from "src/components/Table/components/Row";
 import { DiscriminateUnion, Kinded } from "src/components/Table/types";
 import { TableState } from "src/components/Table/utils/TableState";
-import { visit } from "src/components/Table/utils/visitor";
 
 /**
  * Creates an `api` handle to drive a `GridTable`.
@@ -18,7 +17,7 @@ import { visit } from "src/components/Table/utils/visitor";
  * This is very similar to a `useRef`, except that the parent function has
  * immediate access to `api` and can use it for `useComputed`, instead of
  * having to wait for `ref.current` to be set after the child `GridTable`
- * has ran.
+ * has run.
  */
 export function useGridTableApi<R extends Kinded>(): GridTableApi<R> {
   return useMemo(() => new GridTableApiImpl<R>(), []);
@@ -81,16 +80,9 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
     return this.getSelectedRows(kind).map((row: any) => row.id);
   }
 
-  // The any is not great, but getting the overload to handle the optional kind is annoying
+  // The `any` is not great, but getting the overload to handle the optional kind is annoying
   public getSelectedRows(kind?: string): any {
-    const ids = this.tableState.selectedIds;
-    const selected: GridDataRow<R>[] = [];
-    visit(this.tableState.rows, (row) => {
-      if (row.selectable !== false && ids.includes(row.id) && (!kind || row.kind === kind)) {
-        selected.push(row as any);
-      }
-    });
-    return selected;
+    return this.tableState.selectedRows.filter((row) => !kind || row.kind === kind);
   }
 
   public clearSelections(id?: string) {

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -1,5 +1,6 @@
 import { ObjectConfig, ObjectState, required, useFormStates } from "@homebound/form-state";
 import { Meta } from "@storybook/react";
+import { camelCase } from "change-case";
 import { ReactNode, useMemo, useState } from "react";
 import { Chips } from "src/components/Chips";
 import { Icon } from "src/components/Icon";
@@ -119,6 +120,8 @@ export function Table(props: TableStoryProps) {
   const { nestingDepth, allWhite, vAlign, grouped, rowHeight, bordered, displayAs, totals, rowHover, expandable } =
     props;
   const [filter, setFilter] = useState<string>();
+  const api = useGridTableApi<BeamNestedRow>();
+  const selectedRows: GridDataRow<BeamNestedRow>[] = useComputed(() => api.getSelectedRows(), [api]);
 
   const [rows, columns] = useMemo(() => {
     // Make a copy of the `rows` as we may splice in the `expandableHeader` and we don't want to mutate the original rows array.
@@ -126,7 +129,7 @@ export function Table(props: TableStoryProps) {
     if (expandable) {
       rows = [...rows, { kind: "expandableHeader", id: "expandableHeader" } as GridDataRow<BeamNestedRow>];
     }
-    return [rows, beamNestedColumns(expandable)];
+    return [[...(totals ? beamTotalsRows : []), ...rows], beamNestedColumns(expandable)];
   }, [nestingDepth, expandable]);
 
   return (
@@ -139,18 +142,23 @@ export function Table(props: TableStoryProps) {
       }
     >
       <TableActions>
-        <TextField
-          label="Filter"
-          labelStyle="hidden"
-          placeholder="Search"
-          value={filter}
-          onChange={setFilter}
-          startAdornment={<Icon icon="search" />}
-          clearable
-        />
+        <div>
+          <TextField
+            label="Filter"
+            labelStyle="hidden"
+            placeholder="Search"
+            value={filter}
+            onChange={setFilter}
+            startAdornment={<Icon icon="search" />}
+            clearable
+          />
+          <strong>Selected Row Ids:</strong>{" "}
+          {selectedRows.length > 0 ? selectedRows.map((r) => r.id).join(", ") : "None"}
+        </div>
       </TableActions>
       <div css={Css.fg1.$}>
         <GridTable<BeamNestedRow>
+          api={api}
           as={displayAs === "default" ? undefined : displayAs}
           style={{
             allWhite: allWhite || expandable,
@@ -162,7 +170,7 @@ export function Table(props: TableStoryProps) {
           }}
           sorting={{ on: "client" }}
           columns={columns}
-          rows={[...(totals ? beamTotalsRows : []), ...rows]}
+          rows={rows}
           stickyHeader
           filter={filter}
         />
@@ -339,13 +347,12 @@ function beamNestedRows(levels: 1 | 2 | 3 | 4 = 1): GridDataRow<BeamNestedRow>[]
         const numChildren = (pIdx % 3) + pIdx + idx + 1;
         const children = zeroTo(numChildren).map((cIdx) => {
           const valueMultiplier = cIdx + pIdx + idx + 1;
+          const name = `${idx + 1}0${pIdx + 1}0.${cIdx + 1} - Project Item`;
           return {
             kind: "child" as const,
-            id: `gpp:${ggpIdx + 1}_gp:${idx + 1}_p${pIdx + 1}_c${cIdx + 1}`,
+            id: `row:${camelCase(name)}`,
             data: {
-              name: `${idx + 1}0${pIdx + 1}0.${cIdx + 1} - Project Item${
-                pIdx === 0 ? " with a longer name that will wrap" : ""
-              }`,
+              name: `${name}${pIdx === 0 ? " with a longer name that will wrap" : ""}`,
               original: 1234_56 * valueMultiplier,
               changeOrders: 543_21 * valueMultiplier,
               reallocations: 568_56 * valueMultiplier,
@@ -359,12 +366,13 @@ function beamNestedRows(levels: 1 | 2 | 3 | 4 = 1): GridDataRow<BeamNestedRow>[]
           };
         });
 
+        const name = `${idx + 1}0${pIdx + 1}0 - Cost Code`;
         return {
           kind: "parent" as const,
-          id: `gpp:${ggpIdx + 1}_gp:${idx + 1}_p:${pIdx + 1}`,
+          id: camelCase(`row:${name}`),
           children,
           data: {
-            name: `${idx + 1}0${pIdx + 1}0 - Cost Code${pIdx === 1 ? " with a longer name that will wrap" : ""}`,
+            name: `${name}${pIdx === 1 ? " with a longer name that will wrap" : ""}`,
             original: children.map((c) => c.data.original ?? 0).reduce((acc, n) => acc + n, 0),
             changeOrders: children.map((c) => c.data.changeOrders ?? 0).reduce((acc, n) => acc + n, 0),
             reallocations: children.map((c) => c.data.reallocations ?? 0).reduce((acc, n) => acc + n, 0),
@@ -378,12 +386,13 @@ function beamNestedRows(levels: 1 | 2 | 3 | 4 = 1): GridDataRow<BeamNestedRow>[]
         };
       });
 
+      const name = `${idx + 1}000 - Division`;
       return {
-        id: `gpp:${ggpIdx + 1}_gp:${idx + 1}`,
+        id: camelCase(`row:${name}`),
         kind: "grandparent" as const,
         children: parents,
         data: {
-          name: `${idx + 1}000 - Division`,
+          name,
           original: parents.map((p) => p.data.original ?? 0).reduce((acc, n) => acc + n, 0),
           changeOrders: parents.map((p) => p.data.changeOrders ?? 0).reduce((acc, n) => acc + n, 0),
           reallocations: parents.map((p) => p.data.reallocations ?? 0).reduce((acc, n) => acc + n, 0),
@@ -397,12 +406,13 @@ function beamNestedRows(levels: 1 | 2 | 3 | 4 = 1): GridDataRow<BeamNestedRow>[]
       };
     });
 
+    const name = `Project ${ggpIdx + 1}`;
     return {
-      id: `ggp:${ggpIdx + 1}`,
+      id: camelCase(`row:${name}`),
       kind: "greatgrandparent" as const,
       children: grandParents,
       data: {
-        name: `Project ${ggpIdx + 1}`,
+        name,
         original: grandParents.map((gp) => gp.data.original ?? 0).reduce((acc, n) => acc + n, 0),
         changeOrders: grandParents.map((gp) => gp.data.changeOrders ?? 0).reduce((acc, n) => acc + n, 0),
         reallocations: grandParents.map((gp) => gp.data.reallocations ?? 0).reduce((acc, n) => acc + n, 0),
@@ -495,45 +505,27 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
       greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
       grandparent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
       parent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
-      child: (row) => ({ content: () => numberFormatter(row.original) }),
+      child: (row) => ({ content: () => numberFormatter(row.original), value: row.original }),
       w: "150px",
       expandColumns: [
         numericColumn<BeamNestedRow>({
           expandableHeader: emptyCell,
           totals: emptyCell,
           header: "Version 2",
-          greatgrandparent: (row) => ({
-            content: () => maybeFormatNumber(row.original),
-            value: row.original,
-          }),
-          grandparent: (row) => ({
-            content: () => maybeFormatNumber(row.original),
-            value: row.original,
-          }),
-          parent: (row) => ({
-            content: () => maybeFormatNumber(row.original),
-            value: row.original,
-          }),
-          child: (row) => ({ content: () => numberFormatter(row.original) }),
+          greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
+          grandparent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
+          parent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
+          child: (row) => ({ content: () => numberFormatter(row.original), value: row.original }),
           w: "150px",
         }),
         numericColumn<BeamNestedRow>({
           expandableHeader: emptyCell,
           totals: emptyCell,
           header: "Version 3",
-          greatgrandparent: (row) => ({
-            content: () => maybeFormatNumber(row.original),
-            value: row.original,
-          }),
-          grandparent: (row) => ({
-            content: () => maybeFormatNumber(row.original),
-            value: row.original,
-          }),
-          parent: (row) => ({
-            content: () => maybeFormatNumber(row.original),
-            value: row.original,
-          }),
-          child: (row) => ({ content: () => numberFormatter(row.original) }),
+          greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
+          grandparent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
+          parent: (row) => ({ content: () => maybeFormatNumber(row.original), value: row.original }),
+          child: (row) => ({ content: () => numberFormatter(row.original), value: row.original }),
           w: "150px",
         }),
       ],
@@ -545,39 +537,27 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
       greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.changeOrders), value: row.changeOrders }),
       grandparent: (row) => ({ content: () => maybeFormatNumber(row.changeOrders), value: row.changeOrders }),
       parent: (row) => ({ content: () => maybeFormatNumber(row.changeOrders), value: row.changeOrders }),
-      child: (row) => ({ content: () => numberFormatter(row.changeOrders) }),
+      child: (row) => ({ content: () => numberFormatter(row.changeOrders), value: row.changeOrders }),
       w: "150px",
       expandColumns: [
         numericColumn<BeamNestedRow>({
           expandableHeader: emptyCell,
           totals: emptyCell,
           header: "Version 2",
-          greatgrandparent: (row) => ({
-            content: () => maybeFormatNumber(row.changeOrders),
-            value: row.changeOrders,
-          }),
-          grandparent: (row) => ({
-            content: () => maybeFormatNumber(row.changeOrders),
-            value: row.changeOrders,
-          }),
+          greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.changeOrders), value: row.changeOrders }),
+          grandparent: (row) => ({ content: () => maybeFormatNumber(row.changeOrders), value: row.changeOrders }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.changeOrders), value: row.changeOrders }),
-          child: (row) => ({ content: () => numberFormatter(row.changeOrders) }),
+          child: (row) => ({ content: () => numberFormatter(row.changeOrders), value: row.changeOrders }),
           w: "150px",
         }),
         numericColumn<BeamNestedRow>({
           expandableHeader: emptyCell,
           totals: emptyCell,
           header: "Version 3",
-          greatgrandparent: (row) => ({
-            content: () => maybeFormatNumber(row.changeOrders),
-            value: row.changeOrders,
-          }),
-          grandparent: (row) => ({
-            content: () => maybeFormatNumber(row.changeOrders),
-            value: row.changeOrders,
-          }),
+          greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.changeOrders), value: row.changeOrders }),
+          grandparent: (row) => ({ content: () => maybeFormatNumber(row.changeOrders), value: row.changeOrders }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.changeOrders), value: row.changeOrders }),
-          child: (row) => ({ content: () => numberFormatter(row.changeOrders) }),
+          child: (row) => ({ content: () => numberFormatter(row.changeOrders), value: row.changeOrders }),
           w: "150px",
         }),
       ],
@@ -589,7 +569,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
       greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.reallocations), value: row.reallocations }),
       grandparent: (row) => ({ content: () => maybeFormatNumber(row.reallocations), value: row.reallocations }),
       parent: (row) => ({ content: () => maybeFormatNumber(row.reallocations), value: row.reallocations }),
-      child: (row) => ({ content: () => numberFormatter(row.reallocations) }),
+      child: (row) => ({ content: () => numberFormatter(row.reallocations), value: row.reallocations }),
       w: "150px",
       expandColumns: [
         numericColumn<BeamNestedRow>({
@@ -600,12 +580,9 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
             content: () => maybeFormatNumber(row.reallocations),
             value: row.reallocations,
           }),
-          grandparent: (row) => ({
-            content: () => maybeFormatNumber(row.reallocations),
-            value: row.reallocations,
-          }),
+          grandparent: (row) => ({ content: () => maybeFormatNumber(row.reallocations), value: row.reallocations }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.reallocations), value: row.reallocations }),
-          child: (row) => ({ content: () => numberFormatter(row.reallocations) }),
+          child: (row) => ({ content: () => numberFormatter(row.reallocations), value: row.reallocations }),
           w: "150px",
         }),
         numericColumn<BeamNestedRow>({
@@ -616,12 +593,9 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
             content: () => maybeFormatNumber(row.reallocations),
             value: row.reallocations,
           }),
-          grandparent: (row) => ({
-            content: () => maybeFormatNumber(row.reallocations),
-            value: row.reallocations,
-          }),
+          grandparent: (row) => ({ content: () => maybeFormatNumber(row.reallocations), value: row.reallocations }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.reallocations), value: row.reallocations }),
-          child: (row) => ({ content: () => numberFormatter(row.reallocations) }),
+          child: (row) => ({ content: () => numberFormatter(row.reallocations), value: row.reallocations }),
           w: "150px",
         }),
       ],
@@ -633,7 +607,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
       greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.revised), value: row.revised }),
       grandparent: (row) => ({ content: () => maybeFormatNumber(row.revised), value: row.revised }),
       parent: (row) => ({ content: () => maybeFormatNumber(row.revised), value: row.revised }),
-      child: (row) => ({ content: () => numberFormatter(row.revised) }),
+      child: (row) => ({ content: () => numberFormatter(row.revised), value: row.revised }),
       w: "150px",
       expandColumns: [
         numericColumn<BeamNestedRow>({
@@ -643,7 +617,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
           greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.revised), value: row.revised }),
           grandparent: (row) => ({ content: () => maybeFormatNumber(row.revised), value: row.revised }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.revised), value: row.revised }),
-          child: (row) => ({ content: () => numberFormatter(row.revised) }),
+          child: (row) => ({ content: () => numberFormatter(row.revised), value: row.revised }),
           w: "150px",
         }),
         numericColumn<BeamNestedRow>({
@@ -653,7 +627,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
           greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.revised), value: row.revised }),
           grandparent: (row) => ({ content: () => maybeFormatNumber(row.revised), value: row.revised }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.revised), value: row.revised }),
-          child: (row) => ({ content: () => numberFormatter(row.revised) }),
+          child: (row) => ({ content: () => numberFormatter(row.revised), value: row.revised }),
           w: "150px",
         }),
       ],
@@ -665,7 +639,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
       greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.committed), value: row.committed }),
       grandparent: (row) => ({ content: () => maybeFormatNumber(row.committed), value: row.committed }),
       parent: (row) => ({ content: () => maybeFormatNumber(row.committed), value: row.committed }),
-      child: (row) => ({ content: () => numberFormatter(row.committed) }),
+      child: (row) => ({ content: () => numberFormatter(row.committed), value: row.committed }),
       w: "150px",
       expandColumns: [
         numericColumn<BeamNestedRow>({
@@ -675,7 +649,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
           greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.committed), value: row.committed }),
           grandparent: (row) => ({ content: () => maybeFormatNumber(row.committed), value: row.committed }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.committed), value: row.committed }),
-          child: (row) => ({ content: () => numberFormatter(row.committed) }),
+          child: (row) => ({ content: () => numberFormatter(row.committed), value: row.committed }),
           w: "150px",
         }),
         numericColumn<BeamNestedRow>({
@@ -685,7 +659,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
           greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.committed), value: row.committed }),
           grandparent: (row) => ({ content: () => maybeFormatNumber(row.committed), value: row.committed }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.committed), value: row.committed }),
-          child: (row) => ({ content: () => numberFormatter(row.committed) }),
+          child: (row) => ({ content: () => numberFormatter(row.committed), value: row.committed }),
           w: "150px",
         }),
       ],
@@ -697,7 +671,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
       greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.difference), value: row.difference }),
       grandparent: (row) => ({ content: () => maybeFormatNumber(row.difference), value: row.difference }),
       parent: (row) => ({ content: () => maybeFormatNumber(row.difference), value: row.difference }),
-      child: (row) => ({ content: () => numberFormatter(row.difference) }),
+      child: (row) => ({ content: () => numberFormatter(row.difference), value: row.difference }),
       w: "150px",
       expandColumns: [
         numericColumn<BeamNestedRow>({
@@ -707,7 +681,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
           greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.difference), value: row.difference }),
           grandparent: (row) => ({ content: () => maybeFormatNumber(row.difference), value: row.difference }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.difference), value: row.difference }),
-          child: (row) => ({ content: () => numberFormatter(row.difference) }),
+          child: (row) => ({ content: () => numberFormatter(row.difference), value: row.difference }),
           w: "150px",
         }),
         numericColumn<BeamNestedRow>({
@@ -717,7 +691,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
           greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.difference), value: row.difference }),
           grandparent: (row) => ({ content: () => maybeFormatNumber(row.difference), value: row.difference }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.difference), value: row.difference }),
-          child: (row) => ({ content: () => numberFormatter(row.difference) }),
+          child: (row) => ({ content: () => numberFormatter(row.difference), value: row.difference }),
           w: "150px",
         }),
       ],
@@ -729,7 +703,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
       greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.actuals), value: row.actuals }),
       grandparent: (row) => ({ content: () => maybeFormatNumber(row.actuals), value: row.actuals }),
       parent: (row) => ({ content: () => maybeFormatNumber(row.actuals), value: row.actuals }),
-      child: (row) => ({ content: () => numberFormatter(row.actuals) }),
+      child: (row) => ({ content: () => numberFormatter(row.actuals), value: row.actuals }),
       w: "150px",
       expandColumns: [
         numericColumn<BeamNestedRow>({
@@ -739,7 +713,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
           greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.actuals), value: row.actuals }),
           grandparent: (row) => ({ content: () => maybeFormatNumber(row.actuals), value: row.actuals }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.actuals), value: row.actuals }),
-          child: (row) => ({ content: () => numberFormatter(row.actuals) }),
+          child: (row) => ({ content: () => numberFormatter(row.actuals), value: row.actuals }),
           w: "150px",
         }),
         numericColumn<BeamNestedRow>({
@@ -749,7 +723,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
           greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.actuals), value: row.actuals }),
           grandparent: (row) => ({ content: () => maybeFormatNumber(row.actuals), value: row.actuals }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.actuals), value: row.actuals }),
-          child: (row) => ({ content: () => numberFormatter(row.actuals) }),
+          child: (row) => ({ content: () => numberFormatter(row.actuals), value: row.actuals }),
           w: "150px",
         }),
       ],
@@ -761,7 +735,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
       greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.projected), value: row.projected }),
       grandparent: (row) => ({ content: () => maybeFormatNumber(row.projected), value: row.projected }),
       parent: (row) => ({ content: () => maybeFormatNumber(row.projected), value: row.projected }),
-      child: (row) => ({ content: () => numberFormatter(row.projected) }),
+      child: (row) => ({ content: () => numberFormatter(row.projected), value: row.projected }),
       w: "150px",
       expandColumns: [
         numericColumn<BeamNestedRow>({
@@ -771,7 +745,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
           greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.projected), value: row.projected }),
           grandparent: (row) => ({ content: () => maybeFormatNumber(row.projected), value: row.projected }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.projected), value: row.projected }),
-          child: (row) => ({ content: () => numberFormatter(row.projected) }),
+          child: (row) => ({ content: () => numberFormatter(row.projected), value: row.projected }),
           w: "150px",
         }),
         numericColumn<BeamNestedRow>({
@@ -781,7 +755,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
           greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.projected), value: row.projected }),
           grandparent: (row) => ({ content: () => maybeFormatNumber(row.projected), value: row.projected }),
           parent: (row) => ({ content: () => maybeFormatNumber(row.projected), value: row.projected }),
-          child: (row) => ({ content: () => numberFormatter(row.projected) }),
+          child: (row) => ({ content: () => numberFormatter(row.projected), value: row.projected }),
           w: "150px",
         }),
       ],
@@ -793,7 +767,7 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
       greatgrandparent: (row) => ({ content: () => maybeFormatNumber(row.costToComplete), value: row.costToComplete }),
       grandparent: (row) => ({ content: () => maybeFormatNumber(row.costToComplete), value: row.costToComplete }),
       parent: (row) => ({ content: () => maybeFormatNumber(row.costToComplete), value: row.costToComplete }),
-      child: (row) => ({ content: () => numberFormatter(row.costToComplete) }),
+      child: (row) => ({ content: () => numberFormatter(row.costToComplete), value: row.costToComplete }),
       w: "150px",
       expandColumns: [
         numericColumn<BeamNestedRow>({
@@ -804,15 +778,9 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
             content: () => maybeFormatNumber(row.costToComplete),
             value: row.costToComplete,
           }),
-          grandparent: (row) => ({
-            content: () => maybeFormatNumber(row.costToComplete),
-            value: row.costToComplete,
-          }),
-          parent: (row) => ({
-            content: () => maybeFormatNumber(row.costToComplete),
-            value: row.costToComplete,
-          }),
-          child: (row) => ({ content: () => numberFormatter(row.costToComplete) }),
+          grandparent: (row) => ({ content: () => maybeFormatNumber(row.costToComplete), value: row.costToComplete }),
+          parent: (row) => ({ content: () => maybeFormatNumber(row.costToComplete), value: row.costToComplete }),
+          child: (row) => ({ content: () => numberFormatter(row.costToComplete), value: row.costToComplete }),
           w: "150px",
         }),
         numericColumn<BeamNestedRow>({
@@ -823,15 +791,9 @@ function beamNestedColumns(expandable: boolean = false): GridColumn<BeamNestedRo
             content: () => maybeFormatNumber(row.costToComplete),
             value: row.costToComplete,
           }),
-          grandparent: (row) => ({
-            content: () => maybeFormatNumber(row.costToComplete),
-            value: row.costToComplete,
-          }),
-          parent: (row) => ({
-            content: () => maybeFormatNumber(row.costToComplete),
-            value: row.costToComplete,
-          }),
-          child: (row) => ({ content: () => numberFormatter(row.costToComplete) }),
+          grandparent: (row) => ({ content: () => maybeFormatNumber(row.costToComplete), value: row.costToComplete }),
+          parent: (row) => ({ content: () => maybeFormatNumber(row.costToComplete), value: row.costToComplete }),
+          child: (row) => ({ content: () => numberFormatter(row.costToComplete), value: row.costToComplete }),
           w: "150px",
         }),
       ],

--- a/src/components/Table/TableStyles.tsx
+++ b/src/components/Table/TableStyles.tsx
@@ -50,6 +50,10 @@ export interface GridStyle {
   levels?: Record<number, { cellCss?: Properties; firstContentColumn?: Properties }>;
   /** Allows for customization of the background color used to denote an "active" row */
   activeBgColor?: Palette;
+  /** Defines styles for the group row which displays any "hidden selected" rows */
+  unmatchedSelectedGroupRowCss?: Properties;
+  /** Defines styles for the last row in the "hidden selected" group to provide separation from the rest of the table */
+  unmatchedSelectedLastRowCss?: Properties;
 }
 
 // If adding a new `GridStyleDef`, ensure if it added to the `defKeys` in the `resolveStyles` function below
@@ -151,6 +155,8 @@ function memoizedTableStyles() {
         presentationSettings: { borderless: true, typeScale: "xs", wrap: rowHeight === "flexible" },
         levels: grouped ? groupedLevels : defaultLevels,
         rowHoverColor: Palette.LightBlue100,
+        unmatchedSelectedGroupRowCss: Css.bgYellow100.gray900.xsMd.$,
+        unmatchedSelectedLastRowCss: Css.boxShadow("inset 0px -14px 8px -11px rgba(63,63,63,.18)").$,
       };
     }
 

--- a/src/components/Table/components/CollapseToggle.tsx
+++ b/src/components/Table/components/CollapseToggle.tsx
@@ -1,5 +1,12 @@
 import { useContext } from "react";
-import { GridDataRow, IconButton, IconButtonProps, TableStateContext } from "src/components/index";
+import {
+  GridDataRow,
+  HEADER,
+  IconButton,
+  IconButtonProps,
+  SELECTED_GROUP,
+  TableStateContext,
+} from "src/components/index";
 import { useComputed } from "src/hooks";
 
 export interface GridTableCollapseToggleProps extends Pick<IconButtonProps, "compact"> {
@@ -15,9 +22,11 @@ export function CollapseToggle(props: GridTableCollapseToggleProps) {
   const iconKey = isCollapsed ? "chevronRight" : "chevronDown";
   const headerIconKey = isCollapsed ? "chevronsRight" : "chevronsDown";
 
-  // If we're not a header, only render a toggle if we have child rows to actually collapse
-  const isHeader = row.kind === "header";
-  if (!isHeader && (!row.children || row.children.length === 0)) {
+  // If we're not a header and not the selected group row, only render a toggle if we have child rows to actually collapse
+  const isHeader = row.kind === HEADER;
+  const isSelectedGroup = row.kind === SELECTED_GROUP;
+  const hasChildren = row.children ? row.children.length > 0 : false;
+  if (!isHeader && !isSelectedGroup && !hasChildren) {
     return null;
   }
 

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -1,5 +1,6 @@
 import { observer } from "mobx-react";
 import React, { ReactElement, useContext } from "react";
+import { CollapseToggle, Icon } from "src/components";
 import {
   defaultRenderFn,
   headerRenderFn,
@@ -22,6 +23,7 @@ import {
   isGridCellContent,
   maybeApplyFunction,
   reservedRowKinds,
+  SELECTED_GROUP,
   toContent,
   TOTALS,
   zIndices,
@@ -29,7 +31,7 @@ import {
 import { Css, Palette } from "src/Css";
 import { useComputed } from "src/hooks";
 import { AnyObject } from "src/types";
-import { isFunction } from "src/utils";
+import { isFunction, pluralize } from "src/utils";
 import { shallowEqual } from "src/utils/shallowEqual";
 
 interface RowProps<R extends Kinded> {
@@ -46,6 +48,8 @@ interface RowProps<R extends Kinded> {
   cellHighlight: boolean;
   omitRowHover: boolean;
   hasExpandableHeader: boolean;
+  isUnmatchedSelectedRow: boolean;
+  isLastUnmatchedSelectionRow: boolean;
 }
 
 // We extract Row to its own mini-component primarily so we can React.memo'ize it.
@@ -64,6 +68,8 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
     cellHighlight,
     omitRowHover,
     hasExpandableHeader,
+    isUnmatchedSelectedRow,
+    isLastUnmatchedSelectionRow,
     ...others
   } = props;
 
@@ -75,8 +81,12 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
   const isHeader = row.kind === HEADER;
   const isTotals = row.kind === TOTALS;
   const isExpandableHeader = row.kind === EXPANDABLE_HEADER;
+  const isSelectedGroupRow = row.kind === SELECTED_GROUP;
   const rowStyle = rowStyles?.[row.kind];
   const RowTag = as === "table" ? "tr" : "div";
+  const CellTag = as === "table" ? "td" : "div";
+
+  const numHiddenSelectedRows: number = isSelectedGroupRow ? tableState.unmatchedSelectedRows.length : 0;
 
   const revealOnRowHoverClass = "revealOnRowHover";
 
@@ -98,209 +108,236 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
       [` > .${revealOnRowHoverClass} > *`]: Css.invisible.$,
       [`:hover > .${revealOnRowHoverClass} > *`]: Css.visible.$,
     },
+    ...(isLastUnmatchedSelectionRow && Css.addIn("&>*", style.unmatchedSelectedLastRowCss).$),
   };
 
   let currentColspan = 1;
   // Keep a running count of how many expanded columns are being shown.
   let currentExpandedColumnCount: number = 0;
-  let firstContentColumnStylesApplied = false;
+  let foundFirstContentColumn = false;
   let minStickyLeftOffset = 0;
   let expandColumnHidden = false;
 
   return (
     <RowTag css={rowCss} {...others} data-gridrow {...getCount(row.id)}>
-      {columns.map((column, columnIndex) => {
-        // If the expandable column was hidden, then we need to look at the previous column to format the `expandHeader` and 'header' kinds correctly.
-        const maybeExpandedColumn = expandColumnHidden ? columns[columnIndex - 1] : column;
+      {isSelectedGroupRow ? (
+        <CellTag
+          css={{
+            ...style.cellCss,
+            ...style.unmatchedSelectedGroupRowCss,
+            ...Css.pl0.w(`calc(${columnSizes.join(" + ")})`).$,
+          }}
+          {...(as === "table" ? { colSpan: columns.length } : {})}
+        >
+          <div css={Css.df.aic.gapPx(12).$}>
+            {/* Mimic the collapse column styles to make sure it lines up as expected */}
+            <div css={Css.wPx(38).df.jcc.$}>
+              <CollapseToggle row={row} compact />
+            </div>
 
-        // Figure out if this column should be considered 'expanded' or not. If the column is hidden on expand, then we need to look at the previous column to see if it's expanded.
-        const isExpanded = tableState.expandedColumnIds.includes(maybeExpandedColumn.id);
-        // If the column is hidden on expand, we don't want to render it. We'll flag that it was hidden, so on the next column we can render this column's "expandHeader" property.
-        if (column.hideOnExpand && isExpanded) {
-          expandColumnHidden = true;
-          return <></>;
-        }
+            <div css={Css.df.aic.gap1.$}>
+              <Icon icon="infoCircle" inc={2} />
+              {`${numHiddenSelectedRows} selected ${pluralize(numHiddenSelectedRows, "row")} hidden due to filters`}
+            </div>
+          </div>
+        </CellTag>
+      ) : (
+        columns.map((column, columnIndex) => {
+          // If the expandable column was hidden, then we need to look at the previous column to format the `expandHeader` and 'header' kinds correctly.
+          const maybeExpandedColumn = expandColumnHidden ? columns[columnIndex - 1] : column;
 
-        // Need to keep track of the expanded columns so we can add borders as expected for the header rows
-        const numExpandedColumns = isExpanded
-          ? tableState.getExpandedColumns(maybeExpandedColumn)?.length
-            ? // Subtract 1 if the column is hidden on expand, since we're not rendering it.
-              tableState.getExpandedColumns(maybeExpandedColumn).length - (maybeExpandedColumn.hideOnExpand ? 1 : 0)
-            : 0
-          : 0;
-
-        // If we're rendering the Expandable Header row, then we might need to render the previous column's `expandHeader` property in the case where the column is hidden on expand.
-        column = isExpandableHeader ? maybeExpandedColumn : column;
-
-        const { wrapAction = true, isAction = false } = column;
-
-        const applyFirstContentColumnStyles = !isHeader && !isAction && !firstContentColumnStylesApplied;
-        firstContentColumnStylesApplied ||= applyFirstContentColumnStyles;
-
-        if (column.mw) {
-          // Validate the column's minWidth definition if set.
-          if (!column.mw.endsWith("px") && !column.mw.endsWith("%")) {
-            throw new Error("Beam Table column min-width definition only supports px or percentage values");
+          // Figure out if this column should be considered 'expanded' or not. If the column is hidden on expand, then we need to look at the previous column to see if it's expanded.
+          const isExpanded = tableState.expandedColumnIds.includes(maybeExpandedColumn.id);
+          // If the column is hidden on expand, we don't want to render it. We'll flag that it was hidden, so on the next column we can render this column's "expandHeader" property.
+          if (column.hideOnExpand && isExpanded) {
+            expandColumnHidden = true;
+            return <></>;
           }
-        }
 
-        // When using the variation of the table with an EXPANDABLE_HEADER, then our HEADER and TOTAL rows have special border styling
-        // Keep track of the when we get to the last expanded column so we can apply this styling properly.
-        if (hasExpandableHeader && (isHeader || isTotals)) {
-          // When the value of `currentExpandedColumnCount` is 0, then we have started over.
-          // If the current column `isExpanded`, then store the number of expandable columns.
-          if (currentExpandedColumnCount === 0 && isExpanded) {
-            currentExpandedColumnCount = numExpandedColumns;
-          } else if (currentExpandedColumnCount > 0) {
-            // If value is great than 0, then decrement. Once the value equals 0, then the special styling will be applied below.
-            currentExpandedColumnCount -= 1;
+          // Need to keep track of the expanded columns so we can add borders as expected for the header rows
+          const numExpandedColumns = isExpanded
+            ? tableState.getExpandedColumns(maybeExpandedColumn)?.length
+              ? // Subtract 1 if the column is hidden on expand, since we're not rendering it.
+                tableState.getExpandedColumns(maybeExpandedColumn).length - (maybeExpandedColumn.hideOnExpand ? 1 : 0)
+              : 0
+            : 0;
+
+          // If we're rendering the Expandable Header row, then we might need to render the previous column's `expandHeader` property in the case where the column is hidden on expand.
+          column = isExpandableHeader ? maybeExpandedColumn : column;
+
+          const { wrapAction = true, isAction = false } = column;
+
+          const isFirstContentColumn = !isAction && !foundFirstContentColumn;
+          const applyFirstContentColumnStyles = !isHeader && isFirstContentColumn;
+          foundFirstContentColumn ||= applyFirstContentColumnStyles;
+
+          if (column.mw) {
+            // Validate the column's minWidth definition if set.
+            if (!column.mw.endsWith("px") && !column.mw.endsWith("%")) {
+              throw new Error("Beam Table column min-width definition only supports px or percentage values");
+            }
           }
-        }
 
-        // Reset the expandColumnHidden flag once done with logic based upon it.
-        expandColumnHidden = false;
+          // When using the variation of the table with an EXPANDABLE_HEADER, then our HEADER and TOTAL rows have special border styling
+          // Keep track of the when we get to the last expanded column so we can apply this styling properly.
+          if (hasExpandableHeader && (isHeader || isTotals)) {
+            // When the value of `currentExpandedColumnCount` is 0, then we have started over.
+            // If the current column `isExpanded`, then store the number of expandable columns.
+            if (currentExpandedColumnCount === 0 && isExpanded) {
+              currentExpandedColumnCount = numExpandedColumns;
+            } else if (currentExpandedColumnCount > 0) {
+              // If value is great than 0, then decrement. Once the value equals 0, then the special styling will be applied below.
+              currentExpandedColumnCount -= 1;
+            }
+          }
 
-        // Decrement colspan count and skip if greater than 1.
-        if (currentColspan > 1) {
-          currentColspan -= 1;
-          return null;
-        }
-        const maybeContent = applyRowFn(column, row, api, level, isExpanded);
+          // Reset the expandColumnHidden flag once done with logic based upon it.
+          expandColumnHidden = false;
 
-        // Only use the `numExpandedColumns` as the `colspan` when rendering the "Expandable Header"
-        currentColspan =
-          isGridCellContent(maybeContent) && typeof maybeContent.colspan === "number"
-            ? maybeContent.colspan
-            : isExpandableHeader
-            ? numExpandedColumns + 1
-            : 1;
-        const revealOnRowHover = isGridCellContent(maybeContent) ? maybeContent.revealOnRowHover : false;
+          // Decrement colspan count and skip if greater than 1.
+          if (currentColspan > 1) {
+            currentColspan -= 1;
+            return null;
+          }
+          const maybeContent = applyRowFn(column, row, api, level, isExpanded);
 
-        const canSortColumn =
-          (sortOn === "client" && column.clientSideSort !== false) ||
-          (sortOn === "server" && !!column.serverSideSortKey);
-        const alignment = getAlignment(column, maybeContent);
-        const justificationCss = getJustification(column, maybeContent, as, alignment);
-        const isExpandable =
-          isFunction(column.expandColumns) ||
-          (column.expandColumns && column.expandColumns.length > 0) ||
-          column.expandedWidth !== undefined;
-        const content = toContent(
-          maybeContent,
-          isHeader,
-          canSortColumn,
-          sortOn === "client",
-          style,
-          as,
-          alignment,
-          column,
-          isExpandableHeader,
-          isExpandable,
-          minStickyLeftOffset,
-        );
+          // Only use the `numExpandedColumns` as the `colspan` when rendering the "Expandable Header"
+          currentColspan =
+            isGridCellContent(maybeContent) && typeof maybeContent.colspan === "number"
+              ? maybeContent.colspan
+              : isExpandableHeader
+              ? numExpandedColumns + 1
+              : 1;
+          const revealOnRowHover = isGridCellContent(maybeContent) ? maybeContent.revealOnRowHover : false;
 
-        ensureClientSideSortValueIsSortable(
-          sortOn,
-          isHeader || isTotals || isExpandableHeader,
-          column,
-          columnIndex,
-          maybeContent,
-        );
+          const canSortColumn =
+            (sortOn === "client" && column.clientSideSort !== false) ||
+            (sortOn === "server" && !!column.serverSideSortKey);
+          const alignment = getAlignment(column, maybeContent);
+          const justificationCss = getJustification(column, maybeContent, as, alignment);
+          const isExpandable =
+            isFunction(column.expandColumns) ||
+            (column.expandColumns && column.expandColumns.length > 0) ||
+            column.expandedWidth !== undefined;
 
-        const maybeSticky = ((isGridCellContent(maybeContent) && maybeContent.sticky) || column.sticky) ?? undefined;
-        const maybeStickyColumnStyles =
-          maybeSticky && columnSizes
-            ? {
-                ...Css.sticky.z(zIndices.stickyColumns).bgWhite.$,
-                ...(maybeSticky === "left"
-                  ? Css.left(columnIndex === 0 ? 0 : `calc(${columnSizes.slice(0, columnIndex).join(" + ")})`).$
-                  : {}),
-                ...(maybeSticky === "right"
-                  ? Css.right(
-                      columnIndex + 1 === columnSizes.length
-                        ? 0
-                        : `calc(${columnSizes.slice(columnIndex + 1 - columnSizes.length).join(" + ")})`,
-                    ).$
-                  : {}),
-              }
-            : {};
+          const content = toContent(
+            maybeContent,
+            isHeader,
+            canSortColumn,
+            sortOn === "client",
+            style,
+            as,
+            alignment,
+            column,
+            isExpandableHeader,
+            isExpandable,
+            minStickyLeftOffset,
+            isUnmatchedSelectedRow,
+          );
 
-        // This relies on our column sizes being defined in pixel values, which is currently true as we calculate to pixel values in the `useSetupColumnSizes` hook
-        minStickyLeftOffset += maybeSticky === "left" ? parseInt(columnSizes[columnIndex].replace("px", ""), 10) : 0;
+          ensureClientSideSortValueIsSortable(
+            sortOn,
+            isHeader || isTotals || isExpandableHeader,
+            column,
+            columnIndex,
+            maybeContent,
+          );
 
-        const cellId = `${row.kind}_${row.id}_${column.id}`;
-        const applyCellHighlight = cellHighlight && !!column.id && !isHeader && !isTotals;
-        const isCellActive = tableState.activeCellId === cellId;
+          const maybeSticky = ((isGridCellContent(maybeContent) && maybeContent.sticky) || column.sticky) ?? undefined;
+          const maybeStickyColumnStyles =
+            maybeSticky && columnSizes
+              ? {
+                  ...Css.sticky.z(zIndices.stickyColumns).bgWhite.$,
+                  ...(maybeSticky === "left"
+                    ? Css.left(columnIndex === 0 ? 0 : `calc(${columnSizes.slice(0, columnIndex).join(" + ")})`).$
+                    : {}),
+                  ...(maybeSticky === "right"
+                    ? Css.right(
+                        columnIndex + 1 === columnSizes.length
+                          ? 0
+                          : `calc(${columnSizes.slice(columnIndex + 1 - columnSizes.length).join(" + ")})`,
+                      ).$
+                    : {}),
+                }
+              : {};
 
-        // Note that it seems expensive to calc a per-cell class name/CSS-in-JS output,
-        // vs. setting global/table-wide CSS like `style.cellCss` on the root grid div with
-        // a few descendent selectors. However, that approach means the root grid-applied
-        // CSS has a high-specificity and so its harder for per-page/per-cell business logic
-        // to override it. So, we just calc the combined table-wide+per-cell-overridden CSS here,
-        // in a very CSS-in-JS idiomatic manner.
-        //
-        // In practice we've not seen any performance issues with this from our "large but
-        // not Google spreadsheets" tables.
-        const cellCss = {
-          // Adding `display: flex` so we can align content within the cells, unless it is displayed as a `table`, then use `table-cell`.
-          ...Css.df.if(as === "table").dtc.$,
-          // Apply sticky column/cell styles
-          ...maybeStickyColumnStyles,
-          // Apply any static/all-cell styling
-          ...style.cellCss,
-          // Then override with first/last cell styling
-          ...getFirstOrLastCellCss(style, columnIndex, columns),
-          // Then override with per-cell/per-row justification
-          ...justificationCss,
-          // Then apply any header-specific override
-          ...(isHeader && style.headerCellCss),
-          // Then apply any totals-specific override
-          ...(isTotals && style.totalsCellCss),
-          ...(isTotals && hasExpandableHeader && Css.boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$),
-          // Then apply any expandable header specific override
-          ...(isExpandableHeader && style.expandableHeaderCss),
-          // Conditionally apply the right border styling for the header or totals row when using expandable tables
-          // Only apply if not the last column in the table AND when this column is the last column in the group of expandable column or not expanded AND
-          ...(hasExpandableHeader &&
-            columns.length - 1 !== columnIndex &&
-            (isHeader || isTotals) &&
-            currentExpandedColumnCount === 0 &&
-            Css.boxShadow(`inset -1px -1px 0 ${Palette.Gray200}`).$),
-          // Or level-specific styling
-          ...(!isHeader && !isTotals && !isExpandableHeader && !!style.levels && style.levels[level]?.cellCss),
-          // Level specific styling for the first content column
-          ...(applyFirstContentColumnStyles && !!style.levels && style.levels[level]?.firstContentColumn),
-          // The specific cell's css (if any from GridCellContent)
-          ...rowStyleCellCss,
-          // Apply active row styling for non-nested card styles.
-          ...(isActive ? Css.bgColor(style.activeBgColor ?? Palette.LightBlue50).$ : {}),
-          // Add any cell specific style overrides
-          ...(isGridCellContent(maybeContent) && maybeContent.typeScale ? Css[maybeContent.typeScale].$ : {}),
-          // And any cell specific css
-          ...(isGridCellContent(maybeContent) && maybeContent.css ? maybeContent.css : {}),
-          // Apply cell highlight styles to active cell and hover
-          ...Css.if(applyCellHighlight && isCellActive).br4.boxShadow(`inset 0 0 0 1px ${Palette.LightBlue700}`).$,
-          // Define the width of the column on each cell. Supports col spans.
-          width: `calc(${columnSizes.slice(columnIndex, columnIndex + currentColspan).join(" + ")})`,
-          ...(typeof column.mw === "string" ? Css.mw(column.mw).$ : {}),
-        };
+          // This relies on our column sizes being defined in pixel values, which is currently true as we calculate to pixel values in the `useSetupColumnSizes` hook
+          minStickyLeftOffset += maybeSticky === "left" ? parseInt(columnSizes[columnIndex].replace("px", ""), 10) : 0;
 
-        const cellClassNames = revealOnRowHover ? revealOnRowHoverClass : undefined;
+          const cellId = `${row.kind}_${row.id}_${column.id}`;
+          const applyCellHighlight = cellHighlight && !!column.id && !isHeader && !isTotals;
+          const isCellActive = tableState.activeCellId === cellId;
 
-        const cellOnClick = applyCellHighlight ? () => api.setActiveCellId(cellId) : undefined;
-        const tooltip = isGridCellContent(maybeContent) ? maybeContent.tooltip : undefined;
+          // Note that it seems expensive to calc a per-cell class name/CSS-in-JS output,
+          // vs. setting global/table-wide CSS like `style.cellCss` on the root grid div with
+          // a few descendent selectors. However, that approach means the root grid-applied
+          // CSS has a high-specificity and so its harder for per-page/per-cell business logic
+          // to override it. So, we just calc the combined table-wide+per-cell-overridden CSS here,
+          // in a very CSS-in-JS idiomatic manner.
+          //
+          // In practice we've not seen any performance issues with this from our "large but
+          // not Google spreadsheets" tables.
+          const cellCss = {
+            // Adding `display: flex` so we can align content within the cells, unless it is displayed as a `table`, then use `table-cell`.
+            ...Css.df.if(as === "table").dtc.$,
+            // Apply sticky column/cell styles
+            ...maybeStickyColumnStyles,
+            // Apply any static/all-cell styling
+            ...style.cellCss,
+            // Then override with first/last cell styling
+            ...getFirstOrLastCellCss(style, columnIndex, columns),
+            // Then override with per-cell/per-row justification
+            ...justificationCss,
+            // Then apply any header-specific override
+            ...(isHeader && style.headerCellCss),
+            // Then apply any totals-specific override
+            ...(isTotals && style.totalsCellCss),
+            ...(isTotals && hasExpandableHeader && Css.boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$),
+            // Then apply any expandable header specific override
+            ...(isExpandableHeader && style.expandableHeaderCss),
+            // Conditionally apply the right border styling for the header or totals row when using expandable tables
+            // Only apply if not the last column in the table AND when this column is the last column in the group of expandable column or not expanded AND
+            ...(hasExpandableHeader &&
+              columns.length - 1 !== columnIndex &&
+              (isHeader || isTotals) &&
+              currentExpandedColumnCount === 0 &&
+              Css.boxShadow(`inset -1px -1px 0 ${Palette.Gray200}`).$),
+            // Or level-specific styling
+            ...(!isHeader && !isTotals && !isExpandableHeader && !!style.levels && style.levels[level]?.cellCss),
+            // Level specific styling for the first content column
+            ...(applyFirstContentColumnStyles && !!style.levels && style.levels[level]?.firstContentColumn),
+            // The specific cell's css (if any from GridCellContent)
+            ...rowStyleCellCss,
+            // Apply active row styling for non-nested card styles.
+            ...(isActive ? Css.bgColor(style.activeBgColor ?? Palette.LightBlue50).$ : {}),
+            // Add any cell specific style overrides
+            ...(isGridCellContent(maybeContent) && maybeContent.typeScale ? Css[maybeContent.typeScale].$ : {}),
+            // And any cell specific css
+            ...(isGridCellContent(maybeContent) && maybeContent.css ? maybeContent.css : {}),
+            // Apply cell highlight styles to active cell and hover
+            ...Css.if(applyCellHighlight && isCellActive).br4.boxShadow(`inset 0 0 0 1px ${Palette.LightBlue700}`).$,
+            // Define the width of the column on each cell. Supports col spans.
+            width: `calc(${columnSizes.slice(columnIndex, columnIndex + currentColspan).join(" + ")})`,
+            ...(typeof column.mw === "string" ? Css.mw(column.mw).$ : {}),
+          };
 
-        const renderFn: RenderCellFn<any> =
-          (rowStyle?.renderCell || rowStyle?.rowLink) && wrapAction
-            ? rowLinkRenderFn(as)
-            : isHeader || isTotals || isExpandableHeader
-            ? headerRenderFn(column, as, currentColspan)
-            : rowStyle?.onClick && wrapAction
-            ? rowClickRenderFn(as, api)
-            : defaultRenderFn(as);
+          const cellClassNames = revealOnRowHover ? revealOnRowHoverClass : undefined;
 
-        return renderFn(columnIndex, cellCss, content, row, rowStyle, cellClassNames, cellOnClick, tooltip);
-      })}
+          const cellOnClick = applyCellHighlight ? () => api.setActiveCellId(cellId) : undefined;
+          const tooltip = isGridCellContent(maybeContent) ? maybeContent.tooltip : undefined;
+
+          const renderFn: RenderCellFn<any> =
+            (rowStyle?.renderCell || rowStyle?.rowLink) && wrapAction
+              ? rowLinkRenderFn(as, currentColspan)
+              : isHeader || isTotals || isExpandableHeader
+              ? headerRenderFn(column, as, currentColspan)
+              : rowStyle?.onClick && wrapAction
+              ? rowClickRenderFn(as, api, currentColspan)
+              : defaultRenderFn(as, currentColspan);
+
+          return renderFn(columnIndex, cellCss, content, row, rowStyle, cellClassNames, cellOnClick, tooltip);
+        })
+      )}
     </RowTag>
   );
 }

--- a/src/components/Table/components/cell.tsx
+++ b/src/components/Table/components/cell.tsx
@@ -45,11 +45,17 @@ export type RenderCellFn<R extends Kinded> = (
 ) => ReactNode;
 
 /** Renders our default cell element, i.e. if no row links and no custom renderCell are used. */
-export const defaultRenderFn: (as: RenderAs) => RenderCellFn<any> =
-  (as: RenderAs) => (key, css, content, row, rowStyle, classNames: string | undefined, onClick, tooltip) => {
+export const defaultRenderFn: (as: RenderAs, colSpan: number) => RenderCellFn<any> =
+  (as: RenderAs, colSpan) => (key, css, content, row, rowStyle, classNames: string | undefined, onClick, tooltip) => {
     const Cell = as === "table" ? "td" : "div";
     return (
-      <Cell key={key} css={{ ...css, ...Css.cursor("default").$ }} className={classNames} onClick={onClick}>
+      <Cell
+        key={key}
+        css={{ ...css, ...Css.cursor("default").$ }}
+        className={classNames}
+        onClick={onClick}
+        {...(as === "table" && { colSpan })}
+      >
         {content}
       </Cell>
     );
@@ -70,12 +76,12 @@ export const headerRenderFn: (column: GridColumnWithId<any>, as: RenderAs, colSp
   };
 
 /** Renders a cell element when a row link is in play. */
-export const rowLinkRenderFn: (as: RenderAs) => RenderCellFn<any> =
-  (as: RenderAs) => (key, css, content, row, rowStyle, classNames: string | undefined, onClick, tooltip) => {
+export const rowLinkRenderFn: (as: RenderAs, colSpan: number) => RenderCellFn<any> =
+  (as: RenderAs, colSpan) => (key, css, content, row, rowStyle, classNames: string | undefined, onClick, tooltip) => {
     const to = rowStyle!.rowLink!(row);
     if (as === "table") {
       return (
-        <td key={key} css={{ ...css }} className={classNames}>
+        <td key={key} css={{ ...css }} className={classNames} colSpan={colSpan}>
           <Link to={to} css={Css.noUnderline.color("unset").db.$} className={navLink}>
             {content}
           </Link>
@@ -95,8 +101,8 @@ export const rowLinkRenderFn: (as: RenderAs) => RenderCellFn<any> =
   };
 
 /** Renders a cell that will fire the RowStyle.onClick. */
-export const rowClickRenderFn: (as: RenderAs, api: GridTableApi<any>) => RenderCellFn<any> =
-  (as: RenderAs, api: GridTableApi<any>) =>
+export const rowClickRenderFn: (as: RenderAs, api: GridTableApi<any>, colSpan: number) => RenderCellFn<any> =
+  (as: RenderAs, api: GridTableApi<any>, colSpan) =>
   (key, css, content, row, rowStyle, classNames: string | undefined, onClick, tooltip) => {
     const Cell = as === "table" ? "td" : "div";
     return (
@@ -108,6 +114,7 @@ export const rowClickRenderFn: (as: RenderAs, api: GridTableApi<any>) => RenderC
           rowStyle!.onClick!(row, api);
           onClick && onClick();
         }}
+        {...(as === "table" && { colSpan })}
       >
         {content}
       </Cell>

--- a/src/components/Table/utils/TableState.ts
+++ b/src/components/Table/utils/TableState.ts
@@ -4,7 +4,7 @@ import React from "react";
 import { GridDataRow } from "src/components/Table/components/Row";
 import { GridSortConfig } from "src/components/Table/GridTable";
 import { Direction, GridColumnWithId } from "src/components/Table/types";
-import { ASC, DESC } from "src/components/Table/utils/utils";
+import { ASC, DESC, HEADER, reservedRowKinds, SELECTED_GROUP } from "src/components/Table/utils/utils";
 import { visit } from "src/components/Table/utils/visitor";
 import { isFunction } from "src/utils";
 import { assignDefaultColumnIds } from "./columns";
@@ -29,11 +29,16 @@ export type SelectedState = "checked" | "unchecked" | "partial";
  */
 export class TableState {
   // A set of just row ids, i.e. not row.kind+row.id
-  private readonly collapsedRows = new ObservableSet<string>();
+  private readonly collapsedRows = new ObservableSet<string>([]);
   private persistCollapse: string | undefined;
-  private readonly selectedRows = new ObservableMap<string, SelectedState>();
+  private readonly rowSelectedState = new ObservableMap<string, SelectedState>();
+  // Keep a copy of all the selected GridDataRows - Do not include custom row kinds such as `header`, `totals`, etc.
+  // This allows us to keep track of rows that were selected, but may no longer be defined in `GridTable.rows`
+  public selectedDataRows = new ObservableMap<string, GridDataRow<any>>();
   // Set of just row ids. Keeps track of which rows match the filter. Used to filter rows from `selectedIds`
   private matchedRows = new ObservableSet<string>();
+  // All fully selected data rows that do not match the applied filter, if any. Will not include group/parent rows unless they `inferSelectedState: false`
+  public unmatchedSelectedRows: GridDataRow<any>[] = [];
   // The current list of rows, basically a useRef.current. Not reactive.
   public rows: GridDataRow<any>[] = [];
   // Keeps track of the 'active' row, formatted `${row.kind}_${row.id}`
@@ -75,14 +80,34 @@ export class TableState {
       // Do not observe columns, expect this to be a non-reactive value for us to base our reactive values off of.
       columns: false,
     });
+
     // Whenever our `matchedRows` change (i.e. via filtering) then we need to re-derive header and parent rows' selected state.
     reaction(
       () => [...this.matchedRows.values()].sort(),
       () => {
+        const newlyUnmatchedRows = [...this.selectedDataRows.values()].filter((row) =>
+          unmatchedSelectionsFilter(row, this.matchedRows),
+        );
+
+        // If the unmatched rows went from empty to not empty, then introduce the SELECTED_GROUP row as collapsed
+        if (newlyUnmatchedRows.length > 0 && this.unmatchedSelectedRows.length === 0) {
+          this.collapsedRows.add(SELECTED_GROUP);
+        }
+        // When filters are applied, we need to determine if there are any selected rows that are no longer matched.
+        if (!comparer.shallow(newlyUnmatchedRows, this.unmatchedSelectedRows)) {
+          this.unmatchedSelectedRows = newlyUnmatchedRows;
+        }
+
+        // Re-derive the selected state for both the header and parent rows
         const map = new Map<string, SelectedState>();
-        map.set("header", deriveParentSelected(this.rows.flatMap((row) => this.setNestedSelectedStates(row, map))));
+        map.set(
+          "header",
+          deriveParentSelected(
+            [...this.rows, ...this.unmatchedSelectedRows].flatMap((row) => this.setNestedSelectedStates(row, map)),
+          ),
+        );
         // Merge the changes back into the selected rows state
-        this.selectedRows.merge(map);
+        this.rowSelectedState.merge(map);
       },
       { equals: comparer.shallow },
     );
@@ -105,15 +130,23 @@ export class TableState {
   }
 
   loadSelected(rows: GridDataRow<any>[]): void {
-    const allRows = flattenRows(rows);
-    const selectedRows = allRows.filter((row) => row.initSelected);
-    // Initialize with selected rows as defined
-    const map = new Map<string, SelectedState>();
+    const selectedRows: GridDataRow<any>[] = [];
+    visit(rows, (row) => row.initSelected && selectedRows.push(row));
+    const selectedStateMap = new Map<string, SelectedState>();
+    const selectedRowMap = new Map<string, GridDataRow<any>>();
     selectedRows.forEach((row) => {
-      map.set(row.id, "checked");
+      selectedStateMap.set(row.id, "checked");
+      selectedRowMap.set(row.id, row);
     });
+    this.rowSelectedState.merge(selectedStateMap);
+    this.selectedDataRows.merge(selectedRowMap);
 
-    this.selectedRows.merge(map);
+    // Determine if we need to initially display the unmatched selected group
+    const newlyUnmatchedRows = selectedRows.filter((row) => unmatchedSelectionsFilter(row, this.matchedRows));
+    if (!comparer.shallow(newlyUnmatchedRows, this.unmatchedSelectedRows)) {
+      this.collapsedRows.add(SELECTED_GROUP);
+      this.unmatchedSelectedRows = newlyUnmatchedRows;
+    }
   }
 
   initSortState(sortConfig: GridSortConfig | undefined, columns: GridColumnWithId<any>[]) {
@@ -211,9 +244,12 @@ export class TableState {
         }
       }
     }
-
     // Finally replace our existing list of rows
     this.rows = rows;
+    // Update the selected rows map to include the rows' updated data
+    const selectedRows = new Map();
+    visit(this.rows, (row) => this.selectedDataRows.has(row.id) && selectedRows.set(row.id, row));
+    this.selectedDataRows.merge(selectedRows);
   }
 
   setColumns(columns: GridColumnWithId<any>[], visibleColumnsStorageKey: string | undefined): void {
@@ -361,23 +397,17 @@ export class TableState {
     }
   }
 
-  get selectedIds(): string[] {
-    // Return only ids that are fully checked, i.e. not partial
-    const ids = [...this.selectedRows.entries()]
-      .filter(([id, v]) => this.matchedRows.has(id) && v === "checked")
-      .map(([k]) => k);
-    // Hide our header marker
-    const headerIndex = ids.indexOf("header");
-    if (headerIndex > -1) {
-      ids.splice(headerIndex, 1);
-    }
-    return ids;
+  /** Returns either all data rows (non-header, non-totals, etc) that are selected where `row.selectable !== false` */
+  get selectedRows(): GridDataRow<any>[] {
+    return [...this.selectedDataRows.values()].filter(
+      (row) => row.selectable !== false && !reservedRowKinds.includes(row.kind),
+    );
   }
 
   // Should be called in an Observer/useComputed to trigger re-renders
   getSelected(id: string): SelectedState {
-    // We may not have every row in here, i.e. on 1st page load or after clicking here, so assume unchecked
-    return this.selectedRows.get(id) || "unchecked";
+    // Return the row's selected state if it's been explicitly set. If it is in the selectedDataRows set, then it's selected. Otherwise, it's unchecked.
+    return this.rowSelectedState.get(id) ?? (this.selectedDataRows.has(id) ? "checked" : "unchecked");
   }
 
   selectRow(id: string, selected: boolean): void {
@@ -385,40 +415,93 @@ export class TableState {
       // Select/unselect all has special behavior
       if (selected) {
         // Just mash the header + all rows + children as selected
-        const map = new Map<string, SelectedState>();
-        map.set("header", "checked");
-        visit(this.rows, (row) => this.matchedRows.has(row.id) && row.kind !== "totals" && map.set(row.id, "checked"));
-        this.selectedRows.replace(map);
+        const selectedStateMap = new Map<string, SelectedState>();
+        const selectedRowMap = new Map<string, GridDataRow<any>>();
+        selectedStateMap.set("header", "checked");
+        visit(this.rows, (row) => {
+          if (!reservedRowKinds.includes(row.kind) && this.matchedRows.has(row.id)) {
+            selectedStateMap.set(row.id, "checked");
+            selectedRowMap.set(row.id, row);
+          }
+        });
+        this.rowSelectedState.replace(selectedStateMap);
+        // Use `merge` to ensure we don't lose any row that were selected, but no longer in `this.rows` (i.e. due to server-side filtering)
+        this.selectedDataRows.merge(selectedRowMap);
       } else {
         // Similarly "unmash" all rows + children.
-        this.selectedRows.clear();
+        this.rowSelectedState.clear();
+        this.selectedDataRows.clear();
+        this.unmatchedSelectedRows = [];
       }
     } else {
       // This is the regular/non-header behavior to just add/remove the individual row id,
       // plus percolate the change down-to-child + up-to-parents.
 
       // Find the clicked on row
-      const curr = findRow(this.rows, id);
+      const curr: FoundRow | undefined =
+        findRow(this.rows, id) ??
+        (this.selectedDataRows.has(id) ? { row: this.selectedDataRows.get(id)!, parents: [] } : undefined);
+
       if (!curr) {
         return;
       }
 
       // Everything here & down is deterministically on/off
-      const map = new Map<string, SelectedState>();
-      visit([curr.row], (row) => this.matchedRows.has(row.id) && map.set(row.id, selected ? "checked" : "unchecked"));
+      const selectedStateMap = new Map<string, SelectedState>();
+      visit([curr.row], (row) => {
+        // The `visit` method walks through the selected row and all of its children, if any.
+        // Depending on whether we are determining the clicked row's state or its children, then we handle updating the selection differently.
+
+        // We can tell if we are determining a child row's selected state by checking against the row selected `id` and the row we're currently evaluating `row.id`.
+        const isClickedRow = row.id === id;
+
+        // Only update the selected states if we're updating the clicked row, or if we are checking a child row, then the row must match the filter.
+        // Meaning, rows that are filtered out and displayed in the "selectedGroup" can only change their selection state by interacting with them directly.
+        if (isClickedRow || this.matchedRows.has(row.id)) {
+          selectedStateMap.set(row.id, selected ? "checked" : "unchecked");
+          if (selected) {
+            this.selectedDataRows.set(row.id, row);
+          } else {
+            this.selectedDataRows.delete(row.id);
+          }
+        }
+      });
 
       // Now walk up the parents and see if they are now-all-checked/now-all-unchecked/some-of-each
       for (const parent of [...curr.parents].reverse()) {
         // Only derive selected state of the parent row if `inferSelectedState` is not `false`
         if (parent.children && parent.inferSelectedState !== false) {
-          map.set(parent.id, deriveParentSelected(this.getMatchedChildrenStates(parent.children, map)));
+          const selectedState = deriveParentSelected(this.getMatchedChildrenStates(parent.children, selectedStateMap));
+          if (selectedState === "checked") {
+            this.selectedDataRows.set(parent.id, parent);
+          } else {
+            this.selectedDataRows.delete(parent.id);
+          }
+          selectedStateMap.set(parent.id, selectedState);
         }
       }
 
       // And do the header + top-level "children" as a final one-off
-      map.set("header", deriveParentSelected(this.getMatchedChildrenStates(this.rows, map)));
+      selectedStateMap.set(
+        "header",
+        deriveParentSelected(
+          this.getMatchedChildrenStates([...this.rows, ...this.unmatchedSelectedRows], selectedStateMap),
+        ),
+      );
 
-      this.selectedRows.merge(map);
+      // And merge the new selected state map into the existing one
+      this.rowSelectedState.merge(selectedStateMap);
+
+      // Lastly, we need to update the `unmatchedSelectedRows` if the row was deselected.
+      // (If selected === true, then it's not possible for the row to be in `unmatchedSelectedRows` as you can only select rows that match the filter)
+      if (!selected) {
+        const newlyUnmatchedRows = [...this.selectedDataRows.values()].filter((row) =>
+          unmatchedSelectionsFilter(row, this.matchedRows),
+        );
+        if (!comparer.shallow(newlyUnmatchedRows, this.unmatchedSelectedRows)) {
+          this.unmatchedSelectedRows = newlyUnmatchedRows;
+        }
+      }
     }
   }
 
@@ -441,8 +524,8 @@ export class TableState {
         // Expand all means keep `collapsedIds` empty
         collapsedIds.splice(0, collapsedIds.length);
       } else {
-        // Otherwise push `header` to the list as a hint that we're in the collapsed-all state
-        collapsedIds.push("header");
+        // Otherwise push `header` and `selectedGroup` to the list as a hint that we're in the collapsed-all state
+        collapsedIds.push(HEADER, SELECTED_GROUP);
         // Find all non-leaf rows so that toggling "all collapsed" -> "all not collapsed" opens
         // the parent rows of any level.
         const parentIds = new Set<string>();
@@ -466,6 +549,7 @@ export class TableState {
         collapsedIds.splice(i, 1);
       }
 
+      // TODO: Need to handle the unmatched selected group row.
       // If all rows have been expanded individually, but the 'header' was collapsed, then remove the header from the collapsedIds so it reverts to the expanded state
       if (collapsedIds.length === 1 && collapsedIds[0] === "header") {
         collapsedIds.splice(0, 1);
@@ -485,14 +569,16 @@ export class TableState {
 
   private getMatchedChildrenStates(children: GridDataRow<any>[], map: Map<string, SelectedState>): SelectedState[] {
     const respectedChildren = children.flatMap(getChildrenForDerivingSelectState);
+    // When determining the children selected states to base the parent's state from, then only base this off of rows that match the filter or are in the "hidden selected" group (via the `filter` below)
     return respectedChildren
-      .filter((row) => row.id !== "header" && this.matchedRows.has(row.id))
+      .filter((row) => row.id !== "header" && (this.matchedRows.has(row.id) || this.selectedDataRows.has(row.id)))
       .map((row) => map.get(row.id) || this.getSelected(row.id));
   }
 
   // Recursively traverse through rows to determine selected state of parent rows based on children
+  // Returns the selected states for the immediately children (if any) of the row passed in
   private setNestedSelectedStates(row: GridDataRow<any>, map: Map<string, SelectedState>): SelectedState[] {
-    if (this.matchedRows.has(row.id)) {
+    if (this.matchedRows.has(row.id) || this.selectedDataRows.has(row.id)) {
       // do not derive selected state if there are no children, or if `inferSelectedState` is set to false
       if (!row.children || row.inferSelectedState === false) {
         return [this.getSelected(row.id)];
@@ -509,6 +595,7 @@ export class TableState {
 
 /** Returns the child rows needed for deriving the selected state of a parent/group row */
 function getChildrenForDerivingSelectState(row: GridDataRow<any>): GridDataRow<any>[] {
+  // Only look deeper if the parent row does not infer its selected state
   if (row.children && row.inferSelectedState === false) {
     return [row, ...row.children.flatMap(getChildrenForDerivingSelectState)];
   }
@@ -640,3 +727,12 @@ export type SortState = {
 };
 
 export type SortOn = "client" | "server" | undefined;
+
+function unmatchedSelectionsFilter(row: GridDataRow<any>, matchedRows: ObservableSet<string>) {
+  return (
+    !matchedRows.has(row.id) &&
+    row.selectable !== false &&
+    !reservedRowKinds.includes(row.kind) &&
+    (!row.children || row.inferSelectedState === false)
+  );
+}

--- a/src/components/Table/utils/columns.tsx
+++ b/src/components/Table/utils/columns.tsx
@@ -39,8 +39,8 @@ export function selectColumn<T extends Kinded>(columnDef?: Partial<GridColumn<T>
     id: "beamSelectColumn",
     clientSideSort: false,
     align: "center",
-    // Defining `w: 48px` to accommodate for the `16px` wide checkbox and `16px` of padding on either side.
-    w: "48px",
+    // Defining `w: 40px` to accommodate for the `16px` wide checkbox and `12px` of padding on either side.
+    w: "40px",
     wrapAction: false,
     isAction: true,
     expandColumns: undefined,

--- a/src/components/Table/utils/utils.tsx
+++ b/src/components/Table/utils/utils.tsx
@@ -23,7 +23,13 @@ export function toContent(
   isExpandableHeader: boolean,
   isExpandable: boolean,
   minStickyLeftOffset: number,
+  isUnmatchedSelectedRow: boolean,
 ): ReactNode {
+  // Rows within the unmatched selection group cannot be collapsed
+  if (isUnmatchedSelectedRow && column.id === "beamCollapseColumn") {
+    return <></>;
+  }
+
   let content = isGridCellContent(maybeContent) ? maybeContent.content : maybeContent;
   if (typeof content === "function") {
     // Actually create the JSX by calling `content()` here (which should be as late as
@@ -232,11 +238,21 @@ export function matchesFilter(maybeContent: ReactNode | GridCellContent, filter:
 export const HEADER = "header";
 export const TOTALS = "totals";
 export const EXPANDABLE_HEADER = "expandableHeader";
-export const reservedRowKinds = [HEADER, TOTALS, EXPANDABLE_HEADER];
+export const SELECTED_GROUP = "selectedGroup";
+export const reservedRowKinds = [HEADER, TOTALS, EXPANDABLE_HEADER, SELECTED_GROUP];
 
 export const zIndices = {
   stickyHeader: 4,
   stickyColumns: 3,
   expandableHeaderTitle: 2,
   expandableHeaderIcon: 1,
+};
+
+// The "group row" for selected rows that are hidden by filters.
+export const unmatchedSelectionGroupRow: GridDataRow<any> = {
+  id: SELECTED_GROUP,
+  kind: SELECTED_GROUP,
+  children: [],
+  initCollapsed: true,
+  data: undefined,
 };

--- a/src/inputs/ToggleButton.stories.tsx
+++ b/src/inputs/ToggleButton.stories.tsx
@@ -90,7 +90,6 @@ function ToggleButtonWrapper({ isHovered, isFocused, isPressed, onChange, ...pro
         onChange={
           onChange
             ? (value) => {
-                console.log("selected value = ", value);
                 const result = onChange(value);
                 setSelected(value);
                 if (isPromise(result)) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -89,3 +89,8 @@ export function isFunction(f: any): f is Function {
 export function isDefined<T extends any>(param: T | undefined | null): param is T {
   return param !== null && param !== undefined;
 }
+
+export function pluralize(count: number | unknown[], noun: string, pluralNoun?: string): string {
+  if ((Array.isArray(count) ? count.length : count) === 1) return noun;
+  return pluralNoun || `${noun}s`;
+}


### PR DESCRIPTION
`GridTableApi.getSelectedRows` function previously only would return selected rows that match applied filters (if any). Now the function will return any row that had been selected regardless of filtering (client or server-side). This is done by copying each selected row to a new 'TableState.selectedDataRows' property. This keeps track of every selected "data" row, e.g. not the 'header' or other grouping rows that infer their selection state from child rows. If a grouping row specifies `inferSelectedState: false`, then it will also be considered a "data" row.

Also adds a "unmatched selected group" row which only displays when there are selected rows that are not being rendered in the table (e.g. due to filtering). The "unmatched selected group" will always be initially collapsed when introduced to minimize shifting table rows when rendered.