### PR TITLE
feat: Update Tag and Tooltip support

### DIFF
--- a/src/components/Tag.test.tsx
+++ b/src/components/Tag.test.tsx
@@ -5,7 +5,6 @@ import { Css } from "src/Css";
 describe("Tag", () => {
   it("renders", async () => {
     const r = await render(<Tag text="test" data-testid="testTag" />);
-    expect(r.testTag).toHaveAttribute("title", "test");
     expect(r.testTag.textContent).toBe("test");
   });
 

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,38 +1,55 @@
-import { Icon, IconKey } from "src/components";
+import { Icon, IconKey, maybeTooltip } from "src/components";
 import { Css, Margin, Only, Xss } from "src/Css";
 import { useTestIds } from "src/utils";
+import { ReactNode, useRef, useState } from "react";
+import { useResizeObserver } from "@react-aria/utils";
 
 type TagXss = Margin | "backgroundColor" | "color";
 export type TagType = "info" | "caution" | "warning" | "success" | "neutral";
 interface TagProps<X> {
-  text: string;
+  text: ReactNode;
   // Defaults to "neutral"
   type?: TagType;
   xss?: X;
   icon?: IconKey;
+  /** A tooltip will automatically be displayed if the text is truncated. Set to true to prevent this behavior.
+   * @default false */
+  preventTooltip?: boolean;
 }
 
 /** Tag used for indicating a status */
-export function Tag<X extends Only<Xss<TagXss>, X>>({ text, type, xss, ...otherProps }: TagProps<X>) {
+export function Tag<X extends Only<Xss<TagXss>, X>>(props: TagProps<X>) {
+  const { text, type, xss, preventTooltip = false, ...otherProps } = props;
   const typeStyles = getStyles(type);
   const tid = useTestIds(otherProps);
+  const [showTooltip, setShowTooltip] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+  useResizeObserver({
+    ref,
+    onResize: () => {
+      if (ref.current) {
+        setShowTooltip(ref.current.offsetHeight < ref.current.scrollHeight);
+      }
+    },
+  });
 
-  return (
-    <span
-      {...tid}
-      css={{ ...Css.dif.tinySb.ttu.aic.gapPx(4).pxPx(6).pyPx(2).gray900.br4.$, ...typeStyles, ...xss }}
-      title={text}
-    >
-      {/* Nesting `lineClamp` styles as the padding bottom set would expose the remainder of the text if applied on the same element */}
-      {/* Using `lineClamp1` instead of `truncate` as `truncate` requires a width set to properly truncate and `lineClamp` can smartly do it based on the parent's width */}
-      {otherProps.icon && (
-        <span css={Css.fs0.$}>
-          <Icon icon={otherProps.icon} inc={1.5} />
+  return maybeTooltip({
+    title: !preventTooltip && showTooltip ? text : undefined,
+    children: (
+      <span {...tid} css={{ ...Css.dif.tinySb.ttu.aic.gapPx(4).pxPx(6).pyPx(2).gray900.br4.$, ...typeStyles, ...xss }}>
+        {/* Nesting `lineClamp` styles as the padding bottom set would expose the remainder of the text if applied on the same element */}
+        {/* Using `lineClamp1` instead of `truncate` as `truncate` requires a width set to properly truncate and `lineClamp` can smartly do it based on the parent's width */}
+        {otherProps.icon && (
+          <span css={Css.fs0.$}>
+            <Icon icon={otherProps.icon} inc={1.5} />
+          </span>
+        )}
+        <span ref={ref} css={Css.lineClamp1.wbba.$}>
+          {text}
         </span>
-      )}
-      <span css={Css.lineClamp1.wbba.$}>{text}</span>
-    </span>
-  );
+      </span>
+    ),
+  });
 }
 
 function getStyles(type?: TagType) {

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -3,7 +3,7 @@ import { mergeProps, useTooltip, useTooltipTrigger } from "react-aria";
 import { createPortal } from "react-dom";
 import { usePopper } from "react-popper";
 import { useTooltipTriggerState } from "react-stately";
-import { Css } from "src/Css";
+import { Css, Palette } from "src/Css";
 import { useTestIds } from "src/utils";
 
 // We combine react-popper and aria-tooltip to makeup the tooltip component for the following reasons:
@@ -17,10 +17,11 @@ interface TooltipProps {
   placement?: Placement;
   delay?: number;
   disabled?: boolean;
+  bgColor?: Palette;
 }
 
 export function Tooltip(props: TooltipProps) {
-  const { placement, children, title, disabled, delay = 0 } = props;
+  const { placement, children, title, disabled, delay = 0, bgColor } = props;
 
   const state = useTooltipTriggerState({ delay, isDisabled: disabled });
   const triggerRef = useRef<HTMLElement>(null);
@@ -53,6 +54,7 @@ export function Tooltip(props: TooltipProps) {
           triggerRef={triggerRef}
           content={title}
           placement={placement}
+          bgColor={bgColor}
         />
       )}
     </>
@@ -67,9 +69,10 @@ interface PopperProps {
   triggerRef: React.MutableRefObject<HTMLElement | null>;
   content: ReactNode;
   placement?: Placement;
+  bgColor: Palette | undefined;
 }
 
-function Popper({ triggerRef, content, placement = "auto" }: PopperProps) {
+function Popper({ triggerRef, content, placement = "auto", bgColor = Palette.Gray900 }: PopperProps) {
   const popperRef = useRef(null);
   const [arrowRef, setArrowRef] = useState<HTMLDivElement | null>(null);
   // Since we use `display: contents;` on the `triggerRef`, then the element.offsetTop/Left/etc all equal `0`. This would make
@@ -90,7 +93,7 @@ function Popper({ triggerRef, content, placement = "auto" }: PopperProps) {
       ref={popperRef}
       style={styles.popper}
       {...attributes.popper}
-      css={Css.maxw("320px").bgGray900.white.px1.py("4px").br4.xs.add("zIndex", 999999).$}
+      css={Css.maxw("320px").bgColor(bgColor).bshBasic.white.px1.py("4px").br4.xs.add("zIndex", 999999).$}
     >
       <div ref={setArrowRef} style={{ ...styles.arrow }} id="arrow" />
       {content}


### PR DESCRIPTION
Tag updates:
- 'text' property is now of type ReactNode.
- Conditionally adds tooltip if content overflows
- Can force prevent tooltip from rendering. For cases where you're already wrapping the Tag in a Tooltip to display additional info.

Tooltip updates:
- Support a background color
- Add box-shadow styles