### PR TITLE
feat(accordion): add onToggle

### DIFF
--- a/src/components/Accordion.test.tsx
+++ b/src/components/Accordion.test.tsx
@@ -89,6 +89,23 @@ describe(Accordion, () => {
     expect(titleOnClick).toHaveBeenCalled();
   });
 
+  it("calls the onToggle function when the accordion is expanded/collapsed", async () => {
+    // Given an accordion component with onToggle set
+    const onToggle = jest.fn();
+    // When rendered
+    const r = await render(
+      <Accordion title="Test title" titleOnClick={onToggle}>
+        Test description
+      </Accordion>,
+    );
+    // Then the onToggle function is called when the accordion is expanded
+    click(r.accordion_title);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    // And when it's collapsed
+    click(r.accordion_title);
+    expect(onToggle).toHaveBeenCalledTimes(2);
+  });
+
   it("alters expando behavior when titleOnClick is provided", async () => {
     // When rendered with a titleOnClick set
     const r = await render(

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -22,6 +22,7 @@ export interface AccordionProps<X = AccordionXss> {
    * Allows multiple accordions to be expanded simultaneously (enabled by default)
    */
   index?: number;
+  onToggle?: VoidFunction;
   setExpandedIndex?: Dispatch<SetStateAction<number | undefined>>;
   /** Turns the title into a button. If provided, disables expand/collapse on title text */
   titleOnClick?: VoidFunction;
@@ -46,6 +47,7 @@ export function Accordion<X extends Only<AccordionXss, X>>(props: AccordionProps
     index,
     setExpandedIndex,
     titleOnClick,
+    onToggle,
     omitPadding = false,
     xss,
   } = props;
@@ -82,7 +84,8 @@ export function Accordion<X extends Only<AccordionXss, X>>(props: AccordionProps
   const toggle = useCallback(() => {
     setExpanded((prev) => !prev);
     if (setExpandedIndex) setExpandedIndex(index);
-  }, [index, setExpandedIndex]);
+    if (onToggle) onToggle();
+  }, [index, setExpandedIndex, onToggle]);
 
   const touchableStyle = useMemo(
     () => ({


### PR DESCRIPTION
While `titleOnClick` does something similar, we also need a way to run logic when the accordion is expanded/collapsed without modifying the title or `RotatingChevronIcon` behavior.