### PR TITLE
fix: Attempting to fix ScrollShadow chromatic snapshots

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,9 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "eslint.format.enable": true,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "always"
+  },
   "[typescript]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },

--- a/src/components/ScrollShadows.tsx
+++ b/src/components/ScrollShadows.tsx
@@ -51,16 +51,12 @@ export function ScrollShadows(props: ScrollShadowsProps) {
       setShowStartShadow(start > 0);
       setShowEndShadow(start + boxSize < end);
     },
-    // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [],
+    [horizontal],
   );
 
   // Use a ResizeObserver to update the scroll props to determine if the shadows should be shown.
   // This executes on render and subsequent resizes which could be due to content/`children` changes (such as responses from APIs).
-  // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const onResize = useCallback(() => scrollRef.current && updateScrollProps(scrollRef.current), []);
+  const onResize = useCallback(() => scrollRef.current && updateScrollProps(scrollRef.current), [updateScrollProps]);
   useResizeObserver({ ref: scrollRef, onResize });
 
   return (
@@ -73,8 +69,8 @@ export function ScrollShadows(props: ScrollShadowsProps) {
       }
       {...tid}
     >
-      {showStartShadow && <div css={startShadowStyles} />}
-      {showEndShadow && <div css={endShadowStyles} />}
+      <div css={{ ...startShadowStyles, opacity: showStartShadow ? 1 : 0 }} data-chromatic="ignore" />
+      <div css={{ ...endShadowStyles, opacity: showEndShadow ? 1 : 0 }} data-chromatic="ignore" />
       <div
         css={{
           ...xss,


### PR DESCRIPTION
The idea behind this fix is to use data-chromatic="ignore", as defined in https://www.chromatic.com/docs/ignoring-elements/. I'm thinking it'd be better to always have these elements present to be ignored. Not sure if even with the ignore attribute, having the shadow elements sometimes render and sometimes not would cause the same inconsistencies (which is the current issue).