### PR TITLE
feat: Drag & Drop fast follow for card style rows

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -2020,3 +2020,48 @@ export function DraggableNestedRows() {
     />
   );
 }
+
+export function DraggableCardRows() {
+  const dragColumn = dragHandleColumn<Row>({});
+  const nameColumn: GridColumn<Row> = {
+    header: "Name",
+    data: ({ name }) => ({ content: <div>{name}</div>, sortValue: name }),
+  };
+
+  const actionColumn: GridColumn<Row> = {
+    header: "Action",
+    data: () => <div>Actions</div>,
+    clientSideSort: false,
+  };
+
+  let rowArray: GridDataRow<Row>[] = new Array(26).fill(0);
+  rowArray = rowArray.map((elem, idx) => ({
+    kind: "data",
+    id: "" + (idx + 1),
+    order: idx + 1,
+    data: { name: "" + (idx + 1), value: idx + 1 },
+    draggable: true,
+  }));
+
+  const [rows, setRows] = useState<GridDataRow<Row>[]>([simpleHeader, ...rowArray]);
+
+  // also works with as="table" and as="virtual"
+  return (
+    <GridTable
+      columns={[dragColumn, nameColumn, actionColumn]}
+      onRowDrop={(draggedRow, droppedRow, indexOffset) => {
+        const tempRows = [...rows];
+        // remove dragged row
+        const draggedRowIndex = tempRows.findIndex((r) => r.id === draggedRow.id);
+        const reorderRow = tempRows.splice(draggedRowIndex, 1)[0];
+
+        const droppedRowIndex = tempRows.findIndex((r) => r.id === droppedRow.id);
+
+        // insert it at the dropped row index
+        setRows([...insertAtIndex(tempRows, reorderRow, droppedRowIndex + indexOffset)]);
+      }}
+      rows={[...rows]}
+      style={cardStyle}
+    />
+  );
+}

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -353,7 +353,10 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
 
     // set flags for css spacer
     // don't set none for the row we are entering
