### PR TITLE
fix: Don't show asterisk when readonly.

### DIFF
--- a/src/forms/BoundSelectField.test.tsx
+++ b/src/forms/BoundSelectField.test.tsx
@@ -1,9 +1,9 @@
 import { createObjectState, ObjectConfig, ObjectState, required } from "@homebound/form-state";
-import { click, render } from "@homebound/rtl-utils";
 import { jest } from "@jest/globals";
 import { BoundSelectField } from "src/forms/BoundSelectField";
 import { AuthorHeight, AuthorInput } from "src/forms/formStateDomain";
 import { noop } from "src/utils";
+import { click, render } from "src/utils/rtl";
 
 const sports = [
   { id: "s:1", name: "Football" },
@@ -27,7 +27,13 @@ describe("BoundSelectField", () => {
   it("shows the label", async () => {
     const author = createObjectState(formConfig, { favoriteSport: "s:1" });
     const r = await render(<BoundSelectField field={author.favoriteSport} options={sports} />);
-    expect(r.favoriteSport_label).toHaveTextContent("Favorite Sport");
+    expect(r.favoriteSport_label.textContent).toBe("Favorite Sport *");
+  });
+
+  it("hides asterisk if required & readonly", async () => {
+    const author = createObjectState(formConfig, { favoriteSport: "s:1" });
+    const r = await render(<BoundSelectField field={author.favoriteSport} options={sports} readOnly />);
+    expect(r.favoriteSport_label.textContent).toBe("Favorite Sport");
   });
 
   it("binds to options with displayNames", async () => {

--- a/src/forms/labelUtils.ts
+++ b/src/forms/labelUtils.ts
@@ -1,9 +1,9 @@
 import { usePresentationContext } from "src/components/PresentationContext";
 
-export function getLabelSuffix(required: boolean | undefined): string | undefined {
-  // We promise to always call `getLabelSuffix` deterministically
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+// We promise to always call `getLabelSuffix` deterministically
+export function useLabelSuffix(required: boolean | undefined, readOnly: boolean | undefined): string | undefined {
   const { fieldProps } = usePresentationContext();
+  if (readOnly) return undefined;
   if (required === true) {
     return fieldProps?.labelSuffix?.required;
   } else if (required === false) {

--- a/src/inputs/SelectField.stories.tsx
+++ b/src/inputs/SelectField.stories.tsx
@@ -72,6 +72,7 @@ function Template(args: SelectFieldProps<any, any>) {
         <TestSelectField
           {...args}
           label="Favorite Icon"
+          required={true}
           value={options[2].id}
           options={options}
           unsetLabel="N/A"
@@ -115,6 +116,7 @@ function Template(args: SelectFieldProps<any, any>) {
           label="Favorite Icon - Read Only"
           options={options}
           value={options[2].id}
+          required={true}
           readOnly="Read only reason"
         />
         <TestSelectField

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -16,7 +16,7 @@ import { InlineLabel, Label } from "src/components/Label";
 import { InputStylePalette, usePresentationContext } from "src/components/PresentationContext";
 import { BorderHoverChild, BorderHoverParent } from "src/components/Table/components/Row";
 import { Css, Only, Palette } from "src/Css";
-import { getLabelSuffix } from "src/forms/labelUtils";
+import { useLabelSuffix } from "src/forms/labelUtils";
 import { useGetRef } from "src/hooks/useGetRef";
 import { ErrorMessage } from "src/inputs/ErrorMessage";
 import { getFieldWidth } from "src/inputs/utils";
@@ -111,7 +111,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
   const internalProps: TextFieldInternalProps = (props as any).internalProps || {};
   const { compound = false, forceFocus = false, forceHover = false } = internalProps;
   const errorMessageId = `${inputProps.id}-error`;
-  const labelSuffix = getLabelSuffix(required);
+  const labelSuffix = useLabelSuffix(required, inputProps.readOnly);
   const ElementType: React.ElementType = multiline ? "textarea" : "input";
   const tid = useTestIds(props, defaultTestId(label));
   const [isFocused, setIsFocused] = useState(false);


### PR DESCRIPTION
Fixes usages like:

![image](https://github.com/user-attachments/assets/9c49105e-66ff-49a6-b2df-7c7b523ad71b)

Which admittedly should probably be using StaticFields.
