### PR TITLE
feat: add year selection header option to DatePicker;

### DIFF
--- a/src/components/internal/DatePicker/DatePicker.stories.tsx
+++ b/src/components/internal/DatePicker/DatePicker.stories.tsx
@@ -2,6 +2,8 @@ import { Meta } from "@storybook/react";
 import { useState } from "react";
 import { DatePicker } from "src/components/internal/DatePicker";
 import { jan1, jan10, jan2, jan29 } from "src/forms/formStateDomain";
+import { Css } from "src";
+import { format } from "date-fns";
 
 export default {
   component: DatePicker,
@@ -15,5 +17,32 @@ export default {
 
 export function Default() {
   const [date, setDate] = useState(jan1);
-  return <DatePicker value={date} onSelect={setDate} dottedDays={[jan1, jan2, jan29]} disabledDays={[jan10]} />;
+  return (
+    <div>
+      <DatePicker value={date} onSelect={setDate} dottedDays={[jan1, jan2, jan29]} disabledDays={[jan10]} />
+      <div css={Css.mt1.$}>
+        <strong>Selected Date:</strong>
+        <span css={Css.ml1.$}>{date && format(new Date(date), "MM/dd/yyyy")}</span>
+      </div>
+    </div>
+  );
+}
+
+export function WithYearControlHeader() {
+  const [date, setDate] = useState(jan1);
+  return (
+    <div>
+      <DatePicker
+        useYearPicker
+        value={date}
+        onSelect={setDate}
+        dottedDays={[jan1, jan2, jan29]}
+        disabledDays={[jan10]}
+      />
+      <div css={Css.mt1.$}>
+        <strong>Selected Date:</strong>
+        <span css={Css.ml1.$}>{date && format(new Date(date), "MM/dd/yyyy")}</span>
+      </div>
+    </div>
+  );
 }

--- a/src/components/internal/DatePicker/DatePicker.tsx
+++ b/src/components/internal/DatePicker/DatePicker.tsx
@@ -1,6 +1,6 @@
 import { DayPicker, Matcher } from "react-day-picker";
 import { Day } from "src/components/internal/DatePicker/Day";
-import { Header } from "src/components/internal/DatePicker/Header";
+import { Header, YearSkipHeader } from "src/components/internal/DatePicker/Header";
 import { WeekHeader } from "src/components/internal/DatePicker/WeekHeader";
 import { Css } from "src/Css";
 import { useTestIds } from "src/utils";
@@ -11,16 +11,17 @@ export interface DatePickerProps {
   onSelect: (value: Date) => void;
   disabledDays?: Matcher | Matcher[];
   dottedDays?: Matcher[];
+  useYearPicker?: boolean;
 }
 
 export function DatePicker(props: DatePickerProps) {
-  const { value, onSelect, disabledDays, dottedDays } = props;
+  const { value, onSelect, disabledDays, dottedDays, useYearPicker } = props;
   const tid = useTestIds(props, "datePicker");
 
   return (
     <div css={Css.dib.bgWhite.xs.$} {...tid}>
       <DayPicker
-        components={{ Caption: Header, Head: WeekHeader, Day }}
+        components={{ Caption: useYearPicker ? YearSkipHeader : Header, Head: WeekHeader, Day }}
         // DatePicker only allows for a single date to be `selected` (per our props) though DayPicker expects an array of dates
         selected={value ? [value] : []}
         defaultMonth={value ?? new Date()}

--- a/src/components/internal/DatePicker/DateRangePicker.stories.tsx
+++ b/src/components/internal/DatePicker/DateRangePicker.stories.tsx
@@ -31,3 +31,25 @@ export function Default() {
     </div>
   );
 }
+
+export function WithYearControlHeader() {
+  const [range, setRange] = useState<DateRange | undefined>({ from: jan1, to: jan19 });
+  return (
+    <div>
+      <DateRangePicker
+        useYearPicker
+        range={range}
+        onSelect={setRange}
+        dottedDays={[jan1, jan2, jan29]}
+        disabledDays={[jan10]}
+      />
+      <div css={Css.mt1.$}>
+        <strong>Selected Range:</strong>
+        <span css={Css.ml1.$}>
+          {range?.from && format(new Date(range?.from), "MM/dd/yyyy")} -{" "}
+          {range?.to && format(new Date(range?.to), "MM/dd/yyyy")}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/inputs/DateFields/DateFieldBase.tsx
+++ b/src/inputs/DateFields/DateFieldBase.tsx
@@ -54,6 +54,8 @@ export interface DateFieldBaseProps
   mode: DateFieldMode;
   /** Range filters should only allow a full DateRange or nothing */
   isRangeFilterField?: boolean;
+  /** Render header that skips years in addition to months */
+  useYearPicker?: boolean;
 }
 
 export interface DateSingleFieldBaseProps extends DateFieldBaseProps {
@@ -89,6 +91,7 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
     defaultOpen,
     mode,
     isRangeFilterField = false,
+    useYearPicker = false,
     ...others
   } = props;
 
@@ -330,7 +333,7 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
                     setInputValue(formatDateRange(dr, dateFormats.short) ?? "");
                     onChange(dr);
                   }}
-                  useYearPicker={isRangeFilterField}
+                  useYearPicker={isRangeFilterField || useYearPicker}
                   {...tid.datePicker}
                 />
               ) : (
@@ -342,6 +345,7 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
                     setInputValue(formatDate(d, dateFormats.short) ?? "");
                     onChange(d);
                   }}
+                  useYearPicker={useYearPicker}
                   {...tid.datePicker}
                 />
               )}


### PR DESCRIPTION
Adds the year selection header as an option to SingleDateFields. This is the same component the RangeDateField uses.

<img width="1677" alt="Screenshot 2024-03-21 at 7 27 36 PM" src="https://github.com/homebound-team/beam/assets/108819408/f95212e3-b0f8-411f-937c-a380f0fe0f4e">



[SC-47338](https://app.shortcut.com/homebound-team/story/47338/enable-type-to-edit-and-search-by-year-month-for-mls-list-date-field-on-subject-page)