### PR TITLE
fix: gridtable smooth scroll default; expose options;

### DIFF
--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -1,8 +1,16 @@
 import { comparer } from "mobx";
 import { computedFn } from "mobx-utils";
 import { MutableRefObject, useMemo } from "react";
-import { FlatIndexLocationWithAlign, VirtuosoHandle } from "react-virtuoso";
-import { applyRowFn, createRowLookup, GridRowLookup, isGridCellContent, isJSX, MaybeFn } from "src/components/index";
+import { VirtuosoHandle } from "react-virtuoso";
+import {
+  applyRowFn,
+  createRowLookup,
+  GridRowLookup,
+  GridTableScrollOptions,
+  isGridCellContent,
+  isJSX,
+  MaybeFn,
+} from "src/components/index";
 import { GridDataRow } from "src/components/Table/components/Row";
 import { DiscriminateUnion, Kinded } from "src/components/Table/types";
 import { TableState } from "src/components/Table/utils/TableState";
@@ -29,7 +37,7 @@ export function useGridTableApi<R extends Kinded>(): GridTableApi<R> {
 /** Provides an imperative API for an application page to interact with the table. */
 export type GridTableApi<R extends Kinded> = {
   /** Scrolls row `index` into view; Defaults "smooth" behavior; only supported with `as=virtual` and after a `useEffect`. */
-  scrollToIndex(index: number | FlatIndexLocationWithAlign): void;
+  scrollToIndex(index: GridTableScrollOptions): void;
 
   /** Returns the currently-visible rows. */
   getVisibleRows(): GridDataRow<R>[];
@@ -113,9 +121,11 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
     this.lookup = createRowLookup(this, virtuosoRef);
   }
 
-  public scrollToIndex(index: number | FlatIndexLocationWithAlign): void {
+  public scrollToIndex(index: GridTableScrollOptions): void {
     this.virtuosoRef.current &&
-      this.virtuosoRef.current.scrollToIndex(typeof index === "number" ? { index, behavior: "smooth" } : index);
+      this.virtuosoRef.current.scrollToIndex(
+        typeof index === "number" || index === "LAST" ? { index, behavior: "smooth" } : index,
+      );
   }
 
   public getSelectedRowIds(kind?: string): string[] {

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -36,7 +36,10 @@ export function useGridTableApi<R extends Kinded>(): GridTableApi<R> {
 
 /** Provides an imperative API for an application page to interact with the table. */
 export type GridTableApi<R extends Kinded> = {
-  /** Scrolls row `index` into view; Defaults "smooth" behavior; only supported with `as=virtual` and after a `useEffect`. */
+  /** Scrolls row `index` into view;  only supported with `as=virtual` and after a `useEffect`.
+   *
+   * Defaults "smooth" behavior; Use {index, behavior: "auto"} for instant scroll in cases where grid table has many, many records and the scroll effect is undesirable.
+   * */
   scrollToIndex(index: GridTableScrollOptions): void;
 
   /** Returns the currently-visible rows. */

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -1,7 +1,7 @@
 import { comparer } from "mobx";
 import { computedFn } from "mobx-utils";
 import { MutableRefObject, useMemo } from "react";
-import { VirtuosoHandle } from "react-virtuoso";
+import { FlatIndexLocationWithAlign, VirtuosoHandle } from "react-virtuoso";
 import { applyRowFn, createRowLookup, GridRowLookup, isGridCellContent, isJSX, MaybeFn } from "src/components/index";
 import { GridDataRow } from "src/components/Table/components/Row";
 import { DiscriminateUnion, Kinded } from "src/components/Table/types";
@@ -28,8 +28,8 @@ export function useGridTableApi<R extends Kinded>(): GridTableApi<R> {
 
 /** Provides an imperative API for an application page to interact with the table. */
 export type GridTableApi<R extends Kinded> = {
-  /** Scrolls row `index` into view; only supported with `as=virtual` and after a `useEffect`. */
-  scrollToIndex(index: number): void;
+  /** Scrolls row `index` into view; Defaults "smooth" behavior; only supported with `as=virtual` and after a `useEffect`. */
+  scrollToIndex(index: number | FlatIndexLocationWithAlign): void;
 
   /** Returns the currently-visible rows. */
   getVisibleRows(): GridDataRow<R>[];
@@ -113,8 +113,9 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
     this.lookup = createRowLookup(this, virtuosoRef);
   }
 
-  public scrollToIndex(index: number): void {
-    this.virtuosoRef.current && this.virtuosoRef.current.scrollToIndex(index);
+  public scrollToIndex(index: number | FlatIndexLocationWithAlign): void {
+    this.virtuosoRef.current &&
+      this.virtuosoRef.current.scrollToIndex(typeof index === "number" ? { index, behavior: "smooth" } : index);
   }
 
   public getSelectedRowIds(kind?: string): string[] {

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -123,9 +123,7 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
 
   public scrollToIndex(index: GridTableScrollOptions): void {
     this.virtuosoRef.current &&
-      this.virtuosoRef.current.scrollToIndex(
-        typeof index === "number" || index === "LAST" ? { index, behavior: "smooth" } : index,
-      );
+      this.virtuosoRef.current.scrollToIndex(typeof index === "number" ? { index, behavior: "smooth" } : index);
   }
 
   public getSelectedRowIds(kind?: string): string[] {

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -12,12 +12,11 @@ export type Direction = "ASC" | "DESC";
 export type MaybeFn<T> = T | (() => T);
 export type GridCellAlignment = "left" | "right" | "center";
 
-export type GridTableScrollIndex = number | "LAST";
 export type GridTableScrollOptions =
-  | GridTableScrollIndex
+  | number
   | {
       /** The index of the row to scroll to */
-      index: GridTableScrollIndex;
+      index: number;
       behavior?: "auto" | "smooth";
       /**
        * How to position the row in the viewport

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -12,6 +12,19 @@ export type Direction = "ASC" | "DESC";
 export type MaybeFn<T> = T | (() => T);
 export type GridCellAlignment = "left" | "right" | "center";
 
+export type GridTableScrollIndex = number | "LAST";
+export type GridTableScrollOptions =
+  | GridTableScrollIndex
+  | {
+      /** The index of the row to scroll to */
+      index: GridTableScrollIndex;
+      behavior?: "auto" | "smooth";
+      /**
+       * How to position the row in the viewport
+       */
+      align?: "start" | "center" | "end";
+    };
+
 /**
  * Given an ADT of type T, performs a look up and returns the type of kind K.
  *


### PR DESCRIPTION
Title

Found we needed an update in https://github.com/homebound-team/internal-frontend/pull/6048