### PR TITLE
feat: Adding support for multiple levels of nesting on grid tables, to keep adding marging based on the level of nesting index

### DIFF
--- a/src/components/Table/TableStyles.tsx
+++ b/src/components/Table/TableStyles.tsx
@@ -235,7 +235,8 @@ export const cardStyle: GridStyle = {
   levels: new Proxy({} as Record<string, { rowIndent: number }>, {
     get(_target, level: string) {
       const parsedLevel = parseInt(level);
-      if (Number.isNaN(parsedLevel)) return undefined;
+      // NaN check to prevent incorrect calculation, and the possitive check to prevent negative margin (header usually has -1 level)
+      if (Number.isNaN(parsedLevel) || parsedLevel < 0) return undefined;
 
       const rowIndent = 24 * parsedLevel;
       return { rowIndent };

--- a/src/components/Table/TableStyles.tsx
+++ b/src/components/Table/TableStyles.tsx
@@ -231,10 +231,16 @@ export const cardStyle: GridStyle = {
   },
   rowHoverColor: "none",
   nonHeaderRowHoverCss: Css.bshHover.bcGray700.$,
-  levels: {
-    1: { rowIndent: 24 },
-    2: { rowIndent: 48 },
-  },
+  // this will allow having N amount of nested childs without having to define each level margin
+  levels: new Proxy({} as Record<string, { rowIndent: number }>, {
+    get(_target, level: string) {
+      const parsedLevel = parseInt(level);
+      if (Number.isNaN(parsedLevel)) return undefined;
+
+      const rowIndent = 24 * parsedLevel;
+      return { rowIndent };
+    },
+  }),
 };
 
 export function resolveStyles(style: GridStyle | GridStyleDef): GridStyle {

--- a/src/components/Table/TableStyles.tsx
+++ b/src/components/Table/TableStyles.tsx
@@ -51,15 +51,17 @@ export interface GridStyle {
   /** Minimum table width in pixels. Used when calculating columns sizes */
   minWidthPx?: number;
   /** Css to apply at each level of a parent/child nested table. */
-  levels?: Record<
-    number,
-    {
-      /** Number of pixels to indent the row. This value will be subtracted from the "first content column" width. First content column is the first column that is not an 'action' column (i.e. non-checkbox or non-collapse button column) */
-      rowIndent?: number;
-      cellCss?: Properties;
-      firstContentColumn?: Properties;
-    }
-  >;
+  levels?:
+    | Record<
+        number,
+        {
+          /** Number of pixels to indent the row. This value will be subtracted from the "first content column" width. First content column is the first column that is not an 'action' column (i.e. non-checkbox or non-collapse button column) */
+          rowIndent?: number;
+          cellCss?: Properties;
+          firstContentColumn?: Properties;
+        }
+      >
+    | ((level: number) => { rowIndent?: number; cellCss?: Properties; firstContentColumn?: Properties });
   /** Allows for customization of the background color used to denote an "active" row */
   activeBgColor?: Palette;
   /** Defines styles for the group row which holds the selected rows that have been filtered out */
@@ -232,16 +234,7 @@ export const cardStyle: GridStyle = {
   rowHoverColor: "none",
   nonHeaderRowHoverCss: Css.bshHover.bcGray700.$,
   // this will allow having N amount of nested childs without having to define each level margin
-  levels: new Proxy({} as Record<string, { rowIndent: number }>, {
-    get(_target, level: string) {
-      const parsedLevel = parseInt(level);
-      // NaN check to prevent incorrect calculation, and the possitive check to prevent negative margin (header usually has -1 level)
-      if (Number.isNaN(parsedLevel) || parsedLevel < 0) return undefined;
-
-      const rowIndent = 24 * parsedLevel;
-      return { rowIndent };
-    },
-  }),
+  levels: (level) => ({ rowIndent: level > 0 ? 24 * level : undefined }),
 };
 
 export function resolveStyles(style: GridStyle | GridStyleDef): GridStyle {

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -91,7 +91,8 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
   const showRowHoverColor = !reservedRowKinds.includes(row.kind) && !omitRowHover && style.rowHoverColor !== "none";
 
   const rowStyleCellCss = maybeApplyFunction(row as any, rowStyle?.cellCss);
-  const levelIndent = style.levels && style.levels[level]?.rowIndent;
+  const levelStyle = style.levels && (typeof style.levels === "function" ? style.levels(level) : style.levels[level]);
+  const levelIndent = levelStyle?.rowIndent;
 
   const containerCss = {
     ...Css.add("transition", "padding 0.25s ease-in-out").$,
@@ -308,9 +309,9 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
               currentExpandedColumnCount === 0 &&
               Css.boxShadow(`inset -1px -1px 0 ${Palette.Gray200}`).$),
             // Or level-specific styling
-            ...(!isHeader && !isTotals && !isExpandableHeader && !!style.levels && style.levels[level]?.cellCss),
+            ...(!isHeader && !isTotals && !isExpandableHeader && levelStyle?.cellCss),
             // Level specific styling for the first content column
-            ...(applyFirstContentColumnStyles && !!style.levels && style.levels[level]?.firstContentColumn),
+            ...(applyFirstContentColumnStyles && levelStyle?.firstContentColumn),
             // The specific cell's css (if any from GridCellContent)
             ...rowStyleCellCss,
             // Apply active row styling for non-nested card styles.


### PR DESCRIPTION
example: 
![imagen](https://github.com/homebound-team/beam/assets/72685215/03cfc76b-0d2f-49a8-af12-3036d9c7e163)
