### PR TITLE
feat: Remove vAlign property from TableStyles

### DIFF
--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -40,7 +40,6 @@ interface TableStoryProps extends GridTableProps<any, any> {
   displayAs?: "default" | "virtual" | "table";
   totals?: boolean;
   expandable?: boolean;
-  vAlign?: "top" | "center" | "bottom";
 }
 
 export default {
@@ -90,7 +89,6 @@ export default {
     grouped: { name: "Group styles", control: { type: "boolean" }, if: { arg: "nestingDepth", neq: 1 } },
     bordered: { name: "Bordered", control: { type: "boolean" } },
     allWhite: { name: "All White", control: { type: "boolean" } },
-    vAlign: { name: "Vertical Alignment", options: ["center", "top", "bottom"], control: { type: "select" } },
     rowHover: { name: "Row Hover styles", control: { type: "boolean" } },
     totals: { name: "Show Totals row", control: { type: "boolean" } },
     expandable: { name: "With Expandable Columns", control: { type: "boolean" } },
@@ -116,8 +114,7 @@ type BeamData = {
 type BeamRow = SimpleHeaderAndData<BeamData>;
 
 export function Table(props: TableStoryProps) {
-  const { nestingDepth, allWhite, vAlign, grouped, rowHeight, bordered, displayAs, totals, rowHover, expandable } =
-    props;
+  const { nestingDepth, allWhite, grouped, rowHeight, bordered, displayAs, totals, rowHover, expandable } = props;
   const [filter, setFilter] = useState<string>();
 
   const [rows, columns] = useMemo(() => {
@@ -158,7 +155,6 @@ export function Table(props: TableStoryProps) {
             rowHeight,
             bordered,
             rowHover,
-            vAlign,
           }}
           sorting={{ on: "client" }}
           columns={columns}

--- a/src/components/Table/TableStyles.tsx
+++ b/src/components/Table/TableStyles.tsx
@@ -68,8 +68,6 @@ export interface GridStyleDef {
   bordered?: boolean;
   /** Whether to show a hover effect on rows. Defaults to true */
   rowHover?: boolean;
-  /** Defines the vertical alignment of the content of the cells for the whole table (not including the 'header' rows). Defaults to `center` */
-  vAlign?: "top" | "center" | "bottom";
   /** Defines the Typography for the table body's cells (not the header). This only applies to rows that are not nested/grouped */
   cellTypography?: Typography;
 }
@@ -85,7 +83,6 @@ function memoizedTableStyles() {
       cellHighlight = false,
       allWhite = false,
       bordered = false,
-      vAlign = "center",
       cellTypography = "xs" as const,
     } = props;
 
@@ -95,7 +92,7 @@ function memoizedTableStyles() {
       .join("|");
 
     if (!cache[key]) {
-      const alignItems = vAlign === "center" ? "center" : vAlign === "top" ? "flex-start" : "flex-end";
+      const alignItems = rowHeight === "fixed" ? "center" : "flex-start";
       const groupedLevels = {
         0: {
           cellCss: {
@@ -222,7 +219,6 @@ export function resolveStyles(style: GridStyle | GridStyleDef): GridStyle {
     allWhite: true,
     bordered: true,
     rowHover: true,
-    vAlign: true,
     cellTypography: true,
   };
   const keys = safeKeys(style);


### PR DESCRIPTION
Previous vertical alignment for all table styles was 'center' with the option to change it explicitly. Only reason we ever changed it was to set it to "top" when using "rowHeight: flexible". After revisiting the logic, it makes more sense to have the vAlign be set based on the `rowHeight` property, and not necessary to allow for the vAlign property. Now 'rowHeight: fixed' defaults to 'center' vertical alignment, and 'rowHeight: flexible' defaults to 'top' vertical alignment.