### PR TITLE
fix: Handle "Select All" when only unselectable child rows are present

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1359,6 +1359,66 @@ export function SelectableChildrenRows() {
   );
 }
 
+export function MixedSelectableChildrenRows() {
+  type ParentRow = { kind: "parent"; id: string; data: string };
+  type ChildRow = { kind: "child"; id: string; data: string };
+  type Row = ParentRow | ChildRow;
+
+  const selectCol = selectColumn<Row>();
+
+  const nameCol: GridColumn<Row> = {
+    parent: (name) => name,
+    child: (name) => name,
+    mw: "160px",
+  };
+
+  return (
+    <>
+      <GridTable
+        columns={[collapseColumn<Row>(), selectCol, nameCol]}
+        rows={
+          [
+            simpleHeader,
+            {
+              kind: "parent",
+              id: "1",
+              data: "Howard Stark",
+              children: [
+                // Unselectable child
+                {
+                  kind: "child" as const,
+                  id: "2",
+                  data: "Tony Stark",
+                  selectable: false,
+                },
+              ],
+            },
+            {
+              kind: "parent",
+              id: "3",
+              data: "Odin",
+              children: [
+                // Mixed selectable/unselectable children
+                {
+                  kind: "child" as const,
+                  id: "4",
+                  data: "Thor",
+                },
+                {
+                  kind: "child" as const,
+                  id: "5",
+                  data: "Hulk",
+                  selectable: false,
+                },
+              ],
+            },
+          ] as GridDataRow<Row>[]
+        }
+      />
+    </>
+  );
+}
+
 export function RevealOnRowHover() {
   const nameColumn: GridColumn<Row> = {
     header: "Name",

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -2129,6 +2129,98 @@ describe("GridTable", () => {
     expect(api.current!.getSelectedRowIds()).toEqual(["p1", "p1c1", "p1c2", "p2", "p2c1", "p2c2", "p3", "p3c1"]);
   });
 
+  describe("Select All", () => {
+    it("sets the selected state of the parent row as checked when all children are not selectable", async () => {
+      // Given a table that has a parent row and two non-selectable children rows
+      const rows: GridDataRow<NestedRow>[] = [
+        simpleHeader,
+        {
+          kind: "parent",
+          id: "p1",
+          data: { name: "Group 1" },
+          children: [
+            { kind: "child", id: "p1c1", selectable: false, data: { name: "Non-Selectable Child 1" } },
+            { kind: "child", id: "p1c2", selectable: false, data: { name: "Non-Selectable Child 2" } },
+          ],
+        },
+      ];
+      const api: MutableRefObject<GridTableApi<NestedRow> | undefined> = { current: undefined };
+      const r = await render(<TestFilterAndSelect rows={rows} api={api} />);
+
+      // When triggering all rows as selected
+      click(cellAnd(r, 0, 1, "select"));
+      // Then expect the header row to be checked
+      expect(cellAnd(r, 0, 1, "select")).toBeChecked();
+      // And expect the parent row to be the only row selected since all children are not selectable
+      expect(api.current!.getSelectedRowIds()).toEqual(["p1"]);
+    });
+
+    it("selects parent rows and selectable children when some children are not selectable", async () => {
+      // Given a table that has two parent rows
+      // - One with no selectable children rows and one with selectable and non-selectable children rows
+      const rows: GridDataRow<NestedRow>[] = [
+        simpleHeader,
+        {
+          kind: "parent",
+          id: "p1",
+          data: { name: "Group 1" },
+          children: [
+            // Parent with non-selectable children
+            { kind: "child", id: "p1c1", selectable: false, data: { name: "Non-Selectable Child 1" } },
+            { kind: "child", id: "p1c2", selectable: false, data: { name: "Non-Selectable Child 2" } },
+          ],
+        },
+        {
+          kind: "parent",
+          id: "p2",
+          data: { name: "Group 2" },
+          children: [
+            // Parent with selectable and non-selectable children
+            { kind: "child", id: "p2c1", data: { name: "Selectable Child 1" } },
+            { kind: "child", id: "p2c2", selectable: false, data: { name: "Non-Selectable Child 3" } },
+          ],
+        },
+      ];
+      const api: MutableRefObject<GridTableApi<NestedRow> | undefined> = { current: undefined };
+      const r = await render(<TestFilterAndSelect rows={rows} api={api} />);
+
+      // When triggering all rows as selected
+      click(cellAnd(r, 0, 1, "select"));
+      // Then expect the header row to be checked
+      expect(cellAnd(r, 0, 1, "select")).toBeChecked();
+      // And expect the both parent rows to be selected, along with the selectable child row
+      expect(api.current!.getSelectedRowIds()).toEqual(["p1", "p2", "p2c1"]);
+    });
+
+    it("sets the selected state of the header row as checked when all children are not selectable", async () => {
+      // Given a table that has a header row and two non-selectable children rows
+      const rows: GridDataRow<NestedRow>[] = [
+        simpleHeader,
+        {
+          kind: "child",
+          id: "c1",
+          data: { name: "Child 1" },
+          selectable: false,
+        },
+        {
+          kind: "child",
+          id: "c2",
+          data: { name: "Child 2" },
+          selectable: false,
+        },
+      ];
+      const api: MutableRefObject<GridTableApi<NestedRow> | undefined> = { current: undefined };
+      const r = await render(<TestFilterAndSelect rows={rows} api={api} />);
+
+      // When triggering all rows as selected
+      click(cellAnd(r, 0, 1, "select"));
+      // Then expect the header row to be checked
+      expect(cellAnd(r, 0, 1, "select")).toBeChecked();
+      // And expect there to be no selected rows since all children are not selectable
+      expect(api.current!.getSelectedRowIds()).toEqual([]);
+    });
+  });
+
   // it can switch between partially checked to checked depending on applied filter
   it("can switch between partially checked to checked depending on applied filter", async () => {
     // Given a table that can apply a filter and a parent row with one child will match the filter

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -133,7 +133,8 @@ export class RowState<R extends Kinded> {
     // Parent `selectedState` is special b/c it does not directly depend on the parent's own selected-ness,
     // but instead depends on the current visible children. I.e. a parent might be "selected", but then the
     // client-side filter changes, a child reappears, and we need to transition to partial-ness.
-    if (this.isParent) {
+    // If there are no seclectable children, we should return "checked" if the parent is selected.
+    if (this.isParent && this.hasSelectableChildren) {
       // Use visibleChildren b/c if filters are hiding some of our children, we still want to show fully selected
       const children = this.visibleChildren.filter((c) => c.row.selectable !== false);
       const allChecked = children.every((child) => child.selectedState === "checked");
@@ -150,7 +151,8 @@ export class RowState<R extends Kinded> {
    * wants to show partial-ness whenever any given child is selected.
    */
   get selectedStateForHeader(): SelectedState {
-    if (this.children) {
+    // If there are no seclectable children, we should return "checked" if the parent is selected.
+    if (this.children && this.hasSelectableChildren) {
       const children = this.visibleChildren.filter((c) => c.row.selectable !== false || c.isParent);
       const allChecked = children.every((child) => child.selectedStateForHeader === "checked");
       const allUnchecked = children.every((child) => child.selectedStateForHeader === "unchecked");
@@ -296,6 +298,10 @@ export class RowState<R extends Kinded> {
     // the original/unsorted array if we need to revert to the original sort order.
     if (sortFn) rows = [...rows].sort(sortFn);
     return rows;
+  }
+
+  private get hasSelectableChildren(): boolean {
+    return this.visibleChildren.some((c) => c.row.selectable !== false);
   }
 
   /**


### PR DESCRIPTION
We've encountered an issue where users cannot select or deselect all rows when a table contains only un-selectable rows, whether grouped or not. For example, if a table includes a header row, a group row, and a single un-selectable child row, selecting all leaves the group unselected and the header in an indeterminate state. This fix ensures that the header and/or groups are marked as `checked` even when only un-selectable rows are present.