### PR TITLE
fix: TreeSelectField and treeFilter fixes

### DIFF
--- a/src/components/Filters/Filters.stories.tsx
+++ b/src/components/Filters/Filters.stories.tsx
@@ -169,6 +169,7 @@ function TestFilterPage({ vertical = false, numberOfInlineFilters = 4 }) {
       children: cohorts.map(({ id, name, projects }) => ({
         id,
         name,
+        defaultCollapsed: true,
         children: projects.map(({ id, name }) => ({ id, name })),
       })),
     }));

--- a/src/inputs/TreeSelectField/TreeSelectField.test.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.test.tsx
@@ -3,7 +3,7 @@ import { TreeSelectField } from "src/inputs";
 import { NestedOption } from "src/inputs/TreeSelectField/utils";
 import { HasIdAndName } from "src/types";
 import { noop } from "src/utils";
-import { blur, click, focus, render, wait } from "src/utils/rtl";
+import { blur, click, focus, getSelected, render, wait } from "src/utils/rtl";
 import { useState } from "react";
 
 describe(TreeSelectField, () => {
@@ -681,6 +681,38 @@ describe(TreeSelectField, () => {
     // Then the only remaining option is Baseball
     expect(r.selectedOptionsCount).toHaveTextContent("1");
     expect(r.favoriteLeague_unfocusedPlaceholderContainer).toHaveTextContent("Baseball");
+  });
+
+  it("can reset values to undefined", async () => {
+    // Given a TreeSelectField with values set
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        values={["nba", "mlb"]}
+        options={getNestedOptions()}
+        label="Favorite League"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // Then the options are initially selected
+    expect(getSelected(r.favoriteLeague)).toEqual(["MLB", "NBA"]);
+
+    // When we re-render with values set to undefined (simulating an outside component's "clear" action, i.e. Filters)
+    r.rerender(
+      <TreeSelectField
+        chipDisplay="all"
+        onSelect={noop}
+        values={undefined}
+        options={getNestedOptions()}
+        label="Favorite League"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+
+    // Then the values are reset
+    expect(getSelected(r.favoriteLeague)).toEqual(undefined);
   });
 });
 

--- a/src/inputs/TreeSelectField/utils.ts
+++ b/src/inputs/TreeSelectField/utils.ts
@@ -3,7 +3,7 @@ import { Key } from "react";
 import { Value } from "src/inputs/Value";
 
 type FoundOption<O> = { option: NestedOption<O>; parents: NestedOption<O>[] };
-export type NestedOption<O> = O & { children?: NestedOption<O>[] };
+export type NestedOption<O> = O & { children?: NestedOption<O>[]; defaultCollapsed?: boolean };
 export type NestedOptionsOrLoad<O> =
   | NestedOption<O>[]
   | { current: NestedOption<O>[]; load: () => Promise<{ options: NestedOption<O>[] }> };

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -344,7 +344,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
     ...positionProps.style,
     width: comboBoxRef?.current?.clientWidth,
     // Ensures the menu never gets too small.
-    minWidth: 320,
+    minWidth: 200,
   };
 
   const fieldMaxWidth = getFieldWidth(fullWidth);
@@ -378,7 +378,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
           positionProps={positionProps}
           onClose={() => state.close()}
           isOpen={state.isOpen}
-          minWidth={320}
+          minWidth={200}
         >
           <ListBox
             {...listBoxProps}

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -344,7 +344,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
     ...positionProps.style,
     width: comboBoxRef?.current?.clientWidth,
     // Ensures the menu never gets too small.
-    minWidth: 200,
+    minWidth: 320,
   };
 
   const fieldMaxWidth = getFieldWidth(fullWidth);
@@ -378,7 +378,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
           positionProps={positionProps}
           onClose={() => state.close()}
           isOpen={state.isOpen}
-          minWidth={200}
+          minWidth={320}
         >
           <ListBox
             {...listBoxProps}


### PR DESCRIPTION
Updates/fixes include:
1. TreeSelectField can reset values when outside component sets values to undefined
2. Can set individual groups to be default collapsed
3. Increase min-width of ListBox from 200 to 320px wide per Design feedback