### PR TITLE
fix: multiselect read-only

### DIFF
--- a/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
@@ -27,13 +27,19 @@ function Template(args: TreeSelectFieldProps<HasIdAndName, string>) {
     })),
   }));
 
+  const multipleValuesWithParents = [
+    options[0]!.id, // Development:0
+    options[0]!.children![0]!.id, // Cohort:0
+    options[1]!.children![1]!.id, // Cohort:1
+    options[2]!.children![0]!.children![2]!.id, // Project:3
+  ];
   const singleValueId = [options[0]!.children![0]!.children![0].id];
   const multipleValueIds = [...singleValueId, options[0]!.children![0].children![1].id];
 
   return (
     <div css={Css.df.fdc.gap5.p2.if(args.contrast === true).white.bgGray800.$}>
       <div css={Css.df.fdc.gap3.$}>
-        <TestTreeSelectField
+        {/* <TestTreeSelectField
           {...args}
           values={["c:1:d:0"]}
           options={options}
@@ -63,9 +69,17 @@ function Template(args: TreeSelectFieldProps<HasIdAndName, string>) {
           label="Disabled"
           values={singleValueId}
           options={options}
-        />
+        /> */}
 
         <TestTreeSelectField
+          {...args}
+          readOnly="Read-only parent reason tooltip text"
+          label="Read-only"
+          values={multipleValuesWithParents}
+          options={options}
+        />
+
+        {/* <TestTreeSelectField
           {...args}
           readOnly="Read-only reason tooltip text"
           label="Read-only"
@@ -129,8 +143,8 @@ function Template(args: TreeSelectFieldProps<HasIdAndName, string>) {
               label="Full Width"
               placeholder="Full Width"
             />
-          </div>
-        </div>
+          </div> */}
+        {/* </div> */}
       </div>
     </div>
   );

--- a/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
@@ -73,17 +73,9 @@ function Template(args: TreeSelectFieldProps<HasIdAndName, string>) {
 
         <TestTreeSelectField
           {...args}
-          readOnly="Read-only parent reason tooltip text"
-          label="Read-only"
-          values={multipleValuesWithParents}
-          options={options}
-        />
-
-        <TestTreeSelectField
-          {...args}
           readOnly="Read-only reason tooltip text"
           label="Read-only"
-          values={singleValueId}
+          values={multipleValuesWithParents}
           options={options}
         />
 

--- a/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
@@ -39,7 +39,7 @@ function Template(args: TreeSelectFieldProps<HasIdAndName, string>) {
   return (
     <div css={Css.df.fdc.gap5.p2.if(args.contrast === true).white.bgGray800.$}>
       <div css={Css.df.fdc.gap3.$}>
-        {/* <TestTreeSelectField
+        <TestTreeSelectField
           {...args}
           values={["c:1:d:0"]}
           options={options}
@@ -69,7 +69,7 @@ function Template(args: TreeSelectFieldProps<HasIdAndName, string>) {
           label="Disabled"
           values={singleValueId}
           options={options}
-        /> */}
+        />
 
         <TestTreeSelectField
           {...args}
@@ -79,7 +79,7 @@ function Template(args: TreeSelectFieldProps<HasIdAndName, string>) {
           options={options}
         />
 
-        {/* <TestTreeSelectField
+        <TestTreeSelectField
           {...args}
           readOnly="Read-only reason tooltip text"
           label="Read-only"
@@ -143,8 +143,8 @@ function Template(args: TreeSelectFieldProps<HasIdAndName, string>) {
               label="Full Width"
               placeholder="Full Width"
             />
-          </div> */}
-        {/* </div> */}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -209,14 +209,16 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
       return parents.some((parent) => selectedKeys.includes(valueToKey(getOptionValue(parent))));
     };
 
-    // For the input value, we want to show the label of the selected option(s).
-    const selectedOptionsLabels = selectedOptions.filter((o) => !isParentSelected(o)).map(getOptionLabel);
-
     return {
       selectedKeys,
       inputValue:
-        selectedOptions.length > 0
-          ? selectedOptionsLabels.join(", ")
+        selectedOptions.length === 1
+          ? getOptionLabel(selectedOptions[0])
+          : isReadOnly && selectedOptions.length > 0
+          ? selectedOptions
+              .filter((o) => !isParentSelected(o))
+              .map(getOptionLabel)
+              .join(", ")
           : selectedOptions.length === 0
           ? nothingSelectedText
           : "",

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -202,11 +202,21 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
 
     initialOptions.forEach(areAllChildrenSelected);
 
+    // Given a child option, determine if the parent is selected.
+    const isParentSelected = (option: NestedOption<O>): boolean => {
+      const parents = findOption(initialOptions, valueToKey(getOptionValue(option)), getOptionValue)?.parents;
+      if (!parents) return false;
+      return parents.some((parent) => selectedKeys.includes(valueToKey(getOptionValue(parent))));
+    };
+
+    // For the input value, we want to show the label of the selected option(s).
+    const selectedOptionsLabels = selectedOptions.filter((o) => !isParentSelected(o)).map(getOptionLabel);
+
     return {
       selectedKeys,
       inputValue:
-        selectedOptions.length === 1
-          ? getOptionLabel(selectedOptions[0])
+        selectedOptions.length > 0
+          ? selectedOptionsLabels.join(", ")
           : selectedOptions.length === 0
           ? nothingSelectedText
           : "",

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -404,8 +404,8 @@ function getInputValue<O>(
   multiselect: boolean,
   nothingSelectedText: string,
 ) {
-  return selectedOptions.length === 1
-    ? getOptionLabel(selectedOptions[0])
+  return selectedOptions.length > 0
+    ? selectedOptions.map(getOptionLabel).join(", ")
     : multiselect && selectedOptions.length === 0
     ? nothingSelectedText
     : "";

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -137,7 +137,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
   // Do a one-time initialize of fieldState
   const [fieldState, setFieldState] = useState<FieldState>(() => {
     return {
-      inputValue: getInputValue(selectedOptions, getOptionLabel, multiselect, nothingSelectedText),
+      inputValue: getInputValue(selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly),
       searchValue: undefined,
       optionsLoading: false,
     };
@@ -281,7 +281,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
     } else {
       setFieldState((prevState) => ({
         ...prevState,
-        inputValue: getInputValue(selectedOptions, getOptionLabel, multiselect, nothingSelectedText),
+        inputValue: getInputValue(selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly),
       }));
     }
   }, [state.isOpen, selectedOptions, getOptionLabel, multiselect, nothingSelectedText]);
@@ -403,8 +403,11 @@ function getInputValue<O>(
   getOptionLabel: (o: O) => string,
   multiselect: boolean,
   nothingSelectedText: string,
+  readOnly?: boolean,
 ) {
-  return selectedOptions.length > 0
+  return selectedOptions.length === 1
+    ? getOptionLabel(selectedOptions[0])
+    : readOnly && selectedOptions.length > 0
     ? selectedOptions.map(getOptionLabel).join(", ")
     : multiselect && selectedOptions.length === 0
     ? nothingSelectedText

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -284,7 +284,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
         inputValue: getInputValue(selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly),
       }));
     }
-  }, [state.isOpen, selectedOptions, getOptionLabel, multiselect, nothingSelectedText]);
+  }, [state.isOpen, selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly]);
 
   // For the most part, the returned props contain `aria-*` and `id` attributes for accessibility purposes.
   const {


### PR DESCRIPTION
This PR fixes `TreeSelectField` and `MultiSelectField` read-only renders.