### PR TITLE
fix: SC-59775 fix nested select height after long render

### DIFF
--- a/src/inputs/hooks/useGrowingTextField.stories.tsx
+++ b/src/inputs/hooks/useGrowingTextField.stories.tsx
@@ -6,13 +6,12 @@ import { withRouter, zeroTo } from "src/utils/sb";
 import { SelectField } from "../SelectField";
 
 export default {
-  component: GridTable,
   parameters: { layout: "fullscreen", backgrounds: { default: "white" } },
   decorators: [withRouter()],
 } as Meta;
 
 export function InVirtualizedTable() {
-  const [extraColumn, setExtraColumn] = useState(false);
+  const [extraColumn, setExtraColumn] = useState(true);
   const loadRows = useCallback((offset: number) => {
     return zeroTo(50).map((i) => ({
       kind: "data" as const,
@@ -66,6 +65,12 @@ export function InVirtualizedTable() {
     </div>
   );
 }
+
+InVirtualizedTable.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const button = canvasElement.querySelector("button");
+  // When we toggle the extra column, the table will re-render
+  button?.click();
+};
 
 type HeaderRow = { kind: "header"; data: undefined };
 type ChildRow = { kind: "data"; id: string; data: { name: string; value: number } };

--- a/src/inputs/hooks/useGrowingTextField.stories.tsx
+++ b/src/inputs/hooks/useGrowingTextField.stories.tsx
@@ -1,0 +1,73 @@
+import { Meta } from "@storybook/react";
+import { useCallback, useMemo, useState } from "react";
+import { Button, collapseColumn, column, GridColumn, GridDataRow, GridTable, simpleHeader } from "src/components";
+import { Css } from "src/Css";
+import { withRouter, zeroTo } from "src/utils/sb";
+import { SelectField } from "../SelectField";
+
+export default {
+  component: GridTable,
+  parameters: { layout: "fullscreen", backgrounds: { default: "white" } },
+  decorators: [withRouter()],
+} as Meta;
+
+export function InVirtualizedTable() {
+  const [extraColumn, setExtraColumn] = useState(false);
+  const loadRows = useCallback((offset: number) => {
+    return zeroTo(50).map((i) => ({
+      kind: "data" as const,
+      id: String(i + offset),
+      data: { name: `row ${i + offset}`, value: i + offset },
+    }));
+  }, []);
+
+  const options = useMemo(() => {
+    return zeroTo(50).map((i) => ({ id: i, name: `option ${i}` }));
+  }, []);
+
+  const [data, setData] = useState<GridDataRow<Row>[]>(() => loadRows(0));
+  const rows: GridDataRow<Row>[] = useMemo(() => [simpleHeader, ...data], [data]);
+  const columns: GridColumn<Row>[] = useMemo(
+    () => [
+      ...(extraColumn ? [collapseColumn<Row>()] : []),
+      column<Row>({ header: "Name", data: ({ name }) => name, w: "100px" }),
+      column<Row>({
+        header: "Value",
+        data: ({ value }) => (
+          <SelectField
+            label="test"
+            options={options}
+            value={value}
+            onSelect={() => {}}
+            getOptionLabel={(o) => o.name}
+            getOptionValue={(o) => o.id}
+          />
+        ),
+        w: "200px",
+      }),
+    ],
+    [extraColumn, options],
+  );
+  return (
+    <div css={Css.df.fdc.vh100.$}>
+      <Button onClick={() => setExtraColumn(!extraColumn)} label="Toggle Extra Column" />
+      <div css={Css.fg1.$}>
+        <GridTable
+          as="virtual"
+          columns={columns}
+          rows={rows}
+          infiniteScroll={{
+            onEndReached(index) {
+              setData([...data, ...loadRows(index)]);
+            },
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+type HeaderRow = { kind: "header"; data: undefined };
+type ChildRow = { kind: "data"; id: string; data: { name: string; value: number } };
+
+type Row = HeaderRow | ChildRow;

--- a/src/inputs/hooks/useGrowingTextField.tsx
+++ b/src/inputs/hooks/useGrowingTextField.tsx
@@ -43,6 +43,7 @@ export function useGrowingTextField({ inputRef, inputWrapRef, value, disabled }:
       }
       onHeightChange();
       // This is a hack to re-measure the height of the textarea after all the content has been rendered (i.e. after multiple GridTable children have been rendered)
+      // See the InVirtualizedTable storybook for reproducing this behavior
       setTimeout(() => onHeightChange(), 200);
     }
   }, [onHeightChange, value, inputRef, disabled, inputWrapRef]);

--- a/src/inputs/hooks/useGrowingTextField.tsx
+++ b/src/inputs/hooks/useGrowingTextField.tsx
@@ -42,6 +42,8 @@ export function useGrowingTextField({ inputRef, inputWrapRef, value, disabled }:
         return;
       }
       onHeightChange();
+      // This is a hack to re-measure the height of the textarea after all the content has been rendered (i.e. after multiple GridTable children have been rendered)
+      setTimeout(() => onHeightChange(), 200);
     }
   }, [onHeightChange, value, inputRef, disabled, inputWrapRef]);
 }


### PR DESCRIPTION
Issue: when rendering a SelectField in a GridTable with no nested rows the select renders with the correct height, when updating the table to have nested rows the select field will fail calculating the new correct height, this change adds another delayed called that gives a better chance of having enough time for GridTable finishing the rendering so that `useGrowingTextField` will get the correct value.