### PR TITLE
fix: Fix dateRangeFilter generic to extend string.

### DIFF
--- a/src/components/Filters/DateRangeFilter.tsx
+++ b/src/components/Filters/DateRangeFilter.tsx
@@ -1,4 +1,3 @@
-import { Key } from "react";
 import { Matcher } from "react-day-picker";
 import { BaseFilter } from "src/components/Filters/BaseFilter";
 import { Filter } from "src/components/Filters/types";
@@ -8,32 +7,37 @@ import { DateRange } from "src/types";
 import { TestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
 
-export type DateRangeFilterProps<V extends Value, DV extends DateRangeFilterValue<V>> = {
+export type DateRangeFilterProps<O extends string> = {
   label: string;
-  defaultValue?: DV;
+  defaultValue?: DateRangeFilterValue<O>;
   placeholderText?: string;
   disabledDays?: Matcher | Matcher[];
   // For storybook to support showing dateRange and date filters in same Filter component
   testFieldLabel?: string;
 };
 
-// Using op to align with what is expected from DateFilter at this time.
+// Using op (as in `op: "between"`) to align with what is expected from DateFilter at this time.
 // In the future we should remove that coupling and rely on user to map returned value
-export type DateRangeFilterValue<V extends Value> = { op: V; value: DateRange | undefined };
+export type DateRangeFilterValue<O extends string> = { op: O; value: DateRange | undefined };
 
-export function dateRangeFilter<V extends Key>(
-  props: DateRangeFilterProps<V, DateRangeFilterValue<V>>,
-): (key: string) => Filter<DateRangeFilterValue<V>> {
+export function dateRangeFilter<O extends string>(
+  props: DateRangeFilterProps<O>,
+): (key: string) => Filter<DateRangeFilterValue<O>> {
   return (key) => new DateRangeFilter(key, props);
 }
 
-class DateRangeFilter<V extends Key, DV extends DateRangeFilterValue<V>>
-  extends BaseFilter<DV, DateRangeFilterProps<V, DV>>
-  implements Filter<DV>
+class DateRangeFilter<O extends string>
+  extends BaseFilter<DateRangeFilterValue<O>, DateRangeFilterProps<O>>
+  implements Filter<DateRangeFilterValue<O>>
 {
-  render(value: DV, setValue: (value: DV | undefined) => void, tid: TestIds, inModal: boolean, vertical: boolean) {
+  render(
+    value: DateRangeFilterValue<O>,
+    setValue: (value: DateRangeFilterValue<O> | undefined) => void,
+    tid: TestIds,
+    inModal: boolean,
+    vertical: boolean,
+  ) {
     const { label, placeholderText, disabledDays, testFieldLabel, defaultValue } = this.props;
-
     return (
       <>
         {vertical && <Label label={label} />}
@@ -49,7 +53,7 @@ class DateRangeFilter<V extends Key, DV extends DateRangeFilterValue<V>>
               ? { from: new Date(value.value.from as Date), to: new Date(value.value.to as Date) }
               : undefined
           }
-          onChange={(d) => (d ? setValue({ op: defaultValue?.op, value: d } as DV) : setValue(undefined))}
+          onChange={(d) => (d ? setValue({ op: defaultValue?.op, value: d } as any) : setValue(undefined))}
           disabledDays={disabledDays}
           {...tid[`${defaultTestId(this.label)}_dateField`]}
         />


### PR DESCRIPTION
It had been using React.Key, which is similar-ish to Value, but in newer Reacts starts including `bigint` which our Value doesn't support yet.

...and actually instead of `V` / `Value`, this op is really just modeling the `op: between | before | after | etc` type union, so doesn't need to be anything more than `extends string` afaict.