### PR TITLE
feat: SC-38355 - Accordion compact variant

### DIFF
--- a/src/components/Accordion.stories.tsx
+++ b/src/components/Accordion.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta } from "@storybook/react";
+import { Chip } from "src";
 import { Css } from "src/Css";
 import { Accordion } from "./Accordion";
 
@@ -33,6 +34,7 @@ export function AccordionVariations() {
     </>
   );
 }
+
 export function AccordionSizes() {
   return (
     <>
@@ -52,6 +54,27 @@ export function AccordionSizes() {
         </div>
       </Accordion>
       <Accordion title="Large" size="lg">
+        <div css={Css.sm.$}>
+          Our modern approach to homebuilding makes the process easier and more personal than ever before.
+        </div>
+      </Accordion>
+    </>
+  );
+}
+
+export function Compact() {
+  return (
+    <>
+      <Accordion
+        title={
+          <div css={Css.df.w100.jcsb.aic.$}>
+            <span>Accordion Title</span>
+            <Chip text="$145.85" type="success" compact />
+          </div>
+        }
+        compact
+        size="sm"
+      >
         <div css={Css.sm.$}>
           Our modern approach to homebuilding makes the process easier and more personal than ever before.
         </div>

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -27,6 +27,8 @@ export interface AccordionProps<X = AccordionXss> {
   omitPadding?: boolean;
   /** Styles overrides for padding */
   xss?: X;
+  /** Modifies the typography, padding, icon size and background color of the accordion header */
+  compact?: boolean;
 }
 
 export function Accordion<X extends Only<AccordionXss, X>>(props: AccordionProps<X>) {
@@ -36,7 +38,8 @@ export function Accordion<X extends Only<AccordionXss, X>>(props: AccordionProps
     size,
     disabled = false,
     defaultExpanded = false,
-    topBorder = true,
+    compact = false,
+    topBorder = compact ? false : true,
     bottomBorder = false,
     index,
     setExpandedIndex,
@@ -88,7 +91,8 @@ export function Accordion<X extends Only<AccordionXss, X>>(props: AccordionProps
         aria-expanded={expanded}
         disabled={disabled}
         css={{
-          ...Css.df.jcsb.gap2.aic.w100.p2.baseMd.outline("none").addIn(":hover", Css.bgGray100.$).$,
+          ...Css.df.jcsb.gapPx(12).aic.w100.p2.baseMd.outline("none").onHover.bgGray100.$,
+          ...(compact && Css.smMd.pl2.prPx(10).py1.bgGray100.mbPx(4).br8.onHover.bgGray200.$),
           ...(disabled && Css.gray500.$),
           ...(isFocusVisible && Css.boxShadow(`inset 0 0 0 2px ${Palette.Blue700}`).$),
           ...xss,
@@ -98,9 +102,10 @@ export function Accordion<X extends Only<AccordionXss, X>>(props: AccordionProps
           if (setExpandedIndex) setExpandedIndex(index);
         }}
       >
-        <span>{title}</span>
+        <span css={Css.fg1.tl.$}>{title}</span>
         <span
           css={{
+            ...Css.fs0.$,
             transition: "transform 250ms linear",
             transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
           }}

--- a/src/components/AccordionList.stories.tsx
+++ b/src/components/AccordionList.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta } from "@storybook/react";
+import { Chip } from "src";
 import { Css } from "src/Css";
 import { AccordionProps } from "./Accordion";
 import { AccordionList } from "./AccordionList";
@@ -66,4 +67,38 @@ export function AccordionListWithParentProp() {
     },
   ];
   return <AccordionList accordions={accordions} />;
+}
+
+export function Compact() {
+  const accordions: AccordionProps[] = [
+    {
+      title: (
+        <div css={Css.df.w100.jcsb.aic.$}>
+          <span>First accordion title</span>
+          <Chip text="$145.85" type="success" compact />
+        </div>
+      ),
+      children: <div>Fisrt accordion description</div>,
+    },
+    {
+      title: (
+        <div css={Css.df.w100.jcsb.aic.$}>
+          <span>Second accordion title</span>
+          <Chip text="$145.85" type="success" compact />
+        </div>
+      ),
+      children: <div>Second accordion description</div>,
+      defaultExpanded: true,
+    },
+    {
+      title: (
+        <div css={Css.df.w100.jcsb.aic.$}>
+          <span>Third accordion title</span>
+          <Chip text="$145.85" type="success" compact />
+        </div>
+      ),
+      children: <div>Third accordion description</div>,
+    },
+  ];
+  return <AccordionList size="sm" accordions={accordions} allowMultipleExpanded={false} compact />;
 }

--- a/src/components/AccordionList.tsx
+++ b/src/components/AccordionList.tsx
@@ -7,10 +7,12 @@ interface AccordionListProps {
   /** Allows multiple accordions to be expanded simultaneously (enabled by default) */
   allowMultipleExpanded?: boolean;
   size?: AccordionSize;
+  /** Modifies the typography, padding, icon size and background color of the accordion header */
+  compact?: boolean;
 }
 
 export function AccordionList(props: AccordionListProps) {
-  const { accordions, size, allowMultipleExpanded = true } = props;
+  const { accordions, size, allowMultipleExpanded = true, compact = false } = props;
   const [expandedIndex, setExpandedIndex] = useState<number | undefined>(
     accordions.findIndex((a) => a.defaultExpanded),
   );
@@ -22,9 +24,10 @@ export function AccordionList(props: AccordionListProps) {
         <Accordion
           {...accordionProps}
           {...tid}
+          compact={compact}
           key={index}
           size={size}
-          bottomBorder={index === arr.length - 1}
+          bottomBorder={compact ? false : index === arr.length - 1}
           defaultExpanded={!allowMultipleExpanded && expandedIndex === index}
           index={index}
           setExpandedIndex={setExpandedIndex}


### PR DESCRIPTION
Adds 'compact' variant to the Accordion and AccordionList components. When defining 'compact' it will modify the default typography, padding, icon size and background color of the accordion header.