### PR TITLE
fix: DatePicker to open via click instead of focus

### DIFF
--- a/src/components/Filters/DateRangeFilter.test.tsx
+++ b/src/components/Filters/DateRangeFilter.test.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { FilterDefs, Filters } from "src/components/Filters";
 import { ProjectFilter, taskCompleteFilter } from "src/components/Filters/testDomain";
-import { click, focus, render, type } from "src/utils/rtl";
+import { click, render, type } from "src/utils/rtl";
 
 describe("DateRangeFilter", () => {
   it("shows date placeholder text when not given an initial value", async () => {
@@ -42,7 +42,7 @@ describe("DateRangeFilter", () => {
 
     expect(r.xCircle()).toBeTruthy();
 
-    focus(dateField);
+    click(dateField);
 
     expect(r.queryByTestId("xCircle")).toBeNull();
   });

--- a/src/forms/BoundDateField.test.tsx
+++ b/src/forms/BoundDateField.test.tsx
@@ -12,8 +12,10 @@ describe("BoundDateField", () => {
     const author = createObjectState(formConfig, {});
     const r = await render(<BoundDateField field={author.birthday} onBlur={onBlur} onFocus={onFocus} />);
 
-    // When focus is triggered
+    // When setting focus on the input element
     focus(r.birthday);
+    // And clicking the input element to trigger the date picker
+    click(r.birthday);
     // Then the callback should be triggered
     expect(onFocus).toBeCalledTimes(1);
 
@@ -38,8 +40,8 @@ describe("BoundDateField", () => {
     );
     const r = await render(<BoundDateField field={author.birthday} />);
 
-    // When triggering the Date Picker
-    focus(r.birthday);
+    // When clicking input element to trigger the date picker
+    click(r.birthday);
     // And when selecting a date - Choose the first of these, which should be `jan1`
     click(r.datePickerDay_0);
 

--- a/src/forms/BoundDateRangeField.test.tsx
+++ b/src/forms/BoundDateRangeField.test.tsx
@@ -18,6 +18,9 @@ describe(BoundDateRangeField, () => {
     // Then the callback should be triggered
     expect(onFocus).toBeCalledTimes(1);
 
+    // When clicking the input element to trigger the date picker
+    click(r.saleDates);
+
     // When closing the overlay and putting focus back on the input
     fireEvent.keyDown(r.saleDates_datePicker(), { key: "Escape", code: "Escape" });
 
@@ -39,7 +42,7 @@ describe(BoundDateRangeField, () => {
     const r = await render(<BoundDateRangeField field={author.saleDates} />);
 
     // When triggering the Date Picker
-    focus(r.saleDates);
+    click(r.saleDates);
     // And when selecting a date - Choose the first of these, which should be `jan1`
     click(r.datePickerDay_0);
 

--- a/src/inputs/DateFields/DateField.test.tsx
+++ b/src/inputs/DateFields/DateField.test.tsx
@@ -19,8 +19,8 @@ describe("DateField", () => {
     const onBlur = jest.fn();
     const r = await render(<DateField value={jan2} label="Date" onChange={onChange} onBlur={onBlur} />);
 
-    // When triggering the Date Picker
-    focus(r.date);
+    // When clicking input element to trigger the date picker
+    click(r.date);
     // Then the Date Picker should be shown
     expect(r.date_datePicker()).toBeTruthy();
 

--- a/src/inputs/DateFields/DateFieldBase.test.tsx
+++ b/src/inputs/DateFields/DateFieldBase.test.tsx
@@ -1,3 +1,4 @@
+import { clickAndWait } from "@homebound/rtl-utils";
 import { fireEvent } from "@testing-library/react";
 import { useState } from "react";
 import { jan10, jan2 } from "src/forms/formStateDomain";
@@ -51,26 +52,22 @@ describe(DateFieldBase, () => {
     expect(r.date()).toHaveValue("").toHaveAttribute("placeholder", "Select a date");
   });
 
-  it("resets focus to input field when clicking calendar button and does not call onBlur", async () => {
+  it("clicking calendar button triggers date picker", async () => {
     const onBlur = jest.fn();
     const r = await render(<DateFieldBase mode="single" value={jan2} label="Date" onChange={noop} onBlur={onBlur} />);
     // Given focus set on the input element.
     focus(r.date);
     // When setting focus to the Calendar Icon button
     click(r.date_calendarButton);
-    // Then expect the focus to move back to the input element.
-    expect(r.date()).toHaveFocus();
-    // And firing blur event on the input with the `calendarButton` as the related target
-    fireEvent.blur(r.date(), { relatedTarget: r.date_calendarButton() });
-    // And the `onBlur` should not have been called.
-    expect(onBlur).not.toBeCalled();
+    // Then the date picker should be open
+    expect(r.date_datePicker()).toBeTruthy();
   });
 
   it("does not call onBlur when changing focus to the calendar overlay", async () => {
     const onBlur = jest.fn();
     const r = await render(<DateFieldBase mode="single" value={jan2} label="Date" onChange={noop} onBlur={onBlur} />);
-    // Given focus set on the input element.
-    focus(r.date);
+    // When clicking input element to trigger the date picker
+    click(r.date());
     // When "blur"ing the field with the overlay as the related target
     fireEvent.blur(r.date(), { relatedTarget: r.date_datePicker() });
     // Then `onBlur` should not have been called.
@@ -80,8 +77,8 @@ describe(DateFieldBase, () => {
   it("calls onBlur once the calendar overlay closes and focus is not returned to the input field", async () => {
     const onBlur = jest.fn();
     const r = await render(<DateFieldBase mode="single" value={jan2} label="Date" onChange={noop} onBlur={onBlur} />);
-    // When giving focus to the input element.
-    focus(r.date);
+    // When clicking input element to trigger the date picker
+    click(r.date());
     // Then the overlay should be opened
     expect(r.date_datePicker()).toBeTruthy();
     // expect(r.date()).not.toHaveFocus();
@@ -117,6 +114,8 @@ describe(DateFieldBase, () => {
     );
     // When setting focus on the input element
     focus(r.date);
+    // And clicking the input element to trigger the date picker
+    click(r.date);
     // Then focus should be called.
     expect(onFocus).toBeCalledTimes(1);
     // When closing the overlay
@@ -134,8 +133,8 @@ describe(DateFieldBase, () => {
     const r = await render(
       <DateFieldBase mode="single" value={jan2} label="Date" onChange={noop} onEnter={onEnter} onBlur={onBlur} />,
     );
-    // When focusing on the input
-    focus(r.date);
+    // When clicking input element to trigger the date picker - and awaiting the focus to change
+    await clickAndWait(r.date);
     // Then the overlay should be opened
     expect(r.chevronLeft()).toHaveFocus();
     // When closing the overlay
@@ -201,8 +200,8 @@ describe(DateFieldBase, () => {
       );
     }
     const r = await render(<TestComponent />);
-    // When focusing on the input to open the date picker
-    focus(r.date);
+    // When clicking input element to trigger the date picker
+    click(r.date);
     // And blurring with the date picker as the related target. Demonstrates that the input is not in focus, but the date picker is open
     fireEvent.blur(r.date(), { relatedTarget: r.date_datePicker() });
     // When changing the date from outside the component

--- a/src/inputs/DateFields/DateRangeField.test.tsx
+++ b/src/inputs/DateFields/DateRangeField.test.tsx
@@ -21,8 +21,8 @@ describe(DateRangeField, () => {
     const r = await render(
       <DateRangeField value={{ from: jan2, to: jan10 }} label="Date" onChange={onChange} onBlur={onBlur} />,
     );
-    // And focus set on the input element.
-    focus(r.date());
+    // And clicking input element to trigger the date picker
+    click(r.date());
 
     // When "blur"ing the field with the overlay as the related target
     fireEvent.blur(r.date(), { relatedTarget: r.date_datePicker() });
@@ -48,8 +48,8 @@ describe(DateRangeField, () => {
     const r = await render(
       <DateRangeField value={{ from: jan2, to: jan10 }} label="Date" onChange={onChange} onBlur={onBlur} />,
     );
-    // And focus set on the input element.
-    focus(r.date());
+    // And clicking input element to trigger the date picker
+    click(r.date());
     // When "blur"ing the field with the overlay as the related target
     fireEvent.blur(r.date(), { relatedTarget: r.date_datePicker() });
     // And clicking on a value in the date picker


### PR DESCRIPTION
The DatePicker now opens when the input is clicked instead of when it is focused. This is to prevent the DatePicker from re-opening when focus is returned to the field after selecting a date.

We were managing a variable to know whether or not the focus was returned to the input due to the DatePicker closing. However, there were some race conditions introduced when using multiple FocusScope components. Specifically, when the DateField’s `onChange` method triggers a modal, then we were attempting to return focus to the input field, and at the same time move focus to modal. React-Aria uses a requestAnimationFrame to restoreFocus, which was causing the race condition between when the focus moves and when it gets restored. By removing the behavior of focus triggering the DatePicker, then we completely avoid the race condition, and we can get rid of our ‘closingDatePicker’ variable for determining when focusing the element should trigger the DatePicker.

Updates many tests due to the new behavior