### PR TITLE
fix: TreeSelectField improvements

### DIFF
--- a/src/components/Filters/TreeFilter.test.tsx
+++ b/src/components/Filters/TreeFilter.test.tsx
@@ -19,8 +19,8 @@ describe("TreeFilter", () => {
     click(r.getByRole("option", { name: "Grandparent 0" }));
     click(r.getByRole("option", { name: "Child 1-0-0" }));
     click(r.getByRole("option", { name: "Parent 1-1" }));
-    // Then the filter's value is not empty because filter has persisted
-    expect(r.filter_tree).toHaveValue("All");
+    // Then the filter's value is empty now that we're making selections
+    expect(r.filter_tree).toHaveValue("");
     // Then the filter is set to only return the "root" values that are selected.
     expect(r.value).toHaveTextContent('{"tree":["gp:0","child:1-0-0","parent:1-1"]}');
   });

--- a/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
@@ -272,7 +272,7 @@ function TestTreeSelectField<T extends HasIdAndName, V extends Value>(
     <TreeSelectField<T, V>
       {...(props as any)}
       values={selectedOptions}
-      onSelect={setSelectedOptions}
+      onSelect={({ all }) => setSelectedOptions(all.values)}
       onBlur={action("onBlur")}
       onFocus={action("onFocus")}
       getOptionLabel={(o) => o.name}

--- a/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
@@ -6,7 +6,7 @@ import { Css } from "src/Css";
 import { Value } from "src/inputs/index";
 import { TreeSelectField, TreeSelectFieldProps } from "src/inputs/TreeSelectField/TreeSelectField";
 import { NestedOption } from "src/inputs/TreeSelectField/utils";
-import { HasIdAndName, Optional } from "src/types";
+import { HasIdAndName } from "src/types";
 import { zeroTo } from "src/utils/sb";
 import { Button } from "src/components";
 
@@ -165,24 +165,16 @@ export function OpenMenu() {
     id: `d:${dIdx}`,
     name: `Development ${dIdx}`,
     children: zeroTo(2).map((cIdx) => ({
-      id: `c:${cIdx}`,
+      id: `c:${cIdx}:d:${dIdx}`,
       name: `Cohort ${cIdx}`,
       children: zeroTo(2).map((pIdx) => ({
-        id: `p:${pIdx}`,
+        id: `p:${pIdx}:c:${cIdx}:d:${dIdx}`,
         name: `Project ${pIdx}`,
       })),
     })),
   }));
 
-  return (
-    <TestTreeSelectField
-      chipDisplay="leaf"
-      values={["p:0", "p:1"]}
-      options={options}
-      label="Nested options"
-      placeholder="Select a project"
-    />
-  );
+  return <TestTreeSelectField values={[]} options={options} label="Nested options" placeholder="Select a project" />;
 }
 OpenMenu.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
   const canvas = within(canvasElement);
@@ -273,7 +265,7 @@ export function Interactive() {
 }
 
 function TestTreeSelectField<T extends HasIdAndName, V extends Value>(
-  props: Optional<TreeSelectFieldProps<T, V>, "onSelect" | "getOptionValue" | "getOptionLabel">,
+  props: Omit<TreeSelectFieldProps<T, V>, "onSelect" | "getOptionValue" | "getOptionLabel">,
 ): JSX.Element {
   const [selectedOptions, setSelectedOptions] = useState<V[] | undefined>(props.values);
   return (

--- a/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
@@ -6,8 +6,9 @@ import { Css } from "src/Css";
 import { Value } from "src/inputs/index";
 import { TreeSelectField, TreeSelectFieldProps } from "src/inputs/TreeSelectField/TreeSelectField";
 import { NestedOption } from "src/inputs/TreeSelectField/utils";
-import { HasIdAndName } from "src/types";
+import { HasIdAndName, Optional } from "src/types";
 import { zeroTo } from "src/utils/sb";
+import { Button } from "src/components";
 
 export default {
   component: TreeSelectField,
@@ -164,16 +165,24 @@ export function OpenMenu() {
     id: `d:${dIdx}`,
     name: `Development ${dIdx}`,
     children: zeroTo(2).map((cIdx) => ({
-      id: `c:${cIdx}:d:${dIdx}`,
+      id: `c:${cIdx}`,
       name: `Cohort ${cIdx}`,
       children: zeroTo(2).map((pIdx) => ({
-        id: `p:${pIdx}:c:${cIdx}:d:${dIdx}`,
+        id: `p:${pIdx}`,
         name: `Project ${pIdx}`,
       })),
     })),
   }));
 
-  return <TestTreeSelectField values={[]} options={options} label="Nested options" placeholder="Select a project" />;
+  return (
+    <TestTreeSelectField
+      chipDisplay="leaf"
+      values={["p:0", "p:1"]}
+      options={options}
+      label="Nested options"
+      placeholder="Select a project"
+    />
+  );
 }
 OpenMenu.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
   const canvas = within(canvasElement);
