### PR TITLE
feat: Add GridTable csv export.

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -68,6 +68,35 @@ export function ClientSideSorting() {
   );
 }
 
+export function ClientSideCsv() {
+  const api = useGridTableApi<Row>();
+  const columns: GridColumn<Row>[] = [
+    // Given column one returns JSX, but defines a `sortValue`
+    { header: "Name", data: ({ name }) => ({ content: <div>{name}</div>, sortValue: name }) },
+    // And column two returns a number
+    { header: "Value", data: ({ value }) => value },
+    // And column three returns a string
+    { header: "Value", data: ({ value }) => String(value) },
+    // And column four returns JSX with nothing else
+    { header: "Action", data: () => <div>Actions</div> },
+  ];
+  return (
+    <div>
+      <GridTable
+        api={api}
+        columns={columns}
+        rows={[
+          simpleHeader,
+          { kind: "data", id: "1", data: { name: "c", value: 1 } },
+          { kind: "data", id: "2", data: { name: "B", value: 2 } },
+          { kind: "data", id: "3", data: { name: "a", value: 3 } },
+        ]}
+      />
+      <Button label="Download" onClick={() => api.downloadToCsv("test.csv")} />
+    </div>
+  );
+}
+
 export const Hovering = newStory(
   () => {
     const nameColumn: GridColumn<Row> = { header: "Name", data: ({ name }) => name };

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -12,7 +12,7 @@ import { TableStateContext } from "src/components/Table/utils/TableState";
 import { emptyCell, matchesFilter } from "src/components/Table/utils/utils";
 import { Css, Palette } from "src/Css";
 import { useComputed } from "src/hooks";
-import { Checkbox, SelectField, TextField } from "src/inputs";
+import { SelectField, TextField } from "src/inputs";
 import { noop } from "src/utils";
 import {
   cell,
@@ -27,7 +27,6 @@ import {
   wait,
   withRouter,
 } from "src/utils/rtl";
-import { Button } from "src";
 
 // Most of our tests use this simple Row and 2 columns
 type Data = { name: string; value: number | undefined | null };

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -3793,13 +3793,19 @@ describe("GridTable", () => {
     let api: GridTableApi<Row> | undefined;
 
     const columns: GridColumn<Row>[] = [
-      // Given column one returns JSX, but defines a `sortValue`
+      // Given a column returns JSX, but defines a `sortValue`
       { header: "Name", data: ({ name }) => ({ content: <div>{name}</div>, sortValue: name }) },
-      // And column two returns a number
+      // And a column returns a number
       { header: "Value", data: ({ value }) => value },
-      // And column three returns a string
+      // And a column returns a string
       { header: "Value", data: ({ value }) => String(value) },
-      // And column four returns JSX with nothing else
+      // And a column returns a string with a comma in it
+      { header: "Value", data: ({ value }) => `${value},${value}` },
+      // And a column returns a string with a quote in it
+      { header: "Value", data: ({ value }) => `a quoted "${value}" value` },
+      // And a column returns undefined
+      { header: "Value", data: () => undefined },
+      // And a column returns JSX with nothing else
       { header: "Action", data: () => <div>Actions</div>, isAction: true },
     ];
 
@@ -3811,7 +3817,11 @@ describe("GridTable", () => {
 
     await render(<Test />);
 
-    expect((api as GridTableApiImpl<Row>).generateCsvContent()).toEqual(["Name,Value,Value", "foo,1,1", "bar,2,2"]);
+    expect((api as GridTableApiImpl<Row>).generateCsvContent()).toEqual([
+      "Name,Value,Value,Value,Value,Value",
+      `foo,1,1,"1,1","a quoted ""1"" value",`,
+      `bar,2,2,"2,2","a quoted ""2"" value",`,
+    ]);
   });
 });
 

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -3809,9 +3809,8 @@ describe("GridTable", () => {
     ];
 
     function Test() {
-      const _api = useGridTableApi<Row>();
-      api = _api;
-      return <GridTable<Row> api={_api} columns={columns} rows={rows} />;
+      api = useGridTableApi<Row>();
+      return <GridTable<Row> api={api} columns={columns} rows={rows} />;
     }
 
     await render(<Test />);

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -210,6 +210,8 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
   }
 
   // visibleForTesting, not part of the GridTableApi
+  // ...although maybe it could be public someday, to allow getting the raw the CSV content
+  // and then sending it somewhere else, like directly to a gsheet.
   public generateCsvContent(): string[] {
     // Convert the array of rows into CSV format
     return this.tableState.visibleRows.map((rs) => {
@@ -230,7 +232,7 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
             return isJSX(maybeContent) ? "-" : maybeContent;
           }
         });
-      return values.map(toCsvString).map(escapeCSVField).join(",");
+      return values.map(toCsvString).map(escapeCsvValue).join(",");
     });
   }
 }
@@ -243,14 +245,12 @@ function toCsvString(value: any): string {
   return String(value);
 }
 
-function escapeCSVField(field: string): string {
-  if (field.includes('"') || field.includes(",") || field.includes("\n")) {
-    // Escape quotes by doubling them
-    field = field.replace(/"/g, '""');
-    // Wrap the field in double quotes
-    return `"${field}"`;
+function escapeCsvValue(value: string): string {
+  // Wrap values with special chars in quotes, and double quotes themselves
+  if (value.includes('"') || value.includes(",") || value.includes("\n")) {
+    return `"${value.replace(/"/g, '""')}"`;
   }
-  return field;
+  return value;
 }
 
 function bindMethods(instance: any): void {

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -218,7 +218,12 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
 
   public copyToClipboard(): Promise<void> {
     // Copy the CSV content to the clipboard
-    return navigator.clipboard.writeText(this.generateCsvContent().join("\n"));
+    const content = this.generateCsvContent().join("\n");
+    return navigator.clipboard.writeText(content).catch((err) => {
+      // Let the user know the copy failed...
+      window.alert("Failed to copy to clipboard, probably due to browser restrictions.");
+      throw err;
+    });
   }
 
   // visibleForTesting, not part of the GridTableApi

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -230,9 +230,27 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
             return isJSX(maybeContent) ? "-" : maybeContent;
           }
         });
-      return values.join(",");
+      return values.map(toCsvString).map(escapeCSVField).join(",");
     });
   }
