### PR TITLE
feat: Show plus zero when displayDirection is set.

### DIFF
--- a/src/forms/BoundRadioGroupField.test.tsx
+++ b/src/forms/BoundRadioGroupField.test.tsx
@@ -2,7 +2,7 @@ import { createObjectState, ObjectConfig, ObjectState, required } from "@homebou
 import { render } from "@homebound/rtl-utils";
 import { BoundRadioGroupField } from "src/forms/BoundRadioGroupField";
 import { AuthorInput } from "src/forms/formStateDomain";
-import { click } from "src/utils/rtl";
+import { blur, click, focus } from "src/utils/rtl";
 
 const sports = [
   { value: "s:1", label: "Football" },
@@ -27,12 +27,12 @@ describe("BoundRadioGroupField", () => {
     );
 
     // When focus is triggered on a checkbox
-    r.favoriteSport_s1().focus();
+    focus(r.favoriteSport_s1);
     // Then the callback should be triggered
     expect(onFocus).toBeCalledTimes(1);
 
     // When blur is triggered on a checkbox
-    r.favoriteSport_s1().blur();
+    blur(r.favoriteSport_s1);
     // Then the callback should be triggered
     expect(onBlur).toBeCalledTimes(1);
   });

--- a/src/inputs/NumberField.test.tsx
+++ b/src/inputs/NumberField.test.tsx
@@ -2,6 +2,7 @@ import { change, render, type } from "@homebound/rtl-utils";
 import { fireEvent } from "@testing-library/react";
 import { useState } from "react";
 import { formatValue, NumberField, NumberFieldProps } from "src/inputs/NumberField";
+import { focus } from "src/utils/rtl";
 
 let lastSet: any = undefined;
 
@@ -148,7 +149,7 @@ describe("NumberFieldTest", () => {
     expect(r.cost()).toHaveValue("$14.14");
   });
 
-  it("displays direction of positive values and no direction display for zero", async () => {
+  it("displays direction", async () => {
     const r = await render(
       <>
         <TestNumberField label="Days" type="days" value={123} displayDirection />
@@ -162,7 +163,7 @@ describe("NumberFieldTest", () => {
     expect(r.cents()).toHaveValue("+$4.56");
     expect(r.basisPoints()).toHaveValue("+7.89%");
     expect(r.percent()).toHaveValue("+123%");
-    expect(r.zeroPercent()).toHaveValue("0%");
+    expect(r.zeroPercent()).toHaveValue("+0%");
   });
 
   it("fires onEnter and blurs field", async () => {
@@ -171,7 +172,7 @@ describe("NumberFieldTest", () => {
     // Given a numberfield
     const r = await render(<TestNumberField label="Age" value={10} onBlur={onBlur} onEnter={onEnter} />);
     // With focus
-    r.age().focus();
+    focus(r.age());
     expect(r.age()).toHaveFocus();
     // When hitting the Enter key
     fireEvent.keyDown(r.age(), { key: "Enter" });

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -86,7 +86,7 @@ export function NumberField(props: NumberFieldProps) {
   const isDisabled = !!disabled;
   const isReadOnly = !!readOnly;
   const factor = type === "percent" || type === "cents" ? 100 : type === "basisPoints" ? 10_000 : 1;
-  const signDisplay = displayDirection ? "exceptZero" : "auto";
+  const signDisplay = displayDirection ? "always" : "auto";
   const defaultFormatOptions: Intl.NumberFormatOptions = useMemo(
     () => ({
       [truncate ? "maximumFractionDigits" : "minimumFractionDigits"]: numFractionDigits,

--- a/src/inputs/TextAreaField.test.tsx
+++ b/src/inputs/TextAreaField.test.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Only } from "src/Css";
 import { TextAreaField, TextAreaFieldProps } from "src/inputs";
 import { TextFieldXss } from "src/interfaces";
+import { focus } from "src/utils/rtl";
 
 let lastSet: any = undefined;
 
@@ -37,7 +38,7 @@ describe("TextAreaFieldTest", () => {
     const onEnter = jest.fn();
     const onBlur = jest.fn();
     const r = await render(<TestTextAreaField value="foo" onEnter={onEnter} onBlur={onBlur} preventNewLines />);
-    r.note().focus();
+    focus(r.note);
     expect(r.note()).toHaveFocus();
     fireEvent.keyDown(r.note(), { key: "Enter" });
     expect(onEnter).toBeCalledTimes(1);


### PR DESCRIPTION
This makes it more consisent with the "+$0" we show for read-only diffs, and highlights "this field is a diff" in UIs where the "+" is the only indication that this is a diff field.

I.e. to make this table of inline edit fields more consistent:

![image](https://github.com/homebound-team/beam/assets/6401/417286ed-6b86-4fd2-8301-b49516d9ef89)
