### PR TITLE
fix: Allow click events to pass through tooltip wrapped elements

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -36,7 +36,8 @@ export function Tooltip(props: TooltipProps) {
         {...(!state.isOpen && typeof title === "string" ? { title } : {})}
         {...tid}
         // Add display contents to prevent the tooltip wrapping element from short-circuiting inherited styles (i.e. flex item positioning)
-        css={Css.display("contents").$}
+        // Once the element is `:active`, allow pointer events (i.e. click events) to pass through to the children.
+        css={Css.display("contents").addIn(":active", Css.add("pointerEvents", "none").$).$}
         // Adding `draggable` as a hack to allow focus to continue through this element and into its children.
         // This is due to some code in React-Aria that prevents default due ot mobile browser inconsistencies,
         // and the only way they don't prevent default is if the element is draggable.


### PR DESCRIPTION
Thanks @bsholmes for the solution! 🎉 