### PR TITLE
feat: Add GridDataRow.onSelect.

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1547,6 +1547,43 @@ describe("GridTable", () => {
     expect(api.current!.getSelectedRowIds()).toEqual([]);
   });
 
+  it("fires onSelect", async () => {
+    // Given a parent with a child
+    const actions: string[] = [];
+    const rows: GridDataRow<NestedRow>[] = [
+      simpleHeader,
+      {
+        ...{
+          kind: "parent",
+          id: "p1",
+          data: { name: "parent 1" },
+          onSelect: (isSelected) => actions.push(`parent 1 ${isSelected}`),
+        },
+        children: [
+          {
+            kind: "child",
+            id: "p1c1",
+            data: { name: "child p1c1" },
+            onSelect: (isSelected) => actions.push(`child 1 ${isSelected}`),
+          },
+        ],
+      },
+    ];
+    const columns = [selectColumn<NestedRow>({})];
+    function Test() {
+      return <GridTable<NestedRow> columns={nestedColumns} rows={rows} />;
+    }
+    const r = await render(<Test />);
+    // When we select all
+    click(cell(r, 0, 1).children[0] as any);
+    // Then all rows are shown as selected
+    expect(actions).toEqual(["parent 1 true", "child 1 true"]);
+    // And when we unselect all
+    click(cell(r, 0, 1).children[0] as any);
+    // Then they are unselected
+    expect(actions).toEqual(["parent 1 true", "child 1 true", "parent 1 false", "child 1 false"]);
+  });
+
   it("getSelectedRows can see update rows", async () => {
     const api: MutableRefObject<GridTableApi<Row> | undefined> = { current: undefined };
     const _columns = [selectColumn<Row>(), ...columns];

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -376,4 +376,6 @@ export type GridDataRow<R extends Kinded> = {
   selectable?: false;
   /** Whether this row should infer its selected state based on its children's selected state */
   inferSelectedState?: false;
+  /** Fired when this row changes selected state. */
+  onSelect?: (isSelected: boolean) => void;
 } & IfAny<R, AnyObject, DiscriminateUnion<R, "kind", R["kind"]>>;

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -1,4 +1,4 @@
-import { makeAutoObservable, observable } from "mobx";
+import { makeAutoObservable, observable, reaction } from "mobx";
 import { GridDataRow } from "src/components/Table/components/Row";
 import { RowStates } from "src/components/Table/utils/RowStates";
 import { SelectedState } from "src/components/Table/utils/TableState";
@@ -44,6 +44,13 @@ export class RowState {
     this.selected = !!row.initSelected;
     this.collapsed = states.storage.wasCollapsed(row.id) ?? !!row.initCollapsed;
     makeAutoObservable(this, { row: observable.ref }, { name: `RowState@${row.id}` });
+    const onSelect = row.onSelect;
+    if (onSelect) {
+      reaction(
+        () => this.selectedState,
+        (state) => onSelect(state === "checked"),
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
To replace a `useEffect` that was watching `api.getSelectedRows` to drive "when the row is unselected" logic.