### PR TITLE
fix: Safer selectRow

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1605,6 +1605,21 @@ describe("GridTable", () => {
     expect(api.current!.getSelectedRowIds()).toEqual([]);
   });
 
+  it("can select rows invalid row ids and not blow up", async () => {
+    // Given a table with no rows
+    const rows: GridDataRow<NestedRow>[] = [];
+    const api: MutableRefObject<GridTableApi<NestedRow> | undefined> = { current: undefined };
+    function Test() {
+      const _api = useGridTableApi<NestedRow>();
+      api.current = _api;
+      return <GridTable<NestedRow> api={_api} columns={nestedColumns} rows={rows} />;
+    }
+    await render(<Test />);
+    // When we call selectRow with an invalid row id
+    act(() => api.current!.selectRow("p1"));
+    // Then it does not blow up
+  });
+
   it("only returns selected visible rows", async () => {
     // Given a parent with a child and grandchildren
     const rows: GridDataRow<NestedRow>[] = [

--- a/src/components/Table/utils/RowStates.ts
+++ b/src/components/Table/utils/RowStates.ts
@@ -16,11 +16,14 @@ export class RowStates {
     return [...this.map.values()];
   }
 
-  /** Returns the `RowState` for the given `id`. We should probably require `kind`. */
-  get(id: string): RowState {
-    const rs = this.map.get(id);
-    if (!rs) throw new Error(`No RowState for ${id}`);
-    return rs;
+  /**
+   * Returns the `RowState` for the given `id`. We should probably require `kind`.
+   *
+   * It's common for tests to call `selectRow` w/o a fully-setup table, so callers
+   * should generally handle a missing RowState and treat it as a noop.
+   */
+  get(id: string): RowState | undefined {
+    return this.map.get(id);
   }
 
   /**

--- a/src/components/Table/utils/TableState.ts
+++ b/src/components/Table/utils/TableState.ts
@@ -358,11 +358,12 @@ export class TableState {
   // Should be called in an Observer/useComputed to trigger re-renders
   getSelected(id: string): SelectedState {
     const rs = this.rowStates.get(id);
+    if (!rs) return "unchecked";
     return id === HEADER ? rs.selectedStateForHeader : rs.selectedState;
   }
 
   selectRow(id: string, selected: boolean): void {
-    this.rowStates.get(id).select(selected);
+    this.rowStates.get(id)?.select(selected);
   }
 
   get collapsedIds(): string[] {


### PR DESCRIPTION
I think a number of internal-frontend tests had just ~slightly invalid test cases, and were causing `selectRow`s to happen on rows that don't exist.

Going to try this and see how the test count changes.