### PR TITLE
feat: palette fill as a presentation prop; getInputStylePalette fn prop;

### DIFF
--- a/src/components/PresentationContext.tsx
+++ b/src/components/PresentationContext.tsx
@@ -2,6 +2,8 @@ import { createContext, PropsWithChildren, useContext, useMemo } from "react";
 import { GridStyle } from "src/components/Table";
 import { Typography } from "src/Css";
 
+export type InputStylePalette = "success" | "warning" | "caution" | "info";
+
 export interface PresentationFieldProps {
   numberAlignment?: "left" | "right";
   /** Sets the label position or visibility. Defaults to "above" */
@@ -23,10 +25,12 @@ export interface PresentationFieldProps {
   errorInTooltip?: true;
   /** Allow the fields to grow to the width of its container. By default, fields will extend up to 550px */
   fullWidth?: boolean;
+  /** Changes bg and hoverBg; Takes priority over `contrast`; Useful when showing many fields w/in a table that require user attention; In no way should be used as a replacement for error/focus state */
+  inputStylePalette?: InputStylePalette;
 }
 
 export type PresentationContextProps = {
-  fieldProps?: PresentationFieldProps;
+  fieldProps?: Omit<PresentationFieldProps, "inputStylePalette">;
   gridTableStyle?: GridStyle;
   // Defines whether content should be allowed to wrap or not. `undefined` is treated as true.
   wrap?: boolean;

--- a/src/components/PresentationContext.tsx
+++ b/src/components/PresentationContext.tsx
@@ -30,6 +30,7 @@ export interface PresentationFieldProps {
 }
 
 export type PresentationContextProps = {
+  /** `inputStylePalette` omitted because it is too dependent on the individual field use case to be controlled at this level  */
   fieldProps?: Omit<PresentationFieldProps, "inputStylePalette">;
   gridTableStyle?: GridStyle;
   // Defines whether content should be allowed to wrap or not. `undefined` is treated as true.

--- a/src/inputs/SelectField.stories.tsx
+++ b/src/inputs/SelectField.stories.tsx
@@ -411,7 +411,7 @@ function TestSelectField<T extends object, V extends Value>(
   const [inputStylePalette, setInputStylePalette] = useState<InputStylePalette | undefined>();
 
   // @ts-ignore: Hacking around type props within the testSelectField instead of the SB Template
-  const shouldUseStylePalette: boolean = !!props.options?.some((o) => o.name.includes("style palette when selected"));
+  const shouldUseStylePalette: boolean = props.options === coloredOptions;
 
   return (
     <div css={Css.df.$}>

--- a/src/inputs/SelectField.stories.tsx
+++ b/src/inputs/SelectField.stories.tsx
@@ -31,12 +31,20 @@ type TestOption = {
   icon?: IconKey;
 };
 
-const options: TestOption[] = [
+const standardOptions: TestOption[] = [
   { id: "1", name: "Download", icon: "download" },
   { id: "2", name: "Camera", icon: "camera" },
   { id: "3", name: "Info Circle", icon: "infoCircle" },
   { id: "4", name: "Calendar", icon: "calendar" },
   { id: "5", name: "Dollar dollar bill, ya'll! ".repeat(5), icon: "dollar" },
+];
+
+const coloredOptions: TestOption[] = [
+  { id: "1", name: "Download (SUCCESS style palette when selected)", icon: "download" },
+  { id: "2", name: "Camera (CAUTION style palette when selected)", icon: "camera" },
+  { id: "3", name: "Info Circle (WARNING style palette when selected)", icon: "infoCircle" },
+  { id: "4", name: "Calendar (INFO style palette when selected)", icon: "calendar" },
+  { id: "5", name: "Dollar dollar bill, ya'll!  (NO EXTRA style palette when selected)", icon: "dollar" },
 ];
 
 const optionsWithNumericIds: { id: number; name: string }[] = [
@@ -54,6 +62,7 @@ const booleanOptions = [
 
 function Template(args: SelectFieldProps<any, any>) {
   const loadTestOptions: TestOption[] = zeroTo(1000).map((i) => ({ id: String(i), name: `Project ${i}` }));
+  const options = (args?.options as TestOption[]) ?? standardOptions;
 
   return (
     <div css={Css.df.fdc.gap5.p2.if(args.contrast === true).white.bgGray800.$}>
@@ -222,6 +231,39 @@ Compact.args = { compact: true };
 export const Contrast = Template.bind({});
 // @ts-ignore
 Contrast.args = { compact: true, contrast: true };
+
+// @ts-ignore
+function getInputStylePalette(v) {
+  if (v?.includes(1) || v?.includes("1")) return "success";
+  if (v?.includes(2) || v?.includes("2")) return "caution";
+  if (v?.includes(3) || v?.includes("3")) return "warning";
+  if (v?.includes(4) || v?.includes("4")) return "info";
+  return undefined;
+}
+
+const standardColoredSelectArgs = {
+  options: coloredOptions,
+  // @ts-ignore
+  getInputStylePalette,
+};
+
+export const Colored = Template.bind({});
+// @ts-ignore
+Colored.args = standardColoredSelectArgs;
+
+export const ColoredContrast = Template.bind({});
+// @ts-ignore
+ColoredContrast.args = {
+  contrast: true,
+  ...standardColoredSelectArgs,
+};
+
+export const ColoredCompact = Template.bind({});
+// @ts-ignore
+ColoredCompact.args = {
+  compact: true,
+  ...standardColoredSelectArgs,
+};
 
 const loadTestOptions: TestOption[] = zeroTo(1000).map((i) => ({ id: String(i), name: `Project ${i}` }));
 

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -5,7 +5,7 @@ import { useButton, useComboBox, useFilter, useOverlayPosition } from "react-ari
 import { Item, useComboBoxState, useMultipleSelectionState } from "react-stately";
 import { resolveTooltip } from "src/components";
 import { Popover } from "src/components/internal";
-import { InputStylePalette, PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
+import { PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
 import { Css } from "src/Css";
 import { ComboBoxInput } from "src/inputs/internal/ComboBoxInput";
 import { ListBox } from "src/inputs/internal/ListBox";
@@ -20,8 +20,6 @@ export interface ComboBoxBaseProps<O, V extends Value> extends BeamFocusableProp
   getOptionMenuLabel?: (opt: O, isUnsetOpt?: boolean, isAddNewOption?: boolean) => string | ReactNode;
   getOptionValue: (opt: O) => V;
   getOptionLabel: (opt: O) => string;
-  /** Sets an input style based on the option(s) selected if `inputStylePalette` is not set */
-  getInputStylePalette?: (values: V[] | undefined) => InputStylePalette | undefined;
   /** The current value; it can be `undefined`, even if `V` cannot be. */
   values: V[] | undefined;
   onSelect: (values: V[], opts: O[]) => void;
@@ -95,7 +93,6 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
     borderless,
     unsetLabel,
     inputStylePalette: propsInputStylePalette,
-    getInputStylePalette,
     getOptionLabel: propOptionLabel,
     getOptionValue: propOptionValue,
     getOptionMenuLabel: propOptionMenuLabel,
@@ -151,14 +148,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
   );
 
   const values = useMemo(() => propValues ?? [], [propValues]);
-  const inputStylePalette = useMemo(() => {
-    if (propsInputStylePalette) {
-      return propsInputStylePalette;
-    } else if (getInputStylePalette) {
-      return getInputStylePalette(values);
-    }
-    return undefined;
-  }, [propsInputStylePalette, getInputStylePalette, values]);
+  const inputStylePalette = useMemo(() => propsInputStylePalette, [propsInputStylePalette]);
 
   const selectedOptionsRef = useRef(options.filter((o) => values.includes(getOptionValue(o))));
   const selectedOptions = useMemo(() => {

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -21,7 +21,7 @@ export interface ComboBoxBaseProps<O, V extends Value> extends BeamFocusableProp
   getOptionValue: (opt: O) => V;
   getOptionLabel: (opt: O) => string;
   /** Sets an input style based on the option(s) selected if `inputStylePalette` is not set */
-  getInputStylePalette?: (values: V[]) => InputStylePalette;
+  getInputStylePalette?: (values: V[] | undefined) => InputStylePalette;
   /** The current value; it can be `undefined`, even if `V` cannot be. */
   values: V[] | undefined;
   onSelect: (values: V[], opts: O[]) => void;

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -5,7 +5,7 @@ import { useButton, useComboBox, useFilter, useOverlayPosition } from "react-ari
 import { Item, useComboBoxState, useMultipleSelectionState } from "react-stately";
 import { resolveTooltip } from "src/components";
 import { Popover } from "src/components/internal";
-import { PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
+import { InputStylePalette, PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
 import { Css } from "src/Css";
 import { ComboBoxInput } from "src/inputs/internal/ComboBoxInput";
 import { ListBox } from "src/inputs/internal/ListBox";
@@ -20,6 +20,9 @@ export interface ComboBoxBaseProps<O, V extends Value> extends BeamFocusableProp
   getOptionMenuLabel?: (opt: O, isUnsetOpt?: boolean, isAddNewOption?: boolean) => string | ReactNode;
   getOptionValue: (opt: O) => V;
   getOptionLabel: (opt: O) => string;
+  // TODO: explain yourself
+  // updates input style based on the option(s) selected if `PresentationFieldProps.inputStylePalette` is not set
+  getInputStylePalette?: (values: V[]) => InputStylePalette;
   /** The current value; it can be `undefined`, even if `V` cannot be. */
   values: V[] | undefined;
   onSelect: (values: V[], opts: O[]) => void;
@@ -92,6 +95,8 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
     disabledOptions,
     borderless,
     unsetLabel,
+    inputStylePalette: propsInputStylePalette,
+    getInputStylePalette,
     getOptionLabel: propOptionLabel,
     getOptionValue: propOptionValue,
     getOptionMenuLabel: propOptionMenuLabel,
@@ -147,6 +152,14 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
   );
 
   const values = useMemo(() => propValues ?? [], [propValues]);
+  const inputStylePalette = useMemo(() => {
+    if (propsInputStylePalette) {
+      return propsInputStylePalette;
+    } else if (getInputStylePalette) {
+      return getInputStylePalette(values);
+    }
+    return undefined;
+  }, [propsInputStylePalette, getInputStylePalette, values]);
 
   const selectedOptionsRef = useRef(options.filter((o) => values.includes(getOptionValue(o))));
   const selectedOptions = useMemo(() => {
@@ -379,6 +392,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
     <div css={Css.df.fdc.w100.maxw(fieldMaxWidth).if(labelStyle === "left").maxw100.$} ref={comboBoxRef}>
       <ComboBoxInput
         {...otherProps}
+        inputStylePalette={inputStylePalette}
         fullWidth={fullWidth}
         buttonProps={buttonProps}
         buttonRef={triggerRef}

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -20,8 +20,7 @@ export interface ComboBoxBaseProps<O, V extends Value> extends BeamFocusableProp
   getOptionMenuLabel?: (opt: O, isUnsetOpt?: boolean, isAddNewOption?: boolean) => string | ReactNode;
   getOptionValue: (opt: O) => V;
   getOptionLabel: (opt: O) => string;
-  // TODO: explain yourself
-  // updates input style based on the option(s) selected if `PresentationFieldProps.inputStylePalette` is not set
+  /** Sets an input style based on the option(s) selected if `inputStylePalette` is not set */
   getInputStylePalette?: (values: V[]) => InputStylePalette;
   /** The current value; it can be `undefined`, even if `V` cannot be. */
   values: V[] | undefined;

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -21,7 +21,7 @@ export interface ComboBoxBaseProps<O, V extends Value> extends BeamFocusableProp
   getOptionValue: (opt: O) => V;
   getOptionLabel: (opt: O) => string;
   /** Sets an input style based on the option(s) selected if `inputStylePalette` is not set */
-  getInputStylePalette?: (values: V[] | undefined) => InputStylePalette;
+  getInputStylePalette?: (values: V[] | undefined) => InputStylePalette | undefined;
   /** The current value; it can be `undefined`, even if `V` cannot be. */
   values: V[] | undefined;
   onSelect: (values: V[], opts: O[]) => void;


### PR DESCRIPTION
[SC-61998](https://app.shortcut.com/homebound-team/story/61998/houston-pilot-feedback-update-beam-to-support-coloring-dropdowns) | [Figma](https://www.figma.com/design/xQ3iNLHJCFEJeOi7boONY4/Q1-Q4-2024-%7C-Dynamic-Schedules?node-id=11535-84519&node-type=frame&t=wrjRlakQknbMmW1j-0)

https://github.com/user-attachments/assets/61fdf544-1949-475c-b01d-f805504a7f61


Initially the goal was to only have select fields show color but since the underlying `<TextFieldBase` that actually controls colors takes props from presentationFieldProps it was pretty easy to hook up the components starting from there. So technically our `<MultiselectField also supports `getInputStylePalette` & `inputStylePalette` and our `<TextFields` support `inputStylePalette` as well practically for free. 