### PR TITLE
feat: [SC-68648] Bound Form List Field Support

### DIFF
--- a/src/forms/BoundForm.stories.tsx
+++ b/src/forms/BoundForm.stories.tsx
@@ -37,7 +37,7 @@ export default {
 export function BoundForm() {
   const formState = useFormState({
     config: formConfig,
-    init: { input: { firstName: "John", lastName: "Doe" } },
+    init: { input: { firstName: "John", lastName: "Doe", books: [{ id: "b:1", title: "Book 1", isPublished: true }] } },
   });
 
   return (
@@ -221,6 +221,23 @@ const inputConfig: BoundFormInputConfig<AuthorInput> = [
     }),
   },
 
+  {
+    listFieldBooks: {
+      name: "Book",
+      rows: [{ title: boundTextField(), isPublished: boundSwitchField() }],
+      defaultValues: { isPublished: false, title: undefined },
+      onDelete: (field, objectState) => {
+        console.log(objectState.id.value);
+        if (objectState.id.value) {
+          objectState.set({ delete: true });
+        } else {
+          field.remove(objectState.value);
+        }
+      },
+      filterDeleted: (objectState) => !objectState.delete?.value,
+    },
+  },
+
   // We can support any custom JSX node using the key `reactNode*`
   { reactNodeA: <CustomComponent /> },
 ];
@@ -246,4 +263,13 @@ const formConfig: ObjectConfig<AuthorInput> = {
   switchFieldExample2: { type: "value" },
   toggleChipGroupField: { type: "value" },
   treeSelectExample: { type: "value" },
+  books: {
+    type: "list",
+    config: {
+      id: { type: "value" },
+      isPublished: { type: "value" },
+      title: { type: "value" },
+      delete: { type: "value" },
+    },
+  },
 };

