### PR TITLE
fix: Bump overlay opacity to 0.6.

### DIFF
--- a/src/Css.ts
+++ b/src/Css.ts
@@ -3933,12 +3933,12 @@ class CssBuilder<T extends Properties> {
   }
 
   // underlay
-  /** Sets `position: "fixed"; top: 0; bottom: 0; left: 0; right: 0; display: "flex"; alignItems: "center"; justifyContent: "center"; backgroundColor: "rgba(36,36,36,0.2)"`. */
+  /** Sets `position: "fixed"; top: 0; bottom: 0; left: 0; right: 0; display: "flex"; alignItems: "center"; justifyContent: "center"; backgroundColor: "rgba(36,36,36,0.6)"`. */
   get underlay() {
     return this.add("position", "fixed").add("top", 0).add("bottom", 0).add("left", 0).add("right", 0).add(
       "display",
       "flex",
-    ).add("alignItems", "center").add("justifyContent", "center").add("backgroundColor", "rgba(36,36,36,0.2)");
+    ).add("alignItems", "center").add("justifyContent", "center").add("backgroundColor", "rgba(36,36,36,0.6)");
   }
 
   // visuallyHidden

--- a/truss-config.ts
+++ b/truss-config.ts
@@ -113,7 +113,7 @@ const sections: Sections = {
       display: "flex",
       alignItems: "center",
       justifyContent: "center",
-      backgroundColor: "rgba(36,36,36,0.2)",
+      backgroundColor: "rgba(36,36,36,0.6)",
     }),
   ],
   // Css that would be applied if using react-aria <VisuallyHidden />


### PR DESCRIPTION
Per Dave, the current overlay is too faint.