### PR TITLE
feat: [SC-39801] allow independent parent select for GridTable rows

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -2982,11 +2982,15 @@ describe("GridTable", () => {
       // When selecting the parent
       click(cellAnd(r, 1, 1, "select"));
 
-      // Then all rows should be considered selected
-      expect(cellAnd(r, 0, 1, "select")).toBeChecked();
+      // Then children should not be selected
+      expect(cellAnd(r, 0, 1, "select")).not.toBeChecked();
       expect(cellAnd(r, 1, 1, "select")).toBeChecked();
-      expect(cellAnd(r, 2, 1, "select")).toBeChecked();
-      expect(api.current!.getSelectedRowIds()).toEqual(["p1", "p1c1", "p1c1gc1", "p1c1gc2"]);
+      expect(cellAnd(r, 2, 1, "select")).not.toBeChecked();
+      expect(api.current!.getSelectedRowIds()).toEqual(["p1", "p1c1gc1"]);
+
+      // select children
+      click(cellAnd(r, 0, 1, "select"));
+      click(cellAnd(r, 2, 1, "select"));
 
       // When unselecting a single grand child
       click(cellAnd(r, 3, 1, "select"));

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -360,6 +360,4 @@ export type GridDataRow<R extends Kinded> = {
   selectable?: false;
   /** Whether this row should infer its selected state based on its children's selected state */
   inferSelectedState?: false;
-  /** Whether this row should be selectable as a parent without pushing its selected-ness to its visible children */
-  independentParentSelect?: true;
 } & IfAny<R, AnyObject, DiscriminateUnion<R, "kind", R["kind"]>>;

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -360,4 +360,6 @@ export type GridDataRow<R extends Kinded> = {
   selectable?: false;
   /** Whether this row should infer its selected state based on its children's selected state */
   inferSelectedState?: false;
+  /** Whether this row should be selectable as a parent without pushing its selected-ness to its visible children */
+  independentParentSelect?: true;
 } & IfAny<R, AnyObject, DiscriminateUnion<R, "kind", R["kind"]>>;

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -168,8 +168,10 @@ export class RowState<R extends Kinded> {
     }
     // We don't check inferSelectedState here, b/c even if the parent is considered selectable
     // on its own, we still push down selected-ness to our visible children.
-    for (const child of this.visibleChildren) {
-      child.select(selected);
+    if(!(this.isParent && this.independentParentSelect)) {
+      for (const child of this.visibleChildren) {
+        child.select(selected);
+      }
     }
   }
 
@@ -223,6 +225,10 @@ export class RowState<R extends Kinded> {
 
   private get inferSelectedState(): boolean {
     return this.row.inferSelectedState !== false;
+  }
+
+  private get independentParentSelect(): boolean {
+    return this.row.independentParentSelect !== false;
   }
 
   /** Returns this row and, if we're not collapsed, our children. */

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -168,7 +168,7 @@ export class RowState<R extends Kinded> {
     }
     // We don't check inferSelectedState here, b/c even if the parent is considered selectable
     // on its own, we still push down selected-ness to our visible children.
-    if(!(this.isParent && !!this.independentParentSelect)) {
+    if(!(this.isParent && this.independentParentSelect)) {
       for (const child of this.visibleChildren) {
         child.select(selected);
       }
@@ -228,7 +228,7 @@ export class RowState<R extends Kinded> {
   }
 
   private get independentParentSelect(): boolean {
-    return this.row.independentParentSelect !== false;
+    return !!this.row.independentParentSelect;
   }
 
   /** Returns this row and, if we're not collapsed, our children. */

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -166,9 +166,8 @@ export class RowState<R extends Kinded> {
     if (this.row.selectable !== false) {
       this.selected = selected;
     }
-    // We don't check inferSelectedState here, b/c even if the parent is considered selectable
-    // on its own, we still push down selected-ness to our visible children.
-    if(!(this.isParent && this.independentParentSelect)) {
+
+    if(!(this.isParent && this.inferSelectedState)) {
       for (const child of this.visibleChildren) {
         child.select(selected);
       }
@@ -225,10 +224,6 @@ export class RowState<R extends Kinded> {
 
   private get inferSelectedState(): boolean {
     return this.row.inferSelectedState !== false;
-  }
-
-  private get independentParentSelect(): boolean {
-    return !!this.row.independentParentSelect;
   }
 
   /** Returns this row and, if we're not collapsed, our children. */

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -167,7 +167,7 @@ export class RowState<R extends Kinded> {
       this.selected = selected;
     }
 
-    if(!(this.isParent && this.inferSelectedState)) {
+    if(this.inferSelectedState) {
       for (const child of this.visibleChildren) {
         child.select(selected);
       }

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -168,7 +168,7 @@ export class RowState<R extends Kinded> {
     }
     // We don't check inferSelectedState here, b/c even if the parent is considered selectable
     // on its own, we still push down selected-ness to our visible children.
-    if(!(this.isParent && this.independentParentSelect)) {
+    if(!(this.isParent && !!this.independentParentSelect)) {
       for (const child of this.visibleChildren) {
         child.select(selected);
       }


### PR DESCRIPTION
We have a use case that requires parent rows to be selectable independently of their children, so we should allow that to happen with a simple flag.

This behavior is not handled by the inferSelectedState flag.

[SC-39801](https://app.shortcut.com/homebound-team/story/39801/selecting-add-row-always-selects-and-won-t-let-you-deselect-modify-rows)