### PR TITLE
feat: Add TableState.deleteRows

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -3352,6 +3352,56 @@ describe("GridTable", () => {
       `);
     });
   });
+
+  describe("deleting rows", () => {
+    it("deletes a row", async () => {
+      // Given a table with the ability to delete rows
+      const api: MutableRefObject<GridTableApi<Row> | undefined> = { current: undefined };
+      function TestComponent() {
+        const _api = useGridTableApi<Row>();
+        api.current = _api;
+        const [rows, setRows] = useState<GridDataRow<Row>[]>([
+          simpleHeader,
+          { kind: "data", id: "1", data: { name: "foo", value: 1 } },
+          { kind: "data", id: "2", data: { name: "bar", value: 2 } },
+        ]);
+        return (
+          <>
+            <button
+              onClick={() => {
+                setRows((rows) => rows.filter((r) => !_api.getSelectedRowIds().includes(r.id)));
+                _api.deleteRows(_api.getSelectedRowIds());
+              }}
+              data-testid="deleteRows"
+            />
+            <GridTable columns={[selectColumn<Row>(), ...columns]} rows={rows} api={_api} />
+          </>
+        );
+      }
+      const r = await render(<TestComponent />);
+      // The table has two rows and a header
+      expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+        "
+        | on | Name | Value |
+        | -- | ---- | ----- |
+        | on | foo  | 1     |
+        | on | bar  | 2     |
+        "
+      `);
+      // When selecting a row
+      click(r.select_1);
+      // And clicking the delete button
+      click(r.deleteRows);
+      // Then it is removed from the table
+      expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+        "
+        | on | Name | Value |
+        | -- | ---- | ----- |
+        | on | bar  | 2     |
+        "
+      `);
+    });
+  });
 });
 
 function Collapse({ id }: { id: string }) {

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -48,6 +48,9 @@ export type GridTableApi<R extends Kinded> = {
   /** Set selected state of a row by id */
   selectRow: (id: string, selected?: boolean) => void;
 
+  /** Deletes a row from the table */
+  deleteRows: (ids: string[]) => void;
+
   /** Toggle collapse state of a row by id */
   toggleCollapsedRow: (id: string) => void;
   isCollapsedRow: (id: string) => boolean;
@@ -115,5 +118,9 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
 
   public getVisibleColumnIds() {
     return this.tableState.visibleColumnIds;
+  }
+
+  public deleteRows(ids: string[]) {
+    this.tableState.deleteRows(ids);
   }
 }

--- a/src/components/Table/Table.qa.stories.tsx
+++ b/src/components/Table/Table.qa.stories.tsx
@@ -154,22 +154,32 @@ export function Table(props: TableStoryProps) {
     >
       <TableActions>
         <div css={Css.w("100vw").sm.$}>
-          <TextField
-            label="Filter"
-            labelStyle="hidden"
-            placeholder="Search"
-            value={filter}
-            onChange={setFilter}
-            startAdornment={<Icon icon="search" />}
-            clearable
-          />
+          <div css={Css.df.aic.gap1.$}>
+            <TextField
+              label="Filter"
+              labelStyle="hidden"
+              placeholder="Search"
+              value={filter}
+              onChange={setFilter}
+              startAdornment={<Icon icon="search" />}
+              clearable
+            />
+            <Button
+              label="Change Rows"
+              onClick={() => setRows((rows) => (rows.length === 4 ? nestedRows : newRows))}
+              tooltip="Simulates server side filtering"
+            />
+            <Button
+              label="Delete Rows"
+              onClick={() => {
+                setRows((rows) => rows.filter((r) => !api.getSelectedRowIds().includes(r.id)));
+                // api.deleteRows(api.getSelectedRowIds("child"));
+              }}
+            />
+          </div>
           <div>
             <span css={Css.smMd.mr1.$}>Selected Row Ids:</span>
             {selectedRows.length > 0 ? selectedRows.map((r) => r.id).join(", ") : "None"}
-          </div>
-          <div>
-            <span css={Css.smMd.mr1.$}>Simulate server side filtering:</span>
-            <Button label="Change Rows" onClick={() => setRows((rows) => (rows.length === 4 ? nestedRows : newRows))} />
           </div>
         </div>
       </TableActions>

--- a/src/components/Table/utils/TableState.ts
+++ b/src/components/Table/utils/TableState.ts
@@ -581,6 +581,18 @@ export class TableState {
     }
   }
 
+  deleteRows(ids: string[]): void {
+    this.rows = this.rows.filter((row) => !ids.includes(row.id));
+    this.keptSelectedRows = this.keptSelectedRows.filter((row) => !ids.includes(row.id));
+
+    ids.forEach((id) => {
+      this.selectedDataRows.delete(id);
+      this.rowSelectedState.delete(id);
+      this.collapsedRows.delete(id);
+      this.matchedRows.delete(id);
+    });
+  }
+
   private getMatchedChildrenStates(children: GridDataRow<any>[], map: Map<string, SelectedState>): SelectedState[] {
     const respectedChildren = children.flatMap(getChildrenForDerivingSelectState);
     // When determining the children selected states to base the parent's state from, then only base this off of rows that match the filter or are in the "hidden selected" group (via the `filter` below)


### PR DESCRIPTION
When introducing the 'TableState.keptSelectedRows' we assumed that the reason for a row being removed was due to filters. However, it is possible for a row to be removed intentionally due to deleting it. Adding a 'GridTableApi.deleteRows' method to ensure we do not keep these rows around in the 'keptSelectedRows' and actually delete them.