### PR TITLE
feat: hackday multiselect shows selected options in field

### DIFF
--- a/src/Css.ts
+++ b/src/Css.ts
@@ -3958,6 +3958,15 @@ class CssBuilder<T extends Properties> {
     ).add("alignItems", "center").add("justifyContent", "center").add("backgroundColor", "rgba(36,36,36,0.2)");
   }
 
+  // visuallyHidden
+  /** Sets `position: "absolute"; overflow: "hidden"; clip: "inset(50%)"; clipPath: ""; border: 0; height: "1px"; margin: "-1px"; width: "1px"; padding: 0; whiteSpace: "nowrap"`. */
+  get visuallyHidden() {
+    return this.add("position", "absolute").add("overflow", "hidden").add("clip", "inset(50%)").add("clipPath", "").add(
+      "border",
+      0,
+    ).add("height", "1px").add("margin", "-1px").add("width", "1px").add("padding", 0).add("whiteSpace", "nowrap");
+  }
+
   // contentEmpty
   /** Sets `content: "''"`. */
   get contentEmpty() {

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -50,7 +50,7 @@ export function Pagination(props: PaginationProps) {
       <div css={Css.df.mya.mr2.$} {...tid.pageSizeLabel}>
         Page size:
       </div>
-      <div css={Css.wPx(78).$}>
+      <div css={Css.wPx(95).$}>
         <SelectField
           compact
           label="Page Size"

--- a/src/inputs/MultiSelectField.test.tsx
+++ b/src/inputs/MultiSelectField.test.tsx
@@ -161,9 +161,10 @@ describe("MultiSelectFieldTest", () => {
     // When opening the menu
     fireEvent.click(r.age);
     // Then expect the chip to be disabled
-    expect(r.chip).toHaveAttribute("disabled");
+    const chips = r.queryAllByTestId("chip");
+    expect(chips[1]).toHaveAttribute("disabled");
     // And when clicking on that chip
-    click(r.chip);
+    click(chips[1]);
     // Then the `onSelect` callback is not called
     expect(onSelect).not.toHaveBeenCalled();
   });
@@ -203,7 +204,8 @@ describe("MultiSelectFieldTest", () => {
     // When opening the menu
     click(r.age);
     // And clicking on the chip
-    click(r.chip);
+    const chips = r.queryAllByTestId("chip");
+    click(chips[1]);
     // Then the menu remains open
     expect(r.getByRole("listbox")).toBeInTheDocument();
     // And `onSelect` is called with the correct values

--- a/src/inputs/MultiSelectField.test.tsx
+++ b/src/inputs/MultiSelectField.test.tsx
@@ -25,6 +25,20 @@ describe("MultiSelectFieldTest", () => {
     expect(onSelect).toHaveBeenCalledWith(["1", "3"]);
   });
 
+  it("renders a chip for each selected item", async () => {
+    // Given a MultiSelectField with 3 selected value
+    const r = await render(<TestMultiSelectField values={["1", "2", "3"] as string[]} options={options} />);
+
+    // Then we can see 3 chips rendered
+    const selectionChips = r.queryAllByTestId("chip");
+    expect(selectionChips).toHaveLength(3);
+
+    // And they are rendered with names of the selected options
+    expect(selectionChips[0]).toHaveTextContent("One");
+    expect(selectionChips[1]).toHaveTextContent("Two");
+    expect(selectionChips[2]).toHaveTextContent("Three");
+  });
+
   it("has an empty text box not set", async () => {
     // Given a MultiSelectField with no selected values
     const r = await render(<TestMultiSelectField values={[]} options={options} />);

--- a/src/inputs/TextFieldBase.test.tsx
+++ b/src/inputs/TextFieldBase.test.tsx
@@ -1,5 +1,6 @@
 import { TextFieldBase } from "src/inputs/TextFieldBase";
 import { render } from "src/utils/rtl";
+import { act } from "@testing-library/react";
 
 describe(TextFieldBase, () => {
   it("shows error and helper text", async () => {
@@ -24,5 +25,31 @@ describe(TextFieldBase, () => {
     expect(r.test).toBeDisabled();
     expect(r.query.test_errorMsg).not.toBeInTheDocument();
     expect(r.query.test_helperText).not.toBeInTheDocument();
+  });
+
+  it("handles unfocusedPlaceholder correctly", async () => {
+    // When TextFieldBase is first rendered
+    const r = await render(
+      <TextFieldBase
+        inputProps={{}}
+        unfocusedPlaceholder={"Unfocused placeholder text"}
+        label="Test"
+        errorMsg="Error"
+        helperText="Helper"
+      />,
+    );
+
+    // The unfocused placeholder container is rendered
+    expect(r.test_unfocusedPlaceholderContainer).toBeInTheDocument();
+    // And is visible
+    expect(r.test_unfocusedPlaceholderContainer).not.toHaveStyleRule("position", "absolute");
+
+    // And when we focus the field
+    act(() => {
+      r.test.focus();
+    });
+
+    // Then the unfocused placeholder container is visually hidden
+    expect(r.test_unfocusedPlaceholderContainer).toHaveStyleRule("position", "absolute");
   });
 });

--- a/src/inputs/TextFieldBase.test.tsx
+++ b/src/inputs/TextFieldBase.test.tsx
@@ -1,6 +1,5 @@
 import { TextFieldBase } from "src/inputs/TextFieldBase";
-import { render } from "src/utils/rtl";
-import { act } from "@testing-library/react";
+import { render, focus } from "src/utils/rtl";
 
 describe(TextFieldBase, () => {
   it("shows error and helper text", async () => {
@@ -45,9 +44,7 @@ describe(TextFieldBase, () => {
     expect(r.test_unfocusedPlaceholderContainer).not.toHaveStyleRule("position", "absolute");
 
     // And when we focus the field
-    act(() => {
-      r.test.focus();
-    });
+    focus(r.test);
 
     // Then the unfocused placeholder container is visually hidden
     expect(r.test_unfocusedPlaceholderContainer).toHaveStyleRule("position", "absolute");

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -58,6 +58,8 @@ export interface TextFieldBaseProps<X>
   hideErrorMessage?: boolean;
   // If set, the helper text will always be shown (usually we hide the helper text if read only)
   alwaysShowHelperText?: boolean;
+  // Replaces empty input field and placeholder with node
+  // IE: Multiselect renders list of selected items in the input field
   unfocusedPlaceholder?: ReactNode;
 }
 
@@ -256,7 +258,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
                   {...tid.unfocusedPlaceholderContainer}
                   css={{
                     ...Css.df.fdc.w100.pyPx(2).maxh100.overflowAuto.$,
-                    ...(isFocused && visuallyHidden),
+                    ...(isFocused && Css.visuallyHidden.$),
                   }}
                 >
                   {unfocusedPlaceholder}
@@ -275,7 +277,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
                   ...fieldStyles.input,
                   ...(inputProps.disabled ? fieldStyles.disabled : {}),
                   ...(showHover ? fieldStyles.hover : {}),
-                  ...(unfocusedPlaceholder && !isFocused && visuallyHidden),
+                  ...(unfocusedPlaceholder && !isFocused && Css.visuallyHidden.$),
                   ...xss,
                 }}
                 {...tid}
@@ -331,7 +333,3 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
     </>
   );
 }
-
-// Css that would be applied if using react-aria <VisuallyHidden />
-const visuallyHidden = Css.add("clip", "inset(50%)").add("clipPath", "").add("border", 0).hPx(1).mPx(-1).wPx(1).nowrap
-  .p0.overflowHidden.absolute.$;

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -155,7 +155,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
       // Not using Truss's inline `if` statement here because `addIn` properties do not respect the if statement.
       ...(contrast && Css.addIn("&::selection", Css.bgGray800.$).$),
       // For "multiline" fields we add top and bottom padding of 7px for compact, or 11px for non-compact, to properly match the height of the single line fields
-      ...(multiline ? Css.br4.h100.pyPx(compact ? 7 : 11).add("resize", "none").$ : Css.truncate.$),
+      ...(multiline ? Css.br4.pyPx(compact ? 7 : 11).add("resize", "none").$ : Css.truncate.$),
     },
     hover: Css.bgColor(hoverBgColor).if(contrast).bGray600.$,
     focus: Css.bBlue700.if(contrast).bBlue500.$,
@@ -243,7 +243,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
                 ...(showHover ? fieldStyles.hover : {}),
                 // Only show error styles if the field is not disabled, following the pattern that the error message is also hidden
                 ...(errorMsg && !inputProps.disabled ? fieldStyles.error : {}),
-                ...Css.if(multiline).aifs.mhPx(textAreaMinHeight).$,
+                ...Css.if(multiline).aifs.overflowHidden.mhPx(textAreaMinHeight).$,
               }}
               {...hoverProps}
               ref={inputWrapRef as any}
@@ -257,7 +257,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
                 <div
                   {...tid.unfocusedPlaceholderContainer}
                   css={{
-                    ...Css.df.fdc.w100.pyPx(2).maxh100.overflowAuto.$,
+                    ...Css.df.asc.w100.maxh100.overflowAuto.$,
                     ...(isFocused && Css.visuallyHidden.$),
                   }}
                 >

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -58,6 +58,7 @@ export interface TextFieldBaseProps<X>
   hideErrorMessage?: boolean;
   // If set, the helper text will always be shown (usually we hide the helper text if read only)
   alwaysShowHelperText?: boolean;
+  unfocusedPlaceholder?: ReactNode;
 }
 
 // Used by both TextField and TextArea
@@ -92,6 +93,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
     hideErrorMessage = false,
     alwaysShowHelperText = false,
     fullWidth = fieldProps?.fullWidth ?? false,
+    unfocusedPlaceholder,
   } = props;
 
   const typeScale = fieldProps?.typeScale ?? (inputProps.readOnly && labelStyle !== "hidden" ? "smMd" : "sm");
@@ -176,6 +178,12 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
     e.target.select();
   }, onFocus);
 
+  // Simulate clicking `ElementType` when using an unfocused placeholder
+  function handleUnfocusedPlaceholderClick(e: React.MouseEvent<HTMLDivElement>) {
+    e.stopPropagation();
+    fieldRef.current?.click();
+  }
+
   const showFocus = (isFocused && !inputProps.readOnly) || forceFocus;
   const showHover = (isHovered && !inputProps.disabled && !inputProps.readOnly && !isFocused) || forceHover;
 
@@ -237,11 +245,23 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
               }}
               {...hoverProps}
               ref={inputWrapRef as any}
