### PR TITLE
feat: add divider to menu item

### DIFF
--- a/src/components/ButtonMenu.tsx
+++ b/src/components/ButtonMenu.tsx
@@ -84,6 +84,7 @@ type MenuItemBase = {
   /** Whether the interactive element is disabled. If a ReactNode, it's treated as a "disabled reason" that's shown in a tooltip. */
   disabled?: boolean | ReactNode;
   destructive?: boolean;
+  hasDivider?: boolean;
 };
 
 export type IconMenuItemType = MenuItemBase & {
@@ -96,7 +97,11 @@ export type ImageMenuItemType = MenuItemBase & {
   isAvatar?: boolean;
 };
 
-export type MenuItem = MenuItemBase | IconMenuItemType | ImageMenuItemType;
+export type DividerMenuItemType = MenuItemBase & {
+  hasDivider: boolean;
+};
+
+export type MenuItem = MenuItemBase | IconMenuItemType | ImageMenuItemType | DividerMenuItemType;
 // This is done just to adapt to the React-Aria API for generating Sectioned lists of Menu Items.
 export type MenuSection = MenuItem & { items?: MenuItem[] };
 

--- a/src/components/internal/Menu.stories.tsx
+++ b/src/components/internal/Menu.stories.tsx
@@ -47,6 +47,22 @@ export function IconMenuItems() {
   );
 }
 
+export function DividerMenuItems() {
+  return (
+    <ButtonMenu
+      defaultOpen
+      contrast
+      trigger={{ label: "Menu Trigger" }}
+      items={[
+        { label: "Edit", hasDivider: true, onClick: noop },
+        { label: "Like", onClick: noop },
+        { label: "Favorite", hasDivider: true, onClick: noop },
+        { label: "Delete", onClick: noop },
+      ]}
+    />
+  );
+}
+
 export function AvatarMenuItems() {
   return (
     <ButtonMenu

--- a/src/components/internal/MenuItem.tsx
+++ b/src/components/internal/MenuItem.tsx
@@ -81,7 +81,7 @@ export function MenuItemImpl(props: MenuItemProps) {
       ref={ref}
       css={{
         ...Css.df.aic.py1.px2.cursorPointer.outline0.mh("42px").sm.$,
-        ...(menuItem.hasDivider ? Css.bb.bcGray600.$ : {}),
+        ...(menuItem.hasDivider ? Css.bb.bcGray400.$ : {}),
         ...(!isDisabled && isHovered ? (contrast ? Css.bgGray800.$ : Css.bgGray100.$) : {}),
         ...(isFocused ? Css.add("boxShadow", `inset 0 0 0 1px ${Palette.Blue700}`).$ : {}),
         ...(isDisabled ? Css.gray500.cursorNotAllowed.$ : {}),

--- a/src/components/internal/MenuItem.tsx
+++ b/src/components/internal/MenuItem.tsx
@@ -81,6 +81,7 @@ export function MenuItemImpl(props: MenuItemProps) {
       ref={ref}
       css={{
         ...Css.df.aic.py1.px2.cursorPointer.outline0.mh("42px").sm.$,
+        ...(menuItem.hasDivider ? Css.bb.bcGray200.$ : {}),
         ...(!isDisabled && isHovered ? (contrast ? Css.bgGray800.$ : Css.bgGray100.$) : {}),
         ...(isFocused ? Css.add("boxShadow", `inset 0 0 0 1px ${Palette.Blue700}`).$ : {}),
         ...(isDisabled ? Css.gray500.cursorNotAllowed.$ : {}),

--- a/src/components/internal/MenuItem.tsx
+++ b/src/components/internal/MenuItem.tsx
@@ -81,7 +81,7 @@ export function MenuItemImpl(props: MenuItemProps) {
       ref={ref}
       css={{
         ...Css.df.aic.py1.px2.cursorPointer.outline0.mh("42px").sm.$,
-        ...(menuItem.hasDivider ? Css.bb.bcGray200.$ : {}),
+        ...(menuItem.hasDivider ? Css.bb.bcGray600.$ : {}),
         ...(!isDisabled && isHovered ? (contrast ? Css.bgGray800.$ : Css.bgGray100.$) : {}),
         ...(isFocused ? Css.add("boxShadow", `inset 0 0 0 1px ${Palette.Blue700}`).$ : {}),
         ...(isDisabled ? Css.gray500.cursorNotAllowed.$ : {}),


### PR DESCRIPTION
[SC-54926](https://app.shortcut.com/homebound-team/story/54926/update-libraries-menu)

* Updating our `Libraries` Nav - Menu Item to include `dividers` for specific sections, so updating `MenuItem` to include an optional `hasDivider` prop to render divider lines
* Cannot use `PersistentItems` as that only handles showing one persistent item

![Screenshot 2024-07-31 at 5 45 28 PM](https://github.com/user-attachments/assets/b2b69107-95fe-4232-8dd2-a6b5cc4f57ae)
![Screenshot 2024-07-31 at 5 52 41 PM](https://github.com/user-attachments/assets/5b1fd645-6369-47cd-8357-3183a520df57)