-    recursiveSetDraggedOver(rows.filter((r) => r.id !== row.id), DraggedOver.None);
+    recursiveSetDraggedOver(
+      rows.filter((r) => r.id !== row.id),
+      DraggedOver.None,
+    );
 
     if (draggedRowRef.current) {
       if (draggedRowRef.current.id === row.id) {

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -352,7 +352,8 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
     evt.preventDefault();
 
     // set flags for css spacer
-    recursiveSetDraggedOver(rows, DraggedOver.None);
+    // don't set none for the row we are entering
+    recursiveSetDraggedOver(rows.filter((r) => r.id !== row.id), DraggedOver.None);
 
     if (draggedRowRef.current) {
       if (draggedRowRef.current.id === row.id) {
@@ -373,7 +374,8 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
     evt.preventDefault();
 
     if (draggedRowRef.current) {
-      if (draggedRowRef.current.id === row.id) {
+      if (draggedRowRef.current.id === row.id || !evt.currentTarget) {
+        tableState.maybeSetRowDraggedOver(row.id, DraggedOver.None, draggedRowRef.current);
         return;
       }
 

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -146,12 +146,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
       onDragOver={(evt) => onDragOver?.(row, evt)}
       ref={ref}
     >
-      <RowTag
-        css={rowCss}
-        {...others}
-        data-gridrow
-        {...getCount(row.id)}
-      >
+      <RowTag css={rowCss} {...others} data-gridrow {...getCount(row.id)}>
         {isKeptGroupRow ? (
           <KeptGroupRow as={as} style={style} columnSizes={columnSizes} row={row} colSpan={columns.length} />
         ) : (
@@ -171,7 +166,8 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
             const numExpandedColumns = isExpanded
               ? tableState.numberOfExpandedChildren(maybeExpandedColumn.id)
                 ? // Subtract 1 if the column is hidden on expand, since we're not rendering it.
-                  tableState.numberOfExpandedChildren(maybeExpandedColumn.id) - (maybeExpandedColumn.hideOnExpand ? 1 : 0)
+                  tableState.numberOfExpandedChildren(maybeExpandedColumn.id) -
+                  (maybeExpandedColumn.hideOnExpand ? 1 : 0)
                 : 0
               : 0;
 
@@ -263,7 +259,8 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
               maybeContent,
             );
 
-            const maybeSticky = ((isGridCellContent(maybeContent) && maybeContent.sticky) || column.sticky) ?? undefined;
+            const maybeSticky =
+              ((isGridCellContent(maybeContent) && maybeContent.sticky) || column.sticky) ?? undefined;
             const maybeStickyColumnStyles =
               maybeSticky && columnSizes
                 ? {
@@ -282,7 +279,8 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
                 : {};
 
             // This relies on our column sizes being defined in pixel values, which is currently true as we calculate to pixel values in the `useSetupColumnSizes` hook
-            minStickyLeftOffset += maybeSticky === "left" ? parseInt(columnSizes[columnIndex].replace("px", ""), 10) : 0;
+            minStickyLeftOffset +=
+              maybeSticky === "left" ? parseInt(columnSizes[columnIndex].replace("px", ""), 10) : 0;
 
             const cellId = `${row.kind}_${row.id}_${column.id}`;
             const applyCellHighlight = cellHighlight && !!column.id && !isHeader && !isTotals;

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -136,8 +136,8 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
 
   // debounce drag over callback to avoid excessive re-renders
   const dragOverCallback = useCallback(
-    onDragOver ?? (() => {}),
-    [row],
+    (row: GridDataRow<R>, evt: React.DragEvent<HTMLElement>) => onDragOver?.(row, evt),
+    [onDragOver],
   );
   // when the event is not called, we still need to call preventDefault
   const onDragOverDebounced = useDebouncedCallback(dragOverCallback, 100);
@@ -364,7 +364,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
       onDrop={(evt) => onDrop?.(row, evt)}
       onDragEnter={(evt) => onDragEnter?.(row, evt)}
       onDragOver={(evt) => {
-        // when the event isn't called due to debounce, we still need to 
+        // when the event isn't called due to debounce, we still need to
         // call preventDefault for the drop event to fire
         evt.preventDefault();
         onDragOverDebounced(row, evt);

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -133,7 +133,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
   // used to render the whole row when dragging with the handle
   const ref = useRef<HTMLTableRowElement>(null);
 
-  const RowContent =  () => (
+  const RowContent = () => (
     <RowTag css={rowCss} {...others} data-gridrow {...getCount(row.id)}>
       {isKeptGroupRow ? (
         <KeptGroupRow as={as} style={style} columnSizes={columnSizes} row={row} colSpan={columns.length} />
@@ -154,8 +154,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
           const numExpandedColumns = isExpanded
             ? tableState.numberOfExpandedChildren(maybeExpandedColumn.id)
               ? // Subtract 1 if the column is hidden on expand, since we're not rendering it.
-                tableState.numberOfExpandedChildren(maybeExpandedColumn.id) -
-                (maybeExpandedColumn.hideOnExpand ? 1 : 0)
+                tableState.numberOfExpandedChildren(maybeExpandedColumn.id) - (maybeExpandedColumn.hideOnExpand ? 1 : 0)
               : 0
             : 0;
 
@@ -247,8 +246,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
             maybeContent,
           );
 
-          const maybeSticky =
-            ((isGridCellContent(maybeContent) && maybeContent.sticky) || column.sticky) ?? undefined;
+          const maybeSticky = ((isGridCellContent(maybeContent) && maybeContent.sticky) || column.sticky) ?? undefined;
           const maybeStickyColumnStyles =
             maybeSticky && columnSizes
               ? {
@@ -267,8 +265,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
               : {};
 
           // This relies on our column sizes being defined in pixel values, which is currently true as we calculate to pixel values in the `useSetupColumnSizes` hook
-          minStickyLeftOffset +=
-            maybeSticky === "left" ? parseInt(columnSizes[columnIndex].replace("px", ""), 10) : 0;
+          minStickyLeftOffset += maybeSticky === "left" ? parseInt(columnSizes[columnIndex].replace("px", ""), 10) : 0;
 
           const cellId = `${row.kind}_${row.id}_${column.id}`;
           const applyCellHighlight = cellHighlight && !!column.id && !isHeader && !isTotals;
@@ -362,7 +359,9 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
     >
       <RowContent />
     </div>
-  ) : <RowContent />;
+  ) : (
+    <RowContent />
+  );
 }
 
 /**

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -357,10 +357,12 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
       onDragOver={(evt) => onDragOver?.(row, evt)}
       ref={ref}
     >
-      <RowContent />
+      {RowContent()}
     </div>
   ) : (
-    <RowContent />
+    <>
+    {RowContent()}
+    </>
   );
 }
 

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -360,9 +360,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
       {RowContent()}
     </div>
   ) : (
-    <>
-    {RowContent()}
-    </>
+    <>{RowContent()}</>
   );
 }
 

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -93,9 +93,9 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
   const levelIndent = style.levels && style.levels[level]?.rowIndent;
 
   const containerCss = {
-    ...Css.add("transition", "padding 0.5s ease-in-out").$,
-    ...(rs.isDraggedOver === DraggedOver.Above && Css.add("paddingTop", "35px").$),
-    ...(rs.isDraggedOver === DraggedOver.Below && Css.add("paddingBottom", "35px").$),
+    ...Css.add("transition", "padding 0.25s ease-in-out").$,
+    ...(rs.isDraggedOver === DraggedOver.Above && Css.ptPx(35).$),
+    ...(rs.isDraggedOver === DraggedOver.Below && Css.pbPx(35).$),
   };
 
   const rowCss = {

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -31,7 +31,6 @@ import {
 import { Css, Palette } from "src/Css";
 import { AnyObject } from "src/types";
 import { isFunction } from "src/utils";
-import { Icon } from "src";
 
 interface RowProps<R extends Kinded> {
   as: RenderAs;
@@ -134,9 +133,224 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
   // used to render the whole row when dragging with the handle
   const ref = useRef<HTMLTableRowElement>(null);
 
-  return (
-    // we need to use padding for the drag & drop spacing or else drop events don't fire
-    // and we need a containing element for padding to work correctly with the card style row
+  const RowContent =  () => (
+    <RowTag css={rowCss} {...others} data-gridrow {...getCount(row.id)}>
+      {isKeptGroupRow ? (
+        <KeptGroupRow as={as} style={style} columnSizes={columnSizes} row={row} colSpan={columns.length} />
+      ) : (
+        columns.map((column, columnIndex) => {
+          // If the expandable column was hidden, then we need to look at the previous column to format the `expandHeader` and 'header' kinds correctly.
+          const maybeExpandedColumn = expandColumnHidden ? columns[columnIndex - 1] : column;
+
+          // Figure out if this column should be considered 'expanded' or not. If the column is hidden on expand, then we need to look at the previous column to see if it's expanded.
+          const isExpanded = tableState.isExpandedColumn(maybeExpandedColumn.id);
+          // If the column is hidden on expand, we don't want to render it. We'll flag that it was hidden, so on the next column we can render this column's "expandHeader" property.
+          if (column.hideOnExpand && isExpanded) {
+            expandColumnHidden = true;
+            return <></>;
+          }
+
+          // Need to keep track of the expanded columns so we can add borders as expected for the header rows
+          const numExpandedColumns = isExpanded
+            ? tableState.numberOfExpandedChildren(maybeExpandedColumn.id)
+              ? // Subtract 1 if the column is hidden on expand, since we're not rendering it.
+                tableState.numberOfExpandedChildren(maybeExpandedColumn.id) -
+                (maybeExpandedColumn.hideOnExpand ? 1 : 0)
+              : 0
+            : 0;
+
+          // If we're rendering the Expandable Header row, then we might need to render the previous column's `expandHeader` property in the case where the column is hidden on expand.
+          column = isExpandableHeader ? maybeExpandedColumn : column;
+
+          const { wrapAction = true, isAction = false } = column;
+
+          const isFirstContentColumn = !isAction && !foundFirstContentColumn;
+          const applyFirstContentColumnStyles = !isHeader && isFirstContentColumn;
+          foundFirstContentColumn ||= applyFirstContentColumnStyles;
+
+          if (column.mw) {
+            // Validate the column's minWidth definition if set.
+            if (!column.mw.endsWith("px") && !column.mw.endsWith("%")) {
+              throw new Error("Beam Table column min-width definition only supports px or percentage values");
+            }
+          }
+
+          // When using the variation of the table with an EXPANDABLE_HEADER, then our HEADER and TOTAL rows have special border styling
+          // Keep track of the when we get to the last expanded column so we can apply this styling properly.
+          if (hasExpandableHeader && (isHeader || isTotals)) {
+            // When the value of `currentExpandedColumnCount` is 0, then we have started over.
+            // If the current column `isExpanded`, then store the number of expandable columns.
+            if (currentExpandedColumnCount === 0 && isExpanded) {
+              currentExpandedColumnCount = numExpandedColumns;
+            } else if (currentExpandedColumnCount > 0) {
+              // If value is great than 0, then decrement. Once the value equals 0, then the special styling will be applied below.
+              currentExpandedColumnCount -= 1;
+            }
+          }
+
+          // Reset the expandColumnHidden flag once done with logic based upon it.
+          expandColumnHidden = false;
+
+          // Decrement colspan count and skip if greater than 1.
+          if (currentColspan > 1) {
+            currentColspan -= 1;
+            return null;
+          }
+          const maybeContent = applyRowFn(column as GridColumnWithId<R>, row, rowApi, level, isExpanded, {
+            rowRenderRef: ref,
+            onDragStart,
+            onDragEnd,
+            onDrop,
+            onDragEnter,
+            onDragOver,
+          });
+
+          // Only use the `numExpandedColumns` as the `colspan` when rendering the "Expandable Header"
+          currentColspan =
+            isGridCellContent(maybeContent) && typeof maybeContent.colspan === "number"
+              ? maybeContent.colspan
+              : isExpandableHeader
+              ? numExpandedColumns + 1
+              : 1;
+          const revealOnRowHover = isGridCellContent(maybeContent) ? maybeContent.revealOnRowHover : false;
+
+          const canSortColumn =
+            (sortOn === "client" && column.clientSideSort !== false) ||
+            (sortOn === "server" && !!column.serverSideSortKey);
+          const alignment = getAlignment(column, maybeContent);
+          const justificationCss = getJustification(column, maybeContent, as, alignment);
+          const isExpandable =
+            isFunction(column.expandColumns) ||
+            (column.expandColumns && column.expandColumns.length > 0) ||
+            column.expandedWidth !== undefined;
+
+          const content = toContent(
+            maybeContent,
+            isHeader,
+            canSortColumn,
+            sortOn === "client",
+            style,
+            as,
+            alignment,
+            column,
+            isExpandableHeader,
+            isExpandable,
+            minStickyLeftOffset,
+            isKeptRow,
+          );
+
+          ensureClientSideSortValueIsSortable(
+            sortOn,
+            isHeader || isTotals || isExpandableHeader,
+            column,
+            columnIndex,
+            maybeContent,
+          );
+
+          const maybeSticky =
+            ((isGridCellContent(maybeContent) && maybeContent.sticky) || column.sticky) ?? undefined;
+          const maybeStickyColumnStyles =
+            maybeSticky && columnSizes
+              ? {
+                  ...Css.sticky.z(zIndices.stickyColumns).bgWhite.$,
+                  ...(maybeSticky === "left"
+                    ? Css.left(columnIndex === 0 ? 0 : `calc(${columnSizes.slice(0, columnIndex).join(" + ")})`).$
+                    : {}),
+                  ...(maybeSticky === "right"
+                    ? Css.right(
+                        columnIndex + 1 === columnSizes.length
+                          ? 0
+                          : `calc(${columnSizes.slice(columnIndex + 1 - columnSizes.length).join(" + ")})`,
+                      ).$
+                    : {}),
+                }
+              : {};
+
+          // This relies on our column sizes being defined in pixel values, which is currently true as we calculate to pixel values in the `useSetupColumnSizes` hook
+          minStickyLeftOffset +=
+            maybeSticky === "left" ? parseInt(columnSizes[columnIndex].replace("px", ""), 10) : 0;
+
+          const cellId = `${row.kind}_${row.id}_${column.id}`;
+          const applyCellHighlight = cellHighlight && !!column.id && !isHeader && !isTotals;
+          const isCellActive = tableState.activeCellId === cellId;
+
+          // Note that it seems expensive to calc a per-cell class name/CSS-in-JS output,
+          // vs. setting global/table-wide CSS like `style.cellCss` on the root grid div with
+          // a few descendent selectors. However, that approach means the root grid-applied
+          // CSS has a high-specificity and so its harder for per-page/per-cell business logic
+          // to override it. So, we just calc the combined table-wide+per-cell-overridden CSS here,
+          // in a very CSS-in-JS idiomatic manner.
+          //
+          // In practice we've not seen any performance issues with this from our "large but
+          // not Google spreadsheets" tables.
+          const cellCss = {
+            // Adding `display: flex` so we can align content within the cells, unless it is displayed as a `table`, then use `table-cell`.
+            ...Css.df.if(as === "table").dtc.$,
+            // Apply sticky column/cell styles
+            ...maybeStickyColumnStyles,
+            // Apply any static/all-cell styling
+            ...style.cellCss,
+            // Then override with first/last cell styling
+            ...getFirstOrLastCellCss(style, columnIndex, columns),
+            // Then override with per-cell/per-row justification
+            ...justificationCss,
+            // Then apply any header-specific override
+            ...(isHeader && style.headerCellCss),
+            // Then apply any totals-specific override
+            ...(isTotals && style.totalsCellCss),
+            ...(isTotals && hasExpandableHeader && Css.boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$),
+            // Then apply any expandable header specific override
+            ...(isExpandableHeader && style.expandableHeaderCss),
+            // Conditionally apply the right border styling for the header or totals row when using expandable tables
+            // Only apply if not the last column in the table AND when this column is the last column in the group of expandable column or not expanded AND
+            ...(hasExpandableHeader &&
+              columns.length - 1 !== columnIndex &&
+              (isHeader || isTotals) &&
+              currentExpandedColumnCount === 0 &&
+              Css.boxShadow(`inset -1px -1px 0 ${Palette.Gray200}`).$),
+            // Or level-specific styling
+            ...(!isHeader && !isTotals && !isExpandableHeader && !!style.levels && style.levels[level]?.cellCss),
+            // Level specific styling for the first content column
+            ...(applyFirstContentColumnStyles && !!style.levels && style.levels[level]?.firstContentColumn),
+            // The specific cell's css (if any from GridCellContent)
+            ...rowStyleCellCss,
+            // Apply active row styling for non-nested card styles.
+            ...(isActive ? Css.bgColor(style.activeBgColor ?? Palette.Blue50).$ : {}),
+            // Add any cell specific style overrides
+            ...(isGridCellContent(maybeContent) && maybeContent.typeScale ? Css[maybeContent.typeScale].$ : {}),
+            // And any cell specific css
+            ...(isGridCellContent(maybeContent) && maybeContent.css ? maybeContent.css : {}),
+            // Apply cell highlight styles to active cell and hover
+            ...Css.if(applyCellHighlight && isCellActive).br4.boxShadow(`inset 0 0 0 1px ${Palette.Blue700}`).$,
+            // Define the width of the column on each cell. Supports col spans.
+            // If we have a 'levelIndent' defined, then subtract that amount from the first content column's width to ensure all columns will still line up properly
+            width: `calc(${columnSizes.slice(columnIndex, columnIndex + currentColspan).join(" + ")}${
+              applyFirstContentColumnStyles && levelIndent ? ` - ${levelIndent}px` : ""
+            })`,
+            ...(typeof column.mw === "string" ? Css.mw(column.mw).$ : {}),
+          };
+
+          const cellClassNames = revealOnRowHover ? revealOnRowHoverClass : undefined;
+
+          const cellOnClick = applyCellHighlight ? () => api.setActiveCellId(cellId) : undefined;
+          const tooltip = isGridCellContent(maybeContent) ? maybeContent.tooltip : undefined;
+
+          const renderFn: RenderCellFn<any> =
+            (rowStyle?.renderCell || rowStyle?.rowLink) && wrapAction
+              ? rowLinkRenderFn(as, currentColspan)
+              : isHeader || isTotals || isExpandableHeader
+              ? headerRenderFn(column, as, currentColspan)
+              : rowStyle?.onClick && wrapAction
+              ? rowClickRenderFn(as, api, currentColspan)
+              : defaultRenderFn(as, currentColspan);
+
+          return renderFn(columnIndex, cellCss, content, row, rowStyle, cellClassNames, cellOnClick, tooltip);
+        })
+      )}
+    </RowTag>
+  );
+
+  return row.draggable ? (
     <div
       css={containerCss}
       // these events are necessary to get the dragged-over row for the drop event
@@ -146,222 +360,9 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
       onDragOver={(evt) => onDragOver?.(row, evt)}
       ref={ref}
     >
-      <RowTag css={rowCss} {...others} data-gridrow {...getCount(row.id)}>
-        {isKeptGroupRow ? (
-          <KeptGroupRow as={as} style={style} columnSizes={columnSizes} row={row} colSpan={columns.length} />
-        ) : (
-          columns.map((column, columnIndex) => {
-            // If the expandable column was hidden, then we need to look at the previous column to format the `expandHeader` and 'header' kinds correctly.
-            const maybeExpandedColumn = expandColumnHidden ? columns[columnIndex - 1] : column;
-
-            // Figure out if this column should be considered 'expanded' or not. If the column is hidden on expand, then we need to look at the previous column to see if it's expanded.
-            const isExpanded = tableState.isExpandedColumn(maybeExpandedColumn.id);
-            // If the column is hidden on expand, we don't want to render it. We'll flag that it was hidden, so on the next column we can render this column's "expandHeader" property.
-            if (column.hideOnExpand && isExpanded) {
-              expandColumnHidden = true;
-              return <></>;
-            }
-
-            // Need to keep track of the expanded columns so we can add borders as expected for the header rows
-            const numExpandedColumns = isExpanded
-              ? tableState.numberOfExpandedChildren(maybeExpandedColumn.id)
-                ? // Subtract 1 if the column is hidden on expand, since we're not rendering it.
-                  tableState.numberOfExpandedChildren(maybeExpandedColumn.id) -
-                  (maybeExpandedColumn.hideOnExpand ? 1 : 0)
-                : 0
-              : 0;
-
-            // If we're rendering the Expandable Header row, then we might need to render the previous column's `expandHeader` property in the case where the column is hidden on expand.
-            column = isExpandableHeader ? maybeExpandedColumn : column;
-
-            const { wrapAction = true, isAction = false } = column;
-
-            const isFirstContentColumn = !isAction && !foundFirstContentColumn;
-            const applyFirstContentColumnStyles = !isHeader && isFirstContentColumn;
-            foundFirstContentColumn ||= applyFirstContentColumnStyles;
-
-            if (column.mw) {
-              // Validate the column's minWidth definition if set.
-              if (!column.mw.endsWith("px") && !column.mw.endsWith("%")) {
-                throw new Error("Beam Table column min-width definition only supports px or percentage values");
-              }
-            }
-
-            // When using the variation of the table with an EXPANDABLE_HEADER, then our HEADER and TOTAL rows have special border styling
-            // Keep track of the when we get to the last expanded column so we can apply this styling properly.
-            if (hasExpandableHeader && (isHeader || isTotals)) {
-              // When the value of `currentExpandedColumnCount` is 0, then we have started over.
-              // If the current column `isExpanded`, then store the number of expandable columns.
-              if (currentExpandedColumnCount === 0 && isExpanded) {
-                currentExpandedColumnCount = numExpandedColumns;
-              } else if (currentExpandedColumnCount > 0) {
-                // If value is great than 0, then decrement. Once the value equals 0, then the special styling will be applied below.
-                currentExpandedColumnCount -= 1;
-              }
-            }
-
-            // Reset the expandColumnHidden flag once done with logic based upon it.
-            expandColumnHidden = false;
-
-            // Decrement colspan count and skip if greater than 1.
-            if (currentColspan > 1) {
-              currentColspan -= 1;
-              return null;
-            }
-            const maybeContent = applyRowFn(column as GridColumnWithId<R>, row, rowApi, level, isExpanded, {
-              rowRenderRef: ref,
-              onDragStart,
-              onDragEnd,
-              onDrop,
-              onDragEnter,
-              onDragOver,
-            });
-
-            // Only use the `numExpandedColumns` as the `colspan` when rendering the "Expandable Header"
-            currentColspan =
-              isGridCellContent(maybeContent) && typeof maybeContent.colspan === "number"
-                ? maybeContent.colspan
-                : isExpandableHeader
-                ? numExpandedColumns + 1
-                : 1;
-            const revealOnRowHover = isGridCellContent(maybeContent) ? maybeContent.revealOnRowHover : false;
-
-            const canSortColumn =
-              (sortOn === "client" && column.clientSideSort !== false) ||
-              (sortOn === "server" && !!column.serverSideSortKey);
-            const alignment = getAlignment(column, maybeContent);
-            const justificationCss = getJustification(column, maybeContent, as, alignment);
-            const isExpandable =
-              isFunction(column.expandColumns) ||
-              (column.expandColumns && column.expandColumns.length > 0) ||
-              column.expandedWidth !== undefined;
-
-            const content = toContent(
-              maybeContent,
-              isHeader,
-              canSortColumn,
-              sortOn === "client",
-              style,
-              as,
-              alignment,
-              column,
-              isExpandableHeader,
-              isExpandable,
-              minStickyLeftOffset,
-              isKeptRow,
-            );
-
-            ensureClientSideSortValueIsSortable(
-              sortOn,
-              isHeader || isTotals || isExpandableHeader,
-              column,
-              columnIndex,
-              maybeContent,
-            );
-
-            const maybeSticky =
-              ((isGridCellContent(maybeContent) && maybeContent.sticky) || column.sticky) ?? undefined;
-            const maybeStickyColumnStyles =
-              maybeSticky && columnSizes
-                ? {
-                    ...Css.sticky.z(zIndices.stickyColumns).bgWhite.$,
-                    ...(maybeSticky === "left"
-                      ? Css.left(columnIndex === 0 ? 0 : `calc(${columnSizes.slice(0, columnIndex).join(" + ")})`).$
-                      : {}),
-                    ...(maybeSticky === "right"
-                      ? Css.right(
-                          columnIndex + 1 === columnSizes.length
-                            ? 0
-                            : `calc(${columnSizes.slice(columnIndex + 1 - columnSizes.length).join(" + ")})`,
-                        ).$
-                      : {}),
-                  }
-                : {};
-
-            // This relies on our column sizes being defined in pixel values, which is currently true as we calculate to pixel values in the `useSetupColumnSizes` hook
-            minStickyLeftOffset +=
-              maybeSticky === "left" ? parseInt(columnSizes[columnIndex].replace("px", ""), 10) : 0;
-
-            const cellId = `${row.kind}_${row.id}_${column.id}`;
-            const applyCellHighlight = cellHighlight && !!column.id && !isHeader && !isTotals;
-            const isCellActive = tableState.activeCellId === cellId;
-
-            // Note that it seems expensive to calc a per-cell class name/CSS-in-JS output,
-            // vs. setting global/table-wide CSS like `style.cellCss` on the root grid div with
-            // a few descendent selectors. However, that approach means the root grid-applied
-            // CSS has a high-specificity and so its harder for per-page/per-cell business logic
-            // to override it. So, we just calc the combined table-wide+per-cell-overridden CSS here,
-            // in a very CSS-in-JS idiomatic manner.
-            //
-            // In practice we've not seen any performance issues with this from our "large but
-            // not Google spreadsheets" tables.
-            const cellCss = {
-              // Adding `display: flex` so we can align content within the cells, unless it is displayed as a `table`, then use `table-cell`.
-              ...Css.df.if(as === "table").dtc.$,
-              // Apply sticky column/cell styles
-              ...maybeStickyColumnStyles,
-              // Apply any static/all-cell styling
-              ...style.cellCss,
-              // Then override with first/last cell styling
-              ...getFirstOrLastCellCss(style, columnIndex, columns),
-              // Then override with per-cell/per-row justification
-              ...justificationCss,
-              // Then apply any header-specific override
-              ...(isHeader && style.headerCellCss),
-              // Then apply any totals-specific override
-              ...(isTotals && style.totalsCellCss),
-              ...(isTotals && hasExpandableHeader && Css.boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$),
-              // Then apply any expandable header specific override
-              ...(isExpandableHeader && style.expandableHeaderCss),
-              // Conditionally apply the right border styling for the header or totals row when using expandable tables
-              // Only apply if not the last column in the table AND when this column is the last column in the group of expandable column or not expanded AND
-              ...(hasExpandableHeader &&
-                columns.length - 1 !== columnIndex &&
-                (isHeader || isTotals) &&
-                currentExpandedColumnCount === 0 &&
-                Css.boxShadow(`inset -1px -1px 0 ${Palette.Gray200}`).$),
-              // Or level-specific styling
-              ...(!isHeader && !isTotals && !isExpandableHeader && !!style.levels && style.levels[level]?.cellCss),
-              // Level specific styling for the first content column
-              ...(applyFirstContentColumnStyles && !!style.levels && style.levels[level]?.firstContentColumn),
-              // The specific cell's css (if any from GridCellContent)
-              ...rowStyleCellCss,
-              // Apply active row styling for non-nested card styles.
-              ...(isActive ? Css.bgColor(style.activeBgColor ?? Palette.Blue50).$ : {}),
-              // Add any cell specific style overrides
-              ...(isGridCellContent(maybeContent) && maybeContent.typeScale ? Css[maybeContent.typeScale].$ : {}),
-              // And any cell specific css
-              ...(isGridCellContent(maybeContent) && maybeContent.css ? maybeContent.css : {}),
-              // Apply cell highlight styles to active cell and hover
-              ...Css.if(applyCellHighlight && isCellActive).br4.boxShadow(`inset 0 0 0 1px ${Palette.Blue700}`).$,
-              // Define the width of the column on each cell. Supports col spans.
-              // If we have a 'levelIndent' defined, then subtract that amount from the first content column's width to ensure all columns will still line up properly
-              width: `calc(${columnSizes.slice(columnIndex, columnIndex + currentColspan).join(" + ")}${
-                applyFirstContentColumnStyles && levelIndent ? ` - ${levelIndent}px` : ""
-              })`,
-              ...(typeof column.mw === "string" ? Css.mw(column.mw).$ : {}),
-            };
-
-            const cellClassNames = revealOnRowHover ? revealOnRowHoverClass : undefined;
-
-            const cellOnClick = applyCellHighlight ? () => api.setActiveCellId(cellId) : undefined;
-            const tooltip = isGridCellContent(maybeContent) ? maybeContent.tooltip : undefined;
-
-            const renderFn: RenderCellFn<any> =
-              (rowStyle?.renderCell || rowStyle?.rowLink) && wrapAction
-                ? rowLinkRenderFn(as, currentColspan)
-                : isHeader || isTotals || isExpandableHeader
-                ? headerRenderFn(column, as, currentColspan)
-                : rowStyle?.onClick && wrapAction
-                ? rowClickRenderFn(as, api, currentColspan)
-                : defaultRenderFn(as, currentColspan);
-
-            return renderFn(columnIndex, cellCss, content, row, rowStyle, cellClassNames, cellOnClick, tooltip);
-          })
-        )}
-      </RowTag>
+      <RowContent />
     </div>
-  );
+  ) : <RowContent />;
 }
 
 /**

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -93,8 +93,13 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
   const rowStyleCellCss = maybeApplyFunction(row as any, rowStyle?.cellCss);
   const levelIndent = style.levels && style.levels[level]?.rowIndent;
 
-  const rowCss = {
+  const containerCss = {
     ...Css.add("transition", "padding 0.5s ease-in-out").$,
+    ...(rs.isDraggedOver === DraggedOver.Above && Css.add("paddingTop", "35px").$),
+    ...(rs.isDraggedOver === DraggedOver.Below && Css.add("paddingBottom", "35px").$),
+  };
+
+  const rowCss = {
     ...(!reservedRowKinds.includes(row.kind) && style.nonHeaderRowCss),
     // Optionally include the row hover styles, by default they should be turned on.
     ...(showRowHoverColor && {
@@ -117,8 +122,6 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
       [`:hover > .${revealOnRowHoverClass} > *`]: Css.visible.$,
     },
     ...(isLastKeptRow && Css.addIn("&>*", style.keptLastRowCss).$),
-    ...(rs.isDraggedOver === DraggedOver.Above && Css.add("paddingTop", "35px").$),
-    ...(rs.isDraggedOver === DraggedOver.Below && Css.add("paddingBottom", "35px").$),
   };
 
   let currentColspan = 1;
@@ -132,11 +135,10 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
   const ref = useRef<HTMLTableRowElement>(null);
 
   return (
-    <RowTag
-      css={rowCss}
-      {...others}
-      data-gridrow
-      {...getCount(row.id)}
+    // we need to use padding for the drag & drop spacing or else drop events don't fire
+    // and we need a containing element for padding to work correctly with the card style row
+    <div
+      css={containerCss}
       // these events are necessary to get the dragged-over row for the drop event
       // and spacer styling
       onDrop={(evt) => onDrop?.(row, evt)}
@@ -144,233 +146,223 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
       onDragOver={(evt) => onDragOver?.(row, evt)}
       ref={ref}
     >
-      {/* {row.draggable && (
-        <div
-          draggable={row.draggable}
-          onDragStart={(evt) => {
-            // show the whole row being dragged when dragging with the handle
-            ref.current && evt.dataTransfer.setDragImage(ref.current, 0, 0);
-            return onDragStart?.(row, evt);
-          }}
-          onDragEnd={(evt) => onDragEnd?.(row, evt)}
-          onDrop={(evt) => onDrop?.(row, evt)}
-          onDragEnter={(evt) => onDragEnter?.(row, evt)}
-          onDragOver={(evt) => onDragOver?.(row, evt)}
-          css={Css.mh100.ma.$}
-        >
-          <Icon icon="drag" />
-        </div>
-      )} */}
-      {isKeptGroupRow ? (
-        <KeptGroupRow as={as} style={style} columnSizes={columnSizes} row={row} colSpan={columns.length} />
-      ) : (
-        columns.map((column, columnIndex) => {
-          // If the expandable column was hidden, then we need to look at the previous column to format the `expandHeader` and 'header' kinds correctly.
-          const maybeExpandedColumn = expandColumnHidden ? columns[columnIndex - 1] : column;
+      <RowTag
+        css={rowCss}
+        {...others}
+        data-gridrow
+        {...getCount(row.id)}
+      >
+        {isKeptGroupRow ? (
+          <KeptGroupRow as={as} style={style} columnSizes={columnSizes} row={row} colSpan={columns.length} />
+        ) : (
+          columns.map((column, columnIndex) => {
+            // If the expandable column was hidden, then we need to look at the previous column to format the `expandHeader` and 'header' kinds correctly.
+            const maybeExpandedColumn = expandColumnHidden ? columns[columnIndex - 1] : column;
 
-          // Figure out if this column should be considered 'expanded' or not. If the column is hidden on expand, then we need to look at the previous column to see if it's expanded.
-          const isExpanded = tableState.isExpandedColumn(maybeExpandedColumn.id);
-          // If the column is hidden on expand, we don't want to render it. We'll flag that it was hidden, so on the next column we can render this column's "expandHeader" property.
-          if (column.hideOnExpand && isExpanded) {
-            expandColumnHidden = true;
-            return <></>;
-          }
-
-          // Need to keep track of the expanded columns so we can add borders as expected for the header rows
-          const numExpandedColumns = isExpanded
-            ? tableState.numberOfExpandedChildren(maybeExpandedColumn.id)
-              ? // Subtract 1 if the column is hidden on expand, since we're not rendering it.
-                tableState.numberOfExpandedChildren(maybeExpandedColumn.id) - (maybeExpandedColumn.hideOnExpand ? 1 : 0)
-              : 0
-            : 0;
-
-          // If we're rendering the Expandable Header row, then we might need to render the previous column's `expandHeader` property in the case where the column is hidden on expand.
-          column = isExpandableHeader ? maybeExpandedColumn : column;
-
-          const { wrapAction = true, isAction = false } = column;
-
-          const isFirstContentColumn = !isAction && !foundFirstContentColumn;
-          const applyFirstContentColumnStyles = !isHeader && isFirstContentColumn;
-          foundFirstContentColumn ||= applyFirstContentColumnStyles;
-
-          if (column.mw) {
-            // Validate the column's minWidth definition if set.
-            if (!column.mw.endsWith("px") && !column.mw.endsWith("%")) {
-              throw new Error("Beam Table column min-width definition only supports px or percentage values");
+            // Figure out if this column should be considered 'expanded' or not. If the column is hidden on expand, then we need to look at the previous column to see if it's expanded.
+            const isExpanded = tableState.isExpandedColumn(maybeExpandedColumn.id);
+            // If the column is hidden on expand, we don't want to render it. We'll flag that it was hidden, so on the next column we can render this column's "expandHeader" property.
+            if (column.hideOnExpand && isExpanded) {
+              expandColumnHidden = true;
+              return <></>;
             }
-          }
 
-          // When using the variation of the table with an EXPANDABLE_HEADER, then our HEADER and TOTAL rows have special border styling
-          // Keep track of the when we get to the last expanded column so we can apply this styling properly.
-          if (hasExpandableHeader && (isHeader || isTotals)) {
-            // When the value of `currentExpandedColumnCount` is 0, then we have started over.
-            // If the current column `isExpanded`, then store the number of expandable columns.
-            if (currentExpandedColumnCount === 0 && isExpanded) {
-              currentExpandedColumnCount = numExpandedColumns;
-            } else if (currentExpandedColumnCount > 0) {
-              // If value is great than 0, then decrement. Once the value equals 0, then the special styling will be applied below.
-              currentExpandedColumnCount -= 1;
+            // Need to keep track of the expanded columns so we can add borders as expected for the header rows
+            const numExpandedColumns = isExpanded
+              ? tableState.numberOfExpandedChildren(maybeExpandedColumn.id)
+                ? // Subtract 1 if the column is hidden on expand, since we're not rendering it.
+                  tableState.numberOfExpandedChildren(maybeExpandedColumn.id) - (maybeExpandedColumn.hideOnExpand ? 1 : 0)
+                : 0
+              : 0;
+
+            // If we're rendering the Expandable Header row, then we might need to render the previous column's `expandHeader` property in the case where the column is hidden on expand.
+            column = isExpandableHeader ? maybeExpandedColumn : column;
+
+            const { wrapAction = true, isAction = false } = column;
+
+            const isFirstContentColumn = !isAction && !foundFirstContentColumn;
+            const applyFirstContentColumnStyles = !isHeader && isFirstContentColumn;
+            foundFirstContentColumn ||= applyFirstContentColumnStyles;
+
+            if (column.mw) {
+              // Validate the column's minWidth definition if set.
+              if (!column.mw.endsWith("px") && !column.mw.endsWith("%")) {
+                throw new Error("Beam Table column min-width definition only supports px or percentage values");
+              }
             }
-          }
 
-          // Reset the expandColumnHidden flag once done with logic based upon it.
-          expandColumnHidden = false;
+            // When using the variation of the table with an EXPANDABLE_HEADER, then our HEADER and TOTAL rows have special border styling
+            // Keep track of the when we get to the last expanded column so we can apply this styling properly.
+            if (hasExpandableHeader && (isHeader || isTotals)) {
+              // When the value of `currentExpandedColumnCount` is 0, then we have started over.
+              // If the current column `isExpanded`, then store the number of expandable columns.
+              if (currentExpandedColumnCount === 0 && isExpanded) {
+                currentExpandedColumnCount = numExpandedColumns;
+              } else if (currentExpandedColumnCount > 0) {
+                // If value is great than 0, then decrement. Once the value equals 0, then the special styling will be applied below.
+                currentExpandedColumnCount -= 1;
+              }
+            }
 
-          // Decrement colspan count and skip if greater than 1.
-          if (currentColspan > 1) {
-            currentColspan -= 1;
-            return null;
-          }
-          const maybeContent = applyRowFn(column as GridColumnWithId<R>, row, rowApi, level, isExpanded, {
-            rowRenderRef: ref,
-            onDragStart,
-            onDragEnd,
-            onDrop,
-            onDragEnter,
-            onDragOver,
-          });
+            // Reset the expandColumnHidden flag once done with logic based upon it.
+            expandColumnHidden = false;
 
-          // Only use the `numExpandedColumns` as the `colspan` when rendering the "Expandable Header"
-          currentColspan =
-            isGridCellContent(maybeContent) && typeof maybeContent.colspan === "number"
-              ? maybeContent.colspan
-              : isExpandableHeader
-              ? numExpandedColumns + 1
-              : 1;
-          const revealOnRowHover = isGridCellContent(maybeContent) ? maybeContent.revealOnRowHover : false;
+            // Decrement colspan count and skip if greater than 1.
+            if (currentColspan > 1) {
+              currentColspan -= 1;
+              return null;
+            }
+            const maybeContent = applyRowFn(column as GridColumnWithId<R>, row, rowApi, level, isExpanded, {
+              rowRenderRef: ref,
+              onDragStart,
+              onDragEnd,
+              onDrop,
+              onDragEnter,
+              onDragOver,
+            });
 
-          const canSortColumn =
-            (sortOn === "client" && column.clientSideSort !== false) ||
-            (sortOn === "server" && !!column.serverSideSortKey);
-          const alignment = getAlignment(column, maybeContent);
-          const justificationCss = getJustification(column, maybeContent, as, alignment);
-          const isExpandable =
-            isFunction(column.expandColumns) ||
-            (column.expandColumns && column.expandColumns.length > 0) ||
-            column.expandedWidth !== undefined;
+            // Only use the `numExpandedColumns` as the `colspan` when rendering the "Expandable Header"
+            currentColspan =
+              isGridCellContent(maybeContent) && typeof maybeContent.colspan === "number"
+                ? maybeContent.colspan
+                : isExpandableHeader
+                ? numExpandedColumns + 1
+                : 1;
+            const revealOnRowHover = isGridCellContent(maybeContent) ? maybeContent.revealOnRowHover : false;
 
-          const content = toContent(
-            maybeContent,
-            isHeader,
-            canSortColumn,
-            sortOn === "client",
-            style,
-            as,
-            alignment,
-            column,
-            isExpandableHeader,
-            isExpandable,
-            minStickyLeftOffset,
-            isKeptRow,
-          );
+            const canSortColumn =
+              (sortOn === "client" && column.clientSideSort !== false) ||
+              (sortOn === "server" && !!column.serverSideSortKey);
+            const alignment = getAlignment(column, maybeContent);
+            const justificationCss = getJustification(column, maybeContent, as, alignment);
+            const isExpandable =
+              isFunction(column.expandColumns) ||
+              (column.expandColumns && column.expandColumns.length > 0) ||
+              column.expandedWidth !== undefined;
 
-          ensureClientSideSortValueIsSortable(
-            sortOn,
-            isHeader || isTotals || isExpandableHeader,
-            column,
-            columnIndex,
-            maybeContent,
-          );
+            const content = toContent(
+              maybeContent,
+              isHeader,
+              canSortColumn,
+              sortOn === "client",
+              style,
+              as,
+              alignment,
+              column,
+              isExpandableHeader,
+              isExpandable,
+              minStickyLeftOffset,
+              isKeptRow,
+            );
 
-          const maybeSticky = ((isGridCellContent(maybeContent) && maybeContent.sticky) || column.sticky) ?? undefined;
-          const maybeStickyColumnStyles =
-            maybeSticky && columnSizes
-              ? {
-                  ...Css.sticky.z(zIndices.stickyColumns).bgWhite.$,
-                  ...(maybeSticky === "left"
-                    ? Css.left(columnIndex === 0 ? 0 : `calc(${columnSizes.slice(0, columnIndex).join(" + ")})`).$
-                    : {}),
-                  ...(maybeSticky === "right"
-                    ? Css.right(
-                        columnIndex + 1 === columnSizes.length
-                          ? 0
-                          : `calc(${columnSizes.slice(columnIndex + 1 - columnSizes.length).join(" + ")})`,
-                      ).$
-                    : {}),
-                }
-              : {};
+            ensureClientSideSortValueIsSortable(
+              sortOn,
+              isHeader || isTotals || isExpandableHeader,
+              column,
+              columnIndex,
+              maybeContent,
+            );
 
-          // This relies on our column sizes being defined in pixel values, which is currently true as we calculate to pixel values in the `useSetupColumnSizes` hook
-          minStickyLeftOffset += maybeSticky === "left" ? parseInt(columnSizes[columnIndex].replace("px", ""), 10) : 0;
+            const maybeSticky = ((isGridCellContent(maybeContent) && maybeContent.sticky) || column.sticky) ?? undefined;
+            const maybeStickyColumnStyles =
+              maybeSticky && columnSizes
+                ? {
+                    ...Css.sticky.z(zIndices.stickyColumns).bgWhite.$,
+                    ...(maybeSticky === "left"
+                      ? Css.left(columnIndex === 0 ? 0 : `calc(${columnSizes.slice(0, columnIndex).join(" + ")})`).$
+                      : {}),
+                    ...(maybeSticky === "right"
+                      ? Css.right(
+                          columnIndex + 1 === columnSizes.length
+                            ? 0
+                            : `calc(${columnSizes.slice(columnIndex + 1 - columnSizes.length).join(" + ")})`,
+                        ).$
+                      : {}),
+                  }
+                : {};
 
-          const cellId = `${row.kind}_${row.id}_${column.id}`;
-          const applyCellHighlight = cellHighlight && !!column.id && !isHeader && !isTotals;
-          const isCellActive = tableState.activeCellId === cellId;
+            // This relies on our column sizes being defined in pixel values, which is currently true as we calculate to pixel values in the `useSetupColumnSizes` hook
+            minStickyLeftOffset += maybeSticky === "left" ? parseInt(columnSizes[columnIndex].replace("px", ""), 10) : 0;
 
-          // Note that it seems expensive to calc a per-cell class name/CSS-in-JS output,
-          // vs. setting global/table-wide CSS like `style.cellCss` on the root grid div with
-          // a few descendent selectors. However, that approach means the root grid-applied
-          // CSS has a high-specificity and so its harder for per-page/per-cell business logic
-          // to override it. So, we just calc the combined table-wide+per-cell-overridden CSS here,
-          // in a very CSS-in-JS idiomatic manner.
-          //
-          // In practice we've not seen any performance issues with this from our "large but
-          // not Google spreadsheets" tables.
-          const cellCss = {
-            // Adding `display: flex` so we can align content within the cells, unless it is displayed as a `table`, then use `table-cell`.
-            ...Css.df.if(as === "table").dtc.$,
-            // Apply sticky column/cell styles
-            ...maybeStickyColumnStyles,
-            // Apply any static/all-cell styling
-            ...style.cellCss,
-            // Then override with first/last cell styling
-            ...getFirstOrLastCellCss(style, columnIndex, columns),
-            // Then override with per-cell/per-row justification
-            ...justificationCss,
-            // Then apply any header-specific override
-            ...(isHeader && style.headerCellCss),
-            // Then apply any totals-specific override
-            ...(isTotals && style.totalsCellCss),
-            ...(isTotals && hasExpandableHeader && Css.boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$),
-            // Then apply any expandable header specific override
-            ...(isExpandableHeader && style.expandableHeaderCss),
-            // Conditionally apply the right border styling for the header or totals row when using expandable tables
-            // Only apply if not the last column in the table AND when this column is the last column in the group of expandable column or not expanded AND
-            ...(hasExpandableHeader &&
-              columns.length - 1 !== columnIndex &&
-              (isHeader || isTotals) &&
-              currentExpandedColumnCount === 0 &&
-              Css.boxShadow(`inset -1px -1px 0 ${Palette.Gray200}`).$),
-            // Or level-specific styling
-            ...(!isHeader && !isTotals && !isExpandableHeader && !!style.levels && style.levels[level]?.cellCss),
-            // Level specific styling for the first content column
-            ...(applyFirstContentColumnStyles && !!style.levels && style.levels[level]?.firstContentColumn),
-            // The specific cell's css (if any from GridCellContent)
-            ...rowStyleCellCss,
-            // Apply active row styling for non-nested card styles.
-            ...(isActive ? Css.bgColor(style.activeBgColor ?? Palette.Blue50).$ : {}),
-            // Add any cell specific style overrides
-            ...(isGridCellContent(maybeContent) && maybeContent.typeScale ? Css[maybeContent.typeScale].$ : {}),
-            // And any cell specific css
-            ...(isGridCellContent(maybeContent) && maybeContent.css ? maybeContent.css : {}),
-            // Apply cell highlight styles to active cell and hover
-            ...Css.if(applyCellHighlight && isCellActive).br4.boxShadow(`inset 0 0 0 1px ${Palette.Blue700}`).$,
-            // Define the width of the column on each cell. Supports col spans.
-            // If we have a 'levelIndent' defined, then subtract that amount from the first content column's width to ensure all columns will still line up properly
-            width: `calc(${columnSizes.slice(columnIndex, columnIndex + currentColspan).join(" + ")}${
-              applyFirstContentColumnStyles && levelIndent ? ` - ${levelIndent}px` : ""
-            })`,
-            ...(typeof column.mw === "string" ? Css.mw(column.mw).$ : {}),
-          };
+            const cellId = `${row.kind}_${row.id}_${column.id}`;
+            const applyCellHighlight = cellHighlight && !!column.id && !isHeader && !isTotals;
+            const isCellActive = tableState.activeCellId === cellId;
 
-          const cellClassNames = revealOnRowHover ? revealOnRowHoverClass : undefined;
+            // Note that it seems expensive to calc a per-cell class name/CSS-in-JS output,
+            // vs. setting global/table-wide CSS like `style.cellCss` on the root grid div with
+            // a few descendent selectors. However, that approach means the root grid-applied
+            // CSS has a high-specificity and so its harder for per-page/per-cell business logic
+            // to override it. So, we just calc the combined table-wide+per-cell-overridden CSS here,
+            // in a very CSS-in-JS idiomatic manner.
+            //
+            // In practice we've not seen any performance issues with this from our "large but
+            // not Google spreadsheets" tables.
+            const cellCss = {
+              // Adding `display: flex` so we can align content within the cells, unless it is displayed as a `table`, then use `table-cell`.
+              ...Css.df.if(as === "table").dtc.$,
+              // Apply sticky column/cell styles
+              ...maybeStickyColumnStyles,
+              // Apply any static/all-cell styling
+              ...style.cellCss,
+              // Then override with first/last cell styling
+              ...getFirstOrLastCellCss(style, columnIndex, columns),
+              // Then override with per-cell/per-row justification
+              ...justificationCss,
+              // Then apply any header-specific override
+              ...(isHeader && style.headerCellCss),
+              // Then apply any totals-specific override
+              ...(isTotals && style.totalsCellCss),
+              ...(isTotals && hasExpandableHeader && Css.boxShadow(`inset 0 -1px 0 ${Palette.Gray200}`).$),
+              // Then apply any expandable header specific override
+              ...(isExpandableHeader && style.expandableHeaderCss),
+              // Conditionally apply the right border styling for the header or totals row when using expandable tables
+              // Only apply if not the last column in the table AND when this column is the last column in the group of expandable column or not expanded AND
+              ...(hasExpandableHeader &&
+                columns.length - 1 !== columnIndex &&
+                (isHeader || isTotals) &&
+                currentExpandedColumnCount === 0 &&
+                Css.boxShadow(`inset -1px -1px 0 ${Palette.Gray200}`).$),
+              // Or level-specific styling
+              ...(!isHeader && !isTotals && !isExpandableHeader && !!style.levels && style.levels[level]?.cellCss),
+              // Level specific styling for the first content column
+              ...(applyFirstContentColumnStyles && !!style.levels && style.levels[level]?.firstContentColumn),
+              // The specific cell's css (if any from GridCellContent)
+              ...rowStyleCellCss,
+              // Apply active row styling for non-nested card styles.
+              ...(isActive ? Css.bgColor(style.activeBgColor ?? Palette.Blue50).$ : {}),
+              // Add any cell specific style overrides
+              ...(isGridCellContent(maybeContent) && maybeContent.typeScale ? Css[maybeContent.typeScale].$ : {}),
+              // And any cell specific css
+              ...(isGridCellContent(maybeContent) && maybeContent.css ? maybeContent.css : {}),
+              // Apply cell highlight styles to active cell and hover
+              ...Css.if(applyCellHighlight && isCellActive).br4.boxShadow(`inset 0 0 0 1px ${Palette.Blue700}`).$,
+              // Define the width of the column on each cell. Supports col spans.
+              // If we have a 'levelIndent' defined, then subtract that amount from the first content column's width to ensure all columns will still line up properly
+              width: `calc(${columnSizes.slice(columnIndex, columnIndex + currentColspan).join(" + ")}${
+                applyFirstContentColumnStyles && levelIndent ? ` - ${levelIndent}px` : ""
+              })`,
+              ...(typeof column.mw === "string" ? Css.mw(column.mw).$ : {}),
+            };
 
-          const cellOnClick = applyCellHighlight ? () => api.setActiveCellId(cellId) : undefined;
-          const tooltip = isGridCellContent(maybeContent) ? maybeContent.tooltip : undefined;
+            const cellClassNames = revealOnRowHover ? revealOnRowHoverClass : undefined;
 
-          const renderFn: RenderCellFn<any> =
-            (rowStyle?.renderCell || rowStyle?.rowLink) && wrapAction
-              ? rowLinkRenderFn(as, currentColspan)
-              : isHeader || isTotals || isExpandableHeader
-              ? headerRenderFn(column, as, currentColspan)
-              : rowStyle?.onClick && wrapAction
-              ? rowClickRenderFn(as, api, currentColspan)
-              : defaultRenderFn(as, currentColspan);
+            const cellOnClick = applyCellHighlight ? () => api.setActiveCellId(cellId) : undefined;
+            const tooltip = isGridCellContent(maybeContent) ? maybeContent.tooltip : undefined;
 
-          return renderFn(columnIndex, cellCss, content, row, rowStyle, cellClassNames, cellOnClick, tooltip);
-        })
-      )}
-    </RowTag>
+            const renderFn: RenderCellFn<any> =
+              (rowStyle?.renderCell || rowStyle?.rowLink) && wrapAction
+                ? rowLinkRenderFn(as, currentColspan)
+                : isHeader || isTotals || isExpandableHeader
+                ? headerRenderFn(column, as, currentColspan)
+                : rowStyle?.onClick && wrapAction
+                ? rowClickRenderFn(as, api, currentColspan)
+                : defaultRenderFn(as, currentColspan);
+
+            return renderFn(columnIndex, cellCss, content, row, rowStyle, cellClassNames, cellOnClick, tooltip);
+          })
+        )}
+      </RowTag>
+    </div>
   );
 }
 

--- a/src/components/Table/utils/RowStates.ts
+++ b/src/components/Table/utils/RowStates.ts
@@ -203,6 +203,7 @@ export class RowStates<R extends Kinded> {
     }
 
     // this allows a single-row re-render
+    if(rs.isDraggedOver === draggedOver) return;
     rs.isDraggedOver = draggedOver;
   }
 }

--- a/src/components/Table/utils/RowStates.ts
+++ b/src/components/Table/utils/RowStates.ts
@@ -203,7 +203,7 @@ export class RowStates<R extends Kinded> {
     }
 
     // this allows a single-row re-render
-    if(rs.isDraggedOver === draggedOver) return;
+    if (rs.isDraggedOver === draggedOver) return;
     rs.isDraggedOver = draggedOver;
   }
 }

--- a/src/components/Table/utils/columns.tsx
+++ b/src/components/Table/utils/columns.tsx
@@ -200,23 +200,15 @@ export function dragHandleColumn<T extends Kinded>(columnDef?: Partial<GridColum
     id: "beamDragHandleColumn",
     clientSideSort: false,
     align: "center",
-    // Defining `w: 40px` to accommodate for the `16px` wide checkbox and `12px` of padding on either side.
     w: "40px",
     wrapAction: false,
     isAction: true,
     expandColumns: undefined,
-    // Select Column should not display the select toggle for `expandableHeader` or `totals` row kinds
     expandableHeader: emptyCell,
     totals: emptyCell,
     // Use any of the user's per-row kind methods if they have them.
     ...columnDef,
   };
-
-  // return newMethodMissingProxy(base, (key) => {
-  //   return (data: any, { row, level }: { row: GridDataRow<any>; level: number }) => ({
-  //     content: <CollapseToggle row={row} compact={level > 0} />,
-  //   });
-  // }) as any;
 
   return newMethodMissingProxy(base, (key) => {
     return (data: any, { row, dragData }: { row: GridDataRow<T>; dragData: DragData<T> }) => {
@@ -224,8 +216,6 @@ export function dragHandleColumn<T extends Kinded>(columnDef?: Partial<GridColum
       const { rowRenderRef: ref, onDragStart, onDragEnd, onDrop, onDragEnter, onDragOver } = dragData;
 
       return {
-        // how do we get the callbacks and the ref here?
-        // inject them into the row in the Row component?
         content: row.draggable ? (
           <div
             draggable={row.draggable}

--- a/src/components/Table/utils/utils.tsx
+++ b/src/components/Table/utils/utils.tsx
@@ -273,8 +273,8 @@ export function isCursorBelowMidpoint(target: HTMLElement, clientY: number) {
   const style = window.getComputedStyle(target);
   const rect = target.getBoundingClientRect();
 
-  const pt = parseInt(style.getPropertyValue("padding-top")) / 2;
-  const pb = parseInt(style.getPropertyValue("padding-bottom"));
+  let pt = parseFloat(style.getPropertyValue("padding-top"));
+  const pb = parseFloat(style.getPropertyValue("padding-bottom"));
 
   return clientY > rect.top + pt + (rect.height - pb) / 2;
 }

--- a/src/components/Table/utils/utils.tsx
+++ b/src/components/Table/utils/utils.tsx
@@ -273,7 +273,7 @@ export function isCursorBelowMidpoint(target: HTMLElement, clientY: number) {
   const style = window.getComputedStyle(target);
   const rect = target.getBoundingClientRect();
 
-  let pt = parseFloat(style.getPropertyValue("padding-top"));
+  const pt = parseFloat(style.getPropertyValue("padding-top"));
   const pb = parseFloat(style.getPropertyValue("padding-bottom"));
 
   return clientY > rect.top + pt + (rect.height - pb) / 2;


### PR DESCRIPTION
Card style rows don't work with padding as spacing, and we can't use margin and still get drop events. So we need a containing element for padding and drag & drop events.