### PR TITLE
feat: Move AutoSaveStatus into beam.

### DIFF
--- a/src/components/AutoSaveStatus/AutoSaveStatusProvider.tsx
+++ b/src/components/AutoSaveStatus/AutoSaveStatusProvider.tsx
@@ -1,0 +1,85 @@
+import React, { PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+export enum AutoSaveStatus {
+  IDLE = "idle",
+  SAVING = "saving",
+  DONE = "done",
+  ERROR = "error",
+}
+
+export interface AutoSaveStatusContextType {
+  status: AutoSaveStatus;
+  /** Resets status to IDLE, particularly useful if "Error" or "Done" is stale */
+  resetStatus: VoidFunction;
+  errors: unknown[];
+  /** Notifies AutoSaveContext that a request is in-flight */
+  triggerAutoSave: VoidFunction;
+  /** Notifies AutoSaveContext that a request has settled, optionally taking an error */
+  resolveAutoSave: (error?: unknown) => void;
+}
+
+export const AutoSaveStatusContext = React.createContext<AutoSaveStatusContextType>({
+  status: AutoSaveStatus.IDLE,
+  resetStatus() {},
+  errors: [],
+  triggerAutoSave() {},
+  resolveAutoSave() {},
+});
+
+type AutoSaveStatusProviderProps = PropsWithChildren<{
+  /** After a successful save, reset Status back to `Idle` after this many milliseconds */
+  resetToIdleTimeout?: number;
+}>;
+
+export function AutoSaveStatusProvider({ children, resetToIdleTimeout = 6_000 }: AutoSaveStatusProviderProps) {
+  const [status, setStatus] = useState(AutoSaveStatus.IDLE);
+  const [errors, setErrors] = useState<unknown[]>([]);
+  const [inFlight, setInFlight] = useState(0);
+  const resetToIdleTimeoutRef = useRef<number | null>(null);
+
+  /** Handles setting Status */
+  useEffect(() => {
+    if (inFlight > 0) return setStatus(AutoSaveStatus.SAVING);
+    if (status === AutoSaveStatus.IDLE) return;
+    if (errors.length) return setStatus(AutoSaveStatus.ERROR);
+    return setStatus(AutoSaveStatus.DONE);
+  }, [errors.length, inFlight, status]);
+
+  const triggerAutoSave = useCallback(() => {
+    setInFlight((c) => c + 1);
+    setErrors([]);
+  }, []);
+
+  const resolveAutoSave = useCallback((error?: unknown) => {
+    setInFlight((c) => Math.max(0, c - 1));
+    if (error) setErrors((errs) => errs.concat(error));
+  }, []);
+
+  const resetStatus = useCallback(() => {
+    setStatus(AutoSaveStatus.IDLE);
+    setErrors([]);
+  }, []);
+
+  /** Resets AutoSaveStatus from "Done" to "Idle" after a timeout, if one is provided */
+  useEffect(() => {
+    if (resetToIdleTimeout === undefined) return;
+
+    // Specifically avoid auto-reset if Errors are present
+    if (status !== AutoSaveStatus.DONE) return;
+
+    // Only run the latest Timeout
+    if (resetToIdleTimeoutRef.current) clearTimeout(resetToIdleTimeoutRef.current);
+
+    resetToIdleTimeoutRef.current = window.setTimeout(() => {
+      resetStatus();
+      resetToIdleTimeoutRef.current = null;
+    }, resetToIdleTimeout);
+  }, [resetStatus, resetToIdleTimeout, status]);
+
+  const value = useMemo(
+    () => ({ status, resetStatus, errors, triggerAutoSave, resolveAutoSave }),
+    [errors, resetStatus, resolveAutoSave, status, triggerAutoSave],
+  );
+
+  return <AutoSaveStatusContext.Provider value={value}>{children}</AutoSaveStatusContext.Provider>;
+}

--- a/src/components/AutoSaveStatus/index.ts
+++ b/src/components/AutoSaveStatus/index.ts
@@ -1,0 +1,2 @@
+export { AutoSaveStatus, AutoSaveStatusContext, AutoSaveStatusProvider } from "./AutoSaveStatusProvider";
+export { useAutoSaveStatus } from "./useAutoSaveStatus";

--- a/src/components/AutoSaveStatus/useAutoSaveStatus.test.tsx
+++ b/src/components/AutoSaveStatus/useAutoSaveStatus.test.tsx
@@ -1,0 +1,187 @@
+import { act, renderHook } from "@testing-library/react";
+import { AutoSaveStatus, AutoSaveStatusProvider } from "./AutoSaveStatusProvider";
+import { useAutoSaveStatus } from "./useAutoSaveStatus";
+
+describe(useAutoSaveStatus, () => {
+  /** The internal setTimeout running after tests is spamming the console, so cancel them all here */
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it("renders without a provider", () => {
+    const { result } = renderHook(() => useAutoSaveStatus());
+
+    expect(result.current.status).toBe(AutoSaveStatus.IDLE);
+  });
+
+  it("renders with a provider", () => {
+    const { result } = renderHook(() => useAutoSaveStatus(), {
+      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
+    });
+
+    expect(result.current.status).toBe(AutoSaveStatus.IDLE);
+  });
+
+  it("indicates when something is in-flight", () => {
+    const { result } = renderHook(() => useAutoSaveStatus(), {
+      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
+    });
+
+    act(() => result.current.triggerAutoSave());
+
+    expect(result.current.status).toBe(AutoSaveStatus.SAVING);
+  });
+
+  it("indicates when a request has settled", () => {
+    const { result } = renderHook(() => useAutoSaveStatus(), {
+      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
+    });
+
+    act(() => result.current.triggerAutoSave());
+    act(() => result.current.resolveAutoSave());
+
+    expect(result.current.status).toBe(AutoSaveStatus.DONE);
+  });
+
+  it("indicates when an error happened", () => {
+    const { result } = renderHook(() => useAutoSaveStatus(), {
+      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
+    });
+
+    act(() => result.current.triggerAutoSave());
+    act(() => result.current.resolveAutoSave(new Error("Some error")));
+
+    expect(result.current.status).toBe(AutoSaveStatus.ERROR);
+    expect(result.current.errors.length).toBe(1);
+  });
+
+  it("resets status to Idle when told to", () => {
+    const { result } = renderHook(() => useAutoSaveStatus(), {
+      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
+    });
+
+    act(() => result.current.triggerAutoSave());
+    act(() => result.current.resolveAutoSave());
+    act(() => result.current.resetStatus());
+
+    expect(result.current.status).toBe(AutoSaveStatus.IDLE);
+  });
+
+  it("status goes through the full lifecycle when passed a reset timeout", async () => {
+    // Given a timeout has been passed to `useAutoSave()`
+    const { result } = renderHook(() => useAutoSaveStatus(), {
+      wrapper: ({ children }) => <AutoSaveStatusProvider resetToIdleTimeout={1_000}>{children}</AutoSaveStatusProvider>,
+    });
+    // When we trigger a save
+    act(() => result.current.triggerAutoSave());
+    // Then status is Saving
+    expect(result.current.status).toBe(AutoSaveStatus.SAVING);
+    // And when we trigger a resolution
+    act(() => result.current.resolveAutoSave());
+    // Then status is Done
+    expect(result.current.status).toBe(AutoSaveStatus.DONE);
+    // But when the timer runs out
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    // Then the status is reset to Idle
+    expect(result.current.status).toBe(AutoSaveStatus.IDLE);
+  });
+
+  it("clears errors on reset status", () => {
+    const { result } = renderHook(() => useAutoSaveStatus(), {
+      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
+    });
+    act(() => result.current.triggerAutoSave());
+    act(() => result.current.resolveAutoSave(new Error("some error")));
+    expect(result.current.errors.length).toBe(1);
+    act(() => result.current.resetStatus());
+    expect(result.current.errors.length).toBe(0);
+    expect(result.current.status).toBe(AutoSaveStatus.IDLE);
+  });
+
+  it("does not automatically invoke reset timeout if there are errors", () => {
+    // Given a timeout has been passed to `useAutoSave()`
+    const { result } = renderHook(() => useAutoSaveStatus(), {
+      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
+    });
+
+    act(() => result.current.triggerAutoSave());
+    act(() => result.current.resolveAutoSave(new Error("Some error")));
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
+    expect(result.current.status).toBe(AutoSaveStatus.ERROR);
+    expect(result.current.errors.length).toBe(1);
+  });
+
+  it("does allow manual resetting even if there are errors", () => {
+    // Given a timeout has been passed to `useAutoSave()`
+    const { result } = renderHook(() => useAutoSaveStatus(), {
+      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
+    });
+
+    act(() => result.current.triggerAutoSave());
+    act(() => result.current.resolveAutoSave(new Error("Some error")));
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    act(() => result.current.resetStatus());
+
+    expect(result.current.status).toBe(AutoSaveStatus.IDLE);
+    expect(result.current.errors.length).toBe(0);
+  });
+
+  it("handles multiple in-flight requests", () => {
+    const { result } = renderHook(() => useAutoSaveStatus(), {
+      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
+    });
+
+    // When we trigger 2 AutoSaves and only resolve 1
+    act(() => result.current.triggerAutoSave());
+    act(() => result.current.triggerAutoSave());
+    act(() => result.current.resolveAutoSave());
+
+    // We expect something to still be in-flight
+    expect(result.current.status).toBe(AutoSaveStatus.SAVING);
+
+    // And when we resolve the final one
+    act(() => result.current.resolveAutoSave());
+
+    // We expect it to finally settle
+    expect(result.current.status).toBe(AutoSaveStatus.DONE);
+  });
+
+  it("clears errors when a new save is triggered", () => {
+    const { result } = renderHook(() => useAutoSaveStatus(), {
+      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
+    });
+
+    act(() => result.current.triggerAutoSave());
+    act(() => result.current.resolveAutoSave(new Error("some error")));
+    act(() => result.current.triggerAutoSave());
+
+    expect(result.current.errors.length).toBe(0);
+  });
+
+  it("handles calling resolve too much", () => {
+    const { result } = renderHook(() => useAutoSaveStatus(), {
+      wrapper: ({ children }) => <AutoSaveStatusProvider>{children}</AutoSaveStatusProvider>,
+    });
+
+    // When save hasn't been invoked yet
+    act(() => result.current.resolveAutoSave());
+
+    // Then we effectively didn't run
+    expect(result.current.status).toBe(AutoSaveStatus.IDLE);
+
+    // And when 1 save has triggered, and we resolve too much
+    act(() => result.current.triggerAutoSave());
+    act(() => result.current.resolveAutoSave());
+    act(() => result.current.resolveAutoSave());
+
+    // Then we expect it to be happily "Done"
+    expect(result.current.status).toBe(AutoSaveStatus.DONE);
+  });
+});

--- a/src/components/AutoSaveStatus/useAutoSaveStatus.ts
+++ b/src/components/AutoSaveStatus/useAutoSaveStatus.ts
@@ -1,0 +1,16 @@
+import { useContext } from "react";
+import { AutoSaveStatusContext } from "./AutoSaveStatusProvider";
+
+/**
+ * Provides access to the current auto-save status, i.e. idle/saving/done.
+ *
+ * Applications should generally instrument their network layer, i.e. GraphQL
+ * mutations, to automatically update the auto-save status on any wire call,
+ * and then just use this `useAutoSaveStatus` to "show spinners" in appropriate
+ * places.
+ *
+ * See the `apolloHooks.ts` file in `internal-frontend` for an example.
+ */
+export function useAutoSaveStatus() {
+  return useContext(AutoSaveStatusContext);
+}

--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -1,6 +1,6 @@
-import { AutoSaveStatusProvider } from "@homebound/form-state";
 import { createContext, MutableRefObject, PropsWithChildren, useContext, useMemo, useReducer, useRef } from "react";
 import { OverlayProvider } from "react-aria";
+import { AutoSaveStatusProvider } from "src/components/AutoSaveStatus/index";
 import { Modal, ModalProps } from "src/components/Modal/Modal";
 import { PresentationContextProps, PresentationProvider } from "src/components/PresentationContext";
 import { SnackbarProvider } from "src/components/Snackbar/SnackbarContext";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from "src/components/AutoSaveStatus";
 export * from "src/components/Chip";
 export * from "src/components/Chips";
 export * from "src/components/Table/GridTable";


### PR DESCRIPTION
It originally existed in form-state b/c we used form-state internals to trigger the auto-saving yes/no behavior.

But since then we've moved the "trigger auto-saving yes/no" to the GraphQL mutation instrumentation in apolloHooks, b/c then all pages got the auto-save behavior and not just those using form state.

So, moving it here so we can remove from form-state.