### PR TITLE
feat: Support labelStyle in ToggleChipGroup

### DIFF
--- a/src/components/Filters/MultiFilter.tsx
+++ b/src/components/Filters/MultiFilter.tsx
@@ -54,7 +54,7 @@ class MultiFilter<O, V extends Value> extends BaseFilter<V[], MultiFilterProps<O
             setValue(values.length === 0 ? undefined : (values as V[]));
           }}
           values={(value as string[]) || []}
-          hideLabel={true}
+          labelStyle="hidden"
           {...tid[defaultTestId(this.label)]}
         />
       );

--- a/src/components/PresentationContext.tsx
+++ b/src/components/PresentationContext.tsx
@@ -6,6 +6,8 @@ export interface PresentationFieldProps {
   numberAlignment?: "left" | "right";
   /** Sets the label position or visibility. Defaults to "above" */
   labelStyle?: "inline" | "hidden" | "above" | "left";
+  /** Defines the width property of the input field wrapper when using `labelStyle="left"`. */
+  labelLeftFieldWidth?: number | string;
   labelSuffix?: LabelSuffixStyle;
   // Typically used for compact fields in a table. Removes border and uses an box-shadow for focus behavior
   borderless?: boolean;

--- a/src/forms/FormLines.stories.tsx
+++ b/src/forms/FormLines.stories.tsx
@@ -1,6 +1,14 @@
 import { Meta } from "@storybook/react";
 import { FieldGroup, FormDivider, FormLines } from "src/forms/FormLines";
-import { DateField, MultiSelectField, RichTextField, SelectField, TextAreaField, TreeSelectField } from "src/inputs";
+import {
+  DateField,
+  MultiSelectField,
+  RichTextField,
+  SelectField,
+  TextAreaField,
+  ToggleChipGroup,
+  TreeSelectField,
+} from "src/inputs";
 import { NumberField } from "src/inputs/NumberField";
 import { Switch } from "src/inputs/Switch";
 import { TextField } from "src/inputs/TextField";
@@ -313,8 +321,15 @@ export function WithFieldProps() {
 }
 
 export function WithHorizontalLayout() {
+  const chipOptions = [
+    { label: "Bahamas", value: "m:1" },
+    { label: "Southern California", value: "m:2" },
+    { label: "Northern California", value: "m:3" },
+    { label: "South Bay CA", value: "m:4" },
+    { label: "Austin", value: "m:5" },
+  ];
   return (
-    <FormLines width="lg" labelStyle="left">
+    <FormLines width="lg" labelStyle="left" labelLeftFieldWidth="70%">
       <TextField label="First" value="first" onChange={noop} />
       <SelectField<Options, number>
         label="Second"
@@ -327,6 +342,7 @@ export function WithHorizontalLayout() {
       />
       <TextField label="Read only" readOnly value="read only" onChange={noop} />
       <Switch label="Last" labelStyle="left" selected={true} onChange={noop} />
+      <ToggleChipGroup label="Market" options={chipOptions} values={[]} onChange={noop} />
     </FormLines>
   );
 }

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -1,5 +1,5 @@
 import { Children, cloneElement, ReactNode } from "react";
-import { LabelSuffixStyle, PresentationProvider } from "src/components/PresentationContext";
+import { PresentationFieldProps, PresentationProvider } from "src/components/PresentationContext";
 import { Css } from "src/Css";
 import { useModal } from "src/components";
 
@@ -13,13 +13,13 @@ export type FormWidth =
   /** 100%, works well for showing full width fields, or deferring to the parent width. */
   | "full";
 
-export interface FormLinesProps {
+export interface FormLinesProps
+  extends Pick<PresentationFieldProps, "labelStyle" | "labelLeftFieldWidth" | "labelSuffix" | "compact"> {
   /** Let the user interleave group-less lines and grouped lines. */
   children: ReactNode;
-  labelSuffix?: LabelSuffixStyle;
-  labelStyle?: "inline" | "hidden" | "above" | "left";
   width?: FormWidth;
-  compact?: boolean;
+  /** Increment property (e.g. 1 = 8px). Defines space between form fields */
+  gap?: number;
 }
 
 /**
@@ -30,7 +30,15 @@ export interface FormLinesProps {
  */
 export function FormLines(props: FormLinesProps) {
   const { inModal } = useModal();
-  const { children, width = inModal ? "full" : "lg", labelSuffix, labelStyle, compact } = props;
+  const {
+    children,
+    width = inModal ? "full" : "lg",
+    labelSuffix,
+    labelStyle,
+    compact,
+    gap = 2,
+    labelLeftFieldWidth,
+  } = props;
   let firstFormHeading = true;
 
   // Only overwrite `fieldProps` if new values are explicitly set. Ensures we only set to `undefined` if explicitly set.
@@ -38,6 +46,7 @@ export function FormLines(props: FormLinesProps) {
     ...("labelSuffix" in props ? { labelSuffix } : {}),
     ...("labelStyle" in props ? { labelStyle } : {}),
     ...("compact" in props ? { compact } : {}),
+    ...("labelLeftFieldWidth" in props ? { labelLeftFieldWidth } : {}),
     ...(width === "full" ? { fullWidth: true } : {}),
   };
 
@@ -48,7 +57,7 @@ export function FormLines(props: FormLinesProps) {
           // Note that we're purposefully not using display:flex so that our children's margins will collapse.
           ...Css.w(sizes[width]).$,
           // Purposefully use this instead of childGap3 to put margin-bottom on the last line
-          "& > *": Css.mb2.$,
+          "& > *": Css.mb(gap).$,
         }}
       >
         {Children.map(children, (child) => {

--- a/src/inputs/Switch.stories.tsx
+++ b/src/inputs/Switch.stories.tsx
@@ -126,7 +126,7 @@ function SwitchWrapper({ isHovered, isFocused, ...props }: SwitchWrapperProps) {
   return (
     <div
       css={{
-        "label > div:nth-of-type(1)": {
+        "label > div:nth-of-type(1) > div": {
           ...(isHovered && switchHoverStyles),
           ...(props.selected && isHovered && switchSelectedHoverStyles),
           ...(isFocused && switchFocusStyles),

--- a/src/inputs/Switch.tsx
+++ b/src/inputs/Switch.tsx
@@ -5,6 +5,7 @@ import { Label } from "src/components/Label";
 import { Css, Palette } from "src/Css";
 import { Icon } from "../components/Icon";
 import { toToggleState, useTestIds } from "../utils";
+import { usePresentationContext } from "src/components/PresentationContext";
 
 export interface SwitchProps {
   /** Whether the element should receive focus on render. */
@@ -30,6 +31,8 @@ export interface SwitchProps {
 }
 
 export function Switch(props: SwitchProps) {
+  const { fieldProps } = usePresentationContext();
+  const { labelLeftFieldWidth = "50%" } = fieldProps ?? {};
   const {
     selected: isSelected,
     disabled = false,
@@ -57,7 +60,7 @@ export function Switch(props: SwitchProps) {
       css={{
         ...Css.relative.cursorPointer.df.wmaxc.usn.$,
         ...(labelStyle === "form" && Css.fdc.$),
-        ...(labelStyle === "left" && Css.w100.aic.$),
+        ...(labelStyle === "left" && Css.w100.aic.jcsb.$),
         ...(labelStyle === "inline" && Css.gap2.aic.$),
         ...(labelStyle === "filter" && Css.jcsb.gap1.aic.wa.sm.$),
         ...(labelStyle === "centered" && Css.fdc.aic.$),
@@ -65,7 +68,7 @@ export function Switch(props: SwitchProps) {
       }}
     >
       {labelStyle !== "inline" && labelStyle !== "hidden" && (
-        <div css={Css.if(labelStyle === "left").w50.$}>
+        <div>
           <Label
             label={label}
             tooltip={tooltip}
@@ -74,30 +77,32 @@ export function Switch(props: SwitchProps) {
           />
         </div>
       )}
-      {/* Background */}
-      <div
-        aria-hidden="true"
-        css={{
-          ...Css.wPx(40).hPx(toggleHeight(compact)).bgGray200.br12.relative.transition.$,
-          ...(isHovered && switchHoverStyles),
-          ...(isKeyboardFocus && switchFocusStyles),
-          ...(isDisabled && Css.bgGray300.$),
-          ...(isSelected && Css.bgBlue700.$),
-          ...(isSelected && isHovered && switchSelectedHoverStyles),
-        }}
-      >
-        {/* Circle */}
+      <div css={Css.if(labelStyle === "left").w(labelLeftFieldWidth).$}>
+        {/* Background */}
         <div
+          aria-hidden="true"
           css={{
-            ...switchCircleDefaultStyles(compact),
-            ...(isDisabled && Css.bgGray100.$),
-            ...(isSelected && switchCircleSelectedStyles(compact)),
+            ...Css.wPx(40).hPx(toggleHeight(compact)).bgGray200.br12.relative.transition.$,
+            ...(isHovered && switchHoverStyles),
+            ...(isKeyboardFocus && switchFocusStyles),
+            ...(isDisabled && Css.bgGray300.$),
+            ...(isSelected && Css.bgBlue700.$),
+            ...(isSelected && isHovered && switchSelectedHoverStyles),
           }}
         >
-          {/* Icon */}
-          {withIcon && (
-            <Icon icon={isSelected ? "check" : "x"} color={isSelected ? Palette.Blue700 : Palette.Gray400} />
-          )}
+          {/* Circle */}
+          <div
+            css={{
+              ...switchCircleDefaultStyles(compact),
+              ...(isDisabled && Css.bgGray100.$),
+              ...(isSelected && switchCircleSelectedStyles(compact)),
+            }}
+          >
+            {/* Icon */}
+            {withIcon && (
+              <Icon icon={isSelected ? "check" : "x"} color={isSelected ? Palette.Blue700 : Palette.Gray400} />
+            )}
+          </div>
         </div>
       </div>
       {/* Since we are using childGap, we must wrap the label in an element and

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -66,6 +66,7 @@ export interface TextFieldBaseProps<X>
 // Used by both TextField and TextArea
 export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldBaseProps<X>) {
   const { fieldProps, wrap = false } = usePresentationContext();
+  const { labelLeftFieldWidth = "50%" } = fieldProps ?? {};
   const {
     label,
     required,
@@ -128,7 +129,8 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
       ...Css[typeScale].df.aic.br4.px1.w100
         .bgColor(bgColor)
         .gray900.if(contrast)
-        .white.if(labelStyle === "left").w50.$,
+        .white.if(labelStyle === "left")
+        .w(labelLeftFieldWidth).$,
       // When borderless then perceived vertical alignments are misaligned. As there is no longer a border, then the field looks oddly indented.
       // This typically happens in tables when a column has a mix of static text (i.e. "roll up" rows and table headers) and input fields.
       // To remedy this perceived misalignment then we increase the width by the horizontal padding applied (16px), and set a negative margin left margin to re-center the field.
@@ -149,7 +151,10 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
             .hPx(compactFieldHeight - maybeSmaller).$),
     },
     inputWrapperReadOnly: {
-      ...Css[typeScale].df.aic.w100.gray900.if(contrast).white.if(labelStyle === "left").w50.$,
+      ...Css[typeScale].df.aic.w100.gray900
+        .if(contrast)
+        .white.if(labelStyle === "left")
+        .w(labelLeftFieldWidth).$,
       // If we are hiding the label, then we are typically in a table. Keep the `mh` in this case to ensure editable and non-editable fields in a single table row line up properly
       ...(labelStyle === "hidden" &&
         Css.mhPx(fieldHeight - maybeSmaller)

--- a/src/inputs/ToggleChipGroup.tsx
+++ b/src/inputs/ToggleChipGroup.tsx
@@ -5,6 +5,7 @@ import { maybeTooltip, resolveTooltip } from "src/components";
 import { Label } from "src/components/Label";
 import { Css } from "src/Css";
 import { useTestIds } from "src/utils/useTestIds";
+import { PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
 
 type ToggleChipItemProps = {
   label: string;
@@ -17,25 +18,32 @@ type ToggleChipItemProps = {
   disabled?: boolean | ReactNode;
 };
 
-export interface ToggleChipGroupProps {
+export interface ToggleChipGroupProps extends Pick<PresentationFieldProps, "labelStyle"> {
   label: string;
-  labelStyle?: "above" | "left";
   options: ToggleChipItemProps[];
   values: string[];
   onChange: (values: string[]) => void;
-  hideLabel?: boolean;
 }
 
 export function ToggleChipGroup(props: ToggleChipGroupProps) {
-  const { values, label, labelStyle, options, hideLabel } = props;
+  const { fieldProps } = usePresentationContext();
+  const { labelLeftFieldWidth = "50%" } = fieldProps ?? {};
+  const { values, label, labelStyle = fieldProps?.labelStyle ?? "above", options } = props;
   const state = useCheckboxGroupState({ ...props, value: values });
   const { groupProps, labelProps } = useCheckboxGroup(props, state);
   const tid = useTestIds(props, "toggleChip");
 
   return (
-    <div {...groupProps} css={Css.relative.df.fdc.if(labelStyle === "left").fdr.maxw100.$}>
-      <Label label={label} {...labelProps} hidden={hideLabel} inline={labelStyle === "left"} />
-      <div css={Css.df.gap1.add("flexWrap", "wrap").if(labelStyle === "left").ml2.$}>
+    <div {...groupProps} css={Css.relative.df.fdc.if(labelStyle === "left").fdr.gap2.maxw100.jcsb.$}>
+      <Label label={label} {...labelProps} hidden={labelStyle === "hidden"} inline={labelStyle !== "above"} />
+      <div
+        css={
+          Css.df.gap1
+            .add("flexWrap", "wrap")
+            .if(labelStyle === "left")
+            .w(labelLeftFieldWidth).$
+        }
+      >
         {options.map((o) => (
           <ToggleChip
             key={o.value}


### PR DESCRIPTION
Add support for changing the width allocated between the label and form field when using labelStyle="left" via a 'labelLeftFieldWidth' property on the PresentationContext.FieldProps.

Updates stories to showcase new changes and features