### PR TITLE
feat: Support 'fullWidth' prop on all text fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@homebound/eslint-config": "^1.8.0",
     "@homebound/rtl-react-router-utils": "1.0.3",
     "@homebound/rtl-utils": "^2.65.0",
-    "@homebound/truss": "^1.131.0",
+    "@homebound/truss": "^1.132.0",
     "@homebound/tsconfig": "^1.0.3",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",

--- a/src/Css.ts
+++ b/src/Css.ts
@@ -1133,6 +1133,22 @@ class CssBuilder<T extends Properties> {
   fd(value: Properties["flexDirection"]) {
     return this.add("flexDirection", value);
   }
+  /** Sets `flexWrap: "wrap"`. */
+  get fww() {
+    return this.add("flexWrap", "wrap");
+  }
+  /** Sets `flexWrap: "wrap-reverse"`. */
+  get fwr() {
+    return this.add("flexWrap", "wrap-reverse");
+  }
+  /** Sets `flexWrap: "nowrap"`. */
+  get fwnw() {
+    return this.add("flexWrap", "nowrap");
+  }
+  /** Sets `flexWrap: value`. */
+  flexWrap(value: Properties["flexWrap"]) {
+    return this.add("flexWrap", value);
+  }
 
   // float
   /** Sets `float: "left"`. */

--- a/src/components/Pagination.stories.tsx
+++ b/src/components/Pagination.stories.tsx
@@ -31,7 +31,7 @@ function RenderPagination({ totalRows }: { totalRows: number }) {
   const page = useState({ pageNumber: 1, pageSize: 100 });
   return (
     <>
-      <FormLines labelStyle="left">
+      <FormLines labelStyle="left" width="full">
         <StaticField label="Number of items" value={String(totalRows)} />
         <StaticField label="Current page" value={String(page[0].pageNumber)} />
       </FormLines>

--- a/src/components/PresentationContext.tsx
+++ b/src/components/PresentationContext.tsx
@@ -17,6 +17,8 @@ export interface PresentationFieldProps {
   visuallyDisabled?: false;
   // If set error messages will be rendered as tooltips rather than below the field
   errorInTooltip?: true;
+  /** Allow the fields to grow to the width of its container. By default, fields will extend up to 550px */
+  fullWidth?: boolean;
 }
 
 export type PresentationContextProps = {

--- a/src/forms/FormLines.stories.tsx
+++ b/src/forms/FormLines.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react";
 import { FieldGroup, FormDivider, FormLines } from "src/forms/FormLines";
-import { SelectField } from "src/inputs";
+import { DateField, MultiSelectField, RichTextField, SelectField, TextAreaField, TreeSelectField } from "src/inputs";
 import { NumberField } from "src/inputs/NumberField";
 import { Switch } from "src/inputs/Switch";
 import { TextField } from "src/inputs/TextField";
@@ -13,8 +13,38 @@ export default {
 export function FlatList() {
   return (
     <FormLines>
-      <TextField label="First" value="first" onChange={() => {}} />
-      <TextField label="Last" value="last" onChange={() => {}} />
+      <TextField label="Text Field" value="first" onChange={noop} />
+      <NumberField label="Number Field" value={1} onChange={noop} />
+      <DateField label="Date FIeld" value={undefined} onChange={noop} />
+      <SelectField<Options, number>
+        label="Single Select Field"
+        value={1}
+        options={[
+          { id: 1, name: "Green" },
+          { id: 2, name: "Red" },
+        ]}
+        onSelect={noop}
+      />
+      <MultiSelectField<Options, number>
+        label="Multiselect Field"
+        values={[1]}
+        options={[
+          { id: 1, name: "Soccer" },
+          { id: 2, name: "Basketball" },
+          { id: 3, name: "Football" },
+        ]}
+        onSelect={noop}
+      />
+      <TreeSelectField
+        values={[]}
+        onSelect={noop}
+        options={[{ id: "1", name: "One" }]}
+        label="Tree Select Field"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />
+      <TextAreaField label="Text Area Field" value="" onChange={noop} />
+      <RichTextField label="Rich Text Field" value="" onChange={noop} />
     </FormLines>
   );
 }
@@ -22,8 +52,38 @@ export function FlatList() {
 export function SmallFlatList() {
   return (
     <FormLines width="sm">
-      <TextField label="First" value="first" onChange={() => {}} />
-      <TextField label="Last" value="last" onChange={() => {}} />
+      <TextField label="Text Field" value="first" onChange={noop} />
+      <NumberField label="Number Field" value={1} onChange={noop} />
+      <DateField label="Date FIeld" value={undefined} onChange={noop} />
+      <SelectField<Options, number>
+        label="Single Select Field"
+        value={1}
+        options={[
+          { id: 1, name: "Green" },
+          { id: 2, name: "Red" },
+        ]}
+        onSelect={noop}
+      />
+      <MultiSelectField<Options, number>
+        label="Multiselect Field"
+        values={[1]}
+        options={[
+          { id: 1, name: "Soccer" },
+          { id: 2, name: "Basketball" },
+          { id: 3, name: "Football" },
+        ]}
+        onSelect={noop}
+      />
+      <TreeSelectField
+        values={[]}
+        onSelect={noop}
+        options={[{ id: "1", name: "One" }]}
+        label="Tree Select Field"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />
+      <TextAreaField label="Text Area Field" value="" onChange={noop} />
+      <RichTextField label="Rich Text Field" value="" onChange={noop} />
     </FormLines>
   );
 }
@@ -31,8 +91,38 @@ export function SmallFlatList() {
 export function FullFlatList() {
   return (
     <FormLines width="full">
-      <TextField label="First" value="first" onChange={() => {}} />
-      <TextField label="Last" value="last" onChange={() => {}} />
+      <TextField label="Text Field" value="first" onChange={noop} />
+      <NumberField label="Number Field" value={1} onChange={noop} />
+      <DateField label="Date FIeld" value={undefined} onChange={noop} />
+      <SelectField<Options, number>
+        label="Single Select Field"
+        value={1}
+        options={[
+          { id: 1, name: "Green" },
+          { id: 2, name: "Red" },
+        ]}
+        onSelect={noop}
+      />
+      <MultiSelectField<Options, number>
+        label="Multiselect Field"
+        values={[1]}
+        options={[
+          { id: 1, name: "Soccer" },
+          { id: 2, name: "Basketball" },
+          { id: 3, name: "Football" },
+        ]}
+        onSelect={noop}
+      />
+      <TreeSelectField
+        values={[]}
+        onSelect={noop}
+        options={[{ id: "1", name: "One" }]}
+        label="Tree Select Field"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />
+      <TextAreaField label="Text Area Field" value="" onChange={noop} />
+      <RichTextField label="Rich Text Field" value="" onChange={noop} />
     </FormLines>
   );
 }

--- a/src/forms/FormLines.stories.tsx
+++ b/src/forms/FormLines.stories.tsx
@@ -127,9 +127,9 @@ export function FullFlatList() {
   );
 }
 
-export function SideBySideMedium() {
+export function SideBySideFull() {
   return (
-    <FormLines>
+    <FormLines width="full">
       <FieldGroup>
         <TextField label="First" value="first" onChange={() => {}} />
         <TextField label="Middle" value="middle" onChange={() => {}} />
@@ -170,7 +170,7 @@ export function SideBySideMedium() {
 }
 export function SideBySideLarge() {
   return (
-    <FormLines width="lg">
+    <FormLines>
       <FieldGroup>
         <TextField label="First" value="first" onChange={() => {}} />
         <TextField label="Middle" value="middle" onChange={() => {}} />
@@ -203,6 +203,48 @@ export function SideBySideLarge() {
         <TextField label="City" value="" onChange={noop} />
         <TextField label="State" value="" onChange={noop} />
         <TextField label="Postal Code" value="" onChange={noop} />
+      </FieldGroup>
+      <FieldGroup>
+        <NumberField label="Qty" value={1} onChange={() => {}} />
+        <SelectField<Options, number>
+          label="Unit of Measure"
+          value={1}
+          options={[
+            { id: 1, name: "Each" },
+            { id: 2, name: "Square Feet" },
+          ]}
+          onSelect={noop}
+        />
+      </FieldGroup>
+    </FormLines>
+  );
+}
+
+export function SideBySideMedium() {
+  return (
+    <FormLines width="md">
+      <FieldGroup>
+        <TextField label="First" value="first" onChange={() => {}} />
+        <TextField label="Middle" value="middle" onChange={() => {}} />
+      </FieldGroup>
+      <TextField label="Address" value="123 Main" onChange={() => {}} />
+      <FieldGroup>
+        <Switch label="Primary" labelStyle="form" selected={false} onChange={() => {}} />
+        <Switch label="Signatory" labelStyle="form" selected={true} onChange={() => {}} />
+      </FieldGroup>
+      <FieldGroup>
+        <TextField label="Title" value="Engineer" onChange={() => {}} />
+        <span />
+      </FieldGroup>
+      <FieldGroup>
+        <TextField label="First" value="first" onChange={() => {}} />
+        <TextField label="Middle" value="middle" onChange={() => {}} />
+        <TextField label="Last" value="last" onChange={() => {}} />
+      </FieldGroup>
+      <FieldGroup widths={[2, 1, 2]}>
+        <TextField label="First" value="first" onChange={() => {}} />
+        <TextField label="Middle" value="M" onChange={() => {}} />
+        <TextField label="Last" value="last" onChange={() => {}} />
       </FieldGroup>
       <FieldGroup>
         <NumberField label="Qty" value={1} onChange={() => {}} />

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -28,7 +28,7 @@ export interface FormLinesProps {
  * (see the `FieldGroup` component), where they will be laid out side-by-side.
  */
 export function FormLines(props: FormLinesProps) {
-  const { children, width = "full", labelSuffix, labelStyle, compact } = props;
+  const { children, width = "lg", labelSuffix, labelStyle, compact } = props;
   let firstFormHeading = true;
 
   // Only overwrite `fieldProps` if new values are explicitly set. Ensures we only set to `undefined` if explicitly set.
@@ -36,6 +36,7 @@ export function FormLines(props: FormLinesProps) {
     ...("labelSuffix" in props ? { labelSuffix } : {}),
     ...("labelStyle" in props ? { labelStyle } : {}),
     ...("compact" in props ? { compact } : {}),
+    ...(width === "full" ? { fullWidth: true } : {}),
   };
 
   return (

--- a/src/inputs/Autocomplete.stories.tsx
+++ b/src/inputs/Autocomplete.stories.tsx
@@ -4,22 +4,25 @@ import { within } from "@storybook/testing-library";
 import { useState } from "react";
 import { useFilter } from "react-aria";
 import { Css } from "src/Css";
-import { Autocomplete } from "src/inputs/Autocomplete";
+import { Autocomplete, AutocompleteProps } from "src/inputs/Autocomplete";
 
 export default {
   component: Autocomplete,
 } as Meta;
 
-export const Example: StoryFn = Template.bind({});
+export const Example: StoryFn<AutocompleteProps<any>> = Template.bind({});
 Example.parameters = { chromatic: { disableSnapshot: true } };
 
-export const MenuOpen: StoryFn = Template.bind({});
+export const FullWidth: StoryFn<AutocompleteProps<any>> = Template.bind({});
+FullWidth.args = { fullWidth: true };
+
+export const MenuOpen: StoryFn<AutocompleteProps<any>> = Template.bind({});
 MenuOpen.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
   const canvas = within(canvasElement);
   canvas.getByTestId("heroes").focus();
 };
 
-function Template() {
+function Template(props: AutocompleteProps<any>) {
   const { contains } = useFilter({ sensitivity: "base" });
   const [value, setValue] = useState<string>();
   const allOptions = [
@@ -30,9 +33,10 @@ function Template() {
     { label: "Black Widow", imgSrc: "/black-widow.jpg" },
   ];
   const [options, setOptions] = useState(allOptions);
-
+  console.log("props", props);
   return (
     <Autocomplete<TestOption>
+      {...props}
       label="Heroes"
       labelStyle="hidden"
       getOptionValue={(o) => o.label}

--- a/src/inputs/Autocomplete.tsx
+++ b/src/inputs/Autocomplete.tsx
@@ -9,9 +9,9 @@ import { ListBox } from "src/inputs/internal/ListBox";
 import { TextFieldBase, TextFieldBaseProps } from "src/inputs/TextFieldBase";
 import { Value, valueToKey } from "src/inputs/Value";
 
-interface AutocompleteProps<T>
+export interface AutocompleteProps<T>
   extends Pick<PresentationFieldProps, "labelStyle">,
-    Pick<TextFieldBaseProps<any>, "label" | "clearable" | "startAdornment"> {
+    Pick<TextFieldBaseProps<any>, "label" | "clearable" | "startAdornment" | "fullWidth"> {
   onSelect: (item: T) => void;
   /** A function that returns how to render the an option in the menu. If not set, `getOptionLabel` will be used */
   getOptionMenuLabel?: (o: T) => ReactNode;

--- a/src/inputs/DateFields/DateField.stories.tsx
+++ b/src/inputs/DateFields/DateField.stories.tsx
@@ -6,7 +6,7 @@ import { Css } from "src/Css";
 import { jan1, jan10, jan2 } from "src/forms/formStateDomain";
 import { DateField, DateFieldProps, TextField } from "src/inputs/index";
 import { noop } from "src/utils";
-import { samples } from "src/utils/sb";
+import { samples, withDimensions } from "src/utils/sb";
 
 export default {
   component: Button,
@@ -79,6 +79,7 @@ export function DatePickerOpen() {
     </>
   );
 }
+DatePickerOpen.decorators = [withDimensions()];
 
 function TestDateField(props: Omit<DateFieldProps, "value" | "onChange" | "onBlur" | "onFocus">) {
   const [value, onChange] = useState<Date | undefined>(jan1);

--- a/src/inputs/DateFields/DateField.stories.tsx
+++ b/src/inputs/DateFields/DateField.stories.tsx
@@ -6,11 +6,10 @@ import { Css } from "src/Css";
 import { jan1, jan10, jan2 } from "src/forms/formStateDomain";
 import { DateField, DateFieldProps, TextField } from "src/inputs/index";
 import { noop } from "src/utils";
-import { samples, withDimensions } from "src/utils/sb";
+import { samples } from "src/utils/sb";
 
 export default {
   component: Button,
-  decorators: [withDimensions()],
   parameters: {
     design: {
       type: "figma",
@@ -61,6 +60,7 @@ export function DateFields() {
         disabledDays={[{ before: jan1 }, { after: jan10 }]}
       />,
     ],
+    ["Full Width", <TestDateField label="Date" fullWidth />],
   );
 }
 

--- a/src/inputs/DateFields/DateFieldBase.tsx
+++ b/src/inputs/DateFields/DateFieldBase.tsx
@@ -22,7 +22,10 @@ import { maybeCall, useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
 
 export interface DateFieldBaseProps
-  extends Pick<TextFieldBaseProps<Properties>, "borderless" | "visuallyDisabled" | "labelStyle" | "compact"> {
+  extends Pick<
+    TextFieldBaseProps<Properties>,
+    "borderless" | "visuallyDisabled" | "labelStyle" | "compact" | "fullWidth"
+  > {
   label: string;
   /** Called when the component loses focus */
   onBlur?: () => void;

--- a/src/inputs/DateFields/DateRangeField.stories.tsx
+++ b/src/inputs/DateFields/DateRangeField.stories.tsx
@@ -40,6 +40,7 @@ export function Example() {
         label="Error message"
         errorMsg={rangeInitUndefined ? undefined : "Required"}
       />
+      <DateRangeField {...commonProps} fullWidth label="Full Width Field" />
     </div>
   );
 }

--- a/src/inputs/MultiSelectField.stories.tsx
+++ b/src/inputs/MultiSelectField.stories.tsx
@@ -173,6 +173,11 @@ export function MultiSelectFields() {
           )}
         />
       </div>
+
+      <div css={Css.df.fdc.gap2.$}>
+        <h1 css={Css.lg.$}>Full Width</h1>
+        <TestMultiSelectField fullWidth label="Favorite Icon" values={[options[2].id]} options={options} />
+      </div>
     </div>
   );
 }

--- a/src/inputs/NumberField.stories.tsx
+++ b/src/inputs/NumberField.stories.tsx
@@ -63,6 +63,11 @@ export function NumberFieldStyles() {
         <h1 css={Css.lg.$}>Without grouping</h1>
         <TestNumberField value={123456789} label="No grouping" useGrouping={false} />
       </div>
+
+      <div css={Css.df.fdc.gap2.$}>
+        <h1 css={Css.lg.$}>Full Width</h1>
+        <TestNumberField value={0} label="Age" fullWidth />
+      </div>
     </div>
   );
 }

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -11,7 +11,7 @@ import { TextFieldBase } from "./TextFieldBase";
 export type NumberFieldType = "cents" | "dollars" | "percent" | "basisPoints" | "days";
 
 // exported for testing purposes
-export interface NumberFieldProps extends Pick<PresentationFieldProps, "labelStyle"> {
+export interface NumberFieldProps extends Pick<PresentationFieldProps, "labelStyle" | "fullWidth"> {
   label: string;
   /** If set, the label will be defined as 'aria-label` on the input element */
   type?: NumberFieldType;

--- a/src/inputs/RichTextField.tsx
+++ b/src/inputs/RichTextField.tsx
@@ -8,8 +8,9 @@ import Tribute from "tributejs";
 import "tributejs/dist/tribute.css";
 import "trix/dist/trix";
 import "trix/dist/trix.css";
+import { PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
 
-export interface RichTextFieldProps {
+export interface RichTextFieldProps extends Pick<PresentationFieldProps, "fullWidth"> {
   /** The initial html value to show in the trix editor. */
   value: string | undefined;
   onChange: (html: string | undefined, text: string | undefined, mergeTags: string[]) => void;
@@ -28,8 +29,6 @@ export interface RichTextFieldProps {
   onFocus?: () => void;
   /** For rendering formatted text */
   readOnly?: boolean;
-  /** Will set width to: 100% */
-  fullWidth?: boolean;
 }
 
 /**
@@ -40,7 +39,17 @@ export interface RichTextFieldProps {
  * We also integrate [tributejs]{@link https://github.com/zurb/tribute} for @ mentions.
  */
 export function RichTextField(props: RichTextFieldProps) {
-  const { mergeTags, label, value = "", onChange, onBlur = noop, onFocus = noop, readOnly, fullWidth } = props;
+  const { fieldProps } = usePresentationContext();
+  const {
+    mergeTags,
+    label,
+    value = "",
+    onChange,
+    onBlur = noop,
+    onFocus = noop,
+    readOnly,
+    fullWidth = fieldProps?.fullWidth ?? false,
+  } = props;
 
   // We get a reference to the Editor instance after trix-init fires
   const [editor, setEditor] = useState<Editor>();

--- a/src/inputs/SelectField.stories.tsx
+++ b/src/inputs/SelectField.stories.tsx
@@ -201,6 +201,8 @@ function Template(args: SelectFieldProps<any, any>) {
           disabledOptions={[options[0].id, { value: options[3].id, reason: "Example disabled tooltip" }]}
           helperText="Disabled options can optionally have tooltip text"
         />
+
+        <TestSelectField {...args} fullWidth label="Full Width" value={options[2].id} options={options} />
       </div>
 
       <div css={Css.df.fdc.gap2.$}>

--- a/src/inputs/TextAreaField.stories.tsx
+++ b/src/inputs/TextAreaField.stories.tsx
@@ -40,6 +40,9 @@ export function TextAreaStyles() {
           <TextField label="Regular Field For Reference" value="value" onChange={() => {}} />
         </FormLines>
 
+        <h1 css={Css.lg.$}>Full Width</h1>
+        <TestTextArea label="Description" value="An example description text." fullWidth />
+
         <h1 css={Css.lg.$}>Modified for Blueprint To Do Title</h1>
         <TestTextArea
           label="Title"

--- a/src/inputs/TextField.stories.tsx
+++ b/src/inputs/TextField.stories.tsx
@@ -85,6 +85,11 @@ export function TextFieldStyles() {
           endAdornment={<Icon icon="star" />}
         />
       </div>
+
+      <div css={Css.df.fdc.gap2.$}>
+        <h1 css={Css.lg.$}>Full Width</h1>
+        <TestTextField fullWidth value="" label="Name" />
+      </div>
     </div>
   );
 }

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -14,13 +14,14 @@ import { Icon, IconButton, maybeTooltip } from "src/components";
 import { HelperText } from "src/components/HelperText";
 import { InlineLabel, Label } from "src/components/Label";
 import { usePresentationContext } from "src/components/PresentationContext";
-import { Css, Only, Palette, px } from "src/Css";
+import { Css, Only, Palette } from "src/Css";
 import { getLabelSuffix } from "src/forms/labelUtils";
 import { useGetRef } from "src/hooks/useGetRef";
 import { ErrorMessage } from "src/inputs/ErrorMessage";
 import { BeamTextFieldProps, TextFieldInternalProps, TextFieldXss } from "src/interfaces";
 import { defaultTestId } from "src/utils/defaultTestId";
 import { useTestIds } from "src/utils/useTestIds";
+import { getFieldWidth } from "src/inputs/utils";
 
 export interface TextFieldBaseProps<X>
   extends Pick<
@@ -37,6 +38,7 @@ export interface TextFieldBaseProps<X>
       | "compact"
       | "borderless"
       | "visuallyDisabled"
+      | "fullWidth"
       | "xss"
     >,
     Partial<Pick<BeamTextFieldProps<X>, "onChange">> {
@@ -89,6 +91,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
     errorInTooltip = fieldProps?.errorInTooltip ?? false,
     hideErrorMessage = false,
     alwaysShowHelperText = false,
+    fullWidth = fieldProps?.fullWidth ?? false,
   } = props;
 
   const typeScale = fieldProps?.typeScale ?? (inputProps.readOnly && labelStyle !== "hidden" ? "smMd" : "sm");
@@ -113,8 +116,10 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
     ? [Palette.Gray100, Palette.Gray200, Palette.Gray200]
     : [Palette.White, Palette.Gray100, Palette.Gray100];
 
+  const fieldMaxWidth = getFieldWidth(fullWidth);
+
   const fieldStyles = {
-    container: Css.df.fdc.w100.maxw(px(550)).relative.if(labelStyle === "left").maxw100.fdr.gap2.jcsb.aic.$,
+    container: Css.df.fdc.w100.maxw(fieldMaxWidth).relative.if(labelStyle === "left").maxw100.fdr.gap2.jcsb.aic.$,
     inputWrapper: {
       ...Css[typeScale].df.aic.br4.px1.w100
         .hPx(fieldHeight - maybeSmaller)

--- a/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
@@ -119,6 +119,17 @@ function Template(args: TreeSelectFieldProps<HasIdAndName, string>) {
               placeholder="Hidden label"
             />
           </div>
+
+          <div>
+            <TestTreeSelectField
+              {...args}
+              fullWidth
+              values={[]}
+              options={options}
+              label="Full Width"
+              placeholder="Full Width"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -14,8 +14,8 @@ import { useButton, useComboBox, useFilter, useOverlayPosition } from "react-ari
 import { Item, useComboBoxState, useMultipleSelectionState } from "react-stately";
 import { resolveTooltip } from "src/components";
 import { Popover } from "src/components/internal";
-import { PresentationFieldProps } from "src/components/PresentationContext";
-import { Css, px } from "src/Css";
+import { PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
+import { Css } from "src/Css";
 import { Value } from "src/inputs/index";
 import { ComboBoxInput } from "src/inputs/internal/ComboBoxInput";
 import { ListBox } from "src/inputs/internal/ListBox";
@@ -31,6 +31,7 @@ import {
 import { keyToValue, valueToKey } from "src/inputs/Value";
 import { BeamFocusableProps } from "src/interfaces";
 import { HasIdAndName, Optional } from "src/types";
+import { getFieldWidth } from "src/inputs/utils";
 
 export interface TreeSelectFieldProps<O, V extends Value> extends BeamFocusableProps, PresentationFieldProps {
   /** Renders `opt` in the dropdown menu, defaults to the `getOptionLabel` prop. `isUnsetOpt` is only defined for single SelectField */
@@ -127,6 +128,7 @@ export const CollapsedContext = React.createContext<CollapsedChildrenState<any, 
 });
 
 function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, V>) {
+  const { fieldProps } = usePresentationContext();
   const {
     values,
     options,
@@ -142,6 +144,7 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
     onSelect,
     defaultCollapsed = false,
     placeholder,
+    fullWidth = fieldProps?.fullWidth ?? false,
     ...otherProps
   } = props;
 
@@ -519,8 +522,10 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
     minWidth: 200,
   };
 
+  const fieldMaxWidth = getFieldWidth(fullWidth);
+
   return (
-    <div css={Css.df.fdc.w100.maxw(px(550)).if(labelStyle === "left").maxw100.$} ref={comboBoxRef}>
+    <div css={Css.df.fdc.w100.maxw(fieldMaxWidth).if(labelStyle === "left").maxw100.$} ref={comboBoxRef}>
       <ComboBoxInput
         {...otherProps}
         labelStyle={labelStyle}

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -528,6 +528,7 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
     <div css={Css.df.fdc.w100.maxw(fieldMaxWidth).if(labelStyle === "left").maxw100.$} ref={comboBoxRef}>
       <ComboBoxInput
         {...otherProps}
+        fullWidth={fullWidth}
         labelStyle={labelStyle}
         buttonProps={buttonProps}
         buttonRef={triggerRef}

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -5,11 +5,12 @@ import { Item, useComboBoxState, useMultipleSelectionState } from "react-stately
 import { resolveTooltip } from "src/components";
 import { Popover } from "src/components/internal";
 import { PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
-import { Css, px } from "src/Css";
+import { Css } from "src/Css";
 import { ComboBoxInput } from "src/inputs/internal/ComboBoxInput";
 import { ListBox } from "src/inputs/internal/ListBox";
 import { keyToValue, Value, valueToKey } from "src/inputs/Value";
 import { BeamFocusableProps } from "src/interfaces";
+import { getFieldWidth } from "src/inputs/utils";
 
 /** Base props for either `SelectField` or `MultiSelectField`. */
 export interface ComboBoxBaseProps<O, V extends Value> extends BeamFocusableProps, PresentationFieldProps {
@@ -88,6 +89,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
     getOptionLabel: propOptionLabel,
     getOptionValue: propOptionValue,
     getOptionMenuLabel: propOptionMenuLabel,
+    fullWidth = fieldProps?.fullWidth ?? false,
     ...otherProps
   } = props;
   const labelStyle = otherProps.labelStyle ?? fieldProps?.labelStyle ?? "above";
@@ -320,8 +322,10 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
     minWidth: 200,
   };
 
+  const fieldMaxWidth = getFieldWidth(fullWidth);
+
   return (
-    <div css={Css.df.fdc.w100.maxw(px(550)).if(labelStyle === "left").maxw100.$} ref={comboBoxRef}>
+    <div css={Css.df.fdc.w100.maxw(fieldMaxWidth).if(labelStyle === "left").maxw100.$} ref={comboBoxRef}>
       <ComboBoxInput
         {...otherProps}
         buttonProps={buttonProps}

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -328,6 +328,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
     <div css={Css.df.fdc.w100.maxw(fieldMaxWidth).if(labelStyle === "left").maxw100.$} ref={comboBoxRef}>
       <ComboBoxInput
         {...otherProps}
+        fullWidth={fullWidth}
         buttonProps={buttonProps}
         buttonRef={triggerRef}
         inputProps={inputProps}

--- a/src/inputs/internal/ComboBoxInput.tsx
+++ b/src/inputs/internal/ComboBoxInput.tsx
@@ -90,8 +90,6 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
   const multilineProps = allowWrap ? { textAreaMinHeight: 0, multiline: true } : {};
   useGrowingTextField({ disabled: !allowWrap, inputRef, inputWrapRef, value: inputProps.value });
 
-  console.log("otherProps", otherProps);
-
   return (
     <TextFieldBase
       {...otherProps}

--- a/src/inputs/internal/ComboBoxInput.tsx
+++ b/src/inputs/internal/ComboBoxInput.tsx
@@ -90,6 +90,8 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
   const multilineProps = allowWrap ? { textAreaMinHeight: 0, multiline: true } : {};
   useGrowingTextField({ disabled: !allowWrap, inputRef, inputWrapRef, value: inputProps.value });
 
+  console.log("otherProps", otherProps);
+
   return (
     <TextFieldBase
       {...otherProps}

--- a/src/inputs/utils.ts
+++ b/src/inputs/utils.ts
@@ -1,0 +1,3 @@
+export function getFieldWidth(fullWidth: boolean | undefined) {
+  return fullWidth ? "100%" : "550px";
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2628,7 +2628,7 @@ __metadata:
     "@homebound/form-state": ^2.20.1
     "@homebound/rtl-react-router-utils": 1.0.3
     "@homebound/rtl-utils": ^2.65.0
-    "@homebound/truss": ^1.131.0
+    "@homebound/truss": ^1.132.0
     "@homebound/tsconfig": ^1.0.3
     "@internationalized/number": ^3.0.3
     "@popperjs/core": ^2.11.6
@@ -2790,9 +2790,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@homebound/truss@npm:^1.131.0":
-  version: 1.131.0
-  resolution: "@homebound/truss@npm:1.131.0"
+"@homebound/truss@npm:^1.132.0":
+  version: 1.132.0
+  resolution: "@homebound/truss@npm:1.132.0"
   dependencies:
     change-case: ^4.1.2
     csstype: ^3.1.2
@@ -2800,7 +2800,7 @@ __metadata:
     ts-poet: ^6.1.0
   bin:
     truss: cli.js
-  checksum: 62621df447d11ad801e0fbcdcbe4b6e62c49c4b3946b8fabdb8ce5c4072ea6cae1ba765e0fab4460e7429465e2f59008e99c1fa90e3eeb45b3ce7fd5c6ca0fd8
+  checksum: dac770e17860cb21848bc558de043bb2cc8045b4a6116347582b2c25397a0a35e85ed84cc16ac3d6fe9bc74109699952aa152f9b12ddfbf0a152484986100ee5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds support for a `PresentationFieldProps.fullWidth` property. The following components will respect the property:
- FormLines
- TextField
- TextAreaField
- RichTextField
- SelectField
- MultiSelectField
- DateField
- NumberField
- TreeSelectField

Updates the `FormLines` component to default to the `"lg"` size instead of `"full"`. This will hopefully minimize the impact on existing layouts as the previous default width for each field within `FormLines` was 550px. By using the `lg` size, we'll continue to default the fields within `FormLines` to 550px.