### PR TITLE
fix: SC-64282: Add back in early return for onSearch/debounce

### DIFF
--- a/src/components/Filters/MultiFilter.stories.tsx
+++ b/src/components/Filters/MultiFilter.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta } from "@storybook/react";
-import { screen, userEvent } from "@storybook/test";
 import { useState } from "react";
 import { stageFilter, stageFilterDisabledOptions } from "src/components/Filters/testDomain";
 import { Filters, multiFilter } from "src/components/index";

--- a/src/components/Filters/MultiFilter.stories.tsx
+++ b/src/components/Filters/MultiFilter.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta } from "@storybook/react";
+import { screen, userEvent } from "@storybook/test";
 import { useState } from "react";
 import { stageFilter, stageFilterDisabledOptions } from "src/components/Filters/testDomain";
 import { Filters, multiFilter } from "src/components/index";
@@ -72,4 +73,17 @@ export function LazyLoading() {
     getOptionLabel: (s) => s.name,
   })("key");
   return filter.render([loadTestOptions[2].id, loadTestOptions[4].id], () => {}, {}, true, false);
+}
+
+export function OnSearch() {
+  const [_, setProjectSearch] = useState<string>();
+  const testOptions: HasIdAndName[] = zeroTo(10).map((i) => ({ id: String(i), name: `Project ${i}` }));
+
+  const filter = multiFilter({
+    options: testOptions,
+    getOptionValue: (s) => s.id,
+    getOptionLabel: (s) => s.name,
+    onSearch: (search) => setProjectSearch(search),
+  })("key");
+  return filter.render(undefined, () => {}, {}, true, false);
 }

--- a/src/components/Filters/MultiFilter.test.tsx
+++ b/src/components/Filters/MultiFilter.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent } from "@testing-library/react";
+import { useState } from "react";
+import { FilterDefs, Filters } from "src/components/Filters";
+import { ProjectFilter, stageOnSearch } from "src/components/Filters/testDomain";
+import { click, render, type } from "src/utils/rtl";
+
+describe("MultiSelectFilter", () => {
+  it("shows All by default", async () => {
+    const r = await render(<TestFilters defs={{ stage: stageOnSearch }} />);
+    expect(r.filter_stage).toHaveValue("All");
+  });
+
+  it("allows searching inside the filter", async () => {
+    const r = await render(<TestFilters defs={{ stage: stageOnSearch }} />);
+    // Given a multi-select filter
+    click(r.filter_stage);
+    click(r.getByRole("option", { name: "One" }));
+
+    // And when typing in a value
+    type(r.filter_stage, "One");
+    // Then expect the searched value to be set
+    expect(r.filter_value).toHaveTextContent(JSON.stringify({ stage: ["ONE"] }));
+  });
+});
+
+function TestFilters(props: { defs: FilterDefs<ProjectFilter> }) {
+  const { defs } = props;
+  const [filter, setFilter] = useState<ProjectFilter>({});
+  return (
+    <div>
+      <Filters filterDefs={defs} filter={filter} onChange={setFilter} />
+      <div data-testid="filter_value">{JSON.stringify(filter)}</div>
+    </div>
+  );
+}

--- a/src/components/Filters/MultiFilter.test.tsx
+++ b/src/components/Filters/MultiFilter.test.tsx
@@ -1,4 +1,3 @@
-import { fireEvent } from "@testing-library/react";
 import { useState } from "react";
 import { FilterDefs, Filters } from "src/components/Filters";
 import { ProjectFilter, stageOnSearch } from "src/components/Filters/testDomain";

--- a/src/components/Filters/testDomain.ts
+++ b/src/components/Filters/testDomain.ts
@@ -90,6 +90,13 @@ export const stageFilterDisabledOptions: StageFilter = multiFilter({
   disabledOptions: [{ value: Stage.StageOne, reason: "I have a reason to be disabled." }, Stage.StageTwo],
 });
 
