### PR TITLE
fix: expose `inc` prop on OverlayTriggerProps

### DIFF
--- a/src/components/internal/OverlayTrigger.tsx
+++ b/src/components/internal/OverlayTrigger.tsx
@@ -14,7 +14,7 @@ import { noop, useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
 
 interface TextButtonTriggerProps extends Pick<ButtonProps, "label" | "variant" | "size" | "icon"> {}
-interface IconButtonTriggerProps extends Pick<IconButtonProps, "icon" | "color" | "compact" | "contrast"> {}
+interface IconButtonTriggerProps extends Pick<IconButtonProps, "icon" | "color" | "compact" | "contrast" | "inc"> {}
 interface AvatarButtonTriggerProps extends Pick<AvatarButtonProps, "src" | "name" | "size"> {}
 interface NavLinkButtonTriggerProps extends Pick<NavLinkProps, "active" | "variant" | "icon"> {
   navLabel: string;


### PR DESCRIPTION
I've had to write this

```
      <ButtonMenu
        // @ts-ignore: it works but prop isn't exposed
        trigger={{ icon: "verticalDots", inc: 2.3 }}
```

more than a few times lately 😄  