### PR TITLE
feat: Use observerable.ref for rows as well.

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -3374,6 +3374,8 @@ describe("GridTable", () => {
         | on                                   | bar  | 2     |
         "
       `);
+      // Then the header is fully selected
+      expect(r.select_0()).toHaveAttribute("data-indeterminate", "false");
       // When deselecting the header
       click(r.select_0);
       // Then the kept selected group is hidden

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -153,7 +153,7 @@ export class RowState {
   }
 
   private get visibleChildren(): RowState[] {
-    // The keptGroup is special and it's children are the dynamically kept rows
+    // The keptGroup is special and its children are the dynamically kept rows
     if (this.row.kind === KEPT_GROUP) return this.states.keptRows;
     // Ignore hard-deleted rows, i.e. from `api.deleteRows`; in theory any hard-deleted
     // rows should be removed from `this.children` anyway, by a change to `props.rows`,

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -43,7 +43,7 @@ export class RowState {
   // isDirectlyMatched = accept filters in the constructor and do match here
   // isEffectiveMatched = isDirectlyMatched || hasMatchedChildren
 
-  constructor(states: RowStates, row: GridDataRow<any>) {
+  constructor(private states: RowStates, row: GridDataRow<any>) {
     this.row = row;
     this.selected = !!row.initSelected;
     this.collapsed = states.storage.wasCollapsed(row.id) ?? !!row.initCollapsed;
@@ -115,10 +115,8 @@ export class RowState {
     this.selected = selected;
     // We don't check inferSelectedState here, b/c even if the parent is considered selectable
     // on its own, we still push down selected-ness to our visible children.
-    if (this.children) {
-      for (const child of this.visibleChildren) {
-        child.select(selected);
-      }
+    for (const child of this.visibleChildren) {
+      child.select(selected);
     }
   }
 
@@ -152,8 +150,8 @@ export class RowState {
   }
 
   private get visibleChildren(): RowState[] {
-    // The keptGroup should treat all of its children as visible, as this makes select/unselect all work.
-    if (this.row.kind === KEPT_GROUP) return this.children ?? [];
+    // The keptGroup is special and it's children are the dynamically kept rows
+    if (this.row.kind === KEPT_GROUP) return this.states.keptRows;
     // Ignore hard-deleted rows, i.e. from `api.deleteRows`; in theory any hard-deleted
     // rows should be removed from `this.children` anyway, by a change to `props.rows`,
     // but just in case the user calls _only_ `api.deleteRows`, and expects the row to

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -1,6 +1,8 @@
 import { makeAutoObservable, observable } from "mobx";
-import { GridDataRow, KEPT_GROUP, reservedRowKinds, SelectedState } from "src";
+import { GridDataRow } from "src/components/Table/components/Row";
 import { RowStates } from "src/components/Table/utils/RowStates";
+import { SelectedState } from "src/components/Table/utils/TableState";
+import { KEPT_GROUP, reservedRowKinds } from "src/components/Table/utils/utils";
 
 /**
  * A reactive/observable state of each GridDataRow's current behavior.

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -113,8 +113,9 @@ export class RowState {
    * child of a selected parent row.
    */
   select(selected: boolean): void {
-    if (this.row.selectable === false) return;
-    this.selected = selected;
+    if (this.row.selectable !== false) {
+      this.selected = selected;
+    }
     // We don't check inferSelectedState here, b/c even if the parent is considered selectable
     // on its own, we still push down selected-ness to our visible children.
     for (const child of this.visibleChildren) {

--- a/src/components/Table/utils/RowStates.ts
+++ b/src/components/Table/utils/RowStates.ts
@@ -12,7 +12,7 @@ export class RowStates {
   private map = new ObservableMap<string, RowState>();
   storage = new RowStorage(this);
   // Pre-create our keptGroupRow for if/when we need it.
-  private keptGroupRow: RowState = this.creatKeptGroupRow();
+  private keptGroupRow: RowState = this.createKeptGroupRow();
   private header: RowState | undefined = undefined;
   /** The first level of rows, i.e. not the header (or kept group), but the totals + top-level children. */
   private topRows: RowState[] = [];
@@ -146,17 +146,19 @@ export class RowStates {
   }
 
   /** Create our synthetic "group row" for kept rows, that users never pass in, but we self-inject as needed. */
-  private creatKeptGroupRow(): RowState {
+  private createKeptGroupRow(): RowState {
     // The "group row" for selected rows that are hidden by filters and add the children
     const keptGroupRow: GridDataRow<any> = {
       id: KEPT_GROUP,
       kind: KEPT_GROUP,
       initCollapsed: true,
-      // The kept group is basically always selected
-      initSelected: true,
+      selectable: false,
       data: undefined,
       children: [],
     };
-    return new RowState(this, keptGroupRow);
+    const rs = new RowState(this, keptGroupRow);
+    // Make the RowState behave like a parent, even though we calc its visibleChildren.
+    rs.children = [];
+    return rs;
   }
 }

--- a/src/components/Table/utils/RowStates.ts
+++ b/src/components/Table/utils/RowStates.ts
@@ -69,7 +69,7 @@ export class RowStates {
     if (this.header) {
       this.header.children = [
         // Always add the keptGroupRow, and we'll use keptGroupRow.isMatched=true/false to keep it
-        // from missing up "header is all selected" if its hidden/when there are no kept rows.
+        // from messing up "header is all selected" if its hidden/when there are no kept rows.
         this.keptGroupRow,
         ...this.topRows.filter((rs) => !reservedRowKinds.includes(rs.row.kind)),
       ];

--- a/src/components/Table/utils/RowStates.ts
+++ b/src/components/Table/utils/RowStates.ts
@@ -67,23 +67,16 @@ export class RowStates {
     this.topRows = rows.filter((row) => row !== headerRow).map((row) => addRowAndChildren(row));
     // And attach them to the header for select-all/etc. to work
     if (this.header) {
-      this.header.children = this.topRows.filter((rs) => !reservedRowKinds.includes(rs.row.kind));
+      this.header.children = [
+        // Always add the keptGroupRow, and we'll use keptGroupRow.isMatched=true/false to keep it
+        // from missing up "header is all selected" if its hidden/when there are no kept rows.
+        this.keptGroupRow,
+        ...this.topRows.filter((rs) => !reservedRowKinds.includes(rs.row.kind)),
+      ];
     }
 
     // Then mark any remaining as removed
     for (const state of existing) state.markRemoved();
-
-    const keptRows = this.keptRows;
-    if (keptRows.length > 0) {
-      // Stitch the current keptRows into the placeholder keptGroupRow
-      this.keptGroupRow.children = keptRows;
-      this.keptGroupRow.row.children = keptRows.map((rs) => rs.row);
-      // And then stitch the keptGroupRow itself into the root header, so that the kept rows
-      // are treated as just another child for the header's select/unselect all to work.
-      if (this.header) {
-        this.header.children!.unshift(this.keptGroupRow);
-      }
-    }
 
     // After the first load of real data, we detach collapse state, to respect
     // any incoming initCollapsed.
@@ -136,6 +129,11 @@ export class RowStates {
         rs.isMatched = ids.includes(rs.row.id);
       }
     }
+    // We cheat a little and pretend the "kept group matches the filter" not based on it itself
+    // literally matching the filter, or its children matching the filter (which is typically
+    // how the filter logic works), but if it just has any child rows at all (which actually means
+    // its children did _not_ match the filter, but are kept).
+    this.keptGroupRow.isMatched = this.keptRows.length > 0;
   }
 
   /** Returns kept rows, i.e. those that were user-selected but then client-side or server-side filtered. */
@@ -150,7 +148,15 @@ export class RowStates {
   /** Create our synthetic "group row" for kept rows, that users never pass in, but we self-inject as needed. */
   private creatKeptGroupRow(): RowState {
     // The "group row" for selected rows that are hidden by filters and add the children
-    const keptGroupRow: GridDataRow<any> = { id: KEPT_GROUP, kind: KEPT_GROUP, initCollapsed: true, data: undefined };
+    const keptGroupRow: GridDataRow<any> = {
+      id: KEPT_GROUP,
+      kind: KEPT_GROUP,
+      initCollapsed: true,
+      // The kept group is basically always selected
+      initSelected: true,
+      data: undefined,
+      children: [],
+    };
     return new RowState(this, keptGroupRow);
   }
 }

--- a/src/components/Table/utils/TableState.ts
+++ b/src/components/Table/utils/TableState.ts
@@ -55,12 +55,8 @@ export class TableState {
     // Make ourselves an observable so that mobx will do caching of .collapseIds so
     // that it'll be a stable identity for GridTable to useMemo against.
     makeAutoObservable(this, {
-      // We only shallow observe rows so that:
-      // a) we don't deeply/needlessly proxy-ize a large Apollo fragment cache, but
-      // b) if rows changes, we re-run computeds like getSelectedRows that may need to see the
-      // updated _contents_ of a given row, even if our other selected/matched row states don't change.
-      // (as any b/c rows is private, so the mapped type doesn't see it)
-      rows: observable.shallow,
+      // We use `ref`s so that observables can watch the immutable data change w/o deeply proxy-ifying Apollo fragments
+      rows: observable.ref,
       columns: observable.ref,
     } as any);
 
@@ -138,10 +134,6 @@ export class TableState {
 
   // Updates the list of rows and regenerates the collapsedRows property if needed.
   setRows(rows: GridDataRow<any>[]): void {
-    // Note that because of using `rows: observable.shallow` above, this is always
-    // false, and this logic runs on every render. We can eventually fix this, but it
-    // is convenient b/c it puts no-longer-kept rows back into the right spot in their
-    // parents.
     if (rows !== this.rows) {
       this.rowStates.setRows(rows);
       this.rows = rows;


### PR DESCRIPTION
This means the `setRows` really only runs when rows actually change, hence MobX no longer upgrades the rows array to an ObservableArray behind the scenes.