### PR TITLE
fix: Add required to icon card and icon card group

### DIFF
--- a/src/forms/BoundIconCardField.tsx
+++ b/src/forms/BoundIconCardField.tsx
@@ -30,6 +30,7 @@ export function BoundIconCardField(props: BoundIconCardFieldProps) {
             field.maybeAutoSave();
           }}
           disabled={field.readOnly}
+          // required={field.required}
           {...testId}
           {...others}
         />

--- a/src/forms/BoundIconCardField.tsx
+++ b/src/forms/BoundIconCardField.tsx
@@ -30,7 +30,6 @@ export function BoundIconCardField(props: BoundIconCardFieldProps) {
             field.maybeAutoSave();
           }}
           disabled={field.readOnly}
-          // required={field.required}
           {...testId}
           {...others}
         />

--- a/src/forms/BoundIconCardGroupField.test.tsx
+++ b/src/forms/BoundIconCardGroupField.test.tsx
@@ -45,6 +45,15 @@ describe("BoundIconCardGroupField", () => {
     // Then the callback should be triggered with the current value
     expect(autoSave).toBeCalledWith([Category.Math]);
   });
+
+  it("shows an error message", async () => {
+    // Given a readOnly BoundIconCardField
+    const author = createObjectState(formConfig, { favoriteGenres: [Category.Math] });
+    const r = await render(<BoundIconCardGroupField field={author.favoriteGenres} options={categories} errorMsg="Required" />);
+
+    // Then the icon card should show an error message
+    expect(r.favoriteGenres_errorMsg).toHaveTextContent("Required");
+  });
 });
 
 const formConfig: ObjectConfig<NewAuthor> = {

--- a/src/forms/BoundIconCardGroupField.test.tsx
+++ b/src/forms/BoundIconCardGroupField.test.tsx
@@ -49,7 +49,9 @@ describe("BoundIconCardGroupField", () => {
   it("shows an error message", async () => {
     // Given a readOnly BoundIconCardField
     const author = createObjectState(formConfig, { favoriteGenres: [Category.Math] });
-    const r = await render(<BoundIconCardGroupField field={author.favoriteGenres} options={categories} errorMsg="Required" />);
+    const r = await render(
+      <BoundIconCardGroupField field={author.favoriteGenres} options={categories} errorMsg="Required" />,
+    );
 
     // Then the icon card should show an error message
     expect(r.favoriteGenres_errorMsg).toHaveTextContent("Required");

--- a/src/forms/BoundIconCardGroupField.tsx
+++ b/src/forms/BoundIconCardGroupField.tsx
@@ -31,6 +31,7 @@ export function BoundIconCardGroupField<V extends Value>(props: BoundIconCardGro
             field.maybeAutoSave();
           }}
           disabled={field.readOnly}
+          required={field.required}
           {...testId}
           {...others}
         />

--- a/src/inputs/IconCard.tsx
+++ b/src/inputs/IconCard.tsx
@@ -4,7 +4,7 @@ import { useToggleState } from "react-stately";
 import { Icon, IconProps, maybeTooltip, resolveTooltip } from "src/components";
 import { Css, Palette } from "src/Css";
 import { useGetRef } from "src/hooks/useGetRef";
-import { useTestIds } from "src/utils";
+import { noop, useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
 
 export interface IconCardProps {
@@ -28,7 +28,6 @@ export function IconCard(props: IconCardProps) {
     cardRef,
     label,
     tooltip,
-    required,
     ...otherProps
   } = props;
   const ref = useGetRef(cardRef);

--- a/src/inputs/IconCard.tsx
+++ b/src/inputs/IconCard.tsx
@@ -4,7 +4,7 @@ import { useToggleState } from "react-stately";
 import { Icon, IconProps, maybeTooltip, resolveTooltip } from "src/components";
 import { Css, Palette } from "src/Css";
 import { useGetRef } from "src/hooks/useGetRef";
-import { noop, useTestIds } from "src/utils";
+import { useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
 
 export interface IconCardProps {
@@ -17,6 +17,7 @@ export interface IconCardProps {
   cardRef?: RefObject<HTMLInputElement>;
   disabled?: boolean;
   tooltip?: string;
+  required?: boolean;
 }
 
 export function IconCard(props: IconCardProps) {
@@ -27,6 +28,7 @@ export function IconCard(props: IconCardProps) {
     cardRef,
     label,
     tooltip,
+    required,
     ...otherProps
   } = props;
   const ref = useGetRef(cardRef);

--- a/src/inputs/IconCardGroup.stories.tsx
+++ b/src/inputs/IconCardGroup.stories.tsx
@@ -43,3 +43,21 @@ export function Default() {
     </div>
   );
 }
+
+export function Required() {
+  const [values, setValues] = useState<Category[]>([Category.Math]);
+
+  return (
+    <div>
+      <div css={Css.df.wPx(500).$}>
+        <IconCardGroup
+          label="Icon Card Group"
+          options={categories}
+          onChange={(values) => setValues(values)}
+          values={values}
+          errorMsg="Required"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/inputs/IconCardGroup.tsx
+++ b/src/inputs/IconCardGroup.tsx
@@ -31,6 +31,7 @@ export interface IconCardGroupProps<V extends Value> extends Pick<PresentationFi
   errorMsg?: string;
   helperText?: string | ReactNode;
   disabled?: boolean;
+  required?: boolean;
 }
 
 export function IconCardGroup<V extends Value>(props: IconCardGroupProps<V>) {
@@ -40,6 +41,7 @@ export function IconCardGroup<V extends Value>(props: IconCardGroupProps<V>) {
     label,
     labelStyle = fieldProps?.labelStyle ?? "above",
     values,
+    required,
     errorMsg,
     helperText,
     disabled: isDisabled = false,
@@ -105,6 +107,7 @@ export function IconCardGroup<V extends Value>(props: IconCardGroupProps<V>) {
               selected={isSelected}
               disabled={disabled}
               onChange={() => toggleValue(option.value)}
+              required={required}
               {...tid[option.label]}
             />
           );


### PR DESCRIPTION
[SC-55990](https://app.shortcut.com/homebound-team/story/55990/make-change-type-required-on-change-log-submission-form)

* Adds in `field.required` to the `BoundIconCardFieldGroup`

![Screenshot 2024-09-10 at 12 24 17 PM](https://github.com/user-attachments/assets/5ff9999b-f476-41a6-8df7-4de29fdae5a0)


LOOM: https://www.loom.com/share/12d67c08592d4a4f8bf2e0b556eb88d0