### PR TITLE
feat: [Sc-63907] Skip scrollToIndex if row is already in view

### DIFF
--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -1,7 +1,7 @@
 import { comparer } from "mobx";
 import { computedFn } from "mobx-utils";
 import { MutableRefObject, useMemo } from "react";
-import { VirtuosoHandle } from "react-virtuoso";
+import { ListRange, VirtuosoHandle } from "react-virtuoso";
 import {
   applyRowFn,
   createRowLookup,
@@ -10,6 +10,7 @@ import {
   isGridCellContent,
   isJSX,
   MaybeFn,
+  shouldSkipScrollTo,
 } from "src/components/index";
 import { GridDataRow } from "src/components/Table/components/Row";
 import { DiscriminateUnion, Kinded } from "src/components/Table/types";
@@ -104,6 +105,7 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
   // This is public to GridTable but not exported outside of Beam
   readonly tableState: TableState<R> = new TableState(this);
   virtuosoRef: MutableRefObject<VirtuosoHandle | null> = { current: null };
+  virtuosoRangeRef: MutableRefObject<ListRange | null> = { current: null };
   lookup!: GridRowLookup<R>;
 
   constructor() {
@@ -118,16 +120,29 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
   }
 
   /** Called once by the GridTable when it takes ownership of this api instance. */
-  init(persistCollapse: string | undefined, virtuosoRef: MutableRefObject<VirtuosoHandle | null>) {
+  init(
+    persistCollapse: string | undefined,
+    virtuosoRef: MutableRefObject<VirtuosoHandle | null>,
+    virtuosoRangeRef: MutableRefObject<ListRange | null>,
+  ) {
     // Technically this drives both row-collapse and column-expanded
     if (persistCollapse) this.tableState.loadCollapse(persistCollapse);
     this.virtuosoRef = virtuosoRef;
-    this.lookup = createRowLookup(this, virtuosoRef);
+    this.virtuosoRangeRef = virtuosoRangeRef;
+    this.lookup = createRowLookup(this, virtuosoRef, virtuosoRangeRef);
   }
 
-  public scrollToIndex(index: GridTableScrollOptions): void {
-    this.virtuosoRef.current &&
-      this.virtuosoRef.current.scrollToIndex(typeof index === "number" ? { index, behavior: "smooth" } : index);
+  public scrollToIndex(indexOrOptions: GridTableScrollOptions): void {
+    if (!this.virtuosoRef.current) return;
+
+    const { forceRescroll = true, ...scrollToOpts } =
+      typeof indexOrOptions === "number"
+        ? { index: indexOrOptions, behavior: "smooth" as const, forceRescroll: false }
+        : indexOrOptions;
+
+    if (shouldSkipScrollTo(scrollToOpts.index, this.virtuosoRangeRef, forceRescroll)) return;
+
+    this.virtuosoRef.current.scrollToIndex(scrollToOpts);
   }
 
   public getSelectedRowIds(kind?: string): string[] {

--- a/src/components/Table/GridTableApi.ts
+++ b/src/components/Table/GridTableApi.ts
@@ -135,12 +135,10 @@ export class GridTableApiImpl<R extends Kinded> implements GridTableApi<R> {
   public scrollToIndex(indexOrOptions: GridTableScrollOptions): void {
     if (!this.virtuosoRef.current) return;
 
-    const { forceRescroll = true, ...scrollToOpts } =
-      typeof indexOrOptions === "number"
-        ? { index: indexOrOptions, behavior: "smooth" as const, forceRescroll: false }
-        : indexOrOptions;
+    const scrollToOpts =
+      typeof indexOrOptions === "number" ? { index: indexOrOptions, behavior: "smooth" as const } : indexOrOptions;
 
-    if (shouldSkipScrollTo(scrollToOpts.index, this.virtuosoRangeRef, forceRescroll)) return;
+    if (shouldSkipScrollTo(scrollToOpts.index, this.virtuosoRangeRef)) return;
 
     this.virtuosoRef.current.scrollToIndex(scrollToOpts);
   }

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -19,7 +19,7 @@ export { cardStyle, condensedStyle, defaultStyle, getTableStyles } from "src/com
 export type { GridStyle, RowStyle, RowStyles } from "src/components/Table/TableStyles";
 export * from "src/components/Table/types";
 export * from "src/components/Table/utils/columns";
-export { createRowLookup } from "src/components/Table/utils/GridRowLookup";
+export { createRowLookup, shouldSkipScrollTo } from "src/components/Table/utils/GridRowLookup";
 export type { GridRowLookup } from "src/components/Table/utils/GridRowLookup";
 export { simpleDataRows, simpleHeader } from "src/components/Table/utils/simpleHelpers";
 export type { SimpleHeaderAndData } from "src/components/Table/utils/simpleHelpers";

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -22,8 +22,6 @@ export type GridTableScrollOptions =
        * How to position the row in the viewport
        */
       align?: "start" | "center" | "end";
-      /** Determines if the row should be re-scrolled to even if it's already in view (scrolled to top) */
-      forceRescroll?: boolean;
     };
 
 /**

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -22,6 +22,8 @@ export type GridTableScrollOptions =
        * How to position the row in the viewport
        */
       align?: "start" | "center" | "end";
+      /** Determines if the row should be re-scrolled to even if it's already in view (scrolled to top) */
+      forceRescroll?: boolean;
     };
 
 /**

--- a/src/components/Table/utils/GridRowLookup.ts
+++ b/src/components/Table/utils/GridRowLookup.ts
@@ -101,10 +101,10 @@ export function shouldSkipScrollTo(
   if (!virtuosoRangeRef.current || forceRescroll) return false;
 
   const isAlreadyInView =
-    // Add 1 on each end to account for "overscan" where the next out of view row is usually already rendered
+    // Add 1 on each end to account for "overscan" where the next out of view row is usually already rendered. This isn't a perfect solution,
+    // but our current "overscan" is only set to 50px, so it should be close enough and the library recommended alternative of adding an
+    // intersection observer to each row seems like a not worth it performance hit (https://github.com/petyosi/react-virtuoso/issues/118)
     index >= virtuosoRangeRef.current.startIndex - 1 && index <= virtuosoRangeRef.current.endIndex + 1;
-
-  console.log({ index, virtuosoRangeRef: virtuosoRangeRef.current, isAlreadyInView });
 
   return isAlreadyInView;
 }


### PR DESCRIPTION
* Example use case on the schedule where the `scrollIntoView` is helpful when moving a task to a date that is outside of the current viewport, but we don't want it to move if it's still visible after a given change. https://www.loom.com/share/a58929dc5354403f855628e60212c1e5
* This somewhat hand-rolled implementation is due to virutoso not exposing this option, some context on this thread where the preferred option is to use an intersection observer, but that seems like overkill given there may be 50+ rows rendered on a large screen https://github.com/petyosi/react-virtuoso/issues/118 

