### PR TITLE
feat: Add Row Api with visibleChildren, selectedChildren

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -213,7 +213,7 @@ export function InfiniteScroll() {
     }));
   }, []);
 
-  const [data, setData] = useState<GridDataRow<Row>[]>(loadRows(0));
+  const [data, setData] = useState<GridDataRow<Row>[]>(() => loadRows(0));
   const rows: GridDataRow<Row>[] = useMemo(() => [simpleHeader, ...data], [data]);
   const columns: GridColumn<Row>[] = useMemo(
     () => [

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -901,9 +901,13 @@ export function StickyColumnsAndHeader() {
 
   // Scroll wrapping element's x & y coordinates to demonstrate proper z-indices for sticky header and columns.
   useEffect(() => {
-    if (scrollWrap.current) {
-      scrollWrap.current.scroll(45, 100);
-    }
+    // GridTable's rows have their own useEffect, so use a setTimeout to
+    // run after its useEffect has completed.
+    setTimeout(() => {
+      if (scrollWrap.current) {
+        scrollWrap.current.scroll(45, 100);
+      }
+    }, 1);
   }, []);
 
   return (

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1385,7 +1385,7 @@ describe("GridTable", () => {
   });
 
   it("can access visible child rows", async () => {
-    // Given a parent with a child
+    // Given a parent with two children
     const rows: GridDataRow<NestedRow>[] = [
       {
         ...{ kind: "parent", id: "p1", data: { name: "parent 1" } },
@@ -1395,7 +1395,7 @@ describe("GridTable", () => {
         ],
       },
     ];
-    // And a column where the parent counts the number
+    // And a column where the parent counts the number of visible children
     const columns: GridColumn<NestedRow>[] = [
       ...nestedColumns,
       {
@@ -1423,7 +1423,7 @@ describe("GridTable", () => {
   });
 
   it("can access selected child rows", async () => {
-    // Given a parent with a child
+    // Given a parent with two children
     const rows: GridDataRow<NestedRow>[] = [
       {
         ...{ kind: "parent", id: "p1", data: { name: "parent 1" } },
@@ -1449,7 +1449,7 @@ describe("GridTable", () => {
     expect(cell(r, 0, 2)).toHaveTextContent("parent 1");
     expect(cell(r, 1, 2)).toHaveTextContent("child p1c1");
     expect(cell(r, 2, 2)).toHaveTextContent("child p1c2");
-    // Then we show the number of children
+    // Then we show no children are selected
     expect(cell(r, 0, 3)).toHaveTextContent("0");
     // When we select the 1st child
     click(r.select_1);

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1420,6 +1420,10 @@ describe("GridTable", () => {
     expect(cell(r, 1, 2)).toHaveTextContent("child p1c2");
     // And the parent knows the number of visible children
     expect(cell(r, 0, 3)).toHaveTextContent("1");
+    // And when the parent matches the filter
+    await r.rerender(<GridTable<NestedRow> columns={columns} rows={rows} filter="parent" />);
+    // Then the parent knows both children are shown again
+    expect(cell(r, 0, 3)).toHaveTextContent("2");
   });
 
   it("can access selected child rows", async () => {

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -2328,7 +2328,7 @@ describe("GridTable", () => {
     const row1_changed: GridDataRow<Row> = { kind: "data", id: row1.id, data: { name: "one", value: 3 } };
     r.rerender(<GridTable columns={columns} rows={[header, row1_changed, row2]} />);
     // And the original row re-rendered
-    expect(row(r, 1).getAttribute("data-render")).toEqual("3");
+    expect(row(r, 1).getAttribute("data-render")).toEqual("2");
     // But the 2nd added row did not
     expect(row(r, 2).getAttribute("data-render")).toEqual("1");
   });

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -2210,7 +2210,7 @@ describe("GridTable", () => {
     const row1_changed: GridDataRow<Row> = { kind: "data", id: row1.id, data: { name: "one", value: 3 } };
     r.rerender(<GridTable columns={columns} rows={[header, row1_changed, row2]} />);
     // And the original row re-rendered
-    expect(row(r, 1).getAttribute("data-render")).toEqual("2");
+    expect(row(r, 1).getAttribute("data-render")).toEqual("3");
     // But the 2nd added row did not
     expect(row(r, 2).getAttribute("data-render")).toEqual("1");
   });

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1422,6 +1422,41 @@ describe("GridTable", () => {
     expect(cell(r, 0, 3)).toHaveTextContent("1");
   });
 
+  it("can access selected child rows", async () => {
+    // Given a parent with a child
+    const rows: GridDataRow<NestedRow>[] = [
+      {
+        ...{ kind: "parent", id: "p1", data: { name: "parent 1" } },
+        children: [
+          { kind: "child", id: "p1c1", data: { name: "child p1c1" } },
+          { kind: "child", id: "p1c2", data: { name: "child p1c2" } },
+        ],
+      },
+    ];
+    // And a column where the parent counts the selected children
+    const columns: GridColumn<NestedRow>[] = [
+      ...nestedColumns,
+      {
+        totals: emptyCell,
+        header: emptyCell,
+        parent: (data, { api }) => api.getSelectedChildren("child").length,
+        child: emptyCell,
+        grandChild: emptyCell,
+      },
+    ];
+    const r = await render(<GridTable<NestedRow> columns={columns} rows={rows} />);
+    // And both child rows are initially rendered
+    expect(cell(r, 0, 2)).toHaveTextContent("parent 1");
+    expect(cell(r, 1, 2)).toHaveTextContent("child p1c1");
+    expect(cell(r, 2, 2)).toHaveTextContent("child p1c2");
+    // Then we show the number of children
+    expect(cell(r, 0, 3)).toHaveTextContent("0");
+    // When we select the 1st child
+    click(r.select_1);
+    // Then the parent renders the number of selected children
+    expect(cell(r, 0, 3)).toHaveTextContent("1");
+  });
+
   it("persists collapse", async () => {
     const tableIdentifier = "gridTableTest";
     // Given that parent 2 is set to collapsed in local storage

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -598,7 +598,10 @@ function renderVirtual<R extends Kinded>(
               bottom: infiniteScroll.endOffsetPx ?? 500,
               top: 0,
             },
-            endReached: infiniteScroll.onEndReached,
+            // Add a `index > 0` check b/c Virtuoso is calling this in storybook
+            // with `endReached(0)` at odd times, like on page unload/story load,
+            // which then causes our test data to have duplicate ids in it.
+            endReached: (index) => (index > 0 ? infiniteScroll.onEndReached(index) : 0),
           }
         : {})}
     />

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -1,5 +1,6 @@
 import { MutableRefObject, useMemo } from "react";
 import { VirtuosoHandle } from "react-virtuoso";
+import { createRowLookup, GridRowLookup } from "src/components/index";
 import { GridDataRow } from "src/components/Table/components/Row";
 import { DiscriminateUnion, Kinded } from "src/components/Table/types";
 import { TableState } from "src/components/Table/utils/TableState";
@@ -68,6 +69,7 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
   // This is public to GridTable but not exported outside of Beam
   readonly tableState: TableState<R> = new TableState(this);
   virtuosoRef: MutableRefObject<VirtuosoHandle | null> = { current: null };
+  lookup!: GridRowLookup<R>;
 
   constructor() {
     // This instance gets spread into each row's GridRowApi, so bind the methods up-front
@@ -79,6 +81,7 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
     // Technically this drives both row-collapse and column-expanded
     if (persistCollapse) this.tableState.loadCollapse(persistCollapse);
     this.virtuosoRef = virtuosoRef;
+    this.lookup = createRowLookup(this, virtuosoRef);
   }
 
   public scrollToIndex(index: number): void {

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -62,6 +62,8 @@ export type GridTableApi<R extends Kinded> = {
 export type GridRowApi<R extends Kinded> = GridTableApi<R> & {
   getVisibleChildren(): GridDataRow<R>[];
   getVisibleChildren<K extends R["kind"]>(kind: K): GridDataRow<DiscriminateUnion<R, "kind", K>>[];
+  getSelectedChildren(): GridDataRow<R>[];
+  getSelectedChildren<K extends R["kind"]>(kind: K): GridDataRow<DiscriminateUnion<R, "kind", K>>[];
 };
 
 // Using `FooImpl`to keep the public GridTableApi definition separate.

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -57,18 +57,25 @@ export type GridTableApi<R extends Kinded> = {
   setVisibleColumns(ids: string[]): void;
 };
 
+/** Adds per-row methods to the `api`, i.e. for getting currently-visible children. */
+export type GridRowApi<R extends Kinded> = GridTableApi<R> & {
+  getVisibleChildren(): GridDataRow<R>[];
+  getVisibleChildren<K extends R["kind"]>(kind: K): GridDataRow<DiscriminateUnion<R, "kind", K>>[];
+};
+
 // Using `FooImpl`to keep the public GridTableApi definition separate.
 export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
   // This is public to GridTable but not exported outside of Beam
-  readonly tableState: TableState = new TableState(this);
+  readonly tableState: TableState<R> = new TableState(this);
   virtuosoRef: MutableRefObject<VirtuosoHandle | null> = { current: null };
 
+  constructor() {
+    // This instance gets spread into each row's GridRowApi, so bind the methods up-front
+    bindMethods(this);
+  }
+
   /** Called once by the GridTable when it takes ownership of this api instance. */
-  init(
-    persistCollapse: string | undefined,
-    virtuosoRef: MutableRefObject<VirtuosoHandle | null>,
-    rows: GridDataRow<R>[],
-  ) {
+  init(persistCollapse: string | undefined, virtuosoRef: MutableRefObject<VirtuosoHandle | null>) {
     // Technically this drives both row-collapse and column-expanded
     if (persistCollapse) this.tableState.loadCollapse(persistCollapse);
     this.virtuosoRef = virtuosoRef;
@@ -122,4 +129,10 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
   public deleteRows(ids: string[]) {
     this.tableState.deleteRows(ids);
   }
+}
+
+function bindMethods(instance: any): void {
+  Object.getOwnPropertyNames(Object.getPrototypeOf(instance)).forEach((key) => {
+    if (instance[key] instanceof Function && key !== "constructor") instance[key] = instance[key].bind(instance);
+  });
 }

--- a/src/components/Table/hooks/useSetupColumnSizes.ts
+++ b/src/components/Table/hooks/useSetupColumnSizes.ts
@@ -1,7 +1,7 @@
 import { useResizeObserver } from "@react-aria/utils";
 import { MutableRefObject, useCallback, useEffect, useRef, useState } from "react";
 import { GridStyle } from "src/components/Table/TableStyles";
-import { GridColumnWithId } from "src/components/Table/types";
+import { GridColumnWithId, Kinded } from "src/components/Table/types";
 import { calcColumnSizes } from "src/components/Table/utils/columns";
 import { useDebouncedCallback } from "use-debounce";
 
@@ -24,9 +24,9 @@ import { useDebouncedCallback } from "use-debounce";
  *
  * Disclaimer that we roll our own `fr` b/c we're not in CSS grid anymore.
  */
-export function useSetupColumnSizes(
+export function useSetupColumnSizes<R extends Kinded>(
   style: GridStyle,
-  columns: GridColumnWithId<any>[],
+  columns: GridColumnWithId<R>[],
   resizeRef: MutableRefObject<HTMLElement | null>,
   expandedColumnIds: string[],
 ): string[] {

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -1,14 +1,13 @@
 import { ReactElement, ReactNode } from "react";
 import { GridCellContent } from "src/components/Table/components/cell";
 import { GridDataRow, GridRowKind } from "src/components/Table/components/Row";
-import { GridTableApi } from "src/components/Table/GridTableApi";
+import { GridRowApi } from "src/components/Table/GridTableApi";
 import { Margin, Xss } from "src/Css";
 
 export type Kinded = { kind: string };
 export type GridTableXss = Xss<Margin>;
 export type RenderAs = "div" | "table" | "virtual";
 export type RowTuple<R extends Kinded> = [GridDataRow<R>, ReactElement];
-export type ParentChildrenTuple<R extends Kinded> = [GridDataRow<R>, ParentChildrenTuple<R>[]];
 export type Direction = "ASC" | "DESC";
 
 export type MaybeFn<T> = T | (() => T);
@@ -20,6 +19,7 @@ export type GridCellAlignment = "left" | "right" | "center";
  * See https://stackoverflow.com/a/50125960/355031
  */
 export type DiscriminateUnion<T, K extends keyof T, V extends T[K]> = T extends Record<K, V> ? T : never;
+
 /**
  * Defines how a single column will render each given row `kind` in `R`.
  *
@@ -39,11 +39,11 @@ export type GridColumn<R extends Kinded> = {
     | (DiscriminateUnion<R, "kind", K> extends { data: infer D }
         ? (
             data: D,
-            opts: { row: GridRowKind<R, K>; api: GridTableApi<R>; level: number; expanded: boolean },
+            opts: { row: GridRowKind<R, K>; api: GridRowApi<R>; level: number; expanded: boolean },
           ) => ReactNode | GridCellContent
         : (
             data: undefined,
-            opts: { row: GridRowKind<R, K>; api: GridTableApi<R>; level: number; expanded: boolean },
+            opts: { row: GridRowKind<R, K>; api: GridRowApi<R>; level: number; expanded: boolean },
           ) => ReactNode | GridCellContent);
 } & {
   /**

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -1,13 +1,12 @@
-import { ReactElement, ReactNode } from "react";
+import { ReactNode } from "react";
 import { GridCellContent } from "src/components/Table/components/cell";
-import { GridDataRow, GridRowKind } from "src/components/Table/components/Row";
+import { GridRowKind } from "src/components/Table/components/Row";
 import { GridRowApi } from "src/components/Table/GridTableApi";
 import { Margin, Xss } from "src/Css";
 
 export type Kinded = { kind: string };
 export type GridTableXss = Xss<Margin>;
 export type RenderAs = "div" | "table" | "virtual";
-export type RowTuple<R extends Kinded> = [GridDataRow<R>, ReactElement];
 export type Direction = "ASC" | "DESC";
 
 export type MaybeFn<T> = T | (() => T);

--- a/src/components/Table/utils/ColumnState.ts
+++ b/src/components/Table/utils/ColumnState.ts
@@ -1,5 +1,5 @@
 import { makeAutoObservable, observable } from "mobx";
-import { GridColumnWithId } from "src/components/Table/types";
+import { GridColumnWithId, Kinded } from "src/components/Table/types";
 import { assignDefaultColumnIds } from "src/components/Table/utils/columns";
 import { ColumnStates } from "src/components/Table/utils/ColumnStates";
 import { ColumnStorage } from "src/components/Table/utils/ColumnStorage";
@@ -11,13 +11,13 @@ import { isFunction } from "src/utils/index";
  * This is primarily for tracking visible/expanded columns for tables
  * that use the expandable columns feature.
  */
-export class ColumnState {
-  column: GridColumnWithId<any>;
-  children: ColumnState[] | undefined = undefined;
+export class ColumnState<R extends Kinded> {
+  column: GridColumnWithId<R>;
+  children: ColumnState<R>[] | undefined = undefined;
   private visible = true;
   private expanded = false;
 
-  constructor(private states: ColumnStates, storage: ColumnStorage, column: GridColumnWithId<any>) {
+  constructor(private states: ColumnStates<R>, storage: ColumnStorage<R>, column: GridColumnWithId<R>) {
     this.column = column;
     // If the user sets `canHide: true`, we default to hidden unless they set `initVisible: true`
     this.visible = storage.wasVisible(column.id) ?? (column.canHide ? column.initVisible ?? false : true);
@@ -60,12 +60,12 @@ export class ColumnState {
       const ecs = await expandColumns();
       this.children = assignDefaultColumnIds(ecs).map((ec) => this.states.addColumn(ec));
     } else if (expandColumns) {
-      this.children = expandColumns.map((ec) => this.states.addColumn(ec as GridColumnWithId<any>));
+      this.children = expandColumns.map((ec) => this.states.addColumn(ec as GridColumnWithId<R>));
     }
   }
 
   /** Returns this column, if visible, and its children, if expanded. */
-  get maybeSelfAndChildren(): ColumnState[] {
+  get maybeSelfAndChildren(): ColumnState<R>[] {
     if (!this.visible) {
       return [];
     } else if (this.expanded && this.children) {

--- a/src/components/Table/utils/ColumnStates.ts
+++ b/src/components/Table/utils/ColumnStates.ts
@@ -1,14 +1,14 @@
 import { camelCase } from "change-case";
 import { makeAutoObservable } from "mobx";
-import { GridColumnWithId } from "src";
+import { GridColumnWithId, Kinded } from "src";
 import { ColumnState } from "src/components/Table/utils/ColumnState";
 import { ColumnStorage } from "src/components/Table/utils/ColumnStorage";
 
 /** A reactive/observable wrapper around our columns. */
-export class ColumnStates {
+export class ColumnStates<R extends Kinded> {
   // The top-level list of columns
-  private columns: ColumnState[] = [];
-  private map = new Map<string, ColumnState>();
+  private columns: ColumnState<R>[] = [];
+  private map = new Map<string, ColumnState<R>>();
   private storage = new ColumnStorage(this);
 
   constructor() {
@@ -23,7 +23,7 @@ export class ColumnStates {
    * So like you expand a column, and new columns show up, but we'll remember they
    * were hidden last time you looked at this specific expansion of columns.
    */
-  setColumns(columns: GridColumnWithId<any>[], visibleColumnsStorageKey: string | undefined): void {
+  setColumns(columns: GridColumnWithId<R>[], visibleColumnsStorageKey: string | undefined): void {
     if (columns.some((c) => c.canHide)) {
       // We optionally auto-calc visible columns based on the currently-_potentially_-visible columns
       visibleColumnsStorageKey ??= camelCase(columns.map((c) => c.id).join());
@@ -35,7 +35,7 @@ export class ColumnStates {
   }
 
   /** Adds a column to our state, i.e. maybe a dynamically loaded column. */
-  addColumn(column: GridColumnWithId<any>): ColumnState {
+  addColumn(column: GridColumnWithId<R>): ColumnState<R> {
     const existing = this.map.get(column.id);
     if (!existing) {
       const cs = new ColumnState(this, this.storage, column);
@@ -50,19 +50,19 @@ export class ColumnStates {
   }
 
   /** Returns the `ColumnState` for the given `id`. */
-  get(id: string): ColumnState {
+  get(id: string): ColumnState<R> {
     const cs = this.map.get(id);
     if (!cs) throw new Error(`No ColumnState for ${id}`);
     return cs;
   }
 
   /** Returns all currently-expanded columns. */
-  get expandedColumns(): ColumnState[] {
+  get expandedColumns(): ColumnState<R>[] {
     return this.columns.filter((cs) => cs.isExpanded);
   }
 
   /** Returns a flat list of all visible columns. */
-  get allVisibleColumns(): ColumnState[] {
+  get allVisibleColumns(): ColumnState<R>[] {
     return this.columns.flatMap((cs) => cs.maybeSelfAndChildren);
   }
 

--- a/src/components/Table/utils/ColumnStorage.ts
+++ b/src/components/Table/utils/ColumnStorage.ts
@@ -1,5 +1,5 @@
 import { autorun, reaction } from "mobx";
-import { Kinded } from "src";
+import { Kinded } from "src/components/Table/types";
 import { ColumnStates } from "src/components/Table/utils/ColumnStates";
 import { loadArrayOrUndefined } from "src/components/Table/utils/utils";
 

--- a/src/components/Table/utils/ColumnStorage.ts
+++ b/src/components/Table/utils/ColumnStorage.ts
@@ -1,13 +1,14 @@
 import { autorun, reaction } from "mobx";
+import { Kinded } from "src";
 import { ColumnStates } from "src/components/Table/utils/ColumnStates";
 import { loadArrayOrUndefined } from "src/components/Table/utils/utils";
 
 /** Loads/saves the column state from sessionStorage. */
-export class ColumnStorage {
+export class ColumnStorage<R extends Kinded> {
   private expandedIds: string[] | undefined;
   private visibleIds: string[] | undefined;
 
-  constructor(private states: ColumnStates) {}
+  constructor(private states: ColumnStates<R>) {}
 
   loadExpanded(persistCollapse: string): void {
     const key = `expandedColumn_${persistCollapse}`;

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -311,6 +311,10 @@ export class RowState<R extends Kinded> {
         const children = rs.visibleDirectlyMatchedChildren.map((cs) => cs.row);
         return !kind ? children : children.filter((r) => r.kind === kind);
       },
+      getSelectedChildren(kind?: R["kind"]): GridDataRow<R>[] {
+        const children = (rs.children ?? []).filter((cs) => cs.isSelected).map((cs) => cs.row);
+        return !kind ? children : children.filter((r) => r.kind === kind);
+      },
     } as any;
   }
 

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -199,6 +199,14 @@ export class RowState<R extends Kinded> {
     return keptRows[keptRows.length - 1] === this;
   }
 
+  get key(): string {
+    return `${this.row.kind}-${this.row.id}`;
+  }
+
+  get kind(): string {
+    return this.row.kind;
+  }
+
   get isActive(): boolean {
     return this.states.table.activeRowId === `${this.row.kind}_${this.row.id}`;
   }

--- a/src/components/Table/utils/RowStorage.ts
+++ b/src/components/Table/utils/RowStorage.ts
@@ -1,4 +1,5 @@
 import { reaction } from "mobx";
+import { Kinded } from "src";
 import { RowStates } from "src/components/Table/utils/RowStates";
 import { loadArrayOrUndefined } from "src/components/Table/utils/utils";
 
@@ -13,10 +14,10 @@ import { loadArrayOrUndefined } from "src/components/Table/utils/utils";
  * Unlike most of our other states, this is not directly reactive/an observable,
  * although we do reactive to collapsedRows changing to persist the new state.
  */
-export class RowStorage {
+export class RowStorage<R extends Kinded> {
   private historicalIds: string[] | undefined;
 
-  constructor(private states: RowStates) {}
+  constructor(private states: RowStates<R>) {}
 
   load(persistCollapse: string): void {
     // Load what our previously collapsed rows were

--- a/src/components/Table/utils/TableState.ts
+++ b/src/components/Table/utils/TableState.ts
@@ -151,10 +151,8 @@ export class TableState<R extends Kinded> {
 
   // Updates the list of rows and regenerates the collapsedRows property if needed.
   setRows(rows: GridDataRow<R>[]): void {
-    if (rows !== this.rows) {
-      this.rowStates.setRows(rows);
-      this.rows = rows;
-    }
+    this.rowStates.setRows(rows);
+    this.rows = rows;
   }
 
   setColumns(columns: GridColumnWithId<R>[], visibleColumnsStorageKey: string | undefined): void {

--- a/src/components/Table/utils/TableState.ts
+++ b/src/components/Table/utils/TableState.ts
@@ -60,7 +60,6 @@ export class TableState<R extends Kinded> {
    */
   constructor(api: GridTableApi<any>) {
     this.api = api;
-
     // Make ourselves an observable so that mobx will do caching of .collapseIds so
     // that it'll be a stable identity for GridTable to useMemo against.
     makeAutoObservable(this, {
@@ -69,7 +68,6 @@ export class TableState<R extends Kinded> {
       columns: observable.ref,
       search: observable.ref,
     } as any);
-
     // If the kept rows went from empty to not empty, then introduce the SELECTED_GROUP row as collapsed
     reaction(
       () => [...this.keptRows.values()],

--- a/src/components/Table/utils/columns.tsx
+++ b/src/components/Table/utils/columns.tsx
@@ -98,8 +98,8 @@ function nonKindDefaults() {
  * Calculates column widths using a flexible `calc()` definition that allows for consistent column alignment without the use of `<table />`, CSS Grid, etc layouts.
  * Enforces only fixed-sized units (% and px)
  */
-export function calcColumnSizes(
-  columns: GridColumnWithId<any>[],
+export function calcColumnSizes<R extends Kinded>(
+  columns: GridColumnWithId<R>[],
   tableWidth: number | undefined,
   tableMinWidthPx: number = 0,
   expandedColumnIds: string[],

--- a/src/components/Table/utils/utils.tsx
+++ b/src/components/Table/utils/utils.tsx
@@ -4,7 +4,7 @@ import { GridCellContent } from "src/components/Table/components/cell";
 import { ExpandableHeader } from "src/components/Table/components/ExpandableHeader";
 import { GridDataRow } from "src/components/Table/components/Row";
 import { SortHeader } from "src/components/Table/components/SortHeader";
-import { GridTableApi } from "src/components/Table/GridTableApi";
+import { GridRowApi } from "src/components/Table/GridTableApi";
 import { GridStyle } from "src/components/Table/TableStyles";
 import { GridCellAlignment, GridColumnWithId, Kinded, RenderAs } from "src/components/Table/types";
 import { Css, Palette, Properties } from "src/Css";
@@ -134,7 +134,7 @@ function isContentEmpty(content: ReactNode): boolean {
 export function applyRowFn<R extends Kinded>(
   column: GridColumnWithId<R>,
   row: GridDataRow<R>,
-  api: GridTableApi<R>,
+  api: GridRowApi<R>,
   level: number,
   expanded: boolean,
 ): ReactNode | GridCellContent {


### PR DESCRIPTION
Add a `GridRowApi` that is the same as `GridTableApi` but adds a per-row `visibleChildren` that cells can use to calc things like sums/totals.

I ended up refactoring a lot of the GridRowProps ... I kinda forget why/if I really needed to, but had been meaning to do it for awhile.