### PR TITLE
feat(accordion): clickable title

### DIFF
--- a/src/components/Accordion.stories.tsx
+++ b/src/components/Accordion.stories.tsx
@@ -36,6 +36,16 @@ export function AccordionVariations() {
           Our modern approach to homebuilding makes the process easier and more personal than ever before.
         </div>
       </Accordion>
+      <Accordion title="Compact" compact>
+        <div css={Css.sm.$}>
+          Our modern approach to homebuilding makes the process easier and more personal than ever before.
+        </div>
+      </Accordion>
+      <Accordion title="Clickable Title + Compact" titleOnClick={() => {}} compact>
+        <div css={Css.sm.$}>
+          Our modern approach to homebuilding makes the process easier and more personal than ever before.
+        </div>
+      </Accordion>
     </>
   );
 }

--- a/src/components/Accordion.stories.tsx
+++ b/src/components/Accordion.stories.tsx
@@ -31,6 +31,11 @@ export function AccordionVariations() {
           Our modern approach to homebuilding makes the process easier and more personal than ever before.
         </div>
       </Accordion>
+      <Accordion title="Clickable Title" titleOnClick={() => {}}>
+        <div css={Css.sm.$}>
+          Our modern approach to homebuilding makes the process easier and more personal than ever before.
+        </div>
+      </Accordion>
     </>
   );
 }

--- a/src/components/Accordion.test.tsx
+++ b/src/components/Accordion.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "src/utils/rtl";
+import { click, render } from "src/utils/rtl";
 import { Accordion } from "./Accordion";
 
 describe(Accordion, () => {
@@ -71,5 +71,37 @@ describe(Accordion, () => {
     expect(r.accordion_title).toBeDisabled();
     // And the content is not displayed
     expect(r.query.accordion_content).not.toBeInTheDocument();
+  });
+
+  it("calls the titleOnClick function when the title is clicked", async () => {
+    // Given an accordion component with titleOnClick set
+    const titleOnClick = jest.fn();
+    // When rendered
+    const r = await render(
+      <Accordion title="Test title" titleOnClick={titleOnClick}>
+        Test description
+      </Accordion>,
+    );
+
+    // Then the titleOnClick function is called when the title is clicked
+    click(r.accordion_titleText);
+    expect(titleOnClick).toHaveBeenCalled();
+  });
+
+  it("alters expando behavior when titleOnClick is provided", async () => {
+    // When rendered with a titleOnClick set
+    const r = await render(
+      <Accordion title="Test title" titleOnClick={() => {}}>
+        Test description
+      </Accordion>,
+    );
+
+    click(r.accordion_titleText);
+    // And the content is not displayed
+    expect(r.query.accordion_content).not.toBeInTheDocument();
+
+    // Then the content is displayed when the title is clicked
+    click(r.accordion_title);
+    expect(r.accordion_content).toHaveTextContent("Test description");
   });
 });

--- a/src/components/Accordion.test.tsx
+++ b/src/components/Accordion.test.tsx
@@ -84,7 +84,7 @@ describe(Accordion, () => {
     );
 
     // Then the titleOnClick function is called when the title is clicked
-    click(r.accordion_titleText);
+    click(r.accordion_title);
     expect(titleOnClick).toHaveBeenCalled();
   });
 
