### PR TITLE
fix: scrollshadow chromatic diff issue

### DIFF
--- a/src/components/ScrollShadows.stories.tsx
+++ b/src/components/ScrollShadows.stories.tsx
@@ -5,6 +5,7 @@ import { zeroTo } from "src/utils/sb";
 
 export default {
   component: ScrollShadows,
+  parameters: { delay: 1_000 },
 };
 
 export function Examples() {

--- a/src/components/ScrollShadows.stories.tsx
+++ b/src/components/ScrollShadows.stories.tsx
@@ -1,5 +1,7 @@
 import { Css } from "src";
+import { GridColumn, GridTable, simpleHeader, SimpleHeaderAndData } from "src/components";
 import { ScrollShadows } from "src/components/ScrollShadows";
+import { zeroTo } from "src/utils/sb";
 
 export default {
   component: ScrollShadows,
@@ -14,6 +16,15 @@ export function Examples() {
           20,
         )}
       </ScrollShadows>
+
+      <div css={Css.mt3.bgWhite.br8.wPx(400).oh.$}>
+        <ScrollShadows xss={Css.hPx(200).bgWhite.p1.ba.bcGray200.$}>
+          <GridTable
+            columns={columns}
+            rows={[simpleHeader, ...rowData.map((r) => ({ kind: "data" as const, id: r.id, data: r }))]}
+          />
+        </ScrollShadows>
+      </div>
 
       <div css={Css.mt3.df.fdc.bgWhite.ba.bcGray200.bshBasic.br8.oh.hPx(200).wPx(400).$}>
         <div css={Css.pPx(20).pb2.bgWhite.fw6.$}>Fixed Header</div>
@@ -38,3 +49,19 @@ export function Examples() {
     </>
   );
 }
+
+type Row = SimpleHeaderAndData<RowData>;
+type RowData = { id: string; address: string; homeowner: string; market: string };
+
+const rowData: RowData[] = zeroTo(10).map((i) => ({
+  id: `r:${i + 1}`,
+  address: "1234 Address Lane",
+  market: "SO Cal",
+  homeowner: "John Doe",
+}));
+const columns: GridColumn<Row>[] = [
+  { header: "ID", data: (data) => data.id },
+  { header: "Homeowner", data: (data) => data.homeowner },
+  { header: "Address", data: (data) => data.address },
+  { header: "Market", data: (data) => data.market },
+];

--- a/src/components/ScrollShadows.tsx
+++ b/src/components/ScrollShadows.tsx
@@ -1,5 +1,5 @@
 import { useResizeObserver } from "@react-aria/utils";
-import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ReactNode, useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Css, Palette, Properties, useTestIds } from "src";
 
 interface ScrollShadowsProps {
@@ -64,7 +64,7 @@ export function ScrollShadows(props: ScrollShadowsProps) {
   useResizeObserver({ ref: scrollRef, onResize });
 
   // Hack for sizing more complicated components that might not be fully drawn on initial paint (such as a GridTable)
-  useEffect(() => {
+  useLayoutEffect(() => {
     // This setTimeout (without a delay) allows the current execution thread to complete (DOM is painted with the latest render)
     // by placing the callback into the async event queue to ensure the fully rendered DOM is used for the resize calculations.
     setTimeout(() => onResize(), 0);

--- a/src/components/ScrollShadows.tsx
+++ b/src/components/ScrollShadows.tsx
@@ -1,5 +1,5 @@
 import { useResizeObserver } from "@react-aria/utils";
-import { ReactNode, useCallback, useMemo, useRef, useState } from "react";
+import { ReactNode, useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Css, Palette, Properties, useTestIds } from "src";
 
 interface ScrollShadowsProps {
@@ -62,6 +62,11 @@ export function ScrollShadows(props: ScrollShadowsProps) {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const onResize = useCallback(() => scrollRef.current && updateScrollProps(scrollRef.current), []);
   useResizeObserver({ ref: scrollRef, onResize });
+
+  // Hack for sizing more complicated components that might not be fully drawn on initial paint (such as a GridTable)
+  useLayoutEffect(() => {
+    setTimeout(() => onResize(), 0);
+  }, [onResize]);
 
   return (
     <div

--- a/src/components/ScrollShadows.tsx
+++ b/src/components/ScrollShadows.tsx
@@ -63,8 +63,12 @@ export function ScrollShadows(props: ScrollShadowsProps) {
   const onResize = useCallback(() => scrollRef.current && updateScrollProps(scrollRef.current), []);
   useResizeObserver({ ref: scrollRef, onResize });
 
-  // Hack for sizing more complicated components that might not be fully drawn on initial render (such as a GridTable)
-  useEffect(() => void onResize());
+  // Hack for sizing more complicated components that might not be fully drawn on initial paint (such as a GridTable)
+  useEffect(() => {
+    // This setTimeout (without a delay) allows the current execution thread to complete (DOM is painted with the latest render)
+    // by placing the callback into the async event queue to ensure the fully rendered DOM is used for the resize calculations.
+    setTimeout(() => onResize(), 0);
+  }, [onResize]);
 
   return (
     <div

--- a/src/components/ScrollShadows.tsx
+++ b/src/components/ScrollShadows.tsx
@@ -1,5 +1,5 @@
 import { useResizeObserver } from "@react-aria/utils";
-import { ReactNode, useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Css, Palette, Properties, useTestIds } from "src";
 
 interface ScrollShadowsProps {
@@ -63,10 +63,8 @@ export function ScrollShadows(props: ScrollShadowsProps) {
   const onResize = useCallback(() => scrollRef.current && updateScrollProps(scrollRef.current), []);
   useResizeObserver({ ref: scrollRef, onResize });
 
-  // Hack for sizing more complicated components that might not be fully drawn on initial paint (such as a GridTable)
-  useLayoutEffect(() => {
-    setTimeout(() => onResize(), 0);
-  }, [onResize]);
+  // Hack for sizing more complicated components that might not be fully drawn on initial render (such as a GridTable)
+  useEffect(() => void onResize());
 
   return (
     <div


### PR DESCRIPTION
## Overview
One source of flakey chromatic diffs trace back to the use of the `ScrollShadows` component where the bottom scroll "shadow" element isn't reliably drawn. This generally happens when more complex children components are rendered that may take multiple paints to render the full content. This common flaky example has a `GridTable` nested inside:
<img width="1715" alt="image" src="https://github.com/user-attachments/assets/ce8e551c-7ec5-43db-9721-62043e0b99e6">

When recording how the browser actually paints the component, you can see the initial frames do not include the GridTable (in the 2nd "card" from the top) so the `ScrollShadows` component doesn't think a bottom shadow is needed.
Initial initial paint does not include the full table
![image](https://github.com/user-attachments/assets/c06d41d6-cd31-44a5-8c15-826b8644e61c)

Then on subsequent frames, the table fully renders
![image](https://github.com/user-attachments/assets/ffacb953-6ac8-422d-bfe0-49d221fc5de6)