+export const stageOnSearch: StageFilter = multiFilter({
+  options: stageOptions,
+  getOptionValue: (s) => s.code,
+  getOptionLabel: (s) => s.name,
+  onSearch: () => {},
+});
+
 export const stageSingleFilter: StageSingleFilter = singleFilter({
   options: stageOptions,
   getOptionValue: (s) => s.code,

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -327,7 +327,6 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
   // Call on search callback when the user types in the input field
   useEffect(() => {
     onSearch?.(debouncedSearch ?? "");
-    console.log("debouncedSearch", debouncedSearch);
   }, [onSearch, debouncedSearch]);
 
   // For the most part, the returned props contain `aria-*` and `id` attributes for accessibility purposes.

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -306,6 +306,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
 
   // Reset inputValue when closed or selected changes
   useEffect(() => {
+    if (debouncedSearch) return;
     if (state.isOpen && multiselect) {
       // While the multiselect is open, let the user keep typing
       setFieldState((prevState) => ({
@@ -320,11 +321,12 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
         inputValue: getInputValue(selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly),
       }));
     }
-  }, [state.isOpen, selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly]);
+  }, [state.isOpen, selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly, debouncedSearch]);
 
   // Call on search callback when the user types in the input field
   useEffect(() => {
     onSearch?.(debouncedSearch ?? "");
+    console.log("debouncedSearch", debouncedSearch);
   }, [onSearch, debouncedSearch]);
 
   // For the most part, the returned props contain `aria-*` and `id` attributes for accessibility purposes.

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -306,7 +306,8 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
 
   // Reset inputValue when closed or selected changes
   useEffect(() => {
-    if (debouncedSearch) return;
+    // if we are using the onSearch functionality with debounceSearch, we don't want to reset the input value
+    if (onSearch) return;
     if (state.isOpen && multiselect) {
       // While the multiselect is open, let the user keep typing
       setFieldState((prevState) => ({
@@ -321,7 +322,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
         inputValue: getInputValue(selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly),
       }));
     }
-  }, [state.isOpen, selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly, debouncedSearch]);
+  }, [state.isOpen, selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly, onSearch]);
 
   // Call on search callback when the user types in the input field
   useEffect(() => {

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -322,7 +322,16 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
         inputValue: getInputValue(selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly),
       }));
     }
-  }, [state.isOpen, selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly, onSearch, debouncedSearch]);
+  }, [
+    state.isOpen,
+    selectedOptions,
+    getOptionLabel,
+    multiselect,
+    nothingSelectedText,
+    isReadOnly,
+    onSearch,
+    debouncedSearch,
+  ]);
 
   // Call on search callback when the user types in the input field
   useEffect(() => {

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -307,7 +307,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
   // Reset inputValue when closed or selected changes
   useEffect(() => {
     // if we are using the onSearch functionality with debounceSearch, we don't want to reset the input value
-    if (onSearch) return;
+    if (onSearch && debouncedSearch) return;
     if (state.isOpen && multiselect) {
       // While the multiselect is open, let the user keep typing
       setFieldState((prevState) => ({
@@ -322,7 +322,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
         inputValue: getInputValue(selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly),
       }));
     }
-  }, [state.isOpen, selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly, onSearch]);
+  }, [state.isOpen, selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly, onSearch, debouncedSearch]);
 
   // Call on search callback when the user types in the input field
   useEffect(() => {


### PR DESCRIPTION
A bug was reported on the `ChangeLog` page, where the project filter search was not working
[SC-64282](https://app.shortcut.com/homebound-team/story/64282/projects-filter-not-working-properly-on-change-log)

When I added back in the `debouncedSearch` early return, the project filter was fixed, but it caused a bug with the regular select field per the slack threads below and PRs
* Slack Thread: https://homeboundinc.slack.com/archives/G01QEA5CXL1/p1734450733938479 
* PRs:
   * https://github.com/homebound-team/beam/pull/1017/files#diff-4cfc44d3175cb7b1fc2f316109423cede94d022b834134087a6a15bdbe4f296eL280
   * https://github.com/homebound-team/beam/pull/1098/files

I still think this needs an early return, so I changed it to look at the `onSearch` prop and do an early return from that check.

I tested on front-end and everything looks ok on the Change Log Page

LOOM: https://www.loom.com/share/eefefa2904fb4d70b5515168cbad294a