@@ -96,12 +96,14 @@ describe(Accordion, () => {
       </Accordion>,
     );
 
-    click(r.accordion_titleText);
-    // And the content is not displayed
+    // when the title is clicked
+    click(r.accordion_title);
+    // then the content is not displayed
     expect(r.query.accordion_content).not.toBeInTheDocument();
 
-    // Then the content is displayed when the title is clicked
-    click(r.accordion_title);
+    // when bar is clicked
+    click(r.accordion_toggle);
+    // then the content is displayed
     expect(r.accordion_content).toHaveTextContent("Test description");
   });
 });

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -105,7 +105,7 @@ export function Accordion<X extends Only<AccordionXss, X>>(props: AccordionProps
       }}
     >
       {titleOnClick ? (
-        <div {...focusProps} aria-controls={id} aria-expanded={expanded} css={Css.df.jcsb.$}>
+        <div {...focusProps} aria-controls={id} aria-expanded={expanded} css={Css.df.$}>
           <button {...tid.title} disabled={disabled} css={{ ...touchableStyle, ...Css.fg0.$ }} onClick={titleOnClick}>
             {title}
           </button>

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -79,11 +79,6 @@ export function Accordion<X extends Only<AccordionXss, X>>(props: AccordionProps
   }, [expanded, setContentHeight]);
   useResizeObserver({ ref: contentRef, onResize });
 
-  const expandOrCollapse = useCallback(() => {
-    setExpanded((prior) => !prior);
-    if (setExpandedIndex) setExpandedIndex(index);
-  }, [index, setExpandedIndex]);
-
   return (
     <div
       {...testIds.container}
@@ -105,7 +100,10 @@ export function Accordion<X extends Only<AccordionXss, X>>(props: AccordionProps
           ...(isFocusVisible && Css.boxShadow(`inset 0 0 0 2px ${Palette.Blue700}`).$),
           ...xss,
         }}
-        onClick={expandOrCollapse}
+        onClick={() => {
+          setExpanded((prior) => !prior);
+          if (setExpandedIndex) setExpandedIndex(index);
+        }}
       >
         {titleOnClick ? (
           <button

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -23,6 +23,8 @@ export interface AccordionProps<X = AccordionXss> {
    */
   index?: number;
   setExpandedIndex?: Dispatch<SetStateAction<number | undefined>>;
+  /** Turns the title into a button. If provided, disables expand/collapse on title text */
+  titleOnClick?: VoidFunction;
   /** Used by Accordion list. Sets default padding to 0 for nested accordions */
   omitPadding?: boolean;
   /** Styles overrides for padding */
@@ -43,6 +45,7 @@ export function Accordion<X extends Only<AccordionXss, X>>(props: AccordionProps
     bottomBorder = false,
     index,
     setExpandedIndex,
+    titleOnClick,
     omitPadding = false,
     xss,
   } = props;
@@ -76,6 +79,11 @@ export function Accordion<X extends Only<AccordionXss, X>>(props: AccordionProps
   }, [expanded, setContentHeight]);
   useResizeObserver({ ref: contentRef, onResize });
 
+  const expandOrCollapse = useCallback(() => {
+    setExpanded((prior) => !prior);
+    if (setExpandedIndex) setExpandedIndex(index);
+  }, [index, setExpandedIndex]);
+
   return (
     <div
       {...testIds.container}
@@ -97,12 +105,22 @@ export function Accordion<X extends Only<AccordionXss, X>>(props: AccordionProps
           ...(isFocusVisible && Css.boxShadow(`inset 0 0 0 2px ${Palette.Blue700}`).$),
           ...xss,
         }}
-        onClick={() => {
-          setExpanded(!expanded);
-          if (setExpandedIndex) setExpandedIndex(index);
-        }}
+        onClick={expandOrCollapse}
       >
-        <span css={Css.fg1.tl.$}>{title}</span>
+        {titleOnClick ? (
+          <button
+            {...testIds.titleText}
+            css={Css.fg0.tl.$}
+            onClick={(e) => {
+              e.stopPropagation();
+              titleOnClick();
+            }}
+          >
+            {title}
+          </button>
+        ) : (
+          <span css={Css.fg1.tl.$}>{title}</span>
+        )}
         <span
           css={{
             ...Css.fs0.$,


### PR DESCRIPTION
In DesignPackage, we want to be able to select "All these slots" by clicking on a header, like so:

<img width="348" alt="image" src="https://github.com/homebound-team/beam/assets/20718430/2b03175f-036d-4c20-9986-c8f4a599e86c">

This PR adds an optional `titleOnClick` function that, when provided, slightly alter the behavior of the Accordion:

1. Clicking the title no longer performs expand/collapse
    - We still want whitespace between the icon and title to be clickable, so it has to `fg0` instead of the span's `fg1`
    - Stop propagation so w don't trigger expand's onClick
