### PR TITLE
feat: Add useFilter hook for non-persisted filters

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from "./useBreakpoint";
 export * from "./useComputed";
+export * from "./useFilter";
 export * from "./useGroupBy";
 export * from "./useHover";
 export * from "./usePersistedFilter";

--- a/src/hooks/useFilter.test.tsx
+++ b/src/hooks/useFilter.test.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+import { FilterDefs, Filters, singleFilter } from "src/components";
+import { ProjectFilter, Stage } from "src/components/Filters/testDomain";
+import { useFilter } from "src/hooks/useFilter";
+import { render, wait, withRouter } from "src/utils/rtl";
+
+describe("useFilter", () => {
+  it("initializes with no default values", async () => {
+    // Given a singleFilter with no default value
+    type StageFilter = FilterDefs<ProjectFilter>["stageSingle"];
+    const stage: StageFilter = singleFilter({
+      options: [{ stage: Stage.StageOne }, { stage: Stage.StageTwo }],
+      getOptionValue: (s) => s.stage,
+      getOptionLabel: (s) => (s.stage === Stage.StageOne ? "One" : "Two"),
+    });
+    const r = await render(<TestPage filterDefs={{ stageSingle: stage }} />, withRouter());
+    // Then the filter is initially empty
+    expect(r.filter_stageSingle()).toHaveValue("All");
+    expect(r.applied().textContent).toEqual("{}");
+  });
+
+  it("uses default filter", async () => {
+    // Given a filter with a default value
+    type StageFilter = FilterDefs<ProjectFilter>["stageSingle"];
+    const stage: StageFilter = singleFilter({
+      options: [{ stage: Stage.StageOne }, { stage: Stage.StageTwo }],
+      getOptionValue: (s) => s.stage,
+      getOptionLabel: (s) => (s.stage === Stage.StageOne ? "One" : "Two"),
+      defaultValue: Stage.StageOne,
+    });
+    const r = await render(<TestPage filterDefs={{ stageSingle: stage }} />, withRouter());
+    await wait();
+    // Then the filter renders with one
+    expect(r.filter_stageSingle()).toHaveValue("One");
+    expect(r.applied().textContent).toEqual(`{"stageSingle":"ONE"}`);
+  });
+});
+
+function TestPage(props: { filterDefs: FilterDefs<ProjectFilter> }) {
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const filterDefs = useMemo(() => props.filterDefs, []);
+  const { filter, setFilter } = useFilter({ filterDefs });
+  return (
+    <div>
+      <Filters filter={filter} filterDefs={filterDefs} onChange={setFilter} />
+      Applied: <div data-testid="applied">{JSON.stringify(filter)}</div>
+    </div>
+  );
+}

--- a/src/hooks/useFilter.ts
+++ b/src/hooks/useFilter.ts
@@ -1,0 +1,24 @@
+import { useState } from "react";
+import { FilterDefs } from "src";
+import { safeEntries } from "src/utils";
+
+interface UsePersistedFilterProps<F> {
+  filterDefs: FilterDefs<F>;
+}
+
+interface FilterHook<F> {
+  filter: F;
+  setFilter: (filter: F) => void;
+}
+
+export function useFilter<F>({ filterDefs }: UsePersistedFilterProps<F>): FilterHook<F> {
+  const [filter, setFilter] = useState<F>(
+    Object.fromEntries(
+      safeEntries(filterDefs)
+        .filter(([key, def]) => def(key as string).defaultValue !== undefined)
+        .map(([key, def]) => [key, def(key as string).defaultValue]),
+    ) as F,
+  );
+
+  return { setFilter, filter };
+}


### PR DESCRIPTION
There are times we do _not_ want a filter to be persisted. 
This PR adds a hook to work with Beam's filters to that does not persist the filter values in query params or browser storage