### PR TITLE
feat: Updates to `FormPageLayout` and `BoundForm`

### DIFF
--- a/src/components/Layout/FormPageLayout.test.tsx
+++ b/src/components/Layout/FormPageLayout.test.tsx
@@ -3,7 +3,7 @@ import { FormPageLayout } from "src/components/Layout";
 import { boundCheckboxField, boundTextField } from "src/forms";
 import { AuthorInput } from "src/forms/formStateDomain";
 import { noop } from "src/utils";
-import { render, withRouter } from "src/utils/rtl";
+import { render, type, withRouter } from "src/utils/rtl";
 
 const formConfig: ObjectConfig<AuthorInput> = {
   isAvailable: { type: "value", rules: [required] },
@@ -42,16 +42,22 @@ describe("FormPageLayout", () => {
     expect(r.pageHeaderBreadcrumbs_navLink_1).toHaveTextContent("Users");
 
     // And the action buttons to be rendered with the correct labels and states
-    expect(r.formPageLayout_pageHeader_submitAction).toHaveTextContent("Save");
-    expect(r.formPageLayout_pageHeader_submitAction).not.toBeDisabled();
-    expect(r.formPageLayout_pageHeader_cancelAction).toHaveTextContent("Cancel");
-    expect(r.formPageLayout_pageHeader_cancelAction).not.toBeDisabled();
-    expect(r.formPageLayout_pageHeader_tertiaryAction).toHaveTextContent("Delete");
-    expect(r.formPageLayout_pageHeader_tertiaryAction).toBeDisabled();
+    expect(r.save).toHaveTextContent("Save");
+    expect(r.cancel).toHaveTextContent("Cancel");
+    expect(r.cancel).not.toBeDisabled();
+    expect(r.delete).toHaveTextContent("Delete");
+    expect(r.delete).toBeDisabled();
+
+    // Where the save button is initially disabled for the untouched form
+    expect(r.save).toBeDisabled();
+
+    // And when we change a field, the save button is enabled
+    type(r.firstName, "Jane");
+    expect(r.save).not.toBeDisabled();
 
     // And each of the form sections to be rendered with their fields and titles
     expect(r.formPageLayout_formSection_0).toHaveTextContent("About");
-    expect(r.firstName).toHaveValue("John");
+    expect(r.firstName).toHaveValue("Jane");
     expect(r.lastName).toHaveValue("Doe");
     expect(r.formPageLayout_formSection_1).toHaveTextContent("Settings");
     expect(r.isAvailable).toBeChecked();

--- a/src/components/Layout/FormPageLayout.tsx
+++ b/src/components/Layout/FormPageLayout.tsx
@@ -1,9 +1,8 @@
 import { ObjectState } from "@homebound/form-state";
-import { Observer } from "mobx-react";
 import React, { createRef, RefObject, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useButton, useFocusRing } from "react-aria";
 import { Css, Palette } from "src/Css";
-import { BoundForm, BoundFormInputConfig } from "src/forms";
+import { BoundForm, BoundFormInputConfig, SubmitButton } from "src/forms";
 import { useHover } from "src/hooks";
 import { useTestIds } from "src/utils";
 import { Button, ButtonProps } from "../Button";
@@ -98,42 +97,28 @@ function PageHeader<F>(props: FormPageLayoutProps<F>) {
             {pageTitle}
           </h1>
         </div>
-        <Observer>
-          {() => (
-            <div css={Css.df.gap1.$}>
-              {tertiaryAction && (
-                <Button
-                  label={tertiaryAction.label}
-                  onClick={tertiaryAction.onClick}
-                  variant="tertiary"
-                  disabled={tertiaryAction.disabled}
-                  tooltip={tertiaryAction.tooltip}
-                  {...tids.tertiaryAction}
-                />
-              )}
-              {cancelAction && (
-                <Button
-                  label={cancelAction.label}
-                  onClick={cancelAction.onClick}
-                  variant="secondary"
-                  disabled={cancelAction.disabled}
-                  tooltip={cancelAction.tooltip}
-                  {...tids.cancelAction}
-                />
-              )}
-              {submitAction && (
-                <Button
-                  label={submitAction.label}
-                  onClick={submitAction.onClick}
-                  variant="primary"
-                  disabled={!formState.valid || submitAction.disabled}
-                  tooltip={submitAction.tooltip}
-                  {...tids.submitAction}
-                />
-              )}
-            </div>
+
+        <div css={Css.df.gap1.$}>
+          {tertiaryAction && (
+            <Button
+              label={tertiaryAction.label}
+              onClick={tertiaryAction.onClick}
+              variant="tertiary"
+              disabled={tertiaryAction.disabled}
+              tooltip={tertiaryAction.tooltip}
+            />
           )}
-        </Observer>
+          {cancelAction && (
+            <Button
+              label={cancelAction.label}
+              onClick={cancelAction.onClick}
+              variant="secondary"
+              disabled={cancelAction.disabled}
+              tooltip={cancelAction.tooltip}
+            />
+          )}
+          <SubmitButton form={formState} {...submitAction} />
+        </div>
       </div>
     </header>
   );

--- a/src/components/Layout/FormPageLayout.tsx
+++ b/src/components/Layout/FormPageLayout.tsx
@@ -26,7 +26,7 @@ type FormPageLayoutProps<F> = {
   breadCrumb?: HeaderBreadcrumb | HeaderBreadcrumb[];
   formState: ObjectState<F>;
   formSections: FormSectionConfig<F>;
-  submitAction?: ActionButtonProps;
+  submitAction: ActionButtonProps;
   cancelAction?: ActionButtonProps;
   tertiaryAction?: ActionButtonProps;
   rightSideBar?: SidebarContentProps[];

--- a/src/forms/BoundForm.stories.tsx
+++ b/src/forms/BoundForm.stories.tsx
@@ -168,6 +168,7 @@ const genres: NestedOption<HasIdAndName>[] = [
 ];
 
 type AuthorInput = BaseAuthorInput & {
+  // iconCardSelection is required to test against a mapped type regression on `BoundFormRowInputs`
   iconCardSelection: boolean | null;
   iconCardGroupExample?: string[] | null;
   multiLineSelectExample?: string[] | null;

--- a/src/forms/BoundForm.stories.tsx
+++ b/src/forms/BoundForm.stories.tsx
@@ -98,7 +98,13 @@ export function LoadingBoundForm() {
     if (loadedData) return;
 
     setTimeout(() => {
-      setLoadedData({ firstName: "John", middleInitial: "C", lastName: "Doe", bio: "Some bio" });
+      setLoadedData({
+        firstName: "John",
+        middleInitial: "C",
+        lastName: "Doe",
+        bio: "Some bio",
+        iconCardSelection: true,
+      });
     }, 1000);
   }, [loadedData]);
 
@@ -162,7 +168,7 @@ const genres: NestedOption<HasIdAndName>[] = [
 ];
 
 type AuthorInput = BaseAuthorInput & {
-  iconCardSelection?: boolean | null;
+  iconCardSelection: boolean | null;
   iconCardGroupExample?: string[] | null;
   multiLineSelectExample?: string[] | null;
   radioGroupExample?: string | null;

--- a/src/forms/BoundForm.tsx
+++ b/src/forms/BoundForm.tsx
@@ -5,7 +5,7 @@ import { Css, Only, Properties } from "src/Css";
 import { useComputed } from "src/hooks";
 import { Value } from "src/inputs/Value";
 import { TextFieldXss } from "src/interfaces";
-import { fail, safeEntries, useTestIds } from "src/utils";
+import { fail, useTestIds } from "src/utils";
 import { BoundCheckboxField, BoundCheckboxFieldProps } from "./BoundCheckboxField";
 import { BoundCheckboxGroupField, BoundCheckboxGroupFieldProps } from "./BoundCheckboxGroupField";
 import { BoundDateField, BoundDateFieldProps } from "./BoundDateField";
@@ -38,13 +38,15 @@ type TReactNodePrefix<S extends string> = `${typeof reactNodePrefix}${Capitalize
 
 type CustomReactNodeKey = `${typeof reactNodePrefix}${string}`;
 
-type BoundFormRowInputs<F> = Partial<{
-  [K in keyof F]: BoundFieldInputFn<F>;
-}> & {
-  [K in CustomReactNodeKey]: ReactNode;
-} & {
-  [K in keyof F as TReactNodePrefix<K & string>]: ReactNode;
-};
+type BoundFormRowInputs<F> = Partial<
+  {
+    [K in keyof F]: BoundFieldInputFn<F>;
+  } & {
+    [K in CustomReactNodeKey]: ReactNode;
+  } & {
+    [K in keyof F as TReactNodePrefix<K & string>]: ReactNode;
+  }
+>;
 
 export type BoundFormInputConfig<F> = BoundFormRowInputs<F>[];
 
@@ -90,9 +92,9 @@ function FormRow<F>({ row, formState }: { row: BoundFormRowInputs<F>; formState:
 
   /**  Extract the bound input components with their sizing config or render any "custom" JSX node as-is */
   const componentsWithConfig = useMemo(() => {
-    return safeEntries(row).map(([key, fieldFnOrCustomNode]) => {
+    return Object.entries(row).map(([key, fieldFnOrCustomNode]) => {
       if (typeof fieldFnOrCustomNode === "function" && !isCustomReactNodeKey(key)) {
-        const field = formState[key] ?? fail(`Field ${key.toString()} not found in formState`);
+        const field = formState[key as keyof F] ?? fail(`Field ${key.toString()} not found in formState`);
         const fieldFn =
           (fieldFnOrCustomNode as BoundFormRowInputs<F>[keyof F]) ??
           fail(`Field function not defined for key ${key.toLocaleString()}`);

--- a/src/forms/SubmitButton.tsx
+++ b/src/forms/SubmitButton.tsx
@@ -1,6 +1,7 @@
 import { ObjectState } from "@homebound/form-state";
 import { useLocalObservable } from "mobx-react";
-import { Button, ButtonProps, useComputed } from "src";
+import { useComputed } from "src";
+import { Button, ButtonProps } from "src/components/Button";
 
 export type SubmitButtonProps<T> = Omit<ButtonProps, "label"> & {
   label?: ButtonProps["label"];

--- a/src/inputs/Checkbox.stories.tsx
+++ b/src/inputs/Checkbox.stories.tsx
@@ -31,6 +31,12 @@ export function Checkboxes() {
           <Checkbox onChange={action("onChange")} selected="indeterminate" label="Indeterminate" />
           <Checkbox onChange={action("onChange")} selected={false} disabled label="Disabled while unselected" />
           <Checkbox onChange={action("onChange")} selected={true} disabled label="Disabled while selected" />
+          <Checkbox
+            onChange={action("onChange")}
+            selected={true}
+            disabled="Reason for disabled..."
+            label="Disabled with tooltip while selected"
+          />
         </div>
       </div>
       <div>

--- a/src/inputs/Checkbox.tsx
+++ b/src/inputs/Checkbox.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useRef } from "react";
 import { useCheckbox } from "react-aria";
 import { useToggleState } from "react-stately";
+import { resolveTooltip } from "src/components";
 import { CheckboxBase } from "src/inputs/CheckboxBase";
 
 export interface CheckboxProps {
@@ -16,7 +17,8 @@ export interface CheckboxProps {
   onChange: (selected: boolean) => void;
   /** Additional text displayed below label */
   description?: string;
-  disabled?: boolean;
+  /** Whether the field is disabled. If a ReactNode, it's treated as a "disabled reason" that's shown in a tooltip. */
+  disabled?: boolean | ReactNode;
   errorMsg?: string;
   helperText?: string | ReactNode;
   /** Callback fired when focus removes from the component */
@@ -26,11 +28,11 @@ export interface CheckboxProps {
 }
 
 export function Checkbox(props: CheckboxProps) {
-  const { label, disabled: isDisabled = false, selected, ...otherProps } = props;
+  const { label, disabled = false, selected, ...otherProps } = props;
   // Treat indeterminate as false so that clicking on indeterminate always goes --> true.
   const isSelected = selected === true;
   const isIndeterminate = selected === "indeterminate";
-  const ariaProps = { isSelected, isDisabled, isIndeterminate, ...otherProps };
+  const ariaProps = { isSelected, isDisabled: !!disabled, isIndeterminate, ...otherProps };
   const checkboxProps = { ...ariaProps, "aria-label": label };
   const ref = useRef(null);
   const toggleState = useToggleState(ariaProps);
@@ -39,11 +41,12 @@ export function Checkbox(props: CheckboxProps) {
   return (
     <CheckboxBase
       ariaProps={ariaProps}
-      isDisabled={isDisabled}
+      isDisabled={ariaProps.isDisabled}
       isIndeterminate={isIndeterminate}
       isSelected={isSelected}
       inputProps={inputProps}
       label={label}
+      tooltip={resolveTooltip(disabled)}
       {...otherProps}
     />
   );

--- a/src/inputs/CheckboxBase.tsx
+++ b/src/inputs/CheckboxBase.tsx
@@ -1,6 +1,6 @@
 import { InputHTMLAttributes, ReactNode, useRef } from "react";
 import { mergeProps, useFocusRing, useHover, VisuallyHidden } from "react-aria";
-import { HelperText } from "src/components/HelperText";
+import { HelperText, maybeTooltip } from "src/components";
 import { Css, Palette, px } from "src/Css";
 import { ErrorMessage } from "src/inputs/ErrorMessage";
 import { BeamFocusableProps } from "src/interfaces";
@@ -31,6 +31,8 @@ export interface CheckboxBaseProps extends BeamFocusableProps {
    * @default true
    */
   withLabelElement?: boolean;
+  /** Tooltip content is set when disabled prop is a ReactNode via `Checkbox` component */
+  tooltip?: ReactNode;
 }
 
 export function CheckboxBase(props: CheckboxBaseProps) {
@@ -45,6 +47,7 @@ export function CheckboxBase(props: CheckboxBaseProps) {
     helperText,
     checkboxOnly = false,
     withLabelElement = true,
+    tooltip,
   } = props;
   const ref = useRef(null);
   const { isFocusVisible, focusProps } = useFocusRing(ariaProps);
@@ -52,36 +55,40 @@ export function CheckboxBase(props: CheckboxBaseProps) {
 
   const Tag = withLabelElement ? "label" : "div";
 
-  return (
-    <Tag
-      css={
-        Css.df.cursorPointer.relative
-          // Prevents accidental checkbox clicks due to label width being longer
-          // than the content.
-          .w("max-content")
-          .maxw(px(320))
-          .if(description !== undefined)
-          .maxw(px(344))
-          .if(isDisabled).cursorNotAllowed.$
-      }
-      aria-label={label}
-    >
-      <VisuallyHidden>
-        <input ref={ref} {...mergeProps(inputProps, focusProps)} {...tid} data-indeterminate={isIndeterminate} />
-      </VisuallyHidden>
-      <StyledCheckbox {...props} isFocusVisible={isFocusVisible} {...tid} />
-      {!checkboxOnly && (
-        // Use a mtPx(-2) to better align the label with the checkbox.
-        // Not using align-items: center as the checkbox would align with all content below, where we really want it to stay only aligned with the label
-        <div css={Css.ml1.mtPx(-2).$}>
-          {label && <div css={{ ...labelStyles, ...(isDisabled && disabledColor) }}>{label}</div>}
-          {description && <div css={{ ...descStyles, ...(isDisabled && disabledColor) }}>{description}</div>}
-          {errorMsg && <ErrorMessage errorMsg={errorMsg} {...tid.errorMsg} />}
-          {helperText && <HelperText helperText={helperText} {...tid.helperText} />}
-        </div>
-      )}
-    </Tag>
-  );
+  return maybeTooltip({
+    title: tooltip,
+    placement: "top",
+    children: (
+      <Tag
+        css={
+          Css.df.cursorPointer.relative
+            // Prevents accidental checkbox clicks due to label width being longer
+            // than the content.
+            .w("max-content")
+            .maxw(px(320))
+            .if(description !== undefined)
+            .maxw(px(344))
+            .if(isDisabled).cursorNotAllowed.$
+        }
+        aria-label={label}
+      >
+        <VisuallyHidden>
+          <input ref={ref} {...mergeProps(inputProps, focusProps)} {...tid} data-indeterminate={isIndeterminate} />
+        </VisuallyHidden>
+        <StyledCheckbox {...props} isFocusVisible={isFocusVisible} {...tid} />
+        {!checkboxOnly && (
+          // Use a mtPx(-2) to better align the label with the checkbox.
+          // Not using align-items: center as the checkbox would align with all content below, where we really want it to stay only aligned with the label
+          <div css={Css.ml1.mtPx(-2).$}>
+            {label && <div css={{ ...labelStyles, ...(isDisabled && disabledColor) }}>{label}</div>}
+            {description && <div css={{ ...descStyles, ...(isDisabled && disabledColor) }}>{description}</div>}
+            {errorMsg && <ErrorMessage errorMsg={errorMsg} {...tid.errorMsg} />}
+            {helperText && <HelperText helperText={helperText} {...tid.helperText} />}
+          </div>
+        )}
+      </Tag>
+    ),
+  });
 }
 
 const baseStyles = Css.hPx(16).mw(px(16)).relative.ba.bcGray300.br4.bgWhite.transition.$;


### PR DESCRIPTION
A couple of small changes I noticed while implementing a `FormPageLayout`
* Addresses feedback on making the `submitAction` prop required from here: https://github.com/homebound-team/beam/pull/1123#discussion_r2024891966
* Fixes a type issue where the mapped type for `reactNode*` keys were not made optional if an input type for the form was required
* Also allows the checkbox to show a disabled tooltip
* Swaps out the normal submit action button with `SubmitButton` for the new standard disabled state behavior.