### PR TITLE
chore: Simplify selectors.

### DIFF
--- a/src/components/AccordionList.stories.tsx
+++ b/src/components/AccordionList.stories.tsx
@@ -11,7 +11,7 @@ export default {
 
 export function AccordionListWithMultipleSelections() {
   const accordions: AccordionProps[] = [
-    { title: "First accordion title", children: <div>Fisrt accordion description</div> },
+    { title: "First accordion title", children: <div>First accordion description</div> },
     { title: "Second accordion title", children: <div>Second accordion description</div> },
     { title: "Third accordion title", children: <div>Third accordion description</div> },
   ];

--- a/src/components/AccordionList.tsx
+++ b/src/components/AccordionList.tsx
@@ -22,10 +22,10 @@ export function AccordionList(props: AccordionListProps) {
     <>
       {accordions.map((accordionProps, index, arr) => (
         <Accordion
+          key={index}
           {...accordionProps}
           {...tid}
           compact={compact}
-          key={index}
           size={size}
           bottomBorder={compact ? false : index === arr.length - 1}
           defaultExpanded={!allowMultipleExpanded && expandedIndex === index}

--- a/src/components/Avatar/AvatarButton.stories.tsx
+++ b/src/components/Avatar/AvatarButton.stories.tsx
@@ -63,7 +63,7 @@ export function Examples(props: AvatarButtonProps) {
 /** Hover styled version of the AvatarButton */
 function HoveredAvatarButton(props: AvatarButtonProps) {
   return (
-    <div css={{ button: hoverStyles }}>
+    <div css={{ "& button": hoverStyles }}>
       <AvatarButton {...props} />
     </div>
   );
@@ -72,7 +72,7 @@ function HoveredAvatarButton(props: AvatarButtonProps) {
 /** Pressed styled version of the AvatarButton */
 function PressedAvatarButton(props: AvatarButtonProps) {
   return (
-    <div css={{ button: pressedStyles }}>
+    <div css={{ "& button": pressedStyles }}>
       <AvatarButton {...props} />
     </div>
   );

--- a/src/components/Icon.stories.tsx
+++ b/src/components/Icon.stories.tsx
@@ -187,7 +187,7 @@ export const Icon = (props: IconProps) => {
   return (
     <div css={Css.gray900.$}>
       <h1 css={Css.xl2Sb.$}>Actions</h1>
-      <ul css={Css.dg.gtc("repeat(5, 1fr)").gap3.listReset.$}>
+      <ul css={Css.dg.gtc("repeat(5, 1fr)").gap3.add({ listStyle: "none" }).$}>
         {actionIcons.map((icon, i) => (
           <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />
@@ -196,7 +196,7 @@ export const Icon = (props: IconProps) => {
         ))}
       </ul>
       <h1 css={Css.xl2Sb.$}>Alerts</h1>
-      <ul css={Css.dg.gtc("repeat(5, 1fr)").gap3.listReset.$}>
+      <ul css={Css.dg.gtc("repeat(5, 1fr)").gap3.add({ listStyle: "none" }).$}>
         {alertIcons.map((icon, i) => (
           <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />
@@ -205,7 +205,7 @@ export const Icon = (props: IconProps) => {
         ))}
       </ul>
       <h1 css={Css.xl2Sb.$}>Arrows</h1>
-      <ul css={Css.dg.gtc("repeat(4, 1fr)").gap3.listReset.$}>
+      <ul css={Css.dg.gtc("repeat(4, 1fr)").gap3.add({ listStyle: "none" }).$}>
         {arrowIcons.map((icon, i) => (
           <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />
@@ -214,7 +214,7 @@ export const Icon = (props: IconProps) => {
         ))}
       </ul>
       <h1 css={Css.xl2Sb.$}>Media</h1>
-      <ul css={Css.dg.gtc("repeat(4, 1fr)").gap3.listReset.$}>
+      <ul css={Css.dg.gtc("repeat(4, 1fr)").gap3.add({ listStyle: "none" }).$}>
         {mediaIcons.map((icon, i) => (
           <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />
@@ -223,7 +223,7 @@ export const Icon = (props: IconProps) => {
         ))}
       </ul>
       <h1 css={Css.xl2Sb.$}>Misc</h1>
-      <ul css={Css.dg.gtc("repeat(4, 1fr)").gap3.listReset.$}>
+      <ul css={Css.dg.gtc("repeat(4, 1fr)").gap3.add({ listStyle: "none" }).$}>
         {miscIcons.map((icon, i) => (
           <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />
@@ -232,7 +232,7 @@ export const Icon = (props: IconProps) => {
         ))}
       </ul>
       <h1 css={Css.xl2Sb.$}>Navigation</h1>
-      <ul css={Css.dg.gtc("repeat(4, 1fr)").gap3.listReset.$}>
+      <ul css={Css.dg.gtc("repeat(4, 1fr)").gap3.add({ listStyle: "none" }).$}>
         {navigationIcons.map((icon, i) => (
           <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />
@@ -241,7 +241,7 @@ export const Icon = (props: IconProps) => {
         ))}
       </ul>
       <h1 css={Css.xl2Sb.$}>Weather</h1>
-      <ul css={Css.dg.gtc("repeat(5, 1fr)").gap3.listReset.$}>
+      <ul css={Css.dg.gtc("repeat(5, 1fr)").gap3.add({ listStyle: "none" }).$}>
         {weatherIcons.map((icon, i) => (
           <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />

--- a/src/components/Icon.stories.tsx
+++ b/src/components/Icon.stories.tsx
@@ -187,63 +187,63 @@ export const Icon = (props: IconProps) => {
   return (
     <div css={Css.gray900.$}>
       <h1 css={Css.xl2Sb.$}>Actions</h1>
-      <ul css={{ gap: 24, listStyle: "none", gridTemplateColumns: "repeat(5, 1fr)", ...Css.dg.p0.$ }}>
+      <ul css={Css.dg.gtc("repeat(5, 1fr)").gap3.listReset.$}>
         {actionIcons.map((icon, i) => (
-          <li css={{ gap: 8, ...Css.xsMd.df.aic.fdc.$ }} key={icon}>
+          <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />
             {icon}
           </li>
         ))}
       </ul>
       <h1 css={Css.xl2Sb.$}>Alerts</h1>
-      <ul css={{ gap: 24, listStyle: "none", gridTemplateColumns: "repeat(5, 1fr)", ...Css.dg.p0.$ }}>
+      <ul css={Css.dg.gtc("repeat(5, 1fr)").gap3.listReset.$}>
         {alertIcons.map((icon, i) => (
-          <li css={{ gap: 8, ...Css.xsMd.df.aic.fdc.$ }} key={icon}>
+          <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />
             {icon}
           </li>
         ))}
       </ul>
       <h1 css={Css.xl2Sb.$}>Arrows</h1>
-      <ul css={{ gap: 24, listStyle: "none", gridTemplateColumns: "repeat(4, 1fr)", ...Css.dg.p0.$ }}>
+      <ul css={Css.dg.gtc("repeat(4, 1fr)").gap3.listReset.$}>
         {arrowIcons.map((icon, i) => (
-          <li css={{ gap: 8, ...Css.xsMd.df.aic.fdc.$ }} key={icon}>
+          <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />
             {icon}
           </li>
         ))}
       </ul>
       <h1 css={Css.xl2Sb.$}>Media</h1>
-      <ul css={{ gap: 24, listStyle: "none", gridTemplateColumns: "repeat(4, 1fr)", ...Css.dg.p0.$ }}>
+      <ul css={Css.dg.gtc("repeat(4, 1fr)").gap3.listReset.$}>
         {mediaIcons.map((icon, i) => (
-          <li css={{ gap: 8, ...Css.xsMd.df.aic.fdc.$ }} key={icon}>
+          <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />
             {icon}
           </li>
         ))}
       </ul>
       <h1 css={Css.xl2Sb.$}>Misc</h1>
-      <ul css={{ gap: 24, listStyle: "none", gridTemplateColumns: "repeat(4, 1fr)", ...Css.dg.p0.$ }}>
+      <ul css={Css.dg.gtc("repeat(4, 1fr)").gap3.listReset.$}>
         {miscIcons.map((icon, i) => (
-          <li css={{ gap: 8, ...Css.xsMd.df.aic.fdc.$ }} key={icon}>
+          <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />
             {icon}
           </li>
         ))}
       </ul>
       <h1 css={Css.xl2Sb.$}>Navigation</h1>
-      <ul css={{ gap: 24, listStyle: "none", gridTemplateColumns: "repeat(4, 1fr)", ...Css.dg.p0.$ }}>
+      <ul css={Css.dg.gtc("repeat(4, 1fr)").gap3.listReset.$}>
         {navigationIcons.map((icon, i) => (
-          <li css={{ gap: 8, ...Css.xsMd.df.aic.fdc.$ }} key={icon}>
+          <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />
             {icon}
           </li>
         ))}
       </ul>
       <h1 css={Css.xl2Sb.$}>Weather</h1>
-      <ul css={{ gap: 24, listStyle: "none", gridTemplateColumns: "repeat(5, 1fr)", ...Css.dg.p0.$ }}>
+      <ul css={Css.dg.gtc("repeat(5, 1fr)").gap3.listReset.$}>
         {weatherIcons.map((icon, i) => (
-          <li css={{ gap: 8, ...Css.xsMd.df.aic.fdc.$ }} key={icon}>
+          <li key={icon} css={Css.xsMd.df.aic.fdc.gap1.$}>
             <IconComponent icon={icon} data-testid={icon} id={icon} color={props.color} />
             {icon}
           </li>

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -29,7 +29,15 @@ export const Icon = React.memo((props: IconProps) => {
         height={size}
         viewBox="0 0 24 24"
         xmlns="http://www.w3.org/2000/svg"
-        css={{ "path, rect": Css.fill(color).$, ...(bgColor && Css.bgColor(bgColor).$), ...xss }}
+        css={{
+          // Spread these in b/c they don't type-check for some reason...
+          ...({
+            "& > path": Css.fill(color).$,
+            "& > rect": Css.fill(color).$,
+          } as any),
+          ...(bgColor && Css.bgColor(bgColor).$),
+          ...xss,
+        }}
         data-icon={icon}
         {...other}
       >

--- a/src/components/IconButton.stories.tsx
+++ b/src/components/IconButton.stories.tsx
@@ -121,7 +121,7 @@ export function IconButtonLink() {
 /** Hover styled version of the IconButton */
 function HoveredIconButton(args: IconButtonProps) {
   return (
-    <div css={{ button: args.contrast ? iconButtonContrastStylesHover : iconButtonStylesHover }}>
+    <div css={{ "& button": args.contrast ? iconButtonContrastStylesHover : iconButtonStylesHover }}>
       <IconButton {...args} />
     </div>
   );

--- a/src/components/SuperDrawer/SuperDrawer.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.tsx
@@ -94,7 +94,7 @@ export function SuperDrawer(): ReactPortal | null {
               <AutoSaveStatusProvider>
                 <header css={Css.p3.bb.bcGray200.df.aic.jcsb.gap3.$}>
                   {/* Provide default styling for the `h1` tag within SuperDrawer to help with consistency */}
-                  <div ref={headerRef} css={Css.gray900.fg1.addIn("h1", Css.xl2Sb.$).$}></div>
+                  <div ref={headerRef} css={Css.gray900.fg1.addIn("& h1", Css.xl2Sb.$).$}></div>
                   <IconButton icon="x" onClick={closeDrawer} {...testId.close} />
                 </header>
                 {content}

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -120,7 +120,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
     ...((rowStyle?.rowLink || rowStyle?.onClick) && { "&:hover": Css.cursorPointer.$ }),
     ...maybeApplyFunction(row as any, rowStyle?.rowCss),
     ...{
-      [` > .${revealOnRowHoverClass} > *`]: Css.vh.$,
+      [`> .${revealOnRowHoverClass} > *`]: Css.vh.$,
       [`:hover > .${revealOnRowHoverClass} > *`]: Css.vv.$,
     },
     ...(isLastKeptRow && Css.addIn("&>*", style.keptLastRowCss).$),

--- a/src/components/ToggleChip.tsx
+++ b/src/components/ToggleChip.tsx
@@ -28,8 +28,8 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
           .pyPx(2)
           .gray900.bgGray200.if(disabled)
           .gray600.pr1.mhPx(compact ? 20 : 28).$,
-        ":hover:not(:disabled)": Css.bgGray300.$,
-        ":disabled": Css.cursorNotAllowed.$,
+        "&:hover:not(:disabled)": Css.bgGray300.$,
+        "&:disabled": Css.cursorNotAllowed.$,
         ...xss,
       }}
       disabled={disabled}

--- a/src/foundations/BoxShadow.stories.tsx
+++ b/src/foundations/BoxShadow.stories.tsx
@@ -6,7 +6,7 @@ export default {
 } as Meta;
 
 export const BoxShadow = () => (
-  <div css={{ h1: Css.xl4Sb.mb4.$, h2: Css.xl2Sb.mb4.$ }}>
+  <div css={{ "& > h1": Css.xl4Sb.mb4.$, "& h2": Css.xl2Sb.mb4.$ }}>
     <h1 css={Css.xl2Sb.$}>Drop Shadow</h1>
     <div css={Css.df.gap4.$}>
       <div>

--- a/src/foundations/Color.stories.tsx
+++ b/src/foundations/Color.stories.tsx
@@ -8,7 +8,7 @@ export default {
 export const Color = () => {
   const paletteEntries = Object.entries(Palette);
   return (
-    <div css={{ h1: Css.xl4Sb.mb4.$, h2: Css.xl2Sb.mb4.$ }}>
+    <div css={{ "& > h1": Css.xl4Sb.mb4.$, "& > h2": Css.xl2Sb.mb4.$ }}>
       <h1>Extended Palette</h1>
       <h2>Gray</h2>
       <ListColors palette={paletteEntries.filter(([name]) => name.includes("Gray"))} />

--- a/src/foundations/Typography.stories.tsx
+++ b/src/foundations/Typography.stories.tsx
@@ -12,7 +12,7 @@ export const Typography = () => {
       <table
         css={{
           "& > tr": Css.add("verticalAlign", "top").$,
-          "& > td:nth-of-type(1)": Css.pr4.$,
+          "& > tr > td:nth-of-type(1)": Css.pr4.$,
         }}
       >
         <tr css={Css.tiny.$}>

--- a/src/foundations/Typography.stories.tsx
+++ b/src/foundations/Typography.stories.tsx
@@ -11,8 +11,8 @@ export const Typography = () => {
       <h1 css={Css.xl2Sb.mb3.$}>Typography</h1>
       <table
         css={{
-          tr: Css.add("verticalAlign", "top").$,
-          "td:nth-of-type(1)": Css.pr4.$,
+          "& > tr": Css.add("verticalAlign", "top").$,
+          "& > td:nth-of-type(1)": Css.pr4.$,
         }}
       >
         <tr css={Css.tiny.$}>

--- a/src/inputs/CheckboxBase.tsx
+++ b/src/inputs/CheckboxBase.tsx
@@ -92,7 +92,7 @@ const disabledSelectedBoxStyles = Css.bgGray400.bcGray400.$;
 const disabledColor = Css.gray300.$;
 const focusRingStyles = Css.bshFocus.$;
 const hoverBorderStyles = Css.bcBlue900.$;
-const markStyles = { svg: Css.absolute.topPx(-1).leftPx(-1).$ };
+const markStyles = { ">svg": Css.absolute.topPx(-1).leftPx(-1).$ };
 const labelStyles = Css.smMd.$;
 const descStyles = Css.sm.gray700.$;
 

--- a/src/inputs/Examples.stories.tsx
+++ b/src/inputs/Examples.stories.tsx
@@ -36,7 +36,7 @@ function DrawerWithInputs() {
       <SuperDrawerHeader>
         <h1>5304.01 - Counters</h1>
       </SuperDrawerHeader>
-      <form css={{ ...Css.df.fdc.gap5.$, fieldset: Css.df.fdc.gap2.$, legend: Css.baseMd.mb2.$ }}>
+      <form css={{ ...Css.df.fdc.gap5.$, "& fieldset": Css.df.fdc.gap2.$, "& legend": Css.baseMd.mb2.$ }}>
         <fieldset>
           <legend>Details</legend>
           <TextField label="Item Name" value="Counters" onChange={action("TextField - onChange")} />

--- a/src/inputs/IconCard.stories.tsx
+++ b/src/inputs/IconCard.stories.tsx
@@ -32,7 +32,7 @@ export function Default() {
 /** Hover styled version of the IconButton */
 function HoveredIconCard(args: IconCardProps) {
   return (
-    <div css={{ button: iconCardStylesHover }}>
+    <div css={{ "& button": iconCardStylesHover }}>
       <IconCard {...args} />
     </div>
   );

--- a/src/inputs/Switch.stories.tsx
+++ b/src/inputs/Switch.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
 import { useState } from "react";
-import { Css } from "../Css";
+import { Css } from "src/Css";
 import {
   Switch as SwitchComponent,
   switchFocusStyles,
@@ -23,7 +23,7 @@ export default {
 
 export const Switch = () => {
   return (
-    <div css={{ h1: Css.xl4Sb.mb4.$, h2: Css.xl2Sb.$ }}>
+    <div css={{ "& h1": Css.xl4Sb.mb4.$, "& h2": Css.xl2Sb.$ }}>
       <h1>Switch</h1>
       <div css={Css.df.gap4.fdc.$}>
         <h2>Switch</h2>
@@ -126,7 +126,7 @@ function SwitchWrapper({ isHovered, isFocused, ...props }: SwitchWrapperProps) {
   return (
     <div
       css={{
-        "label > div:nth-of-type(1) > div": {
+        "& label > div:nth-of-type(1) > div": {
           ...(isHovered && switchHoverStyles),
           ...(props.selected && isHovered && switchSelectedHoverStyles),
           ...(isFocused && switchFocusStyles),

--- a/src/inputs/ToggleButton.stories.tsx
+++ b/src/inputs/ToggleButton.stories.tsx
@@ -24,7 +24,7 @@ export default {
 
 export const ToggleButton = () => {
   return (
-    <div css={{ h1: Css.xl4Sb.mb4.$, h2: Css.xl2Sb.$ }}>
+    <div css={{ "& h1": Css.xl4Sb.mb4.$, "& h2": Css.xl2Sb.$ }}>
       <h1>Toggle Button</h1>
       <div css={Css.df.gap4.fdc.aifs.$}>
         <ToggleButtonWrapper label="Inactive" />
@@ -41,7 +41,7 @@ export const ToggleButton = () => {
 
 export const AsyncToggleButton = () => {
   return (
-    <div css={{ h1: Css.xl4Sb.mb4.$, h2: Css.xl2Sb.$ }}>
+    <div css={{ "& h1": Css.xl4Sb.mb4.$, "& h2": Css.xl2Sb.$ }}>
       <h1>Toggle Button</h1>
       <div css={Css.df.gap4.fdc.$}>
         <h3>Resolved (2s)</h3>
@@ -76,7 +76,7 @@ function ToggleButtonWrapper({ isHovered, isFocused, isPressed, onChange, ...pro
   return (
     <div
       css={{
-        label: {
+        "& label": {
           ...(isHovered && toggleHoverStyles),
           ...(isPressed && togglePressStyles),
           ...(isFocused && toggleFocusStyles),


### PR DESCRIPTION
I'm prototyping a CSS runtime, Fela, that wants `&` at the start of selectors; emotion supports that as well, so just move to that.