+              onClick={unfocusedPlaceholder ? handleUnfocusedPlaceholderClick : undefined}
             >
               {labelStyle === "inline" && label && (
                 <InlineLabel multiline={multiline} labelProps={labelProps} label={label} {...tid.label} />
               )}
               {startAdornment && <span css={Css.df.aic.asc.fs0.br4.pr1.$}>{startAdornment}</span>}
+              {unfocusedPlaceholder && (
+                <div
+                  {...tid.unfocusedPlaceholderContainer}
+                  css={{
+                    ...Css.df.fdc.w100.pyPx(2).maxh100.overflowAuto.$,
+                    ...(isFocused && visuallyHidden),
+                  }}
+                >
+                  {unfocusedPlaceholder}
+                </div>
+              )}
               <ElementType
                 {...mergeProps(
                   inputProps,
@@ -255,6 +275,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
                   ...fieldStyles.input,
                   ...(inputProps.disabled ? fieldStyles.disabled : {}),
                   ...(showHover ? fieldStyles.hover : {}),
+                  ...(unfocusedPlaceholder && !isFocused && visuallyHidden),
                   ...xss,
                 }}
                 {...tid}
@@ -310,3 +331,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
     </>
   );
 }
+
+// Css that would be applied if using react-aria <VisuallyHidden />
+const visuallyHidden = Css.add("clip", "inset(50%)").add("clipPath", "").add("border", 0).hPx(1).mPx(-1).wPx(1).nowrap
+  .p0.overflowHidden.absolute.$;

