### PR TITLE
fix: email icon to use `clipRule` instead of `clip-rule`;

### DIFF
--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -361,7 +361,7 @@ export const Icons = {
   email: (
     <path
       fillRule="evenodd"
-      clip-rule="evenodd"
+      clipRule="evenodd"
       d="M19.7885 7.82129L11.9381 14.1015L4.13462 7.41281V18.0529H19.7885V7.82129ZM5.92342 6.13462L11.9851 11.3303L18.4797 6.13462H5.92342ZM2 20.1875V4H21.9231V6.02293L21.9673 6.07821L21.9231 6.11359V20.1875H2Z"
     />
   ),


### PR DESCRIPTION
This was getting really annoying and I needed to release a new beam version anyway to use a `calendar-x` icon that was added as a `chore` 😃 

![Screenshot 2024-10-14 at 11 53 25 AM](https://github.com/user-attachments/assets/807289d1-15a7-4fbd-b4bc-b994882daed3)
