### PR TITLE
fix: Nudge the modal close icon to the middle.

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -116,15 +116,7 @@ interface ModalExampleProps
     TestModalContentProps {}
 
 function ModalExample(props: ModalExampleProps) {
-  const {
-    size,
-    showLeftAction,
-    initNumSentences = 1,
-    forceScrolling,
-    withTag,
-    withDateField,
-    drawHeaderBorder = false,
-  } = props;
+  const { size, forceScrolling, drawHeaderBorder = false } = props;
   const { openModal } = useModal();
   const open = () =>
     openModal({

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -120,8 +120,8 @@ export function Modal(props: ModalProps) {
                     .if(isFixedHeight)
                     .hPx(height)
                     .if(sm)
-                    .add("height", "100dvh")
-                    .add("width", "100dvw")
+                    .h("100dvh")
+                    .w("100dvw")
                     .maxh("none").br0.$
                 }
                 ref={ref}
@@ -136,7 +136,7 @@ export function Modal(props: ModalProps) {
                   Use `fdrr` so that the close icon won't sit between "modal header search field"
                   and the modal body results in the DOM focus order, i.e. in our global search modal.
                 */}
-                <header css={Css.df.fdrr.p3.fs0.if(drawHeaderBorder).bb.bcGray200.$}>
+                <header css={Css.df.fdrr.p3.fs0.aic.if(drawHeaderBorder).bb.bcGray200.$}>
                   <span css={Css.fs0.pl1.$}>
                     <IconButton icon="x" onClick={closeModal} {...testId.titleClose} />
                   </span>


### PR DESCRIPTION
The `x` used to be top aligned:

![image](https://github.com/homebound-team/beam/assets/6401/a6916af0-39a2-4ee5-b3c6-e87650cd2fa3)