--- a/src/inputs/internal/ComboBoxInput.tsx
+++ b/src/inputs/internal/ComboBoxInput.tsx
@@ -85,12 +85,13 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
   const [isFocused, setIsFocused] = useState(false);
   const isMultiSelect = state.selectionManager.selectionMode === "multiple";
   const showNumSelection = isMultiSelect && state.selectionManager.selectedKeys.size > 1;
+  // Show selections as chips
+  const hasSelection = state.selectionManager.selectedKeys.size > 0;
   // For MultiSelect only show the `fieldDecoration` when input is not in focus.
   const showFieldDecoration =
     (!isMultiSelect || (isMultiSelect && !isFocused)) && fieldDecoration && selectedOptions.length === 1;
 
   const multilineProps = allowWrap ? { textAreaMinHeight: 0, multiline: true } : {};
-  useGrowingTextField({ disabled: !allowWrap, inputRef, inputWrapRef, value: inputProps.value });
 
   const chipLabels = isTree ? selectedOptionsLabels || [] : selectedOptions.map((o) => getOptionLabel(o));
 
@@ -98,7 +99,7 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
     <TextFieldBase
       {...otherProps}
       {...multilineProps}
-      unfocusedPlaceholder={showNumSelection && <Chips compact={otherProps.compact} values={chipLabels} />}
+      unfocusedPlaceholder={hasSelection && <Chips compact={otherProps.compact} values={chipLabels} />}
       inputRef={inputRef}
       inputWrapRef={inputWrapRef}
       errorMsg={errorMsg}

