### PR TITLE
fix: Use getElementById to find the listbox.

### DIFF
--- a/src/utils/rtl.tsx
+++ b/src/utils/rtl.tsx
@@ -16,6 +16,7 @@ import {
   Wrapper,
 } from "@homebound/rtl-utils";
 import { prettyDOM } from "@testing-library/react";
+import { fail } from "mobx-utils";
 import { ReactElement } from "react";
 import { BeamProvider } from "src/components";
 export {
@@ -216,9 +217,7 @@ function ensureListBoxOpen(select: HTMLElement): void {
 }
 
 function selectOption(select: HTMLElement, optionValue: string) {
-  const body = select.closest("body") as HTMLElement;
-  const listboxId = select.getAttribute("aria-controls");
-  const listbox = body.querySelector(`#${listboxId}`) as HTMLElement;
+  const listbox = findListBox(select);
   const options: NodeListOf<HTMLElement> = listbox.querySelectorAll("[role=option]");
   // Allow searching for options by their data-key (value) or textContent (label)
   const optionToSelect = Array.from(options).find(
@@ -243,9 +242,7 @@ export function getSelected(element: HTMLElement): string[] | string | undefined
 
   ensureListBoxOpen(select);
 
-  const body = select.closest("body") as HTMLElement;
-  const listboxId = select.getAttribute("aria-controls");
-  const listbox = body.querySelector(`#${listboxId}`) as HTMLElement;
+  const listbox = findListBox(select);
   const options: NodeListOf<HTMLElement> = listbox.querySelectorAll("[role=option]");
 
   const selections: string[] = Array.from(options)
@@ -262,14 +259,17 @@ export function getOptions(element: HTMLElement): string[] {
   assertListBoxInput(select);
   ensureListBoxOpen(select);
 
-  const body = select.closest("body") as HTMLElement;
-  const listboxId = select.getAttribute("aria-controls");
-  const listbox = body.querySelector(`#${listboxId}`) as HTMLElement;
+  const listbox = findListBox(select);
   const options: NodeListOf<HTMLElement> = listbox.querySelectorAll("[role=option]");
 
   return Array.from(options)
     .map((o: HTMLElement) => o.dataset.label ?? o.dataset.key ?? "")
     .filter((o) => !!o);
+}
+
+function findListBox(select: HTMLElement): HTMLElement {
+  const listboxId = select.getAttribute("aria-controls") || fail("aria-controls attribute not found");
+  return document.getElementById(listboxId) || fail("listbox not found");
 }
 
 function assertListBoxInput(select: HTMLElement): select is HTMLInputElement {


### PR DESCRIPTION
Something in my React 18 branch doesn't like the `#` selector we make:

```
SyntaxError: '#react-aria2127286360-:r5m:' is not a valid selector
    at emit (/home/circleci/project/node_modules/nwsapi/src/nwsapi.js:557:17)
    at _querySelectorAll (/home/circleci/project/node_modules/nwsapi/src/nwsapi.js:1494:9)
    at Object._querySelector [as first] (/home/circleci/project/node_modules/nwsapi/src/nwsapi.js:1405:14)
    at HTMLBodyElementImpl.querySelector (/home/circleci/project/node_modules/jsdom/lib/jsdom/living/nodes/ParentNode-impl.js:69:44)
    at HTMLBodyElement.querySelector (/home/circleci/project/node_modules/jsdom/lib/jsdom/living/generated/Element.js:1094:58)
    at selectOption (/home/circleci/project/node_modules/@homebound/beam/dist/utils/rtl.js:173:26)
    at /home/circleci/project/node_modules/@homebound/beam/dist/utils/rtl.js:150:43
    at Array.forEach (<anonymous>)
    at select (/home/circleci/project/node_modules/@homebound/beam/dist/utils/rtl.js:150:18)
    at select (/home/circleci/project/src/utils/rtl.tsx:207:14)
    at Object.<anonymous> (/home/circleci/project/src/routes/developments/lot-summary/sequence-sheet/components/lot-detail/PlanInformationTab.test.tsx:267:11)
```

So skip the selector and go straight to getElementById.