### PR TITLE
feat: add modal prop to force modal interaction;

### DIFF
--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -28,7 +28,7 @@ export const Medium = () => <ModalExample />;
 export const Large = () => <ModalExample size="lg" />;
 export const LargeFixedHeight = () => <ModalExample size={{ width: "lg", height: 300 }} forceScrolling={true} />;
 export const WithScroll = () => <ModalExample initNumSentences={50} />;
-export const ForceModalInteraction = () => <ModalExample forceModalInteraction />;
+export const ForceModalInteraction = () => <ModalExample allowClosing={false} />;
 export const LeftAction = () => <ModalExample showLeftAction />;
 export const FilterableDynamicHeight = () => <ModalFilterTableExample />;
 export const FilterableStaticHeight = () => (
@@ -114,7 +114,7 @@ export function ModalForm() {
 }
 
 interface ModalExampleProps
-  extends Pick<ModalProps, "size" | "forceScrolling" | "drawHeaderBorder" | "forceModalInteraction">,
+  extends Pick<ModalProps, "size" | "forceScrolling" | "drawHeaderBorder" | "allowClosing">,
     TestModalContentProps {}
 
 function ModalExample(props: ModalExampleProps) {
@@ -126,7 +126,7 @@ function ModalExample(props: ModalExampleProps) {
     withTag,
     withDateField,
     drawHeaderBorder = false,
-    forceModalInteraction = false,
+    allowClosing = true,
   } = props;
   const { openModal } = useModal();
   const open = () =>
@@ -135,7 +135,7 @@ function ModalExample(props: ModalExampleProps) {
       forceScrolling,
       content: <TestModalContent {...props} />,
       drawHeaderBorder,
-      forceModalInteraction,
+      allowClosing,
     });
   // Immediately open the modal for Chromatic snapshots
   // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -28,6 +28,7 @@ export const Medium = () => <ModalExample />;
 export const Large = () => <ModalExample size="lg" />;
 export const LargeFixedHeight = () => <ModalExample size={{ width: "lg", height: 300 }} forceScrolling={true} />;
 export const WithScroll = () => <ModalExample initNumSentences={50} />;
+export const ForceModalInteraction = () => <ModalExample forceModalInteraction />;
 export const LeftAction = () => <ModalExample showLeftAction />;
 export const FilterableDynamicHeight = () => <ModalFilterTableExample />;
 export const FilterableStaticHeight = () => (
@@ -113,7 +114,7 @@ export function ModalForm() {
 }
 
 interface ModalExampleProps
-  extends Pick<ModalProps, "size" | "forceScrolling" | "drawHeaderBorder">,
+  extends Pick<ModalProps, "size" | "forceScrolling" | "drawHeaderBorder" | "forceModalInteraction">,
     TestModalContentProps {}
 
 function ModalExample(props: ModalExampleProps) {
@@ -125,6 +126,7 @@ function ModalExample(props: ModalExampleProps) {
     withTag,
     withDateField,
     drawHeaderBorder = false,
+    forceModalInteraction = false,
   } = props;
   const { openModal } = useModal();
   const open = () =>
@@ -133,6 +135,7 @@ function ModalExample(props: ModalExampleProps) {
       forceScrolling,
       content: <TestModalContent {...props} />,
       drawHeaderBorder,
+      forceModalInteraction,
     });
   // Immediately open the modal for Chromatic snapshots
   // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -31,6 +31,13 @@ export interface ModalProps {
   api?: MutableRefObject<ModalApi | undefined>;
   /** Adds a border for the header. */
   drawHeaderBorder?: boolean;
+  /**
+   * Hides `x` icon and removes ability to close modal by clicking outside of it.
+   *
+   * Relies on you to provide a way to close the modal, i.e. a cancel or confirm button.
+   * Useful if you definitely need to force the user to make a choice.
+   * */
+  forceModalInteraction?: boolean;
 }
 
 export type ModalApi = {
@@ -43,7 +50,7 @@ export type ModalApi = {
  * Provides underlay, modal container, and header. Will disable scrolling of page under the modal.
  */
 export function Modal(props: ModalProps) {
-  const { size = "md", content, forceScrolling, api, drawHeaderBorder = false } = props;
+  const { size = "md", content, forceScrolling, api, drawHeaderBorder = false, forceModalInteraction = false } = props;
   const isFixedHeight = typeof size !== "string";
   const ref = useRef(null);
   const { modalBodyDiv, modalFooterDiv, modalHeaderDiv } = useBeamContext();
@@ -56,7 +63,10 @@ export function Modal(props: ModalProps) {
       isDismissable: true,
       shouldCloseOnInteractOutside: (el) => {
         // Do not close the Modal if the user is interacting with the Tribute mentions dropdown (via RichTextField) or with another 3rd party dialog (such as a lightbox) on top of it.
-        return !(el.closest(".tribute-container") || el.closest("[role='dialog']") || el.closest("[role='alert']"));
+        return (
+          !forceModalInteraction &&
+          !(el.closest(".tribute-container") || el.closest("[role='dialog']") || el.closest("[role='alert']"))
+        );
       },
     },
     ref,
@@ -138,7 +148,7 @@ export function Modal(props: ModalProps) {
                 */}
                 <header css={Css.df.fdrr.p3.fs0.if(drawHeaderBorder).bb.bcGray200.$}>
                   <span css={Css.fs0.pl1.$}>
-                    <IconButton icon="x" onClick={closeModal} {...testId.titleClose} />
+                    {!forceModalInteraction && <IconButton icon="x" onClick={closeModal} {...testId.titleClose} />}
                   </span>
                   <h1 css={Css.fg1.xl2Sb.gray900.$} ref={modalHeaderRef} {...titleProps} {...testId.title} />
                 </header>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -32,12 +32,13 @@ export interface ModalProps {
   /** Adds a border for the header. */
   drawHeaderBorder?: boolean;
   /**
-   * Hides `x` icon and removes ability to close modal by clicking outside of it.
+   * Defaults to `true`
+   * Renders `x` icon and closes modal when users click outside of it.
    *
-   * Relies on you to provide a way to close the modal, i.e. a cancel or confirm button.
+   * When false, relies on you to provide a way to close the modal, i.e. a cancel or confirm button.
    * Useful if you definitely need to force the user to make a choice.
    * */
-  forceModalInteraction?: boolean;
+  allowClosing?: boolean;
 }
 
 export type ModalApi = {
@@ -50,7 +51,7 @@ export type ModalApi = {
  * Provides underlay, modal container, and header. Will disable scrolling of page under the modal.
  */
 export function Modal(props: ModalProps) {
-  const { size = "md", content, forceScrolling, api, drawHeaderBorder = false, forceModalInteraction = false } = props;
+  const { size = "md", content, forceScrolling, api, drawHeaderBorder = false, allowClosing = true } = props;
   const isFixedHeight = typeof size !== "string";
   const ref = useRef(null);
   const { modalBodyDiv, modalFooterDiv, modalHeaderDiv } = useBeamContext();
@@ -64,7 +65,7 @@ export function Modal(props: ModalProps) {
       shouldCloseOnInteractOutside: (el) => {
         // Do not close the Modal if the user is interacting with the Tribute mentions dropdown (via RichTextField) or with another 3rd party dialog (such as a lightbox) on top of it.
         return (
-          !forceModalInteraction &&
+          allowClosing &&
           !(el.closest(".tribute-container") || el.closest("[role='dialog']") || el.closest("[role='alert']"))
         );
       },
@@ -148,7 +149,7 @@ export function Modal(props: ModalProps) {
                 */}
                 <header css={Css.df.fdrr.p3.fs0.if(drawHeaderBorder).bb.bcGray200.$}>
                   <span css={Css.fs0.pl1.$}>
-                    {!forceModalInteraction && <IconButton icon="x" onClick={closeModal} {...testId.titleClose} />}
+                    {allowClosing && <IconButton icon="x" onClick={closeModal} {...testId.titleClose} />}
                   </span>
                   <h1 css={Css.fg1.xl2Sb.gray900.$} ref={modalHeaderRef} {...titleProps} {...testId.title} />
                 </header>

--- a/src/components/Modal/TestModalContent.tsx
+++ b/src/components/Modal/TestModalContent.tsx
@@ -19,7 +19,7 @@ export interface TestModalContentProps {
   withDateField?: boolean;
   withTextArea?: boolean;
   withTextField?: boolean;
-  forceModalInteraction?: boolean;
+  allowClosing?: boolean;
 }
 
 /** A fake modal content component that we share across the modal and superdrawer stories. */
@@ -94,7 +94,7 @@ export function TestModalContent(props: TestModalContentProps) {
             label="Apply"
             onClick={() => {
               action("Primary action");
-              props?.forceModalInteraction && closeModal();
+              !props?.allowClosing && closeModal();
             }}
             disabled={primaryDisabled}
           />

--- a/src/components/Modal/TestModalContent.tsx
+++ b/src/components/Modal/TestModalContent.tsx
@@ -19,6 +19,7 @@ export interface TestModalContentProps {
   withDateField?: boolean;
   withTextArea?: boolean;
   withTextField?: boolean;
+  forceModalInteraction?: boolean;
 }
 
 /** A fake modal content component that we share across the modal and superdrawer stories. */
@@ -89,7 +90,14 @@ export function TestModalContent(props: TestModalContentProps) {
         )}
         <div css={Css.df.gap1.$}>
           <Button label="Cancel" onClick={closeModal} variant="tertiary" />
-          <Button label="Apply" onClick={action("Primary action")} disabled={primaryDisabled} />
+          <Button
+            label="Apply"
+            onClick={() => {
+              action("Primary action");
+              props?.forceModalInteraction && closeModal();
+            }}
+            disabled={primaryDisabled}
+          />
         </div>
       </ModalFooter>
     </>


### PR DESCRIPTION
Orchestration has been asked to combine the dynamic schedule draft mode with the standard view. The draft pages were built as individual routes using a shared store to pass task changes between them. In combining these pages, we need to warn users their changes will be lost before allowing them to navigate away. Since we're using a shared store and not just a shared form I want to update Blueprints `<NavigationContext />` `navigationCheckCallbacks` to support more robust nav checks. I've gotten that working, but since the inner `<NavigationPrompt />` from `react-router-navigation-prompt` passes its own callback when a cancel action happens, routing breaks if a user clicks outside of our modal or closes with the `x` icon since the NavigationPrompt inner onCancel callback is never called. 

Context (branch is WIP):
- [NavigationContext.tsx changes](https://github.com/homebound-team/internal-frontend/compare/main...sc-60329/schedules-merge-draft-view#diff-3e5dd94f92d2a5b4d5e1e0b362d7d8e2d9ec52af58eb9cfd833a0e195d56ed3d)
- [Using new callback type](https://github.com/homebound-team/internal-frontend/compare/main...sc-60329/schedules-merge-draft-view#diff-832d5b6b2b80a4d541fbe0eb1a55eaf856777b136a6f2e4540880035f544be87R82)

TLDR: Needed a way to force users to interact with the modal.


https://github.com/user-attachments/assets/6e5c631c-e7e9-4ffc-8c1f-4299afb15c29