@@ -227,8 +236,44 @@ export function AsyncOptions() {
   );
 }
 
+export function Interactive() {
+  const options: NestedOption<HasIdAndName>[] = zeroTo(3).map((dIdx) => ({
+    id: `d:${dIdx}`,
+    name: `Development ${dIdx}`,
+    children: zeroTo(2).map((cIdx) => ({
+      id: `c:${cIdx}`,
+      name: `Cohort ${cIdx}`,
+      children: zeroTo(3).map((pIdx) => ({
+        id: `p:${pIdx}`,
+        name: `Project ${pIdx}`,
+      })),
+    })),
+  }));
+
+  const [values, setValues] = useState<string[]>(["p:0"]);
+
+  return (
+    <div css={Css.df.fdc.gap2.aifs.$}>
+      <div css={Css.df.gap2.$}>
+        <Button label="Clear selections" onClick={() => setValues([])} />
+        <Button label="Select Project 1" onClick={() => setValues(["p:1"])} />
+      </div>
+      <TreeSelectField
+        multiline
+        disabledOptions={["p:0"]}
+        chipDisplay="leaf"
+        values={values}
+        options={options}
+        onSelect={(newValues) => setValues(newValues.leaf.values)}
+        label="Favorite League"
+        placeholder="Select a league"
+      />
+    </div>
+  );
+}
+
 function TestTreeSelectField<T extends HasIdAndName, V extends Value>(
-  props: Omit<TreeSelectFieldProps<T, V>, "onSelect" | "getOptionValue" | "getOptionLabel">,
+  props: Optional<TreeSelectFieldProps<T, V>, "onSelect" | "getOptionValue" | "getOptionLabel">,
 ): JSX.Element {
   const [selectedOptions, setSelectedOptions] = useState<V[] | undefined>(props.values);
   return (

--- a/src/inputs/TreeSelectField/TreeSelectField.test.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.test.tsx
@@ -4,6 +4,7 @@ import { NestedOption } from "src/inputs/TreeSelectField/utils";
 import { HasIdAndName } from "src/types";
 import { noop } from "src/utils";
 import { blur, click, focus, render, wait } from "src/utils/rtl";
+import { useState } from "react";
 
 describe(TreeSelectField, () => {
   it("renders", async () => {
@@ -441,6 +442,199 @@ describe(TreeSelectField, () => {
     );
     // As all the options for "Football" are selected it should only count as one option selected
     expect(r.selectedOptionsCount).toHaveTextContent("2");
+  });
+
+  it("can disable options", async () => {
+    // Given a TreeSelectField with disabled options
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        values={[]}
+        options={getNestedOptions()}
+        disabledOptions={["nba"]}
+        label="Favorite League"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // When opening the options
+    click(r.favoriteLeague);
+    // Then the disabled option is disabled
+    expect(r.getByRole("option", { name: "NBA" })).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("selects all matching options when there are duplicates and only the child is passed as values", async () => {
+    // Given the multiple parents with duplicate children
+    const options: NestedOption<HasIdAndName>[] = [
+      { id: "p:1", name: "Parent 1", children: [{ id: "c:1", name: "Child 1" }] },
+      { id: "p:2", name: "Parent 2", children: [{ id: "c:1", name: "Child 1" }] },
+    ];
+    // And the TreeSelectField with just the one child set as the value.
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        values={["c:1"]}
+        options={options}
+        label="Favorite League"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+
+    // When we open the menu
+    click(r.favoriteLeague);
+    // Then all matching options are selected
+    expect(r.getAllByRole("option", { name: "Child 1" })[0]).toHaveAttribute("aria-selected", "true");
+    expect(r.getAllByRole("option", { name: "Child 1" })[1]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("selects all matching options when there are duplicates and only the parent is passed as the value", async () => {
+    // Given the multiple parents with duplicate children
+    const options: NestedOption<HasIdAndName>[] = [
+      { id: "p:1", name: "Parent 1", children: [{ id: "c:1", name: "Child 1" }] },
+      { id: "p:2", name: "Parent 2", children: [{ id: "c:1", name: "Child 1" }] },
+    ];
+    // And the TreeSelectField with just the one child set as the value.
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        values={["p:1"]}
+        options={options}
+        label="Favorite League"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+
+    // When we open the menu
+    click(r.favoriteLeague);
+    // Then all matching options are selected
+    expect(r.getAllByRole("option", { name: "Child 1" })[0]).toHaveAttribute("aria-selected", "true");
+    expect(r.getAllByRole("option", { name: "Child 1" })[1]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("returns a deduped list when selecting duplicate options", async () => {
+    // Given the multiple parents with duplicate children
+    const options: NestedOption<HasIdAndName>[] = [
+      { id: "p:1", name: "Parent 1", children: [{ id: "c:1", name: "Child 1" }] },
+      { id: "p:2", name: "Parent 2", children: [{ id: "c:1", name: "Child 1" }] },
+    ];
+    // With a mocked onSelect
+    const onSelect = jest.fn();
+    // And the TreeSelectField
+    const r = await render(
+      <TreeSelectField
+        onSelect={onSelect}
+        values={[]}
+        options={options}
+        label="Favorite League"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+
+    // When we open the menu
+    click(r.favoriteLeague);
+    // And selecting the first child
+    click(r.getAllByRole("option", { name: "Child 1" })[0]);
+
+    // Then all matching options are selected
+    expect(r.getAllByRole("option", { name: "Child 1" })[0]).toHaveAttribute("aria-selected", "true");
+    expect(r.getAllByRole("option", { name: "Child 1" })[1]).toHaveAttribute("aria-selected", "true");
+
+    // And only the one child option is returned along with both parents
+    expect(onSelect.mock.calls[0][0].all.values).toEqual(["c:1", "p:2", "p:1"]);
+    expect(onSelect.mock.calls[0][0].leaf.values).toEqual(["c:1"]);
+    expect(onSelect.mock.calls[0][0].root.values).toEqual(["p:1", "p:2"]);
+  });
+
+  it("respects chipDisplay for 'root' (default)", async () => {
+    // Given the TreeSelectField with top level options selected and no chipDisplay set
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        values={["baseball", "basketball"]}
+        options={getNestedOptions()}
+        label="Favorite League"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+
+    // Then the selected options display only Baseball and Basketball
+    expect(r.selectedOptionsCount).toHaveTextContent("2");
+    expect(r.favoriteLeague_unfocusedPlaceholderContainer).toHaveTextContent("BaseballBasketball");
+  });
+
+  it("respects chipDisplay for 'leaf'", async () => {
+    // Given the TreeSelectField with top level options selected and chipDisplay of 'leaf'
+    const r = await render(
+      <TreeSelectField
+        chipDisplay="leaf"
+        onSelect={noop}
+        values={["baseball", "basketball"]}
+        options={getNestedOptions()}
+        label="Favorite League"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+
+    // Then the selected options display as (both baseball and basketball leagues).
+    expect(r.selectedOptionsCount).toHaveTextContent("4");
+    expect(r.favoriteLeague_unfocusedPlaceholderContainer).toHaveTextContent("MLBMinor League BaseballNBAWNBA");
+  });
+
+  it("respects chipDisplay for 'all'", async () => {
+    // Given the TreeSelectField with top level options selected and chipDisplay of 'all'
+    const r = await render(
+      <TreeSelectField
+        chipDisplay="all"
+        onSelect={noop}
+        values={["baseball", "basketball"]}
+        options={getNestedOptions()}
+        label="Favorite League"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+
+    // Then the selected options displays all
+    expect(r.selectedOptionsCount).toHaveTextContent("6");
+    expect(r.favoriteLeague_unfocusedPlaceholderContainer).toHaveTextContent(
+      "BaseballMLBMinor League BaseballBasketballNBAWNBA",
+    );
+  });
+
+  it("updates values when the caller modifies them", async () => {
+    // Given a stateful component that has initial values set, and a button to clear the options
+    function Test() {
+      const [values, setValues] = useState<string[]>(["baseball", "basketball"]);
+      return (
+        <>
+          <button data-testid="update" onClick={() => setValues(["baseball"])} />
+          <TreeSelectField
+            onSelect={({ all }) => setValues(all.values)}
+            values={values}
+            options={getNestedOptions()}
+            label="Favorite League"
+            getOptionValue={(o) => o.id}
+            getOptionLabel={(o) => o.name}
+          />
+        </>
+      );
+    }
+    const r = await render(<Test />);
+
+    // Then the options are initially selected
+    expect(r.selectedOptionsCount).toHaveTextContent("2");
+
+    // When clicking the update button to remove Basketball from the values
+    click(r.update);
+
+    // Then the only remaining option is Baseball
+    expect(r.selectedOptionsCount).toHaveTextContent("1");
+    expect(r.favoriteLeague_unfocusedPlaceholderContainer).toHaveTextContent("Baseball");
   });
 });
 

--- a/src/inputs/TreeSelectField/TreeSelectField.test.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.test.tsx
@@ -46,6 +46,52 @@ describe(TreeSelectField, () => {
     expect(r.toggleListBox).toBeDisabled();
   });
 
+  it("doesn't select disabled options when the parent is selected", async () => {
+    // Given a TreeSelect field with no options select, and a disabled option
+    const onSelect = jest.fn();
+    const r = await render(
+      <TreeSelectField
+        onSelect={onSelect}
+        options={getNestedOptions()}
+        disabledOptions={["nba"]}
+        label="Favorite League"
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+
+    // When selecting the Basketball option
+    click(r.favoriteLeague);
+    click(r.getByRole("option", { name: "Basketball" }));
+
+    // Then only the WNBA option is selected
+    expect(onSelect.mock.calls[0][0].leaf.values).toEqual(["wnba"]);
+  });
+
+  it("doesn't deselect disabled options when the parent is deselected", async () => {
+    // Given a TreeSelect field with all basketball options select, and a "NBA" is disabled
+    const onSelect = jest.fn();
+    const r = await render(
+      <TreeSelectField
+        onSelect={onSelect}
+        options={getNestedOptions()}
+        disabledOptions={["nba"]}
+        label="Favorite League"
+        values={["nba", "wnba"]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+
+    // When de-selecting the Basketball option
+    click(r.favoriteLeague);
+    click(r.getByRole("option", { name: "Basketball" }));
+
+    // Then only the WNBA option is de-selected
+    expect(onSelect.mock.calls[0][0].leaf.values).toEqual(["nba"]);
+  });
+
   it("renders readonly", async () => {
     // Given a readonly TreeSelectField
     const r = await render(

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -544,7 +544,8 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
 
         setFieldState((prevState) => ({
           ...prevState,
-          inputValue: nothingSelectedText,
+          // Since we reset the list of options upon selection changes, then set the `inputValue` to empty string to reflect that.
+          inputValue: "",
           filteredOptions: initialOptions.flatMap((o) => levelOptions(o, 0)),
           selectedKeys: [...selectedKeys],
           selectedOptions,

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -464,7 +464,7 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
           for (const { option, parents } of maybeOptions) {
             // If the option has children, then we need to unselect those children as well
             if (option.children && option.children.length > 0) {
-              // Ensure we do not impact children that are disabled. They should be able to toggled on/off
+              // Ensure we do not impact children that are disabled. They shouldn't be able to toggled on/off
               const childrenKeys = option.children
                 .flatMap(flattenOptions)
                 .map((o) => valueToKey(getOptionValue(o)))

--- a/src/inputs/TreeSelectField/utils.ts
+++ b/src/inputs/TreeSelectField/utils.ts
@@ -29,8 +29,28 @@ export type TreeSelectResponse<O, V extends Value> = {
   root: { values: V[]; options: O[] };
 };
 
-/** Finds an option by Key, and returns it + any parents. */
+/** Finds first option by Key, and returns it + any parents. */
 export function findOption<O, V extends Value>(
+  options: NestedOption<O>[],
+  key: Key,
+  getOptionValue: (o: O) => V,
+): FoundOption<O> | undefined {
+  // This is technically an array of "maybe FoundOption"
+  const todo: FoundOption<O>[] = options.map((option) => ({ option, parents: [] }));
+  while (todo.length > 0) {
+    const curr = todo.pop()!;
+    if (getOptionValue(curr.option) === key) {
+      return curr;
+    } else if (curr.option.children) {
+      // Search our children and pass along us as the parent
+      todo.push(...curr.option.children.map((option) => ({ option, parents: [...curr.parents, curr.option] })));
+    }
+  }
+  return undefined;
+}
+
+/** Finds all options by Key, and returns it + any parents. */
+export function findOptions<O, V extends Value>(
   options: NestedOption<O>[],
   key: Key,
   getOptionValue: (o: O) => V,

--- a/src/inputs/TreeSelectField/utils.ts
+++ b/src/inputs/TreeSelectField/utils.ts
@@ -34,19 +34,20 @@ export function findOption<O, V extends Value>(
   options: NestedOption<O>[],
   key: Key,
   getOptionValue: (o: O) => V,
-): FoundOption<O> | undefined {
-  // This is technically an array of "maybe FoundRow"
+): FoundOption<O>[] {
+  // This is technically an array of "maybe FoundOption"
   const todo: FoundOption<O>[] = options.map((option) => ({ option, parents: [] }));
+  const found = [];
   while (todo.length > 0) {
     const curr = todo.pop()!;
     if (getOptionValue(curr.option) === key) {
-      return curr;
+      found.push(curr);
     } else if (curr.option.children) {
       // Search our children and pass along us as the parent
       todo.push(...curr.option.children.map((option) => ({ option, parents: [...curr.parents, curr.option] })));
     }
   }
-  return undefined;
+  return found;
 }
 
 export function flattenOptions<O>(o: NestedOption<O>): NestedOption<O>[] {


### PR DESCRIPTION
Improvements includes:
- Configurable 'chipDisplay' to only show the leaf, root, or all options in the field and tooltip.
- Supports disabled leaf nodes.
- Dedupes selections if there are multiple of the same option within different trees
- Respects changes to 'values' prop