### PR TITLE
fix: add types to export from PresentationContext;

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -34,6 +34,7 @@ export * from "./Modal/useModal";
 export { NavLink } from "./NavLink";
 export * from "./Pagination";
 export { PresentationProvider } from "./PresentationContext";
+export type { InputStylePalette, PresentationFieldProps } from "./PresentationContext";
 export * from "./ScrollShadows";
 export * from "./Snackbar";
 export * from "./Stepper";


### PR DESCRIPTION
Add a few types we're using on the FE to `components/index.ts` so we dont have to import from dist;