### PR TITLE
fix: Update tree select field state

### DIFF
--- a/src/components/Filters/TreeFilter.test.tsx
+++ b/src/components/Filters/TreeFilter.test.tsx
@@ -19,8 +19,8 @@ describe("TreeFilter", () => {
     click(r.getByRole("option", { name: "Grandparent 0" }));
     click(r.getByRole("option", { name: "Child 1-0-0" }));
     click(r.getByRole("option", { name: "Parent 1-1" }));
-    // Then the filter's value is empty because multiple options are selected
-    expect(r.filter_tree).toHaveValue("");
+    // Then the filter's value is not empty because filter has persisted
+    expect(r.filter_tree).toHaveValue("All");
     // Then the filter is set to only return the "root" values that are selected.
     expect(r.value).toHaveTextContent('{"tree":["gp:0","child:1-0-0","parent:1-1"]}');
   });

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -459,6 +459,8 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
 
         setFieldState((prevState) => ({
           ...prevState,
+          inputValue: nothingSelectedText,
+          filteredOptions: initialOptions.flatMap((o) => levelOptions(o, 0)),
           selectedKeys: [...selectedKeys],
           selectedOptions,
         }));


### PR DESCRIPTION
[SC-44850](https://app.shortcut.com/homebound-team/story/44850/bug-bash-row-height-expands-too-much-when-adding-alot-of-scope)

* Previously if you selected a parent in the tree select and clicked inside of the input, the selection would stick and you could not select another option. 
* This fix allows us to persist the selected option (filter) and show other options for users to select.

BUG Video: https://www.loom.com/share/3a420d77f70e4470a18e3f598984e5cb

Fix Video: https://www.loom.com/share/d8155d01a0764cf9816c4249302ada1e
