### PR TITLE
fix: Prefer option.name if it exists.

### DIFF
--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -10,11 +10,11 @@ export function defaultOptionValue<O>(opt: O): any {
 export function defaultOptionLabel<O>(opt: O): any {
   if (typeof opt !== "object" || !opt) fail(`Option ${opt} has no id or code`);
   // Use `in` because returning undefined is fine
-  return "displayName" in opt
+  return "name" in opt
+    ? opt.name
+    : "displayName" in opt
     ? opt.displayName
     : "label" in opt
     ? opt.label
-    : "name" in opt
-    ? opt.name
     : fail(`Option ${JSON.stringify(opt)} has no displayName, label, or name`);
 }


### PR DESCRIPTION
This keeps backwards compatibility with the prior `defaultOptionLabel`.