### PR TITLE
feat: Add loading spinner option to infinite scroll

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -251,17 +251,17 @@ export function InfiniteScrollWithLoader() {
     }));
   }, []);
 
-  const [loading, setLoading] = useState(false);
   const [data, setData] = useState<GridDataRow<Row>[]>(() => loadRows(0));
 
   // Simulate a slower network call that doesn't finish before the user reaches the end of the list
-  const fetchMoreDate = useCallback(
-    (index: number) => {
-      setLoading(true);
-      setTimeout(() => {
-        setData([...data, ...loadRows(index)]);
-        setLoading(false);
-      }, 1_500);
+  const fetchMoreData = useCallback(
+    async (index: number) => {
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          setData([...data, ...loadRows(index)]);
+          resolve();
+        }, 1_500);
+      });
     },
     [data, loadRows],
   );
@@ -284,10 +284,7 @@ export function InfiniteScrollWithLoader() {
           stickyHeader={true}
           rows={rows}
           infiniteScroll={{
-            onEndReached(index) {
-              fetchMoreDate(index);
-            },
-            nextPageLoading: loading,
+            onEndReached: fetchMoreData,
           }}
         />
       </div>

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -242,6 +242,59 @@ export function InfiniteScroll() {
   );
 }
 
+export function InfiniteScrollWithLoader() {
+  const loadRows = useCallback((offset: number) => {
+    return zeroTo(10).map((i) => ({
+      kind: "data" as const,
+      id: String(i + offset),
+      data: { name: `row ${i + offset}`, value: i + offset },
+    }));
+  }, []);
+
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState<GridDataRow<Row>[]>(() => loadRows(0));
+
+  // Simulate a slower network call that doesn't finish before the user reaches the end of the list
+  const fetchMoreDate = useCallback(
+    (index: number) => {
+      setLoading(true);
+      setTimeout(() => {
+        setData([...data, ...loadRows(index)]);
+        setLoading(false);
+      }, 1_500);
+    },
+    [data, loadRows],
+  );
+
+  const rows: GridDataRow<Row>[] = useMemo(() => [simpleHeader, ...data], [data]);
+  const columns: GridColumn<Row>[] = useMemo(
+    () => [
+      { header: "Name", data: ({ name }) => name, w: "200px" },
+      { header: "Value", data: ({ value }) => value },
+    ],
+    [],
+  );
+  return (
+    <div css={Css.df.fdc.vh100.$}>
+      <div css={Css.fg1.$}>
+        <GridTable
+          as="virtual"
+          columns={columns}
+          sorting={{ on: "client", initial: ["id", "ASC"] }}
+          stickyHeader={true}
+          rows={rows}
+          infiniteScroll={{
+            onEndReached(index) {
+              fetchMoreDate(index);
+            },
+            nextPageLoading: loading,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
 export function NoRowsFallback() {
   const nameColumn: GridColumn<Row> = { header: "Name", data: ({ name }) => name };
   const valueColumn: GridColumn<Row> = { header: "Value", data: ({ value }) => value };

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -244,7 +244,7 @@ export function InfiniteScroll() {
 
 export function InfiniteScrollWithLoader() {
   const loadRows = useCallback((offset: number) => {
-    return zeroTo(10).map((i) => ({
+    return zeroTo(25).map((i) => ({
       kind: "data" as const,
       id: String(i + offset),
       data: { name: `row ${i + offset}`, value: i + offset },

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -2,6 +2,7 @@ import memoizeOne from "memoize-one";
 import { runInAction } from "mobx";
 import React, { MutableRefObject, ReactElement, useEffect, useMemo, useRef } from "react";
 import { Components, Virtuoso, VirtuosoHandle } from "react-virtuoso";
+import { Loader } from "src/components";
 import { DiscriminateUnion, GridRowKind } from "src/components/index";
 import { PresentationFieldProps, PresentationProvider } from "src/components/PresentationContext";
 import { GridTableApi, GridTableApiImpl } from "src/components/Table/GridTableApi";
@@ -548,7 +549,17 @@ function renderVirtual<R extends Kinded>(
           />
         )),
         List: VirtualRoot(listStyle, columns as any, id, xss),
-        Footer: () => <div css={footerStyle} />,
+        Footer: () => {
+          return (
+            <div css={footerStyle}>
+              {infiniteScroll?.nextPageLoading && (
+                <div css={Css.h5.df.aic.jcc.$}>
+                  <Loader size={"xs"} />
+                </div>
+              )}
+            </div>
+          );
+        },
       }}
       // Pin/sticky both the header row(s) + firstRowMessage to the top
       topItemCount={stickyHeader ? tableHeadRows.length : 0}

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -127,4 +127,6 @@ export type InfiniteScroll = {
   onEndReached: (index: number) => void;
   /** The number of pixels from the bottom of the list to eagerly trigger `onEndReached`. The default is 500px. */
   endOffsetPx?: number;
+  /** When true, will append a loading spinner footer to let the user know the next page is still loading */
+  nextPageLoading?: boolean;
 };

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -123,10 +123,8 @@ export type Pin = { at: "first" | "last"; filter?: boolean };
 export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N;
 
 export type InfiniteScroll = {
-  /** will be called when the user scrolls to the end of the list with the last item index as an argument.  */
-  onEndReached: (index: number) => void;
+  /** will be called when the user scrolls to the end of the list with the last item index as an argument. Return a promise to automatically show a loading spinner.  */
+  onEndReached: (index: number) => void | Promise<void>;
   /** The number of pixels from the bottom of the list to eagerly trigger `onEndReached`. The default is 500px. */
   endOffsetPx?: number;
-  /** When true, will append a loading spinner footer to let the user know the next page is still loading */
-  nextPageLoading?: boolean;
 };


### PR DESCRIPTION
* Adds a new `nextPageLoading` option to `GridTable` `infiniteScroll` prop that will show a loading spinner in the footer when provided the `query.loading` boolean. In an ideal world, the scroll would truly be "infinite" AKA we fetch the next page before a user reaches the end, but a slow connection or very fast scroll could leave an awkward gap where it's unclear if you've reached the true end or are just waiting for the next page. 
* Demo Story: https://60466f7d43c37c0021788867-ivzonzyhpo.chromatic.com/?path=/story/components-table-gridtable--infinite-scroll-with-loader

https://www.loom.com/share/9d6a9dd24ee74b8f9001e1a6dda91a6e?sid=e13b2cc3-ffc0-4294-aed0-2e9bae5c9853