### PR TITLE
fix: Clear search terms and reset dropdown options when dropdowns re-open

### DIFF
--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -316,7 +316,11 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
     }
     if (isOpen) {
       // reset the input field to allow the user to start typing to filter
-      setFieldState((prevState) => ({ ...prevState, inputValue: "" }));
+      setFieldState((prevState) => ({
+        ...prevState,
+        inputValue: "",
+        filteredOptions: initialOptions.flatMap((o) => levelOptions(o, 0)),
+      }));
     }
   }
 

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -281,6 +281,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
     } else {
       setFieldState((prevState) => ({
         ...prevState,
+        searchValue: "",
         inputValue: getInputValue(selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly),
       }));
     }


### PR DESCRIPTION
# SC-47696

https://www.loom.com/share/27ec8874b4f549b2813dd8563ea7b68f?sid=d55983ea-d3f2-4679-a658-03a3fc9cbffd