### PR TITLE
fix: Enable SubmitButton on new entities.

### DIFF
--- a/src/forms/BoundCheckboxGroupField.tsx
+++ b/src/forms/BoundCheckboxGroupField.tsx
@@ -28,6 +28,7 @@ export function BoundCheckboxGroupField(props: BoundCheckboxGroupFieldProps) {
       {() => (
         <CheckboxGroup
           label={label}
+          required={field.required}
           values={field.value || []}
           onChange={(values) => {
             onChange(values);

--- a/src/forms/BoundToggleChipGroupField.tsx
+++ b/src/forms/BoundToggleChipGroupField.tsx
@@ -17,7 +17,16 @@ export function BoundToggleChipGroupField(props: BoundToggleChipGroupFieldProps)
   const testId = useTestIds(props, field.key);
   return (
     <Observer>
-      {() => <ToggleChipGroup label={label} values={field.value || []} onChange={onChange} {...testId} {...others} />}
+      {() => (
+        <ToggleChipGroup
+          label={label}
+          required={field.required}
+          values={field.value || []}
+          onChange={onChange}
+          {...testId}
+          {...others}
+        />
+      )}
     </Observer>
   );
 }

--- a/src/forms/FormStateApp.tsx
+++ b/src/forms/FormStateApp.tsx
@@ -22,29 +22,41 @@ import {
   FieldGroup,
   FormDivider,
   StaticField,
+  SubmitButton,
 } from "src/forms";
 import { BoundCheckboxGroupField } from "src/forms/BoundCheckboxGroupField";
 import { BoundTreeSelectField } from "src/forms/BoundTreeSelectField";
 import { FormLines } from "src/forms/FormLines";
-import { AuthorInput } from "src/forms/formStateDomain";
+import { AuthorInput, jan1 } from "src/forms/formStateDomain";
 import { useComputed } from "src/hooks";
 import { CheckboxGroupItemOption, NestedOption } from "src/inputs";
 import { HasIdAndName } from "src/types";
 
 export function FormStateApp() {
-  // Simulate getting the initial form state back from a server call
-  const queryResponse = useMemo(
-    () => ({
-      firstName: "a1",
-      books: [...Array(2)].map((_, i) => ({
-        id: String(i),
-        title: `b${i}`,
-        classification: { number: `10${i + 1}`, category: `Test Category ${i}` },
-      })),
-    }),
-    [],
-  );
   const [readOnly, setReadOnly] = useState(false);
+  const [isNew, setIsNew] = useState(false);
+  const [enableOn, setEnableOn] = useState<"valid" | "dirty">("dirty");
+  // Simulate getting the initial form state back from a server call
+  const queryResponse = useMemo(() => {
+    return isNew
+      ? {}
+      : {
+          id: "a:1",
+          firstName: "a1",
+          lastName: "l1",
+          birthday: jan1,
+          heightInInches: 72,
+          favoriteShapes: ["sh:2"],
+          favoriteGenres: ["g:2"],
+          favoriteColors: ["c:2"],
+          animals: ["a:2"],
+          books: [...Array(2)].map((_, i) => ({
+            id: String(i),
+            title: `b${i}`,
+            classification: { number: `10${i + 1}`, category: `Test Category ${i}` },
+          })),
+        };
+  }, [isNew]);
 
   const formState = useFormState({
     config: formConfig,
@@ -63,113 +75,82 @@ export function FormStateApp() {
     [],
   );
 
-  const sports = [
-    { id: undefined as any, name: "Undecided" },
-    { id: "s:1", name: "Football" },
-    { id: "s:2", name: "Soccer" },
-  ];
-
-  const colors: CheckboxGroupItemOption[] = [
-    { value: "c:1", label: "Blue" },
-    { value: "c:2", label: "Red" },
-    { value: "c:3", label: "Green" },
-  ];
-
-  const shapes = [
-    { id: "sh:1", name: "Triangle" },
-    { id: "sh:2", name: "Square" },
-    { id: "sh:3", name: "Circle" },
-  ];
-
-  const animals = [
-    { value: "a:1", label: "Cat" },
-    { value: "a:2", label: "Dog" },
-    { value: "a:3", label: "Fish" },
-    { value: "a:4", label: "Iguana" },
-    { value: "a:5", label: "Turtle" },
-  ];
-
-  const genres: NestedOption<HasIdAndName>[] = [
-    {
-      id: "g:1",
-      name: "Action",
-      children: [
-        {
-          id: "g:2",
-          name: "Action Adventure",
-          children: [{ id: "g:3", name: "Action Adventure Comedy" }],
-        },
-        { id: "g:4", name: "Action Comedy" },
-      ],
-    },
-    { id: "g:5", name: "Comedy", children: [{ id: "g:6", name: "Comedy Drama" }] },
-  ];
-
   return (
-    <Observer>
-      {() => (
-        <div css={Css.df.$}>
-          <header css={Css.wPx(700).$}>
-            <FormLines labelSuffix={{ required: "*", optional: "(Opt)" }}>
-              <b>Author</b>
-              <BoundTextField field={formState.firstName} />
-              <BoundTextField field={formState.middleInitial} />
-              <BoundTextField field={formState.lastName} />
-              <BoundDateField field={formState.birthday} />
-              <FieldGroup>
-                <StaticField label="Revenue" value="$500" />
-                <StaticField label="Website">
-                  <a href="https://google.com">google.com</a>
-                </StaticField>
-              </FieldGroup>
-              <BoundNumberField field={formState.heightInInches} />
-              <FormDivider />
-              <BoundSelectField field={formState.favoriteSport} options={sports} />
-              <BoundMultiSelectField field={formState.favoriteShapes} options={shapes} />
-              <BoundTreeSelectField field={formState.favoriteGenres} options={genres} />
-              <FormDivider />
-              <BoundCheckboxGroupField field={formState.favoriteColors} options={colors} />
-              <BoundToggleChipGroupField field={formState.animals} options={animals} />
-              <FormDivider />
-              <BoundSwitchField field={formState.isAvailable} />
-            </FormLines>
+    <div css={Css.df.$}>
+      <header css={Css.wPx(700).$}>
+        <FormLines>
+          <b>Author</b>
+          <BoundTextField field={formState.firstName} />
+          <BoundTextField field={formState.middleInitial} />
+          <BoundTextField field={formState.lastName} />
+          <BoundDateField field={formState.birthday} />
+          <FieldGroup>
+            <StaticField label="Revenue" value="$500" />
+            <StaticField label="Website">
+              <a href="https://google.com">google.com</a>
+            </StaticField>
+          </FieldGroup>
+          <BoundNumberField field={formState.heightInInches} />
+          <FormDivider />
+          <BoundSelectField field={formState.favoriteSport} options={sports} />
+          <BoundMultiSelectField field={formState.favoriteShapes} options={shapes} />
+          <BoundTreeSelectField field={formState.favoriteGenres} options={genres} />
+          <FormDivider />
+          <BoundCheckboxGroupField field={formState.favoriteColors} options={colors} />
+          <BoundToggleChipGroupField field={formState.animals} options={animals} />
+          <FormDivider />
+          <BoundSwitchField field={formState.isAvailable} />
+        </FormLines>
 
-            <div>
-              <strong>
-                Books
-                <IconButton
-                  icon="plus"
-                  onClick={() => formState.books.add({ id: String(formState.books.value.length) })}
-                />
-              </strong>
-              <GridTable<Row> columns={columns} rows={rows} />
-            </div>
-
-            <div css={Css.df.gap1.$}>
-              <Button onClick={() => formState.revertChanges()} label="Cancel" />
-              <Button
-                onClick={() => {
-                  if (formState.canSave()) {
-                    formState.commitChanges();
-                  }
-                }}
-                label="Save"
-              />
-            </div>
-          </header>
-          <div>
-            <div>
-              <Button label="Read Only" onClick={() => setReadOnly(!readOnly)} />
-            </div>
-
-            <div css={Css.mt1.$}>
-              <strong>Form Values:</strong>
-              <pre>{JSON.stringify(formState.value, null, 2)}</pre>
-            </div>
-          </div>
+        <div>
+          <strong>
+            Books
+            <IconButton icon="plus" onClick={() => formState.books.add({ id: String(formState.books.value.length) })} />
+          </strong>
+          <GridTable<Row> columns={columns} rows={rows} />
         </div>
-      )}
-    </Observer>
+      </header>
+      <div>
+        <div css={Css.df.gap1.$}>
+          <Button variant="secondary" onClick={() => formState.revertChanges()} label="Cancel" />
+          <SubmitButton
+            form={formState}
+            enableOn={enableOn}
+            onClick={() => {
+              if (formState.canSave()) {
+                formState.commitChanges();
+              }
+            }}
+            label="Save"
+          />
+          (using {enableOn})
+        </div>
+
+        <Observer>
+          {() => (
+            <div css={Css.mt1.$}>
+              <strong>Form Values</strong>
+              <pre>dirty {String(formState.dirty)}</pre>
+              <pre>valid {String(formState.valid)}</pre>
+              <pre>{JSON.stringify(formState.value, null, 2)}</pre>
+              {formState.errors.map((message) => (
+                <pre>{message}</pre>
+              ))}
+            </div>
+          )}
+        </Observer>
+
+        <div css={Css.df.gap2.$}>
+          <Button variant="text" label="Read Only" onClick={() => setReadOnly(!readOnly)} />
+          <Button variant="text" label={isNew ? "Existing" : "New"} onClick={() => setIsNew(!isNew)} />
+          <Button
+            variant="text"
+            label={enableOn === "valid" ? "Dirty" : "Valid"}
+            onClick={() => setEnableOn(enableOn === "valid" ? "dirty" : "valid")}
+          />
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -193,6 +174,7 @@ type FormValue = ObjectState<AuthorInput>;
 
 // Configure the fields/behavior for AuthorInput's fields
 export const formConfig: ObjectConfig<AuthorInput> = {
+  id: { type: "value" },
   firstName: { type: "value", rules: [required] },
   middleInitial: { type: "value" },
   lastName: { type: "value", rules: [required] },
@@ -213,3 +195,45 @@ export const formConfig: ObjectConfig<AuthorInput> = {
   animals: { type: "value", rules: [required] },
   isAvailable: { type: "value" },
 };
+
+const sports = [
+  { id: undefined as any, name: "Undecided" },
+  { id: "s:1", name: "Football" },
+  { id: "s:2", name: "Soccer" },
+];
+
+const colors: CheckboxGroupItemOption[] = [
+  { value: "c:1", label: "Blue" },
+  { value: "c:2", label: "Red" },
+  { value: "c:3", label: "Green" },
+];
+
+const shapes = [
+  { id: "sh:1", name: "Triangle" },
+  { id: "sh:2", name: "Square" },
+  { id: "sh:3", name: "Circle" },
+];
+
+const animals = [
+  { value: "a:1", label: "Cat" },
+  { value: "a:2", label: "Dog" },
+  { value: "a:3", label: "Fish" },
+  { value: "a:4", label: "Iguana" },
+  { value: "a:5", label: "Turtle" },
+];
+
+const genres: NestedOption<HasIdAndName>[] = [
+  {
+    id: "g:1",
+    name: "Action",
+    children: [
+      {
+        id: "g:2",
+        name: "Action Adventure",
+        children: [{ id: "g:3", name: "Action Adventure Comedy" }],
+      },
+      { id: "g:4", name: "Action Comedy" },
+    ],
+  },
+  { id: "g:5", name: "Comedy", children: [{ id: "g:6", name: "Comedy Drama" }] },
+];

--- a/src/forms/FormStateApp.tsx
+++ b/src/forms/FormStateApp.tsx
@@ -35,7 +35,6 @@ import { HasIdAndName } from "src/types";
 export function FormStateApp() {
   const [readOnly, setReadOnly] = useState(false);
   const [isNew, setIsNew] = useState(false);
-  const [enableOn, setEnableOn] = useState<"valid" | "dirty">("dirty");
   // Simulate getting the initial form state back from a server call
   const queryResponse = useMemo(() => {
     return isNew
@@ -115,7 +114,6 @@ export function FormStateApp() {
           <Button variant="secondary" onClick={() => formState.revertChanges()} label="Cancel" />
           <SubmitButton
             form={formState}
-            enableOn={enableOn}
             onClick={() => {
               if (formState.canSave()) {
                 formState.commitChanges();
@@ -123,7 +121,6 @@ export function FormStateApp() {
             }}
             label="Save"
           />
-          (using {enableOn})
         </div>
 
         <Observer>
@@ -143,11 +140,6 @@ export function FormStateApp() {
         <div css={Css.df.gap2.$}>
           <Button variant="text" label="Read Only" onClick={() => setReadOnly(!readOnly)} />
           <Button variant="text" label={isNew ? "Existing" : "New"} onClick={() => setIsNew(!isNew)} />
-          <Button
-            variant="text"
-            label={enableOn === "valid" ? "Dirty" : "Valid"}
-            onClick={() => setEnableOn(enableOn === "valid" ? "dirty" : "valid")}
-          />
         </div>
       </div>
     </div>

--- a/src/forms/SubmitButton.test.tsx
+++ b/src/forms/SubmitButton.test.tsx
@@ -28,7 +28,7 @@ describe("SubmitButton", () => {
     click(r.submit);
     expect(onClick).not.toHaveBeenCalled();
 
-    // ANd once we make it valid
+    // And once we make it valid
     act(() => author.firstName.set("f2"));
     // We can click and submit
     click(r.submit);

--- a/src/forms/SubmitButton.test.tsx
+++ b/src/forms/SubmitButton.test.tsx
@@ -8,8 +8,8 @@ import { SubmitButton } from "src/forms/SubmitButton";
 describe("SubmitButton", () => {
   it("disables if the form is clean", async () => {
     const onClick = jest.fn();
-    // Given a submit button for an invalid form
-    const author = createObjectState(formConfig, { firstName: "f1" });
+    // Given a submit button for a valid form
+    const author = createObjectState(formConfig, { id: "a:1", firstName: "f1" });
     const r = await render(<SubmitButton form={author} onClick={onClick} />);
 
     // Then the submit button is initially disabled because nothing is dirty
@@ -18,7 +18,7 @@ describe("SubmitButton", () => {
     click(r.submit);
     expect(onClick).not.toHaveBeenCalled();
 
-    // But once we change a field, it becomes enabled
+    // But once we change a field, it becomes enabled (even though its invalid)
     act(() => author.firstName.set(""));
     expect(r.submit).toBeEnabled();
     // Even though it's invalid, so clicking submit still won't do anything
@@ -46,8 +46,20 @@ describe("SubmitButton", () => {
     click(r.submit);
     expect(onClick).not.toHaveBeenCalled();
   });
+
+  it("enables for new entities", async () => {
+    const onClick = jest.fn();
+    // Given a submit button for a valid form
+    const author = createObjectState(formConfig, { firstName: "f1" });
+    const r = await render(<SubmitButton form={author} onClick={onClick} />);
+    // Then the submit button is enabled because we might be duplicating
+    expect(r.submit).toBeEnabled();
+    click(r.submit);
+    expect(onClick).toHaveBeenCalled();
+  });
 });
 
 const formConfig: ObjectConfig<AuthorInput> = {
+  id: { type: "value" },
   firstName: { type: "value", rules: [required] },
 };

--- a/src/forms/SubmitButton.test.tsx
+++ b/src/forms/SubmitButton.test.tsx
@@ -4,35 +4,50 @@ import { jest } from "@jest/globals";
 import { act } from "@testing-library/react";
 import { AuthorInput } from "src/forms/formStateDomain";
 import { SubmitButton } from "src/forms/SubmitButton";
+import { clickAndWait } from "src/utils/rtlUtils";
 
 describe("SubmitButton", () => {
-  it("disables if the form is clean", async () => {
+  it("when editing, disables if the form is clean", async () => {
     const onClick = jest.fn();
-    // Given a submit button for a valid form
+    // Given a submit button for an existing entity (id is set)
     const author = createObjectState(formConfig, { id: "a:1", firstName: "f1" });
     const r = await render(<SubmitButton form={author} onClick={onClick} />);
 
     // Then the submit button is initially disabled because nothing is dirty
     expect(r.submit).not.toBeEnabled();
+
     // And clicking submit doesn't call the onClick handler
     click(r.submit);
     expect(onClick).not.toHaveBeenCalled();
 
-    // But once we change a field, it becomes enabled (even though its invalid)
+    // And if we change a field to invalid
     act(() => author.firstName.set(""));
-    expect(r.submit).toBeEnabled();
+    // Then we stay disabled
+    expect(r.submit).not.toBeEnabled();
     // Even though it's invalid, so clicking submit still won't do anything
     click(r.submit);
     expect(onClick).not.toHaveBeenCalled();
 
-    // But once we make it valid
+    // ANd once we make it valid
     act(() => author.firstName.set("f2"));
     // We can click and submit
     click(r.submit);
     expect(onClick).toHaveBeenCalled();
   });
 
-  it("disables if the form is dirty but overridden via prop", async () => {
+  it("when creating, enables for initial click", async () => {
+    const onClick = jest.fn();
+    // Given a submit button for a new entity (no id set)
+    const author = createObjectState(formConfig, { firstName: "f1" });
+    const r = await render(<SubmitButton form={author} onClick={onClick} />);
+    // Then the submit button is enabled (to show validation errors)
+    expect(r.submit).toBeEnabled();
+    // This is not an async call, but it makes the re-render-without-act error to go away :thinking:
+    await clickAndWait(r.submit);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("disables if the form is dirty but disabled via prop", async () => {
     const onClick = jest.fn();
     // Given a form is dirty so saveable to formState
     const author = createObjectState(formConfig, { firstName: "f1" });
@@ -45,17 +60,6 @@ describe("SubmitButton", () => {
     // And clicking it ignores the handler
     click(r.submit);
     expect(onClick).not.toHaveBeenCalled();
-  });
-
-  it("enables for new entities", async () => {
-    const onClick = jest.fn();
-    // Given a submit button for a valid form
-    const author = createObjectState(formConfig, { firstName: "f1" });
-    const r = await render(<SubmitButton form={author} onClick={onClick} />);
-    // Then the submit button is enabled because we might be duplicating
-    expect(r.submit).toBeEnabled();
-    click(r.submit);
-    expect(onClick).toHaveBeenCalled();
   });
 });
 

--- a/src/forms/SubmitButton.tsx
+++ b/src/forms/SubmitButton.tsx
@@ -30,7 +30,7 @@ export function SubmitButton<T>(props: SubmitButtonProps<T>) {
         // canSave will touch any not-yet-keyed-in fields to show errors
         state.clicked = true;
         if (form.canSave()) {
-          void onClick(e);
+          return onClick(e);
         }
       }}
       {...others}

--- a/src/forms/SubmitButton.tsx
+++ b/src/forms/SubmitButton.tsx
@@ -1,30 +1,34 @@
 import { ObjectState } from "@homebound/form-state";
+import { useLocalObservable } from "mobx-react";
 import { Button, ButtonProps, useComputed } from "src";
 
 export type SubmitButtonProps<T> = Omit<ButtonProps, "label"> & {
   label?: ButtonProps["label"];
-  enableOn?: "valid" | "dirty";
   form: ObjectState<T>;
 };
 
 /** Provides a Button that will auto-disable if `formState` is invalid. */
 export function SubmitButton<T>(props: SubmitButtonProps<T>) {
-  const { form, disabled, onClick, label = "Submit", enableOn = "dirty", ...others } = props;
+  const { form, disabled, onClick, label = "Submit", ...others } = props;
   if (typeof onClick === "string") {
     throw new Error("SubmitButton.onClick doesn't support strings yet");
   }
-  // Enable the button whenever the form is dirty, even if the form is partially invalid,
-  // because submitting will then force-touch all fields and show all errors instead of
-  // just errors-so-far.
+
+  const state = useLocalObservable(() => ({ clicked: false }));
+
   const canSubmit = useComputed(() => {
-    return enableOn === "valid" ? form.valid : form.dirty || form.isNewEntity;
-  }, [form, enableOn]);
+    // We generally prefer to "enable when dirty && valid", *but* when creating new entities,
+    // showing Save as enabled can be a good way for the user to "try and save" and get all the
+    // previously-hidden error messages to show up (b/c `canSave` touches the form fields).
+    return form.isNewEntity && !state.clicked ? true : form.dirty && form.valid;
+  }, [form]);
   return (
     <Button
       label={label}
       disabled={disabled || !canSubmit}
       onClick={(e) => {
         // canSave will touch any not-yet-keyed-in fields to show errors
+        state.clicked = true;
         if (form.canSave()) {
           void onClick(e);
         }

--- a/src/forms/SubmitButton.tsx
+++ b/src/forms/SubmitButton.tsx
@@ -15,11 +15,13 @@ export function SubmitButton<T>(props: SubmitButtonProps<T>) {
   // Enable the button whenever the form is dirty, even if the form is partially invalid,
   // because submitting will then force-touch all fields and show all errors instead of
   // just errors-so-far.
-  const dirty = useComputed(() => form.dirty, [form]);
+  const canSubmit = useComputed(() => {
+    return form.dirty || form.isNewEntity;
+  }, [form]);
   return (
     <Button
       label={label}
-      disabled={disabled || !dirty}
+      disabled={disabled || !canSubmit}
       onClick={(e) => {
         // canSave will touch any not-yet-keyed-in fields to show errors
         if (form.canSave()) {

--- a/src/forms/SubmitButton.tsx
+++ b/src/forms/SubmitButton.tsx
@@ -3,12 +3,13 @@ import { Button, ButtonProps, useComputed } from "src";
 
 export type SubmitButtonProps<T> = Omit<ButtonProps, "label"> & {
   label?: ButtonProps["label"];
+  enableOn?: "valid" | "dirty";
   form: ObjectState<T>;
 };
 
 /** Provides a Button that will auto-disable if `formState` is invalid. */
 export function SubmitButton<T>(props: SubmitButtonProps<T>) {
-  const { form, disabled, onClick, label = "Submit", ...others } = props;
+  const { form, disabled, onClick, label = "Submit", enableOn = "dirty", ...others } = props;
   if (typeof onClick === "string") {
     throw new Error("SubmitButton.onClick doesn't support strings yet");
   }
@@ -16,8 +17,8 @@ export function SubmitButton<T>(props: SubmitButtonProps<T>) {
   // because submitting will then force-touch all fields and show all errors instead of
   // just errors-so-far.
   const canSubmit = useComputed(() => {
-    return form.dirty || form.isNewEntity;
-  }, [form]);
+    return enableOn === "valid" ? form.valid : form.dirty || form.isNewEntity;
+  }, [form, enableOn]);
   return (
     <Button
       label={label}

--- a/src/inputs/CheckboxGroup.tsx
+++ b/src/inputs/CheckboxGroup.tsx
@@ -5,6 +5,7 @@ import { HelperText } from "src/components/HelperText";
 import { Label } from "src/components/Label";
 import { PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
 import { Css } from "src/Css";
+import { useLabelSuffix } from "src/forms/labelUtils";
 import { CheckboxBase } from "src/inputs/CheckboxBase";
 import { ErrorMessage } from "src/inputs/ErrorMessage";
 import { useTestIds } from "src/utils";
@@ -20,6 +21,7 @@ export interface CheckboxGroupItemOption {
 
 export interface CheckboxGroupProps extends Pick<PresentationFieldProps, "labelStyle"> {
   label: string;
+  required?: boolean;
   /** Called when a checkbox is selected or deselected */
   onChange: (values: string[]) => void;
   /** Options for the checkboxes contained within the CheckboxGroup. */
@@ -48,17 +50,19 @@ export function CheckboxGroup(props: CheckboxGroupProps) {
     onBlur,
     onFocus,
     columns = 1,
+    required,
   } = props;
 
   const state = useCheckboxGroupState({ ...props, value: values });
   const { groupProps, labelProps } = useCheckboxGroup(props, state);
   const tid = useTestIds(props);
+  const labelSuffix = useLabelSuffix(required, false);
 
   return (
     <div {...groupProps} css={Css.if(labelStyle === "left").df.fdr.$} onBlur={onBlur} onFocus={onFocus} {...tid}>
       {labelStyle !== "hidden" && (
         <div css={Css.if(labelStyle === "left").w50.$}>
-          <Label label={label} {...labelProps} {...tid.label} />
+          <Label label={label} {...labelProps} {...tid.label} suffix={labelSuffix} />
         </div>
       )}
       <div css={Css.dg.gtc(`repeat(${columns}, auto)`).gap2.$}>

--- a/src/inputs/ToggleChipGroup.tsx
+++ b/src/inputs/ToggleChipGroup.tsx
@@ -5,6 +5,7 @@ import { maybeTooltip, resolveTooltip } from "src/components";
 import { Label } from "src/components/Label";
 import { PresentationFieldProps, usePresentationContext } from "src/components/PresentationContext";
 import { Css, Palette, Xss } from "src/Css";
+import { useLabelSuffix } from "src/forms/labelUtils";
 import { useTestIds } from "src/utils/useTestIds";
 
 type ToggleChipXss = Xss<"color" | "backgroundColor">;
@@ -25,6 +26,7 @@ export interface ToggleChipGroupProps extends Pick<PresentationFieldProps, "labe
   label: string;
   options: ToggleChipItemProps[];
   values: string[];
+  required?: boolean;
   onChange: (values: string[]) => void;
   xss?: ToggleChipXss;
 }
@@ -32,14 +34,21 @@ export interface ToggleChipGroupProps extends Pick<PresentationFieldProps, "labe
 export function ToggleChipGroup(props: ToggleChipGroupProps) {
   const { fieldProps } = usePresentationContext();
   const { labelLeftFieldWidth = "50%" } = fieldProps ?? {};
-  const { values, label, labelStyle = fieldProps?.labelStyle ?? "above", options, xss } = props;
+  const { values, label, labelStyle = fieldProps?.labelStyle ?? "above", options, required, xss } = props;
   const state = useCheckboxGroupState({ ...props, value: values });
   const { groupProps, labelProps } = useCheckboxGroup(props, state);
   const tid = useTestIds(props, "toggleChip");
+  const labelSuffix = useLabelSuffix(required, false);
 
   return (
     <div {...groupProps} css={Css.relative.df.fdc.if(labelStyle === "left").fdr.gap2.maxw100.jcsb.$}>
-      <Label label={label} {...labelProps} hidden={labelStyle === "hidden"} inline={labelStyle !== "above"} />
+      <Label
+        label={label}
+        {...labelProps}
+        hidden={labelStyle === "hidden"}
+        inline={labelStyle !== "above"}
+        suffix={labelSuffix}
+      />
       <div
         css={
           Css.df.gap1


### PR DESCRIPTION
When duplicating an entity, we might have a form that is valid but also not dirty, b/c technically the user hasn't touched anything yet, but we've prefilled existing values, and still want want to allowing hitting Save.