### PR TITLE
fix: SC-37802 Prevent DatePicker triggering virtual keyboard on touch devices

### DIFF
--- a/src/components/internal/DatePicker/DatePickerOverlay.tsx
+++ b/src/components/internal/DatePicker/DatePickerOverlay.tsx
@@ -8,8 +8,6 @@ interface DatePickerOverlayProps {
 // Small wrapper around DatePicker to provide necessary styling and state handling when displayed as an overlay.
 export function DatePickerOverlay({ overlayProps, children }: PropsWithChildren<DatePickerOverlayProps>) {
   return (
-    // Adds `tabIndex` so clicking within the DatePicker will provide a `e.relatedTarget` on blur and focus events.
-    // This allows for components such as the DateField to conditionally trigger their 'onBlur' prop. E.g. If the user leaves the field to interact with the DatePicker, then don't call onBlur
     <div css={Css.br4.bshModal.$} {...overlayProps}>
       {children}
     </div>

--- a/src/components/internal/DatePicker/DatePickerOverlay.tsx
+++ b/src/components/internal/DatePicker/DatePickerOverlay.tsx
@@ -10,7 +10,7 @@ export function DatePickerOverlay({ overlayProps, children }: PropsWithChildren<
   return (
     // Adds `tabIndex` so clicking within the DatePicker will provide a `e.relatedTarget` on blur and focus events.
     // This allows for components such as the DateField to conditionally trigger their 'onBlur' prop. E.g. If the user leaves the field to interact with the DatePicker, then don't call onBlur
-    <div css={Css.br4.bshModal.$} {...overlayProps} tabIndex={0}>
+    <div css={Css.br4.bshModal.$} {...overlayProps}>
       {children}
     </div>
   );

--- a/src/forms/BoundDateField.test.tsx
+++ b/src/forms/BoundDateField.test.tsx
@@ -12,12 +12,15 @@ describe("BoundDateField", () => {
     const author = createObjectState(formConfig, {});
     const r = await render(<BoundDateField field={author.birthday} onBlur={onBlur} onFocus={onFocus} />);
 
-    // When focus is triggered on a checkbox
+    // When focus is triggered
     focus(r.birthday);
     // Then the callback should be triggered
     expect(onFocus).toBeCalledTimes(1);
 
-    // When blur is triggered on a checkbox
+    // When closing the overlay and putting focus back on the input
+    fireEvent.keyDown(r.birthday_datePicker(), { key: "Escape", code: "Escape" });
+
+    // When blur is triggered
     blur(r.birthday());
     // Then the callback should be triggered
     expect(onBlur).toBeCalledTimes(1);

--- a/src/forms/BoundDateField.test.tsx
+++ b/src/forms/BoundDateField.test.tsx
@@ -19,6 +19,7 @@ describe("BoundDateField", () => {
 
     // When closing the overlay and putting focus back on the input
     fireEvent.keyDown(r.birthday_datePicker(), { key: "Escape", code: "Escape" });
+    expect(onBlur).toBeCalledTimes(0);
 
     // When blur is triggered
     blur(r.birthday());

--- a/src/forms/BoundDateRangeField.test.tsx
+++ b/src/forms/BoundDateRangeField.test.tsx
@@ -18,6 +18,9 @@ describe(BoundDateRangeField, () => {
     // Then the callback should be triggered
     expect(onFocus).toBeCalledTimes(1);
 
+    // When closing the overlay and putting focus back on the input
+    fireEvent.keyDown(r.saleDates_datePicker(), { key: "Escape", code: "Escape" });
+
     // When blur is triggered on a checkbox
     blur(r.saleDates);
     // Then the callback should be triggered

--- a/src/inputs/DateFields/DateField.test.tsx
+++ b/src/inputs/DateFields/DateField.test.tsx
@@ -30,14 +30,12 @@ describe("DateField", () => {
 
     // And when selecting a date - Choose the first of these, which should be `jan1`
     click(r.datePickerDay_0);
-    // Then then Date Picker should close
+    // Then the Date Picker should close
     expect(r.queryByTestId("date_datePicker")).toBeFalsy();
     // And the input's value should reflect the new date.
     expect(r.date()).toHaveValue("01/01/20");
     expect(onChange).toBeCalledTimes(1);
     expect(new Date(onChange.mock.calls[0][0]).toDateString()).toEqual(jan1.toDateString());
-    // And the date picker closes
-    expect(onBlur).toBeCalledTimes(1);
   });
 
   it("resets to previous date if user enters invalid value", async () => {

--- a/src/inputs/DateFields/DateFieldBase.test.tsx
+++ b/src/inputs/DateFields/DateFieldBase.test.tsx
@@ -57,7 +57,7 @@ describe(DateFieldBase, () => {
     // Given focus set on the input element.
     focus(r.date);
     // When setting focus to the Calendar Icon button
-    focus(r.date_calendarButton);
+    click(r.date_calendarButton);
     // Then expect the focus to move back to the input element.
     expect(r.date()).toHaveFocus();
     // And firing blur event on the input with the `calendarButton` as the related target
@@ -80,20 +80,17 @@ describe(DateFieldBase, () => {
   it("calls onBlur once the calendar overlay closes and focus is not returned to the input field", async () => {
     const onBlur = jest.fn();
     const r = await render(<DateFieldBase mode="single" value={jan2} label="Date" onChange={noop} onBlur={onBlur} />);
-    // Given focus set on the input element.
+    // When giving focus to the input element.
     focus(r.date);
-    // When "blur"ing the field with the overlay as the related target
-    fireEvent.blur(r.date(), { relatedTarget: r.date_datePicker() });
-    // Then `onBlur` is not called because the user is now interacting with the overlay
+    // Then the overlay should be opened
+    expect(r.date_datePicker()).toBeTruthy();
+    // expect(r.date()).not.toHaveFocus();
+    // Then `onBlur` is not called because the overlay is now open
     expect(onBlur).not.toBeCalled();
-    // When setting focus on the date.
-    focus(r.date);
     // And modify the date field to close the overlay - This should trigger an `onBlur` event due to the overlay closing and the field no longer having focus.
     fireEvent.input(r.date(), { target: { value: "01/29/20" } });
     // Then the overlay should close
     expect(r.queryByTestId("date_datePicker")).toBeFalsy();
-    // onBlur should have been called as the focus was removed from both the overlay calendar and the input field.
-    expect(onBlur).toBeCalledTimes(1);
 
     // Given focus set on the input element.
     focus(r.date);
@@ -105,8 +102,10 @@ describe(DateFieldBase, () => {
     fireEvent.keyDown(r.date_datePicker(), { key: "Escape", code: "Escape" });
     // Then the overlay should close
     expect(r.queryByTestId("date_datePicker")).toBeFalsy();
+    // When blur-ing the field with the overlay closed
+    blur(r.date);
     // Then `onBlur` should have been called
-    expect(onBlur).toBeCalledTimes(2);
+    expect(onBlur).toBeCalledTimes(1);
   });
 
   it("can fire onFocus and onBlur when interacting with the input field only", async () => {
@@ -120,7 +119,9 @@ describe(DateFieldBase, () => {
     focus(r.date);
     // Then focus should be called.
     expect(onFocus).toBeCalledTimes(1);
-    // When firing the blur event
+    // When closing the overlay
+    fireEvent.keyDown(r.date_datePicker(), { key: "Escape", code: "Escape" });
+    // And firing the blur event with the overlay closed
     blur(r.date);
     // Then onBlur should be called
     expect(onBlur).toBeCalledTimes(1);
@@ -133,9 +134,15 @@ describe(DateFieldBase, () => {
     const r = await render(
       <DateFieldBase mode="single" value={jan2} label="Date" onChange={noop} onEnter={onEnter} onBlur={onBlur} />,
     );
-    // When changing the input value to an valid date
+    // When focusing on the input
     focus(r.date);
-    expect(r.date()).toHaveFocus();
+    // Then the overlay should be opened
+    expect(r.chevronLeft()).toHaveFocus();
+    // When closing the overlay
+    fireEvent.keyDown(r.date_datePicker(), { key: "Escape", code: "Escape" });
+    expect(r.queryByTestId("date_datePicker")).toBeFalsy();
+    // And putting focus back on the input
+    focus(r.date);
     // And when hitting the Enter key
     fireEvent.keyDown(r.date(), { key: "Enter" });
     // And the onEnter and onBlur callbacks should be triggered

--- a/src/inputs/DateFields/DateFieldBase.tsx
+++ b/src/inputs/DateFields/DateFieldBase.tsx
@@ -108,7 +108,6 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
   const tid = useTestIds(props, defaultTestId(label));
   const isDisabled = !!disabled;
   const isReadOnly = !!readOnly;
-  const isTouchDevice = "ontouchstart" in window;
 
   const textFieldProps = {
     ...others,
@@ -129,6 +128,8 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
   const { labelProps, inputProps } = useTextField(
     {
       ...textFieldProps,
+      // Setting `inputMode` to none. This disables the virtual keyboard from being triggered on touch devices
+      inputMode: "none",
       onFocus: () => {
         isFocused.current = true;
         // Open overlay on focus of the input, only if the focus is not triggered due to the overlay being closed.
@@ -306,7 +307,6 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
         inputProps={{ ...inputProps, size: inputSize }}
         inputRef={inputRef}
         inputWrapRef={inputWrapRef}
-        preventEdit={isTouchDevice}
         onChange={(v) => {
           // hide the calendar if the user is manually entering the date
           onPickerClose();

--- a/src/inputs/DateFields/DateRangeField.test.tsx
+++ b/src/inputs/DateFields/DateRangeField.test.tsx
@@ -39,8 +39,6 @@ describe(DateRangeField, () => {
     const { from, to } = onChange.mock.calls[0][0];
     expect(new Date(from).toDateString()).toEqual(new Date("01/01/2020").toDateString());
     expect(new Date(to).toDateString()).toEqual(new Date("01/10/2020").toDateString());
-    // And `onBlur` should have been called
-    expect(onBlur).toBeCalledTimes(1);
   });
 
   it("can unset the input value while selecting dates", async () => {

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -56,6 +56,9 @@ export interface TextFieldBaseProps<X>
   hideErrorMessage?: boolean;
   // If set, the helper text will always be shown (usually we hide the helper text if read only)
   alwaysShowHelperText?: boolean;
+  // If set, the field will be treated as "read-only" in order to prevent the virtual keyboard on touch devices.
+  // It cannot be edited directly. It can be changed via other methods, though (i.e. DatePicker).
+  preventEdit?: boolean;
 }
 
 // Used by both TextField and TextArea
@@ -89,6 +92,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
     errorInTooltip = fieldProps?.errorInTooltip ?? false,
     hideErrorMessage = false,
     alwaysShowHelperText = false,
+    preventEdit = false,
   } = props;
 
   const typeScale = fieldProps?.typeScale ?? (inputProps.readOnly && labelStyle !== "hidden" ? "smMd" : "sm");
@@ -243,8 +247,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
                 {...(errorMsg ? { "aria-errormessage": errorMessageId } : {})}
                 ref={fieldRef as any}
                 rows={multiline ? 1 : undefined}
-                // Make the input field readOnly if the field explicitly sets it to `true`
-                readOnly={inputProps.readOnly}
+                readOnly={preventEdit}
                 css={{
                   ...fieldStyles.input,
                   ...(inputProps.disabled ? fieldStyles.disabled : {}),

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -56,9 +56,6 @@ export interface TextFieldBaseProps<X>
   hideErrorMessage?: boolean;
   // If set, the helper text will always be shown (usually we hide the helper text if read only)
   alwaysShowHelperText?: boolean;
-  // If set, the field will be treated as "read-only" in order to prevent the virtual keyboard on touch devices.
-  // It cannot be edited directly. It can be changed via other methods, though (i.e. DatePicker).
-  preventEdit?: boolean;
 }
 
 // Used by both TextField and TextArea
@@ -92,7 +89,6 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
     errorInTooltip = fieldProps?.errorInTooltip ?? false,
     hideErrorMessage = false,
     alwaysShowHelperText = false,
-    preventEdit = false,
   } = props;
 
   const typeScale = fieldProps?.typeScale ?? (inputProps.readOnly && labelStyle !== "hidden" ? "smMd" : "sm");
@@ -247,7 +243,6 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
                 {...(errorMsg ? { "aria-errormessage": errorMessageId } : {})}
                 ref={fieldRef as any}
                 rows={multiline ? 1 : undefined}
-                readOnly={preventEdit}
                 css={{
                   ...fieldStyles.input,
                   ...(inputProps.disabled ? fieldStyles.disabled : {}),


### PR DESCRIPTION
Fixes issue where the DatePicker was often rendering underneath the virtual keyboard, preventing users from using the DatePicker. To fix this, DateFieldBase now identifies if it is being used on a touch device. If it is, then it sets the new `TextFieldBase.preventEdit` property to set the input as "readonly". This forces touch screen users to only use the DatePicker for changing dates.

Additional changes include:
 - Move focus to the DatePicker once it is opened and return focus to input when DatePicker is closed.

Updates tests based on new logic for moving focus around