### PR TITLE
feat: Add Banner component

### DIFF
--- a/src/components/Banner.test.tsx
+++ b/src/components/Banner.test.tsx
@@ -1,0 +1,23 @@
+import { Banner } from "src";
+import { click, render } from "src/utils/rtl";
+
+describe(Banner, () => {
+  it("should render", async () => {
+    // Given the Banner with a message and no onClose callback
+    const r = await render(<Banner type="warning" message="Banner message" />);
+    // Then the banner should be visible
+    expect(r.banner_message).toHaveTextContent("Banner message");
+    // And there should be no close button
+    expect(r.query.banner_close).not.toBeInTheDocument();
+  });
+
+  it("should trigger onClose", async () => {
+    const onClose = jest.fn();
+    // Given the Banner with a message and an onClose callback
+    const r = await render(<Banner type="warning" message="Banner message" onClose={onClose} />);
+    // When clicking on the close button
+    click(r.banner_close);
+    // Then the onClose callback should be called
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,0 +1,48 @@
+import { ReactNode } from "react";
+import { Icon, IconKey } from "src/components/Icon";
+import { IconButton } from "src/components/IconButton";
+import { Css, Palette, Properties } from "src/Css";
+import { useTestIds } from "src/utils";
+
+export interface BannerProps {
+  type: BannerTypes;
+  message: ReactNode;
+  onClose?: VoidFunction;
+}
+
+export function Banner(props: BannerProps) {
+  const { type, message, onClose = false, ...others } = props;
+  const tid = useTestIds(others, "banner");
+  return (
+    <div css={{ ...variantStyles[type], ...Css.df.aic.w100.gap1.p2.gray900.base.bshBasic.$ }} {...tid} role="alert">
+      <span css={Css.fs0.$}>
+        <Icon icon={typeToIcon[type]} {...tid.type} color={Palette.Gray900} />
+      </span>
+      <span css={Css.fg1.$} {...tid.message}>
+        {message}
+      </span>
+      {onClose && (
+        <span css={Css.lh(0).$}>
+          <IconButton icon="x" onClick={onClose} {...tid.close} color={Palette.Gray900} />
+        </span>
+      )}
+    </div>
+  );
+}
+const typeToIcon: Record<BannerTypes, IconKey> = {
+  success: "checkCircle",
+  info: "infoCircle",
+  warning: "error",
+  alert: "errorCircle",
+  error: "xCircle",
+};
+
+const variantStyles: Record<BannerTypes, Properties> = {
+  success: Css.bgGreen100.gray900.$,
+  info: Css.bgBlue100.gray900.$,
+  warning: Css.bgYellow200.gray900.$,
+  alert: Css.bgGray200.gray900.$,
+  error: Css.bgRed100.gray900.$,
+};
+
+export type BannerTypes = "error" | "warning" | "success" | "info" | "alert";

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,49 +1,9 @@
-import { Icon, IconKey } from "src/components/Icon";
-import { Css, Palette, Properties } from "src/Css";
+import { Banner } from "src/components";
 import { useTestIds } from "src/utils";
-import { IconButton } from "../IconButton";
 import { useToastContext } from "./ToastContext";
 
 export function Toast() {
   const { setNotice, notice } = useToastContext();
   const tid = useTestIds({}, "toast");
-  return (
-    <>
-      {notice && (
-        <div
-          css={{ ...variantStyles[notice.type], ...Css.df.aic.w100.gap1.p2.gray900.base.bshBasic.$ }}
-          {...tid}
-          role="alert"
-        >
-          <span css={Css.fs0.$}>
-            <Icon icon={typeToIcon[notice.type]} {...tid.type} color={Palette.Gray900} />
-          </span>
-          <span css={Css.fg1.$} {...tid.message}>
-            {notice.message}
-          </span>
-          <span css={Css.lh(0).$}>
-            <IconButton icon="x" onClick={() => setNotice(undefined)} {...tid.close} color={Palette.Gray900} />
-          </span>
-        </div>
-      )}
-    </>
-  );
+  return <>{notice && <Banner {...notice} {...tid} onClose={() => setNotice(undefined)} />}</>;
 }
-
-const typeToIcon: Record<ToastTypes, IconKey> = {
-  success: "checkCircle",
-  info: "infoCircle",
-  warning: "error",
-  alert: "errorCircle",
-  error: "xCircle",
-};
-
-const variantStyles: Record<ToastTypes, Properties> = {
-  success: Css.bgGreen100.gray900.$,
-  info: Css.bgBlue100.gray900.$,
-  warning: Css.bgYellow200.gray900.$,
-  alert: Css.bgGray200.gray900.$,
-  error: Css.bgRed100.gray900.$,
-};
-
-export type ToastTypes = "error" | "warning" | "success" | "info" | "alert";

--- a/src/components/Toast/ToastContext.tsx
+++ b/src/components/Toast/ToastContext.tsx
@@ -1,10 +1,7 @@
 import React, { createContext, ReactNode, useContext, useMemo, useState } from "react";
-import { ToastTypes } from "./Toast";
+import { BannerProps } from "src/components";
 
-export interface ToastNoticeProps {
-  type: ToastTypes;
-  message: ReactNode;
-}
+export interface ToastNoticeProps extends Omit<BannerProps, "onClose"> {}
 
 export type ToastContextProps = {
   notice: ToastNoticeProps | undefined;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,8 @@ export * from "./Accordion";
 export * from "./AccordionList";
 export * from "./AutoSaveIndicator";
 export * from "./Avatar";
+export * from "./Banner";
+export type { BannerProps } from "./Banner";
 export { BeamProvider } from "./BeamContext";
 export * from "./Button";
 export * from "./ButtonDatePicker";


### PR DESCRIPTION
Extracts the "banner" element inside of the Toast component to be its own component. This allows the `Banner` to be rendered/used independently from the `Toast`/`useToast` methods.