+}
+
+function toCsvString(value: any): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return value.toString();
+  if (typeof value === "boolean") return value ? "true" : "false";
+  return String(value);
+}
+
+function escapeCSVField(field: string): string {
+  if (field.includes('"') || field.includes(",") || field.includes("\n")) {
+    // Escape quotes by doubling them
+    field = field.replace(/"/g, '""');
+    // Wrap the field in double quotes
+    return `"${field}"`;
+  }
+  return field;
 }
 
 function bindMethods(instance: any): void {

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -80,6 +80,13 @@ export type GridTableApi<R extends Kinded> = {
    * This currently assumes client-side pagination/sorting, i.e. we have the full dataset in memory.
    */
   downloadToCsv(fileName: string): void;
+
+  /**
+   * Copies the table's current content to the clipboard.
+   *
+   * This currently assumes client-side pagination/sorting, i.e. we have the full dataset in memory.
+   */
+  copyToClipboard(): Promise<void>;
 };
 
 /** Adds per-row methods to the `api`, i.e. for getting currently-visible children. */
@@ -207,6 +214,11 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
     document.body.appendChild(link);
     link.click();
     document.body.removeChild(link);
+  }
+
+  public copyToClipboard(): Promise<void> {
+    // Copy the CSV content to the clipboard
+    return navigator.clipboard.writeText(this.generateCsvContent().join("\n"));
   }
 
   // visibleForTesting, not part of the GridTableApi

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -15,6 +15,7 @@ import { ensureClientSideSortValueIsSortable } from "src/components/Table/utils/
 import { TableStateContext } from "src/components/Table/utils/TableState";
 import {
   applyRowFn,
+  DragData,
   EXPANDABLE_HEADER,
   getAlignment,
   getFirstOrLastCellCss,
@@ -198,14 +199,18 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
             currentColspan -= 1;
             return null;
           }
-          const maybeContent = applyRowFn(column as GridColumnWithId<R>, row, rowApi, level, isExpanded, {
+
+          // Combine all our drag stuff into a mini-context/parameter object...
+          const dragData: DragData<R> = {
             rowRenderRef: ref,
             onDragStart,
             onDragEnd,
             onDrop,
             onDragEnter,
             onDragOver: onDragOverDebounced,
-          });
+          };
+
+          const maybeContent = applyRowFn(column as GridColumnWithId<R>, row, rowApi, level, isExpanded, dragData);
 
           // Only use the `numExpandedColumns` as the `colspan` when rendering the "Expandable Header"
           currentColspan =

--- a/src/components/Table/components/cell.tsx
+++ b/src/components/Table/components/cell.tsx
@@ -9,10 +9,14 @@ import { Css, Properties, Typography } from "src/Css";
 /**
  * Allows a cell to be more than just a RectNode, i.e. declare its alignment or
  * primitive value for filtering and sorting.
+ *
+ * For a given column, the `GridColumn` can either return a static `GridCellContent`, or
+ * more likely use a function that returns a per-column/per-row `GridCellContent` that defines
+ * the value (and it's misc alignment/css/etc) for this specific cell.
  */
 export type GridCellContent = {
   /** The JSX content of the cell. Virtual tables that client-side sort should use a function to avoid perf overhead. */
-  content: ReactNode | (() => ReactNode);
+  content: MaybeFn<ReactNode>;
   alignment?: GridCellAlignment;
   /** Allow value to be a function in case it's a dynamic value i.e. reading from an inline-edited proxy. */
   value?: MaybeFn<number | string | Date | boolean | null | undefined>;

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -33,8 +33,9 @@ export type DiscriminateUnion<T, K extends keyof T, V extends T[K]> = T extends 
 export type GridColumn<R extends Kinded> = {
   /** Require a render function for each row `kind`. */
   [K in R["kind"]]:
-    | string
-    | GridCellContent
+    | string // static data, i.e. `firstNameColumn = { header: "First Name" }`
+    | GridCellContent // static-ish cell, i.e. `firstNameColumn = { header: { content: ... } }`
+    // Functions for dynamic data, i.e. `firstNameColumn = { header: (data) => data.firstName }`
     | (DiscriminateUnion<R, "kind", K> extends { data: infer D }
         ? (
             data: D,

--- a/src/components/Table/utils/utils.tsx
+++ b/src/components/Table/utils/utils.tsx
@@ -174,7 +174,7 @@ export function getFirstOrLastCellCss<R extends Kinded>(
 }
 
 /** A heuristic to detect the result of `React.createElement` / i.e. JSX. */
-function isJSX(content: any): boolean {
+export function isJSX(content: any): boolean {
   return typeof content === "object" && content && "type" in content && "props" in content;
 }
 


### PR DESCRIPTION
As easy as:

```
const api = useGridTableApi();

<Button onClick={() => api.downloadToCsv("report.csv")} label="CSV" />
```

Currently assumes all of the data is already available client-side -- not really sure how this would work with server-side driven pagination.

Also assumes we want all of the columns/rows included, and that they're directly mapped from the `content` / `value` keys. We could also add a `csvValue` to let columns provide CSV-specific values.

![image](https://github.com/user-attachments/assets/46b2a3da-f16d-4cdf-ae7b-a85f7b6db32b)
