### PR TITLE
fix: Use dvh/dvw instead of vh/vw for mobile

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -120,7 +120,8 @@ export function Modal(props: ModalProps) {
                     .if(isFixedHeight)
                     .hPx(height)
                     .if(sm)
-                    .vh100.add("width", "100vw")
+                    .add("height", "100dvh")
+                    .add("width", "100dvw")
                     .maxh("none").br0.$
                 }
                 ref={ref}


### PR DESCRIPTION
Use `height: 100dvh` (dynamic viewport height) vs `100vh` as it takes into account the address bar and other "chrome" added around the viewport. This results in a better output for the screen. 

`dvh` and `dvw` has been supported in iOS, and most browsers since early-mid 2022. More specifically as of iOS/Safari v15.4, Chrome v108, Firefox v101. See MDN docs for a more complete [browser support](https://developer.mozilla.org/en-US/docs/Web/CSS/length#browser_compatibility).

| **100vh** | **100dvh** |
|-----------| -----------|
| ![Simulator Screenshot - iPhone 15 - 2024-04-22 at 10 06 25](https://github.com/homebound-team/beam/assets/1143861/4636e053-cdef-4302-aa6a-31b66c967771) | ![Simulator Screenshot - iPhone 15 - 2024-04-22 at 10 07 16](https://github.com/homebound-team/beam/assets/1143861/5fb80525-c072-40db-ae5a-fed3077c5ca3) |
