### PR TITLE
fix: Form Labels to not extend full width of field

### DIFF
--- a/src/components/Label.tsx
+++ b/src/components/Label.tsx
@@ -27,7 +27,13 @@ function LabelComponent<X extends Only<Xss<LabelXss>, X>>(props: LabelProps<X>) 
     <label
       {...labelProps}
       {...others}
-      css={{ ...Css.dif.aic.gap1.sm.gray700.mbPx(inline ? 0 : 4).if(contrast).white.$, ...xss }}
+      css={{
+        ...Css.dif.aic.gap1.sm.gray700
+          .mbPx(inline ? 0 : 4)
+          .if(contrast)
+          .white.if(!inline).asfs.$,
+        ...xss,
+      }}
     >
       {label}
       {suffix && ` ${suffix}`}

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -188,6 +188,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
             labelProps={labelProps}
             hidden={labelStyle === "hidden" || compound}
             label={label}
+            inline={labelStyle !== "above"}
             suffix={labelSuffix}
             contrast={contrast}
             {...tid.label}

--- a/src/inputs/ToggleChipGroup.tsx
+++ b/src/inputs/ToggleChipGroup.tsx
@@ -34,7 +34,7 @@ export function ToggleChipGroup(props: ToggleChipGroupProps) {
 
   return (
     <div {...groupProps} css={Css.relative.df.fdc.if(labelStyle === "left").fdr.maxw100.$}>
-      <Label label={label} {...labelProps} hidden={hideLabel} />
+      <Label label={label} {...labelProps} hidden={hideLabel} inline={labelStyle === "left"} />
       <div css={Css.df.gap1.add("flexWrap", "wrap").if(labelStyle === "left").ml2.$}>
         {options.map((o) => (
           <ToggleChip


### PR DESCRIPTION
Kind of an annoying issue that I've see is you try to click away from a SelectField to close the menu, but instead the menu flickers and opens back up. This was due to clicking above the field, which happened to be still clicking on the label element which was taking up the full width of its container. When clicking a label element, then the focus is set to the associated field. By adding 'align-self: flex-start', then the label element no longer extends the full width of the container.

See Loom for example:
https://www.loom.com/share/7b2dd9d22c1a457f991aca884a45731b