### PR TITLE
fix: allow searching in collapsed TreeSelectField

### DIFF
--- a/src/inputs/TreeSelectField/TreeSelectField.test.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.test.tsx
@@ -394,6 +394,32 @@ describe(TreeSelectField, () => {
     expect(r.getByRole("option", { name: "WNBA" })).toBeVisible();
   });
 
+  it("can filter options even if parent if collapsed", async () => {
+    // Given a TreeSelectField with nested options
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={getNestedOptions()}
+        label="Favorite League"
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    // When opening the options
+    click(r.favoriteLeague);
+    // Then the child options are visible
+    expect(r.getByRole("option", { name: "MLB" })).toBeVisible();
+    // When we collapse the parent option
+    click(r.treeOption_collapseToggle_basketball);
+    // And typing in the filter input
+    fireEvent.input(r.favoriteLeague, { target: { value: "nba" } });
+    // Then only the options that match the filter are visible
+    expect(r.queryAllByRole("option")).toHaveLength(2);
+    expect(r.getByRole("option", { name: "NBA" })).toBeVisible();
+    expect(r.getByRole("option", { name: "WNBA" })).toBeVisible();
+  });
+
   it("shows the correct input text when selecting options", async () => {
     // Given a TreeSelectField with nested options
     const r = await render(

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -325,6 +325,7 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
   // Update the filtered options when the input value changes
   const onInputChange = useCallback(
     (inputValue: string) => {
+      console.log({ inputValue });
       setFieldState((prevState) => {
         return {
           ...prevState,
@@ -691,7 +692,8 @@ function levelOptions<O, V extends Value>(
   const actualLevel = filtering ? 0 : level;
   return [
     [o, actualLevel],
-    ...(o.children?.length && !collapsedKeys.includes(valueToKey(getOptionValue(o)))
+    // Flat map the children if the parent is not collapsed or if we are filtering (for the search results)
+    ...(o.children?.length && (!collapsedKeys.includes(valueToKey(getOptionValue(o))) || filtering)
       ? o.children.flatMap((oc: NestedOption<O>) =>
           levelOptions(oc, actualLevel + 1, filtering, collapsedKeys, getOptionValue),
         )

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -325,7 +325,6 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
   // Update the filtered options when the input value changes
   const onInputChange = useCallback(
     (inputValue: string) => {
-      console.log({ inputValue });
       setFieldState((prevState) => {
         return {
           ...prevState,


### PR DESCRIPTION
Allows to filter options on a tree select field even if the parent option is collapsed.