--- a/src/inputs/internal/ComboBoxInput.tsx
+++ b/src/inputs/internal/ComboBoxInput.tsx
@@ -9,7 +9,7 @@ import React, {
 } from "react";
 import { mergeProps } from "react-aria";
 import { ComboBoxState } from "react-stately";
-import { Icon } from "src/components";
+import { Chips, Icon, Tooltip } from "src/components";
 import { PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
 import { Css } from "src/Css";
 import { useGrowingTextField } from "src/inputs/hooks/useGrowingTextField";
@@ -92,10 +92,13 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
   const multilineProps = allowWrap ? { textAreaMinHeight: 0, multiline: true } : {};
   useGrowingTextField({ disabled: !allowWrap, inputRef, inputWrapRef, value: inputProps.value });
 
+  const chipLabels = isTree ? selectedOptionsLabels || [] : selectedOptions.map((o) => getOptionLabel(o));
+
   return (
     <TextFieldBase
       {...otherProps}
       {...multilineProps}
+      unfocusedPlaceholder={showNumSelection && <Chips compact={otherProps.compact} values={chipLabels} />}
       inputRef={inputRef}
       inputWrapRef={inputWrapRef}
       errorMsg={errorMsg}
@@ -103,12 +106,14 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
       xss={otherProps.labelStyle !== "inline" && !inputProps.readOnly ? Css.fw5.$ : {}}
       startAdornment={
         (showNumSelection && (
-          <span
-            css={Css.wPx(16).hPx(16).fs0.br100.bgBlue700.white.tinySb.df.aic.jcc.$}
-            data-testid="selectedOptionsCount"
-          >
-            {isTree ? selectedOptionsLabels?.length : state.selectionManager.selectedKeys.size}
-          </span>
+          <Tooltip title={<SelectedOptionBullets labels={chipLabels} />}>
+            <span
+              css={Css.wPx(16).hPx(16).fs0.br100.bgBlue700.white.tinySb.df.aic.jcc.$}
+              data-testid="selectedOptionsCount"
+            >
+              {isTree ? selectedOptionsLabels?.length : state.selectionManager.selectedKeys.size}
+            </span>
+          </Tooltip>
         )) ||
         (showFieldDecoration && fieldDecoration(selectedOptions[0]))
       }
@@ -249,4 +254,8 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
       }}
     />
   );
+}
+
+function SelectedOptionBullets({ labels = [] }: { labels: string[] | undefined }) {
+  return <div>{labels?.map((label) => <li key={label}>{label}</li>)}</div>;
 }

--- a/truss-config.ts
+++ b/truss-config.ts
@@ -116,6 +116,21 @@ const sections: Sections = {
       backgroundColor: "rgba(36,36,36,0.2)",
     }),
   ],
+  // Css that would be applied if using react-aria <VisuallyHidden />
+  visuallyHidden: () => [
+    newMethod("visuallyHidden", {
+      position: "absolute",
+      overflow: "hidden",
+      clip: "inset(50%)",
+      clipPath: "",
+      border: 0,
+      height: "1px",
+      margin: "-1px",
+      width: "1px",
+      padding: 0,
+      whiteSpace: "nowrap",
+    }),
+  ],
   contentEmpty: () => [newMethod("contentEmpty", { content: "''" })],
 };
 


### PR DESCRIPTION
All multiselect fields will show selected options within the field. Tab functionality is preserved. It's not a full rework like what's laid out in [this old Figma](https://www.figma.com/design/GEXYjIEDKFRjoFbnrt515r/New-Multiselect-Component-%E2%9C%A8?node-id=5-14&t=QHpFO2gb9HhNE2yB-0) but should make some people happy.


https://github.com/homebound-team/beam/assets/108819408/a4ac3709-630c-4834-863d-e6b3e13c9b1f

- This also adds a list tooltip to the selected count.
  - ![Screenshot 2024-05-17 at 3 01 33 PM](https://github.com/homebound-team/beam/assets/108819408/2e5f756a-5b6b-47f8-9091-89af3229dfc1)

Couple spots I could use some design help
  - 
- I set the placeholder container width to `100%` to fill the space. It does introduce some weirdness when fields extend far. How should we handle this?
  - ![Screenshot 2024-05-17 at 2 49 02 PM](https://github.com/homebound-team/beam/assets/108819408/ec7e108f-f70e-402b-86d7-af8cbe4e50a5)
- When packed into a tight table the scrollbars obstruct the view and aren't very viually appealing. Granted with the tooltip on selected count now you can get more info at a glance than we had before but it still bugs me.
  - ![Screenshot 2024-05-17 at 2 57 39 PM](https://github.com/homebound-team/beam/assets/108819408/292373c3-2449-41f6-9af9-4c143bc15c69)
