### PR TITLE
feat: Add ReactNode support for NavLink labels

### DIFF
--- a/src/components/NavLink.test.tsx
+++ b/src/components/NavLink.test.tsx
@@ -13,4 +13,12 @@ describe("NavLink", () => {
     const r = await render(<NavLink href="/projects" label="Link" variant="global" data-testid="link" />, withRouter());
     expect(r.link).not.toHaveAttribute("target").not.toHaveAttribute("rel");
   });
+
+  it("can render jsx for a label", async () => {
+    const r = await render(
+      <NavLink href="/projects" label={<div>Navlink button</div>} variant="global" data-testid="link" />,
+      withRouter(),
+    );
+    expect(r.link).toHaveTextContent("Navlink button");
+  });
 });

--- a/src/components/NavLink.tsx
+++ b/src/components/NavLink.tsx
@@ -1,5 +1,5 @@
 import { AriaButtonProps } from "@react-types/button";
-import { RefObject, useMemo } from "react";
+import { ReactNode, RefObject, useMemo } from "react";
 import { mergeProps, useButton, useFocusRing, useHover } from "react-aria";
 import type { IconKey } from "src/components";
 import { navLink } from "src/components";
@@ -15,7 +15,7 @@ export interface NavLinkProps extends BeamFocusableProps {
   disabled?: boolean;
   /** if `href` isn't provided, it is treated as a <button> */
   href?: string;
-  label: string;
+  label: ReactNode;
   icon?: IconKey;
   variant: NavLinkVariant;
   openInNew?: boolean;


### PR DESCRIPTION
This will enable the use of custom styling (e.g. padding) within the label, providing flexibility needed for the upcoming `SideNav` redesign.
 
<img width="304" alt="image" src="https://github.com/user-attachments/assets/94cfefab-7126-4972-a5a9-1b533c1d9aa6" />
