### PR TITLE
feat: Add GridTable.csvPrefixRows.

### DIFF
--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -3821,6 +3821,26 @@ describe("GridTable", () => {
       `bar,2,2,"2,2","a quoted ""2"" value",`,
     ]);
   });
+
+  it("can download csvs with extra rows", async () => {
+    let api: GridTableApi<Row> | undefined;
+    // Given a table with 1 column
+    const columns: GridColumn<Row>[] = [{ header: "Value", data: ({ value }) => value }];
+    // And just 1 extra csv rows that adds a header
+    const extraCsvRows: string[][] = [["Report Title", "From: here", `To: "there"...`]];
+    function Test() {
+      api = useGridTableApi<Row>();
+      return <GridTable<Row> api={api} columns={columns} rows={rows} csvPrefixRows={extraCsvRows} />;
+    }
+    await render(<Test />);
+    // When we generate the csv, then the extra rows are included
+    expect((api as GridTableApiImpl<Row>).generateCsvContent()).toEqual([
+      `Report Title,From: here,"To: ""there""..."`,
+      "Value",
+      "1",
+      "2",
+    ]);
+  });
 });
 
 function Collapse({ id }: { id: string }) {

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -170,7 +170,13 @@ export interface GridTableProps<R extends Kinded, X> {
   infiniteScroll?: InfiniteScroll;
   /** Callback for when a row is selected or unselected. */
   onRowSelect?: OnRowSelect<R>;
-
+  /**
+   * Custom prefix rows for any CSV output, i.e. a header like "Report X as of date Y with filter Z".
+   *
+   * We except the `string[][]` to be an array of cells, and `copyToClipboard` and `downloadToCsv` will drop them into
+   * the csv output basically unchanged, albeit we will escape any special chars like double quotes and newlines.
+   */
+  csvPrefixRows?: string[][];
   /** Drag & drop Callback. */
   onRowDrop?: (draggedRow: GridDataRow<R>, droppedRow: GridDataRow<R>, indexOffset: number) => void;
 }
@@ -218,6 +224,7 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
     infiniteScroll,
     onRowSelect,
     onRowDrop: droppedCallback,
+    csvPrefixRows,
   } = props;
 
   const columnsWithIds = useMemo(() => assignDefaultColumnIds(_columns), [_columns]);
@@ -267,10 +274,11 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
       tableState.setRows(rows);
       tableState.setColumns(columnsWithIds, visibleColumnsStorageKey);
       tableState.setSearch(filter);
+      tableState.setCsvPrefixRows(csvPrefixRows);
       tableState.activeRowId = activeRowId;
       tableState.activeCellId = activeCellId;
     });
-  }, [tableState, rows, columnsWithIds, visibleColumnsStorageKey, activeRowId, activeCellId, filter]);
+  }, [tableState, rows, columnsWithIds, visibleColumnsStorageKey, activeRowId, activeCellId, filter, csvPrefixRows]);
 
   const columns: GridColumnWithId<R>[] = useComputed(() => {
     return tableState.visibleColumns as GridColumnWithId<R>[];

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -230,8 +230,9 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
   // ...although maybe it could be public someday, to allow getting the raw the CSV content
   // and then sending it somewhere else, like directly to a gsheet.
   public generateCsvContent(): string[] {
+    const csvPrefixRows = this.tableState.csvPrefixRows?.map((row) => row.map(escapeCsvValue).join(",")) ?? [];
     // Convert the array of rows into CSV format
-    return this.tableState.visibleRows.map((rs) => {
+    const dataRows = this.tableState.visibleRows.map((rs) => {
       const values = this.tableState.visibleColumns
         .filter((c) => !c.isAction)
         .map((c) => {
@@ -251,6 +252,7 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
         });
       return values.map(toCsvString).map(escapeCsvValue).join(",");
     });
+    return [...csvPrefixRows, ...dataRows];
   }
 }
 

--- a/src/components/Table/utils/TableState.ts
+++ b/src/components/Table/utils/TableState.ts
@@ -43,6 +43,8 @@ export class TableState<R extends Kinded> {
   activeCellId: string | undefined = undefined;
   /** Stores the current client-side type-ahead search/filter. */
   search: string[] = [];
+  /** Stores whether CSVs should have some prefix rows. */
+  csvPrefixRows: string[][] | undefined = undefined;
 
   // Tracks the current `sortConfig`
   public sortConfig: GridSortConfig | undefined;
@@ -165,6 +167,10 @@ export class TableState<R extends Kinded> {
   setSearch(search: string | undefined): void {
     // Break up "foo bar" into `[foo, bar]` and a row must match both `foo` and `bar`
     this.search = (search && search.split(/ +/)) || [];
+  }
+
+  setCsvPrefixRows(csvPrefixRows: string[][] | undefined): void {
+    this.csvPrefixRows = csvPrefixRows;
   }
 
   get visibleRows(): RowState<R>[] {


### PR DESCRIPTION
To add csv-specific rows to an export/copy.