### PR TITLE
chore: Export BaseFilter so that custom filters can be created by consumers

### DIFF
--- a/src/components/Filters/index.ts
+++ b/src/components/Filters/index.ts
@@ -13,3 +13,4 @@ export * from "./Filters";
 export { toggleFilter } from "./ToggleFilter";
 export * from "./types";
 export * from "./utils";
+export { BaseFilter } from "./BaseFilter";


### PR DESCRIPTION
We have had a request for a very bespoke filter which does not make sense to include in beam. Exporting `BaseFilter` so that other custom filters can be developed by consumers of beam.