--- a/src/forms/BoundForm.stories.tsx
+++ b/src/forms/BoundForm.stories.tsx
@@ -228,11 +228,11 @@ const inputConfig: BoundFormInputConfig<AuthorInput> = [
       onNew: (objectState) => {
         objectState.add({ title: undefined, isPublished: false });
       },
-      onDelete: (field, objectState) => {
-        if (objectState.id.value) {
-          objectState.set({ delete: true });
+      onDelete: (listFieldState, rowObjectState) => {
+        if (rowObjectState.id.value) {
+          rowObjectState.set({ delete: true });
         } else {
-          field.remove(objectState.value);
+          listFieldState.remove(rowObjectState.value);
         }
       },
       filterDeleted: (objectState) => !objectState.delete?.value,

--- a/src/forms/BoundForm.stories.tsx
+++ b/src/forms/BoundForm.stories.tsx
@@ -1,4 +1,4 @@
-import { ObjectConfig, required, useFormState } from "@homebound/form-state";
+import { FieldState, ObjectConfig, required, useFormState } from "@homebound/form-state";
 import { Meta } from "@storybook/react";
 import { useEffect, useState } from "react";
 import { Css } from "src/Css";
@@ -27,6 +27,7 @@ import { NestedOption } from "src/inputs";
 import { IconCardGroupItemOption } from "src/inputs/IconCardGroup";
 import { HasIdAndName } from "src/types";
 import { withBeamDecorator } from "src/utils/sb";
+import { BoundTextAreaField } from "./BoundTextAreaField";
 import { AuthorInput as BaseAuthorInput } from "./formStateDomain";
 
 export default {
@@ -37,7 +38,13 @@ export default {
 export function BoundForm() {
   const formState = useFormState({
     config: formConfig,
-    init: { input: { firstName: "John", lastName: "Doe", books: [{ id: "b:1", title: "Book 1", isPublished: true }] } },
+    init: {
+      input: {
+        firstName: "John",
+        lastName: "Doe",
+        books: [{ id: "b:1", title: "Book 1", isPublished: true, summary: "Example summary" }],
+      },
+    },
   });
 
   return (
@@ -123,6 +130,16 @@ export function LoadingBoundForm() {
 
 function CustomComponent() {
   return <div css={Css.p4.br4.ba.bcGray200.$}>Example Custom Component</div>;
+}
+
+// Wrapper around the BoundTextAreaField to test the `reactNode: (rowState) => ReactNode`
+// works for getting access to "row" level object states for list fields
+function CustomSummaryField({ field }: { field: FieldState<string | null | undefined> }) {
+  return (
+    <div>
+      <BoundTextAreaField label="Summary" field={field} />
+    </div>
+  );
 }
 
 const sportsOptions = [
@@ -224,9 +241,13 @@ const inputConfig: BoundFormInputConfig<AuthorInput> = [
   {
     listFieldBooks: {
       name: "Book",
-      rows: [{ title: boundTextField() }, { isPublished: boundSwitchField() }],
+      rows: [
+        { title: boundTextField() },
+        { isPublished: boundSwitchField() },
+        { reactNodeSummary: (rowState) => <CustomSummaryField field={rowState.summary} /> },
+      ],
       onNew: (objectState) => {
-        objectState.add({ title: undefined, isPublished: false });
+        objectState.add({ title: undefined, isPublished: false, summary: undefined });
       },
       onDelete: (listFieldState, rowObjectState) => {
         if (rowObjectState.id.value) {
@@ -271,6 +292,7 @@ const formConfig: ObjectConfig<AuthorInput> = {
       isPublished: { type: "value" },
       title: { type: "value", rules: [required] },
       delete: { type: "value" },
+      summary: { type: "value" },
     },
   },
 };

--- a/src/forms/BoundForm.stories.tsx
+++ b/src/forms/BoundForm.stories.tsx
@@ -256,7 +256,7 @@ const inputConfig: BoundFormInputConfig<AuthorInput> = [
           listFieldState.remove(rowObjectState.value);
         }
       },
-      filterDeleted: (objectState) => !objectState.delete?.value,
+      filterDeleted: (rowObjectState) => !rowObjectState.delete?.value,
     },
   },
 

--- a/src/forms/BoundForm.stories.tsx
+++ b/src/forms/BoundForm.stories.tsx
@@ -225,7 +225,9 @@ const inputConfig: BoundFormInputConfig<AuthorInput> = [
     listFieldBooks: {
       name: "Book",
       rows: [{ title: boundTextField() }, { isPublished: boundSwitchField() }],
-      defaultValues: { isPublished: false, title: undefined },
+      onNew: (objectState) => {
+        objectState.add({ title: undefined, isPublished: false });
+      },
       onDelete: (field, objectState) => {
         if (objectState.id.value) {
           objectState.set({ delete: true });

--- a/src/forms/BoundForm.stories.tsx
+++ b/src/forms/BoundForm.stories.tsx
@@ -224,10 +224,9 @@ const inputConfig: BoundFormInputConfig<AuthorInput> = [
   {
     listFieldBooks: {
       name: "Book",
-      rows: [{ title: boundTextField(), isPublished: boundSwitchField() }],
+      rows: [{ title: boundTextField() }, { isPublished: boundSwitchField() }],
       defaultValues: { isPublished: false, title: undefined },
       onDelete: (field, objectState) => {
-        console.log(objectState.id.value);
         if (objectState.id.value) {
           objectState.set({ delete: true });
         } else {
@@ -268,7 +267,7 @@ const formConfig: ObjectConfig<AuthorInput> = {
     config: {
       id: { type: "value" },
       isPublished: { type: "value" },
-      title: { type: "value" },
+      title: { type: "value", rules: [required] },
       delete: { type: "value" },
     },
   },

--- a/src/forms/BoundForm.test.tsx
+++ b/src/forms/BoundForm.test.tsx
@@ -1,12 +1,22 @@
 import { createObjectState, ObjectConfig, required } from "@homebound/form-state";
-import { render } from "src/utils/rtl";
+import { act } from "@testing-library/react";
+import { click, render } from "src/utils/rtl";
 import { boundCheckboxField, BoundForm, boundTextField } from "./BoundForm";
+import { ListFieldConfig } from "./BoundListField";
 import { AuthorInput } from "./formStateDomain";
 
 const formConfig: ObjectConfig<AuthorInput> = {
   isAvailable: { type: "value", rules: [required] },
   firstName: { type: "value", rules: [required] },
   lastName: { type: "value" },
+  books: {
+    type: "list",
+    config: {
+      title: { type: "value", rules: [required] },
+      isPublished: { type: "value" },
+      delete: { type: "value" },
+    },
+  },
 };
 
 describe("BoundForm", () => {
@@ -29,5 +39,101 @@ describe("BoundForm", () => {
     expect(r.firstName).toHaveValue("John");
     expect(r.lastName).toHaveValue("Doe");
     expect(r.isAvailable).toBeChecked();
+  });
+
+  describe("BoundListField", () => {
+    it("renders list field with items", async () => {
+      // Given a formState with a list field containing items
+      const formState = createObjectState(formConfig, {
+        firstName: "John",
+        books: [
+          { title: "Book 1", isPublished: true },
+          { title: "Book 2", isPublished: false },
+        ],
+      });
+
+      const listFieldConfig: ListFieldConfig<AuthorInput, "books"> = {
+        name: "Book",
+        rows: [{ title: boundTextField() }, { isPublished: boundCheckboxField() }],
+        onNew: (objectState) => {
+          objectState.add({ title: "", isPublished: false });
+        },
+      };
+
+      // When rendered with a list field
+      const r = await render(<BoundForm formState={formState} rows={[{ listFieldBooks: listFieldConfig }]} />);
+
+      // Then expect the list field to be rendered with its items
+      expect(r.listField).toBeInTheDocument();
+      expect(r.getAllByTestId("listFieldRow")).toHaveLength(2);
+      expect(r.listFieldRow_name_0).toHaveTextContent("Book 1");
+      expect(r.listFieldRow_name_1).toHaveTextContent("Book 2");
+    });
+
+    it("adds new items to list field", async () => {
+      // Given a formState with an empty list field
+      const formState = createObjectState(formConfig, {
+        firstName: "John",
+        books: [],
+      });
+
+      const listFieldConfig: ListFieldConfig<AuthorInput, "books"> = {
+        name: "Book",
+        rows: [{ title: boundTextField() }, { isPublished: boundCheckboxField() }],
+        onNew: (objectState) => {
+          objectState.add({ title: "", isPublished: false });
+        },
+      };
+
+      // When rendered with a list field
+      const r = await render(<BoundForm formState={formState} rows={[{ listFieldBooks: listFieldConfig }]} />);
+
+      // And the add button is clicked
+      act(() => click(r.addBook));
+
+      // Then expect a new item to be added
+      expect(r.getAllByTestId("listFieldRow")).toHaveLength(1);
+      expect(r.listFieldRow_name_0).toHaveTextContent("Book 1");
+    });
+
+    it("deletes items from list field", async () => {
+      // Given a formState with a list field containing items
+      const formState = createObjectState(formConfig, {
+        firstName: "John",
+        books: [
+          { title: "Book 1", isPublished: true },
+          { title: "Book 2", isPublished: false },
+        ],
+      });
+
+      const listFieldConfig: ListFieldConfig<AuthorInput, "books"> = {
+        name: "Book",
+        rows: [{ title: boundTextField() }, { isPublished: boundCheckboxField() }],
+        onNew: (objectState) => {
+          objectState.add({ title: "", isPublished: false });
+        },
+        onDelete: (listFieldState, rowObjectState) => {
+          if (rowObjectState.id?.value) {
+            rowObjectState.set({ delete: true });
+          } else {
+            listFieldState.remove(rowObjectState.value);
+          }
+        },
+        filterDeleted: (objectState) => !objectState.delete?.value,
+      };
+
+      // When rendered with a list field
+      const r = await render(<BoundForm formState={formState} rows={[{ listFieldBooks: listFieldConfig }]} />);
+
+      // We expect the two book rows to be rendered
+      expect(r.getAllByTestId("listFieldRow")).toHaveLength(2);
+
+      // And the delete button is clicked for the first book
+      act(() => click(r.listFieldRow_menu_0));
+      act(() => click(r.listFieldRow_menu_delete));
+
+      // Then expect the first book to be removed from the list
+      expect(r.getAllByTestId("listFieldRow")).toHaveLength(1);
+    });
   });
 });

--- a/src/forms/BoundForm.tsx
+++ b/src/forms/BoundForm.tsx
@@ -1,5 +1,5 @@
 import { FieldState, ObjectState } from "@homebound/form-state";
-import { ReactNode, useMemo } from "react";
+import { ReactNode, useCallback, useMemo } from "react";
 import { LoadingSkeleton } from "src/components";
 import { Css, Only, Properties } from "src/Css";
 import { useComputed } from "src/hooks";
@@ -38,7 +38,7 @@ const reactNodePrefix = "reactNode";
 type TReactNodePrefix<S extends string> = `${typeof reactNodePrefix}${CapitalizeFirstLetter<S>}`;
 type CustomReactNodeKey = `${typeof reactNodePrefix}${string}`;
 
-const listFieldPrefix = "listField";
+export const listFieldPrefix = "listField";
 type TListFieldPrefix<S extends string> = `${typeof listFieldPrefix}${CapitalizeFirstLetter<S>}`;
 
 export type BoundFormRowInputs<F> = Partial<
@@ -81,6 +81,10 @@ export function BoundForm<F>(props: BoundFormProps<F>) {
 
   const tid = useTestIds({}, "boundForm");
 
+  const getRowKey = useCallback((row: BoundFormRowInputs<F>, rowType: string) => {
+    return `${rowType}-${Object.keys(row).join("-")}`;
+  }, []);
+
   return (
     <div {...tid}>
       <FormLines width="full" gap={3.5}>
@@ -94,10 +98,6 @@ export function BoundForm<F>(props: BoundFormProps<F>) {
       </FormLines>
     </div>
   );
-}
-
-function getRowKey<F>(row: BoundFormRowInputs<F>, rowType: string) {
-  return `${rowType}-${Object.keys(row).join("-")}`;
 }
 
 export function FormRow<F>({ row, formState }: { row: BoundFormRowInputs<F>; formState: ObjectState<F> }) {

--- a/src/forms/BoundForm.tsx
+++ b/src/forms/BoundForm.tsx
@@ -117,11 +117,10 @@ export function FormRow<F>({ row, formState }: { row: BoundFormRowInputs<F>; for
         return { component, key, minWidth };
       }
 
-      console.log(isCustomReactNodeKey(key), formState);
-      // Handle reactNode fields that are callbacks
+      // Handle reactNode fields that are functions (to get access to nested formState list rows)
       if (isCustomReactNodeKey(key) && typeof fieldFnOrCustomNode === "function") {
-        const nodeCallback = fieldFnOrCustomNode as (formState: ObjectState<F>) => ReactNode;
-        return { component: nodeCallback(formState), key };
+        const nodeAsFunction = fieldFnOrCustomNode as (formState: ObjectState<F>) => ReactNode;
+        return { component: nodeAsFunction(formState), key };
       }
 
       return { component: fieldFnOrCustomNode as ReactNode, key };

--- a/src/forms/BoundForm.tsx
+++ b/src/forms/BoundForm.tsx
@@ -154,7 +154,7 @@ function FormRow<F>({ row, formState }: { row: BoundFormRowInputs<F>; formState:
   const itemFlexBasis = 100 / componentsWithConfig.length - 3;
 
   return (
-    <div css={Css.df.fww.gap2.$} {...tid}>
+    <div css={Css.df.fww.aic.gap2.$} {...tid}>
       {componentsWithConfig.map(({ component, key, minWidth }) => (
         <div css={Css.mw(minWidth).fb(`${itemFlexBasis}%`).fg1.$} key={key.toString()}>
           {isLoading ? <LoadingSkeleton size="lg" /> : component}
@@ -184,6 +184,13 @@ function ListField<F>({ row, formState }: { row: BoundFormRowInputs<F>; formStat
     [filterDeleted],
   );
 
+  // Ensure all list rows are valid (satisfied rules) before allowing the user to add a new row
+  const listIsValid = useComputed(() => listFieldObjectState.valid, [filteredRows]);
+
+  const onAdd = useCallback(() => {
+    listFieldObjectState.add(Object.assign({}, listFieldConfig.defaultValues));
+  }, [listFieldObjectState, listFieldConfig]);
+
   return (
     <Observer>
       {() => (
@@ -202,8 +209,9 @@ function ListField<F>({ row, formState }: { row: BoundFormRowInputs<F>; formStat
             <Button
               icon="plus"
               label={`Add ${listFieldConfig.name}`}
-              onClick={() => listFieldObjectState.add(Object.assign({}, listFieldConfig.defaultValues))}
+              onClick={onAdd}
               variant="secondary"
+              disabled={!listIsValid}
             />
           </div>
         </div>

--- a/src/forms/BoundListField.tsx
+++ b/src/forms/BoundListField.tsx
@@ -1,0 +1,128 @@
+import { ListFieldState, ObjectState } from "@homebound/form-state";
+import { Observer } from "mobx-react";
+import { useCallback } from "react";
+import { Button, ButtonMenu } from "src/components";
+import { Css } from "src/Css";
+import { useComputed } from "src/hooks";
+import { fail } from "src/utils";
+import { BoundFormInputConfig, BoundFormRowInputs, FormRow } from "./BoundForm";
+
+// Helper type to identify array type fields in the input type that contain objects
+// Where books: Books[] would be a valid listField, but bookIds: string[] would not
+export type ListFieldKey<F> = {
+  [K in keyof F]: F[K] extends (infer T)[] | null | undefined ? (T extends object ? K : never) : never;
+}[keyof F];
+
+// Helper type to get the nested field keys from the listField input type
+export type ListSubFields<F, K extends keyof F> = F[K] extends (infer T)[] | null | undefined ? T : never;
+
+export type ListFieldConfig<F, K extends keyof F> = {
+  name: string;
+  onNew: (objectState: ListFieldState<ListSubFields<F, K>>) => void;
+  rows: BoundFormInputConfig<ListSubFields<F, K>>;
+  onDelete?: (field: ObjectState<F>[K], objectState: ObjectState<ListSubFields<F, K>>) => void;
+  filterDeleted?: (objectState: ObjectState<ListSubFields<F, K>>) => boolean;
+};
+
+export function ListField<F>({ row, formState }: { row: BoundFormRowInputs<F>; formState: ObjectState<F> }) {
+  const listFieldEntry = Object.entries(row).find(([key, _]) => isListFieldKey(key))!;
+  const [prefixedFormKey, fieldConfig] = listFieldEntry;
+  // Convert the prefixed listField key back to the original form key by stripping the prefix and lowercasing the first letter
+  const listFieldKey = prefixedFormKey.replace(new RegExp(`^listField(.)`), (_, c) =>
+    c.toLowerCase(),
+  ) as ListFieldKey<F>;
+  const listFieldConfig = fieldConfig as ListFieldConfig<F, keyof F>;
+  const listFieldObjectState = formState[listFieldKey] as unknown as ListFieldState<ListSubFields<F, keyof F>>;
+
+  const { filterDeleted, onNew } = listFieldConfig;
+
+  const filteredRows = useComputed(
+    () =>
+      filterDeleted
+        ? listFieldObjectState.rows.filter((rowState) => filterDeleted(rowState))
+        : listFieldObjectState.rows,
+    [filterDeleted],
+  );
+
+  // Ensure all list rows are valid (satisfied rules) before allowing the user to add a new row
+  const listIsValid = useComputed(() => listFieldObjectState.valid, [filteredRows]);
+
+  return (
+    <Observer>
+      {() => (
+        <div css={Css.df.fdc.gap3.ba.bcGray300.br4.p2.$}>
+          {filteredRows.map((rowState: ObjectState<ListSubFields<F, keyof F>>, index: number) => (
+            <ListFieldRowInputs
+              key={`listFieldRowInputs-${listFieldKey}-${index}`}
+              rowState={rowState}
+              rowNumber={index + 1}
+              listFieldConfig={listFieldConfig}
+              formState={formState}
+              listFieldKey={listFieldKey}
+            />
+          ))}
+          <div>
+            <Button
+              icon="plus"
+              label={`Add ${listFieldConfig.name}`}
+              onClick={() => onNew(listFieldObjectState)}
+              variant="secondary"
+              disabled={!listIsValid}
+            />
+          </div>
+        </div>
+      )}
+    </Observer>
+  );
+}
+
+function ListFieldRowInputs<F>({
+  rowState,
+  rowNumber,
+  listFieldConfig,
+  formState,
+  listFieldKey,
+}: {
+  rowState: ObjectState<ListSubFields<F, keyof F>>;
+  rowNumber: number;
+  listFieldConfig: ListFieldConfig<F, keyof F>;
+  formState: ObjectState<F>;
+  listFieldKey: ListFieldKey<F>;
+}) {
+  const { onDelete } = listFieldConfig;
+
+  const onRowDelete = useCallback(() => {
+    if (!onDelete) return;
+    onDelete(formState[listFieldKey], rowState);
+  }, [onDelete, formState, listFieldKey, rowState]);
+
+  return (
+    <>
+      <div css={Css.df.jcsb.pb1.bb.bcGray300.$}>
+        <span css={Css.baseSb.$}>
+          {listFieldConfig.name} {rowNumber}
+        </span>
+        {onDelete && (
+          <ButtonMenu trigger={{ icon: "verticalDots" }} items={[{ label: "Delete", onClick: onRowDelete }]} />
+        )}
+      </div>
+      {listFieldConfig.rows.map((row, rowIndex) => (
+        <FormRow key={`listField-${listFieldKey}-row-${rowIndex}`} row={row} formState={rowState} />
+      ))}
+    </>
+  );
+}
+
+export function isListFieldKey(key: string | number | symbol): key is ListFieldKey<unknown> {
+  return key.toString().startsWith("listField");
+}
+
+export function isListFieldRow<F>(row: BoundFormRowInputs<F>) {
+  const rowKeys = Object.keys(row);
+  const maybeListFieldKey = rowKeys.find((key) => isListFieldKey(key));
+  if (maybeListFieldKey) {
+    if (rowKeys.length > 1) fail("List fields cannot be combined with other fields in the same row");
+    return true;
+  }
+  return false;
+}

--- a/src/forms/BoundListField.tsx
+++ b/src/forms/BoundListField.tsx
@@ -23,7 +23,7 @@ export type ListFieldConfig<F, K extends keyof F> = {
    * it is passed the both the top-level `listFieldState` as well as the individual row/record `objectState`.
    * If left blank, the delete action menu will not be shown. */
   onDelete?: (listFieldState: ObjectState<F>[K], rowObjectState: ObjectState<ListSubFields<F, K>>) => void;
-  filterDeleted?: (objectState: ObjectState<ListSubFields<F, K>>) => boolean;
+  filterDeleted?: (rowObjectState: ObjectState<ListSubFields<F, K>>) => boolean;
 };
 
 export function ListField<F>({ row, formState }: { row: BoundFormRowInputs<F>; formState: ObjectState<F> }) {

--- a/src/forms/BoundListField.tsx
+++ b/src/forms/BoundListField.tsx
@@ -52,7 +52,7 @@ export function ListField<F>({ row, formState }: { row: BoundFormRowInputs<F>; f
   return (
     <Observer>
       {() => (
-        <div css={Css.df.fdc.gap3.ba.bcGray300.br4.p2.$}>
+        <div css={Css.df.fdc.gap3.$}>
           {filteredRows.map((rowState: ObjectState<ListSubFields<F, keyof F>>, index: number) => (
             <ListFieldRowInputs
               key={`listFieldRowInputs-${listFieldKey}-${index}`}
@@ -95,7 +95,7 @@ function ListFieldRowInputs<F>({
 
   return (
     <>
-      <div css={Css.df.jcsb.pb1.bb.bcGray300.$}>
+      <div css={Css.df.jcsb.$}>
         <span css={Css.baseSb.$}>
           {listFieldConfig.name} {rowNumber}
         </span>

--- a/src/forms/BoundListField.tsx
+++ b/src/forms/BoundListField.tsx
@@ -3,7 +3,7 @@ import { Observer } from "mobx-react";
 import { Button, ButtonMenu } from "src/components";
 import { Css } from "src/Css";
 import { useComputed } from "src/hooks";
-import { fail } from "src/utils";
+import { fail, useTestIds } from "src/utils";
 import { BoundFormInputConfig, BoundFormRowInputs, FormRow, listFieldPrefix } from "./BoundForm";
 
 // Helper type to identify array type fields in the input type that contain objects
@@ -37,6 +37,7 @@ export function ListField<F>({ row, formState }: { row: BoundFormRowInputs<F>; f
   const listFieldObjectState = formState[listFieldKey] as unknown as ListFieldState<ListSubFields<F, keyof F>>;
 
   const { filterDeleted, onNew } = listFieldConfig;
+  const tid = useTestIds({}, "listField");
 
   const filteredRows = useComputed(
     () =>
@@ -52,7 +53,7 @@ export function ListField<F>({ row, formState }: { row: BoundFormRowInputs<F>; f
   return (
     <Observer>
       {() => (
-        <div css={Css.df.fdc.gap3.$}>
+        <div css={Css.df.fdc.gap3.$} {...tid}>
           {filteredRows.map((rowState: ObjectState<ListSubFields<F, keyof F>>, index: number) => (
             <ListFieldRowInputs
               key={`listFieldRowInputs-${listFieldKey}-${index}`}
@@ -92,17 +93,19 @@ function ListFieldRowInputs<F>({
   listFieldKey: ListFieldKey<F>;
 }) {
   const { onDelete } = listFieldConfig;
+  const tid = useTestIds({}, "listFieldRow");
 
   return (
     <>
-      <div css={Css.df.jcsb.$}>
-        <span css={Css.baseSb.$}>
+      <div css={Css.df.jcsb.$} {...tid}>
+        <span css={Css.baseSb.$} {...tid.name}>
           {listFieldConfig.name} {rowNumber}
         </span>
         {onDelete && (
           <ButtonMenu
             trigger={{ icon: "verticalDots" }}
             items={[{ label: "Delete", onClick: () => onDelete(formState[listFieldKey], rowState) }]}
+            {...tid.menu}
           />
         )}
       </div>

--- a/src/forms/formStateDomain.ts
+++ b/src/forms/formStateDomain.ts
@@ -47,6 +47,7 @@ export interface AuthorAddress {
 export interface BookInput {
   id?: string | null | undefined;
   title?: string | null | undefined;
+  summary?: string | null | undefined;
   classification?: DeweyDecimalClassification;
   delete?: boolean | null | undefined;
   isPublished?: boolean;


### PR DESCRIPTION
Provides a standardized way to implement a "list" type filed from `form-state` within the new `BoundForm` layout
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/3951edd2-5b73-4353-baae-28dd832fbff4" />

Example config:
```ts
  {
    listFieldBooks: {
      name: "Book",
      rows: [{ title: boundTextField() }, { isPublished: boundSwitchField() }],
      onNew: (objectState) => {
        objectState.add({ title: undefined, isPublished: false });
      },
      onDelete: (listFieldState, rowObjectState) => {
        if (rowObjectState.id.value) {
          rowObjectState.set({ delete: true });
        } else {
          listFieldState.remove(rowObjectState.value);
        }
      },
      filterDeleted: (objectState) => !objectState.delete?.value,
    }
```
