### PR TITLE
fix: Call setMatchedRows from useEffect

### DIFF
--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -401,7 +401,9 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
     visibleDataRows = visibleDataRows.slice(0, filterMaxRows + keptSelectedRows.length);
   }
 
-  tableState.setMatchedRows(filteredRowIds);
+  useEffect(() => {
+    tableState.setMatchedRows(filteredRowIds);
+  }, [tableState, filteredRowIds]);
 
   // Push back to the caller a way to ask us where a row is.
   const { rowLookup } = props;

--- a/src/components/Table/utils/TableState.ts
+++ b/src/components/Table/utils/TableState.ts
@@ -32,7 +32,7 @@ export class TableState {
   private readonly collapsedRows = new ObservableSet<string>([]);
   private persistCollapse: string | undefined;
   // The current list of rows, basically a useRef.current. Only shallow reactive.
-  public rows: GridDataRow<any>[] = [];
+  private rows: GridDataRow<any>[] = [];
   private readonly rowStates = new RowStates();
   // Keeps track of the 'active' row, formatted `${row.kind}_${row.id}`
   activeRowId: string | undefined = undefined;
@@ -74,7 +74,7 @@ export class TableState {
       rows: observable.shallow,
       // Do not observe columns, expect this to be a non-reactive value for us to base our reactive values off of.
       columns: false,
-    });
+    } as any);
 
     // If the kept rows went from empty to not empty, then introduce the SELECTED_GROUP row as collapsed
     reaction(

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -34,16 +34,3 @@ expect.extend({
     }
   },
 });
-
-// Suppress warnings about prop changes causing observables in other components to re-render.
-const error = console.error.bind(console);
-console.error = function () {
-  if (
-    arguments.length > 0 &&
-    typeof arguments[0] === "string" &&
-    arguments[0].startsWith("Warning: Cannot update a component")
-  ) {
-    return;
-  }
-  error(...arguments);
-};


### PR DESCRIPTION
This doesn't really change any behavior/fix any bugs, it is just more kosher/avoids the React warning.