### PR TITLE
feat: Update Chip components

### DIFF
--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -62,13 +62,13 @@ const typeStyles: Record<ChipType, Properties> = {
   success: Css.bgGreen100.$,
   light: Css.bgWhite.$,
   dark: Css.bgGray900.white.$,
-  neutral: Css.bgGray100.$,
+  neutral: Css.bgGray200.$,
   darkMode: Css.bgGray700.white.$,
   info: Css.bgBlue100.$,
 };
 
 export const chipBaseStyles = (compact?: boolean) =>
-  Css.xsMd.dif.aic.br16.px1.gapPx(4).pyPx(pyHeight(compact)).mhPx(minhPx(compact)).gray900.bgGray100.$;
+  Css.xsMd.dif.aic.br16.px1.gapPx(4).pyPx(pyHeight(compact)).mhPx(minhPx(compact)).gray900.bgGray200.$;
 
 const pyHeight = (compact?: boolean) => (compact ? 2 : 4);
 const minhPx = (compact?: boolean) => (compact ? 20 : 24);

--- a/src/components/Chip.tsx
+++ b/src/components/Chip.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, useMemo } from "react";
 import { Icon, IconKey } from "src/components/Icon";
 import { usePresentationContext } from "src/components/PresentationContext";
 import { maybeTooltip } from "src/components/Tooltip";
@@ -23,32 +23,32 @@ export interface ChipProps<X> {
   text: ReactNode;
   title?: ReactNode;
   xss?: X;
+  // Defaults to "neutral"
   type?: ChipType;
   compact?: boolean;
   icon?: IconKey;
 }
 
 /** Kinda like a chip, but read-only, so no `onClick` or `hover`. */
-export function Chip<X extends Only<Xss<Margin | "color" | "backgroundColor">, X>>({
-  type = ChipTypes.neutral,
-  ...props
-}: ChipProps<X>) {
+export function Chip<X extends Only<Xss<Margin | "color" | "backgroundColor">, X>>(props: ChipProps<X>) {
   const { fieldProps } = usePresentationContext();
-  const { text, title, xss = {}, compact = fieldProps?.compact, icon } = props;
+  const { text, title, xss = {}, compact = fieldProps?.compact, icon, type = ChipTypes.neutral } = props;
   const tid = useTestIds(props, "chip");
+
+  const styles = useMemo(
+    () => ({
+      ...chipBaseStyles(compact),
+      ...typeStyles[type],
+      ...xss,
+    }),
+    [type, xss, compact],
+  );
 
   return maybeTooltip({
     title,
     placement: "bottom",
     children: (
-      <span
-        css={{
-          ...Css[compact ? "xs" : "sm"].dif.aic.gapPx(4).br16.pl1.px1.pyPx(2).gray900.$,
-          ...typeStyles[type],
-          ...xss,
-        }}
-        {...tid}
-      >
+      <span css={styles} {...tid}>
         {icon && <Icon icon={icon} inc={2} xss={Css.fs0.$} />}
         <span css={Css.lineClamp1.wbba.$}>{text}</span>
       </span>
@@ -58,11 +58,17 @@ export function Chip<X extends Only<Xss<Margin | "color" | "backgroundColor">, X
 
 const typeStyles: Record<ChipType, Properties> = {
   caution: Css.bgYellow200.$,
-  warning: Css.bgRed200.$,
-  success: Css.bgGreen200.$,
+  warning: Css.bgRed100.$,
+  success: Css.bgGreen100.$,
   light: Css.bgWhite.$,
   dark: Css.bgGray900.white.$,
-  neutral: Css.bgGray200.$,
+  neutral: Css.bgGray100.$,
   darkMode: Css.bgGray700.white.$,
   info: Css.bgBlue100.$,
 };
+
+export const chipBaseStyles = (compact?: boolean) =>
+  Css.xsMd.dif.aic.br16.px1.gapPx(4).pyPx(pyHeight(compact)).mhPx(minhPx(compact)).gray900.bgGray100.$;
+
+const pyHeight = (compact?: boolean) => (compact ? 2 : 4);
+const minhPx = (compact?: boolean) => (compact ? 20 : 24);

--- a/src/components/Chips.test.tsx
+++ b/src/components/Chips.test.tsx
@@ -6,19 +6,23 @@ describe("Chips", () => {
     { text: "123", title: "tooltip" },
     { text: "abc", title: "" },
   ];
+
   it("renders", async () => {
     const r = await render(<Chips values={values} />);
+
     expect(r.chip_0.textContent).toBe("123");
     expect(r.chip_1.textContent).toBe("abc");
     expect(r.tooltip).toHaveAttribute("title", "tooltip");
+    expect(r.chip_0).toHaveStyle({
+      "min-height": "24px",
+    });
   });
 
-  it("can set compact to change size to xs", async () => {
+  it("can set compact to change size", async () => {
     const r = await render(<Chips values={values} compact />);
+
     expect(r.chip_0).toHaveStyle({
-      fontSize: "12px",
-      fontWeight: "400",
-      lineHeight: "16px",
+      "min-height": "20px",
     });
   });
 });

--- a/src/components/ToggleChip.stories.tsx
+++ b/src/components/ToggleChip.stories.tsx
@@ -14,45 +14,54 @@ export default {
   },
 } as Meta;
 
-export const DefaultToggleChip = newStory(
+export const Default = newStory(
   () => (
-    <div css={Css.df.fdc.gap4.bgWhite.p2.$}>
-      <div>
-        <h2 css={Css.mb1.$}>Standard</h2>
-        <div css={Css.wPx(300).df.fdc.aifs.gap2.$}>
-          <ToggleChip text="Default" onClick={action("click")} />
-          <ToggleChip text="Icon" icon="attachment" onClick={action("click")} />
-          <ToggleChip text="Disabled" disabled onClick={action("click")} />
-          <ToggleChip text="Hovered" onClick={action("click")} />
-          <ToggleChip text="No x chip" clearable={false} onClick={action("click")} />
-          <ToggleChip text="Active" clearable={false} active={true} onClick={action("click")} />
-          <ToggleChip text={"Long text ".repeat(5)} icon="attachment" onClick={action("click")} />
-        </div>
-      </div>
-
-      <div>
-        <h2 css={Css.mb1.$}>Compact</h2>
-        <div css={Css.wPx(300).df.fdc.aifs.gap2.$}>
-          <PresentationProvider fieldProps={{ compact: true }}>
-            <ToggleChip text="Default" onClick={action("click")} />
-            <ToggleChip text="Icon" icon="attachment" onClick={action("click")} />
-            <ToggleChip text="Disabled" disabled onClick={action("click")} />
-            <ToggleChip text="Hovered" onClick={action("click")} />
-            <ToggleChip text="No x chip" clearable={false} onClick={action("click")} />
-            <ToggleChip text="Active" clearable={false} active={true} onClick={action("click")} />
-            <ToggleChip text={"Long text ".repeat(5)} icon="attachment" onClick={action("click")} />
-          </PresentationProvider>
-        </div>
+    <div css={Css.bgWhite.p2.$}>
+      <div css={Css.wPx(300).df.fdc.aifs.gap2.$}>
+        <ExampleToggleChips />
       </div>
     </div>
   ),
   {
-    play: async ({ canvasElement }) => {
-      const canvas = within(canvasElement);
-      const chip = canvas.getByText("Hovered");
-      return waitFor(async () => {
-        await userEvent.hover(chip);
-      });
-    },
+    play: hoverPlayFn(),
   },
 );
+
+export const Compact = newStory(
+  () => (
+    <div css={Css.bgWhite.p2.$}>
+      <div css={Css.wPx(300).df.fdc.aifs.gap2.$}>
+        <PresentationProvider fieldProps={{ compact: true }}>
+          <ExampleToggleChips />
+        </PresentationProvider>
+      </div>
+    </div>
+  ),
+  {
+    play: hoverPlayFn(),
+  },
+);
+
+function ExampleToggleChips() {
+  return (
+    <>
+      <ToggleChip text="Default" onClick={action("click")} />
+      <ToggleChip text="Icon" icon="attachment" onClick={action("click")} />
+      <ToggleChip text="Disabled" disabled onClick={action("click")} />
+      <ToggleChip text="Hovered" onClick={action("click")} />
+      <ToggleChip text="No x chip" clearable={false} onClick={action("click")} />
+      <ToggleChip text="Active" clearable={false} active={true} onClick={action("click")} />
+      <ToggleChip text={"Long text ".repeat(5)} icon="attachment" onClick={action("click")} />
+    </>
+  );
+}
+
+function hoverPlayFn() {
+  return async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement);
+    const chip = canvas.getByText("Hovered");
+    return waitFor(async () => {
+      await userEvent.hover(chip);
+    });
+  };
+}

--- a/src/components/ToggleChip.stories.tsx
+++ b/src/components/ToggleChip.stories.tsx
@@ -1,6 +1,8 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
+import { userEvent, waitFor, within } from "@storybook/test";
 import { Css, PresentationProvider, ToggleChip } from "src/index";
+import { newStory } from "src/utils/sb";
 
 export default {
   component: ToggleChip,
@@ -12,30 +14,45 @@ export default {
   },
 } as Meta;
 
-export function DefaultToggleChip() {
-  return (
+export const DefaultToggleChip = newStory(
+  () => (
     <div css={Css.df.fdc.gap4.bgWhite.p2.$}>
-      <div css={Css.wPx(300).df.fdc.aifs.gap2.$}>
-        <ToggleChip text="Input chip" onClick={action("click")} />
-        <ToggleChip text="Input chip" icon="attachment" onClick={action("click")} />
-        <ToggleChip text="Disabled chip" disabled onClick={action("click")} />
-        <ToggleChip text="Filter chip" clearable={false} onClick={action("click")} />
-        <ToggleChip text="Filter chip" clearable={false} active={true} onClick={action("click")} />
-        <ToggleChip text="+2 more" clearable={false} active={true} onClick={action("click")} />
-        <ToggleChip text={"Input chip ".repeat(10)} icon="attachment" onClick={action("click")} />
+      <div>
+        <h2 css={Css.mb1.$}>Standard</h2>
+        <div css={Css.wPx(300).df.fdc.aifs.gap2.$}>
+          <ToggleChip text="Default" onClick={action("click")} />
+          <ToggleChip text="Icon" icon="attachment" onClick={action("click")} />
+          <ToggleChip text="Disabled" disabled onClick={action("click")} />
+          <ToggleChip text="Hovered" onClick={action("click")} />
+          <ToggleChip text="No x chip" clearable={false} onClick={action("click")} />
+          <ToggleChip text="Active" clearable={false} active={true} onClick={action("click")} />
+          <ToggleChip text={"Long text ".repeat(5)} icon="attachment" onClick={action("click")} />
+        </div>
       </div>
 
       <div>
         <h2 css={Css.mb1.$}>Compact</h2>
         <div css={Css.wPx(300).df.fdc.aifs.gap2.$}>
           <PresentationProvider fieldProps={{ compact: true }}>
-            <ToggleChip text="Input chip" onClick={action("click")} />
-            <ToggleChip text="Input chip" icon="attachment" onClick={action("click")} />
-            <ToggleChip text="Disabled Chip" disabled onClick={action("click")} />
-            <ToggleChip text={"Input chip ".repeat(10)} icon="attachment" onClick={action("click")} />
+            <ToggleChip text="Default" onClick={action("click")} />
+            <ToggleChip text="Icon" icon="attachment" onClick={action("click")} />
+            <ToggleChip text="Disabled" disabled onClick={action("click")} />
+            <ToggleChip text="Hovered" onClick={action("click")} />
+            <ToggleChip text="No x chip" clearable={false} onClick={action("click")} />
+            <ToggleChip text="Active" clearable={false} active={true} onClick={action("click")} />
+            <ToggleChip text={"Long text ".repeat(5)} icon="attachment" onClick={action("click")} />
           </PresentationProvider>
         </div>
       </div>
     </div>
-  );
-}
+  ),
+  {
+    play: async ({ canvasElement }) => {
+      const canvas = within(canvasElement);
+      const chip = canvas.getByText("Hovered chip");
+      return waitFor(async () => {
+        await userEvent.hover(chip);
+      });
+    },
+  },
+);

--- a/src/components/ToggleChip.stories.tsx
+++ b/src/components/ToggleChip.stories.tsx
@@ -14,20 +14,25 @@ export default {
 
 export function DefaultToggleChip() {
   return (
-    <div css={Css.df.fdc.gap4.$}>
+    <div css={Css.df.fdc.gap4.bgWhite.p2.$}>
       <div css={Css.wPx(300).df.fdc.aifs.gap2.$}>
-        <ToggleChip text="First Last" onClick={action("click")} />
-        <ToggleChip text="Disabled Chip" disabled onClick={action("click")} />
-        <ToggleChip text={"First Last ".repeat(10)} onClick={action("click")} />
+        <ToggleChip text="Input chip" onClick={action("click")} />
+        <ToggleChip text="Input chip" icon="attachment" onClick={action("click")} />
+        <ToggleChip text="Disabled chip" disabled onClick={action("click")} />
+        <ToggleChip text="Filter chip" clearable={false} onClick={action("click")} />
+        <ToggleChip text="Filter chip" clearable={false} active={true} onClick={action("click")} />
+        <ToggleChip text="+2 more" clearable={false} active={true} onClick={action("click")} />
+        <ToggleChip text={"Input chip ".repeat(10)} icon="attachment" onClick={action("click")} />
       </div>
 
       <div>
         <h2 css={Css.mb1.$}>Compact</h2>
         <div css={Css.wPx(300).df.fdc.aifs.gap2.$}>
           <PresentationProvider fieldProps={{ compact: true }}>
-            <ToggleChip text="First Last" onClick={action("click")} />
+            <ToggleChip text="Input chip" onClick={action("click")} />
+            <ToggleChip text="Input chip" icon="attachment" onClick={action("click")} />
             <ToggleChip text="Disabled Chip" disabled onClick={action("click")} />
-            <ToggleChip text={"First Last ".repeat(10)} onClick={action("click")} />
+            <ToggleChip text={"Input chip ".repeat(10)} icon="attachment" onClick={action("click")} />
           </PresentationProvider>
         </div>
       </div>

--- a/src/components/ToggleChip.stories.tsx
+++ b/src/components/ToggleChip.stories.tsx
@@ -46,11 +46,9 @@ function ExampleToggleChips() {
   return (
     <>
       <ToggleChip text="Default" onClick={action("click")} />
-      <ToggleChip text="Icon" icon="attachment" onClick={action("click")} />
+      <ToggleChip text="With Icon" icon="attachment" onClick={action("click")} />
       <ToggleChip text="Disabled" disabled onClick={action("click")} />
       <ToggleChip text="Hovered" onClick={action("click")} />
-      <ToggleChip text="No x chip" clearable={false} onClick={action("click")} />
-      <ToggleChip text="Active" clearable={false} active={true} onClick={action("click")} />
       <ToggleChip text={"Long text ".repeat(5)} icon="attachment" onClick={action("click")} />
     </>
   );

--- a/src/components/ToggleChip.stories.tsx
+++ b/src/components/ToggleChip.stories.tsx
@@ -49,7 +49,7 @@ export const DefaultToggleChip = newStory(
   {
     play: async ({ canvasElement }) => {
       const canvas = within(canvasElement);
-      const chip = canvas.getByText("Hovered chip");
+      const chip = canvas.getByText("Hovered");
       return waitFor(async () => {
         await userEvent.hover(chip);
       });

--- a/src/components/ToggleChip.test.tsx
+++ b/src/components/ToggleChip.test.tsx
@@ -32,10 +32,4 @@ describe("ToggleChip", () => {
 
     expect(r.chip_icon).toBeInTheDocument();
   });
-
-  it("can be rendered without the x icon", async () => {
-    const r = await render(<ToggleChip text="Without x icon" onClick={noop} clearable={false} />);
-
-    expect(r.query.chip_x).not.toBeInTheDocument();
-  });
 });

--- a/src/components/ToggleChip.test.tsx
+++ b/src/components/ToggleChip.test.tsx
@@ -1,0 +1,33 @@
+import { noop } from "src/utils";
+import { click, render } from "src/utils/rtl";
+import { ToggleChip } from "./ToggleChip";
+
+describe("ToggleChip", () => {
+  it("renders", async () => {
+    const r = await render(<ToggleChip text="Toggle me" onClick={noop} />);
+    expect(r.chip.textContent).toBe("Toggle me");
+    expect(r.chip_x).toBeInTheDocument();
+  });
+
+  it("handles click events", async () => {
+    const onClick = jest.fn();
+    const r = await render(<ToggleChip text="Click me" onClick={onClick} />);
+    await click(r.chip);
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it("can be disabled", async () => {
+    const r = await render(<ToggleChip text="Disabled" onClick={noop} disabled />);
+    expect(r.chip).toBeDisabled();
+  });
+
+  it("can render with an additional icon", async () => {
+    const r = await render(<ToggleChip text="With icon" icon="attachment" onClick={noop} />);
+    expect(r.chip_icon).toBeInTheDocument();
+  });
+
+  it("can be rendered without the x icon", async () => {
+    const r = await render(<ToggleChip text="Without x icon" onClick={noop} clearable={false} />);
+    expect(r.query.chip_x).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ToggleChip.test.tsx
+++ b/src/components/ToggleChip.test.tsx
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { noop } from "src/utils";
 import { click, render } from "src/utils/rtl";
 import { ToggleChip } from "./ToggleChip";
@@ -5,6 +6,7 @@ import { ToggleChip } from "./ToggleChip";
 describe("ToggleChip", () => {
   it("renders", async () => {
     const r = await render(<ToggleChip text="Toggle me" onClick={noop} />);
+
     expect(r.chip.textContent).toBe("Toggle me");
     expect(r.chip_x).toBeInTheDocument();
   });
@@ -12,22 +14,28 @@ describe("ToggleChip", () => {
   it("handles click events", async () => {
     const onClick = jest.fn();
     const r = await render(<ToggleChip text="Click me" onClick={onClick} />);
-    await click(r.chip);
+    click(r.chip);
+
     expect(onClick).toHaveBeenCalled();
   });
 
   it("can be disabled", async () => {
     const r = await render(<ToggleChip text="Disabled" onClick={noop} disabled />);
+
     expect(r.chip).toBeDisabled();
+    // and the x icon is not displayed when disabled
+    expect(r.query.chip_x).not.toBeInTheDocument();
   });
 
   it("can render with an additional icon", async () => {
     const r = await render(<ToggleChip text="With icon" icon="attachment" onClick={noop} />);
+
     expect(r.chip_icon).toBeInTheDocument();
   });
 
   it("can be rendered without the x icon", async () => {
     const r = await render(<ToggleChip text="Without x icon" onClick={noop} clearable={false} />);
+
     expect(r.query.chip_x).not.toBeInTheDocument();
   });
 });

--- a/src/components/ToggleChip.tsx
+++ b/src/components/ToggleChip.tsx
@@ -49,7 +49,7 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
       </span>
       {/* x icon is not displayed when chip is disabled */}
       {!disabled && (
-        <span css={{ ...Css.fs0.br16.bgGray100.$, ...(isHovered && chipHoverStyles) }} {...tid.x}>
+        <span css={{ ...Css.fs0.br16.bgGray200.$, ...(isHovered && chipHoverStyles) }} {...tid.x}>
           <Icon icon="x" color={Palette.Gray600} inc={2} />
         </span>
       )}
@@ -57,5 +57,5 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
   );
 }
 
-export const chipHoverStyles = Css.bgGray200.$;
+export const chipHoverStyles = Css.bgGray300.$;
 export const chipDisabledStyles = Css.gray600.cursorNotAllowed.$;

--- a/src/components/ToggleChip.tsx
+++ b/src/components/ToggleChip.tsx
@@ -49,7 +49,7 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
       </span>
       {/* x icon is not displayed when chip is disabled */}
       {!disabled && (
-        <span css={{ ...Css.fs0.br16.bgGray100.$, ...(isHovered && !disabled && chipHoverStyles) }} {...tid.x}>
+        <span css={{ ...Css.fs0.br16.bgGray100.$, ...(isHovered && chipHoverStyles) }} {...tid.x}>
           <Icon icon="x" color={Palette.Gray600} inc={2} />
         </span>
       )}

--- a/src/components/ToggleChip.tsx
+++ b/src/components/ToggleChip.tsx
@@ -13,12 +13,10 @@ export interface ToggleChipProps<X> {
   xss?: X;
   disabled?: boolean;
   icon?: IconKey;
-  clearable?: boolean;
-  active?: boolean;
 }
 
 export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipProps<X>) {
-  const { text, onClick, xss = {}, disabled = false, icon, clearable = true, active = false } = props;
+  const { text, onClick, xss = {}, disabled = false, icon } = props;
   const { fieldProps } = usePresentationContext();
   const { hoverProps, isHovered } = useHover({});
 
@@ -31,9 +29,8 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
       css={{
         ...chipBaseStyles(compact),
         ...(isHovered && !disabled && chipHoverStyles),
-        ...(active && activeStyles),
-        // Use a lower right-padding to get closer to the `X` circle when clearable
-        ...(clearable && Css.prPx(4).$),
+        // Use a lower right-padding to get closer to the `X` circle when clearable, i.e. not disabled
+        ...(!disabled && Css.prPx(4).$),
         ...(disabled && { ...chipDisabledStyles, ...Css.pr1.$ }),
         ...xss,
       }}
@@ -50,7 +47,8 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
       <span css={Css.tal.lineClamp1.wbba.if(disabled).pr0.$} title={text}>
         {text}
       </span>
-      {!disabled && clearable && (
+      {/* x icon is not displayed when chip is disabled */}
+      {!disabled && (
         <span css={{ ...Css.fs0.br16.bgGray100.$, ...(isHovered && !disabled && chipHoverStyles) }} {...tid.x}>
           <Icon icon="x" color={Palette.Gray600} inc={2} />
         </span>
@@ -61,4 +59,3 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
 
 export const chipHoverStyles = Css.bgGray200.$;
 export const chipDisabledStyles = Css.gray600.cursorNotAllowed.$;
-const activeStyles = Css.bgBlue600.white.$;

--- a/src/components/ToggleChip.tsx
+++ b/src/components/ToggleChip.tsx
@@ -30,11 +30,11 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
       type="button"
       css={{
         ...chipBaseStyles(compact),
-        ...(isHovered && !disabled && hoverStyles),
+        ...(isHovered && !disabled && chipHoverStyles),
         ...(active && activeStyles),
         // Use a lower right-padding to get closer to the `X` circle when clearable
         ...(clearable && Css.prPx(4).$),
-        ...(disabled && disabledStyles),
+        ...(disabled && { ...chipDisabledStyles, ...Css.pr1.$ }),
         ...xss,
       }}
       disabled={disabled}
@@ -51,7 +51,7 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
         {text}
       </span>
       {!disabled && clearable && (
-        <span css={{ ...Css.fs0.br16.bgGray100.$, ...(isHovered && !disabled && hoverStyles) }} {...tid.x}>
+        <span css={{ ...Css.fs0.br16.bgGray100.$, ...(isHovered && !disabled && chipHoverStyles) }} {...tid.x}>
           <Icon icon="x" color={Palette.Gray600} inc={2} />
         </span>
       )}
@@ -59,6 +59,6 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
   );
 }
 
-const hoverStyles = Css.bgGray200.$;
-const disabledStyles = Css.gray600.cursorNotAllowed.pr1.$;
+export const chipHoverStyles = Css.bgGray200.$;
+export const chipDisabledStyles = Css.gray600.cursorNotAllowed.$;
 const activeStyles = Css.bgBlue600.white.$;

--- a/src/components/ToggleChip.tsx
+++ b/src/components/ToggleChip.tsx
@@ -1,7 +1,9 @@
-import { Icon } from "src/components/Icon";
+import { Icon, IconKey } from "src/components/Icon";
 import { usePresentationContext } from "src/components/PresentationContext";
 import { Css, Margin, Only, Palette, Xss } from "src/Css";
+import { useHover } from "src/hooks";
 import { useTestIds } from "src/utils/useTestIds";
+import { chipBaseStyles } from "./Chip";
 
 type ToggleChipXss = Xss<Margin>;
 
@@ -10,11 +12,16 @@ export interface ToggleChipProps<X> {
   onClick: () => void;
   xss?: X;
   disabled?: boolean;
+  icon?: IconKey;
+  clearable?: boolean;
+  active?: boolean;
 }
 
 export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipProps<X>) {
-  const { text, onClick, xss = {}, disabled = false } = props;
+  const { text, onClick, xss = {}, disabled = false, icon, clearable = true, active = false } = props;
   const { fieldProps } = usePresentationContext();
+  const { hoverProps, isHovered } = useHover({});
+
   // If compact, then use a smaller type scale
   const compact = fieldProps?.compact;
   const tid = useTestIds(props, "chip");
@@ -22,28 +29,36 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
     <button
       type="button"
       css={{
-        ...Css[compact ? "xs" : "sm"].dif.aic.br16.pl1
-          // Use a lower right-padding to get closer to the `X` circle when not disabled
-          .prPx(2)
-          .pyPx(2)
-          .gray900.bgGray200.if(disabled)
-          .gray600.pr1.mhPx(compact ? 20 : 28).$,
-        "&:hover:not(:disabled)": Css.bgGray300.$,
-        "&:disabled": Css.cursorNotAllowed.$,
+        ...chipBaseStyles(compact),
+        ...(isHovered && !disabled && hoverStyles),
+        ...(active && activeStyles),
+        // Use a lower right-padding to get closer to the `X` circle when clearable
+        ...(clearable && Css.prPx(4).$),
+        ...(disabled && disabledStyles),
         ...xss,
       }}
       disabled={disabled}
       onClick={onClick}
+      {...hoverProps}
       {...tid}
     >
-      <span css={Css.prPx(6).tal.lineClamp1.wbba.if(disabled).pr0.$} title={text}>
+      {icon && (
+        <span css={Css.fs0.$}>
+          <Icon icon={icon} color={Palette.Gray900} inc={2} />
+        </span>
+      )}
+      <span css={Css.tal.lineClamp1.wbba.if(disabled).pr0.$} title={text}>
         {text}
       </span>
-      {!disabled && (
-        <span css={Css.fs0.br16.bgGray400.$}>
-          <Icon icon="x" color={Palette.Gray700} inc={compact ? 2 : undefined} />
+      {!disabled && clearable && (
+        <span css={{ ...Css.fs0.br16.bgGray100.$, ...(isHovered && !disabled && hoverStyles) }}>
+          <Icon icon="x" color={Palette.Gray600} inc={2} />
         </span>
       )}
     </button>
   );
 }
+
+const hoverStyles = Css.bgGray200.$;
+const disabledStyles = Css.gray600.cursorNotAllowed.pr1.$;
+const activeStyles = Css.bgBlue600.white.$;

--- a/src/components/ToggleChip.tsx
+++ b/src/components/ToggleChip.tsx
@@ -43,7 +43,7 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
       {...tid}
     >
       {icon && (
-        <span css={Css.fs0.$}>
+        <span css={Css.fs0.$} {...tid.icon}>
           <Icon icon={icon} color={Palette.Gray900} inc={2} />
         </span>
       )}
@@ -51,7 +51,7 @@ export function ToggleChip<X extends Only<ToggleChipXss, X>>(props: ToggleChipPr
         {text}
       </span>
       {!disabled && clearable && (
-        <span css={{ ...Css.fs0.br16.bgGray100.$, ...(isHovered && !disabled && hoverStyles) }}>
+        <span css={{ ...Css.fs0.br16.bgGray100.$, ...(isHovered && !disabled && hoverStyles) }} {...tid.x}>
           <Icon icon="x" color={Palette.Gray600} inc={2} />
         </span>
       )}

--- a/src/inputs/ChipSelectField.tsx
+++ b/src/inputs/ChipSelectField.tsx
@@ -2,11 +2,18 @@ import { camelCase } from "change-case";
 import { Key, ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { mergeProps, useButton, useFocus, useOverlayPosition, useSelect } from "react-aria";
 import { Item, Section, useListData, useSelectState } from "react-stately";
-import { Icon, maybeTooltip, resolveTooltip } from "src/components";
+import {
+  chipBaseStyles,
+  chipDisabledStyles,
+  chipHoverStyles,
+  Icon,
+  maybeTooltip,
+  resolveTooltip,
+} from "src/components";
 import { Popover } from "src/components/internal";
 import { Label } from "src/components/Label";
 import { usePresentationContext } from "src/components/PresentationContext";
-import { Css } from "src/Css";
+import { Css, Palette } from "src/Css";
 import { ChipTextField } from "src/inputs/ChipTextField";
 import { ListBox } from "src/inputs/internal/ListBox";
 import { ListBoxChip } from "src/inputs/internal/ListBoxChip";
@@ -62,7 +69,7 @@ export function ChipSelectField<O, V extends Value>(
   const typeScale = fieldProps?.typeScale ?? "sm";
   const isDisabled = !!disabled;
   const showClearButton = !disabled && clearable && !!value;
-  const chipStyles = useMemo(() => Css[typeScale].tal.bgGray300.gray900.br16.pxPx(10).pyPx(2).$, [typeScale]);
+  const chipStyles = { ...chipBaseStyles(), ...Css.pyPx(2).gap0.aiStretch.$ };
   // Controls showing the focus border styles.
   const [visualFocus, setVisualFocus] = useState(false);
   const [isClearFocused, setIsClearFocused] = useState(false);
@@ -241,7 +248,7 @@ export function ChipSelectField<O, V extends Value>(
             ref={wrapperRef}
             css={{
               ...chipStyles,
-              ...Css.dif.relative.p0.mwPx(32).if(!value).bgGray200.$,
+              ...Css.relative.p0.mwPx(32).$,
               ...(visualFocus ? Css.bshFocus.$ : {}),
               ...(showInput ? Css.dn.$ : {}),
             }}
@@ -252,8 +259,8 @@ export function ChipSelectField<O, V extends Value>(
               ref={buttonRef}
               css={{
                 ...Css.tal.br16.pxPx(10).pyPx(2).outline0.if(showClearButton).prPx(4).borderRadius("16px 0 0 16px").$,
-                ...(isDisabled ? Css.cursorNotAllowed.gray700.$ : {}),
-                "&:hover:not(:disabled)": Css.bgGray400.if(!value).bgGray300.$,
+                ...(isDisabled ? chipDisabledStyles : {}),
+                "&:hover:not(:disabled)": chipHoverStyles,
               }}
               title={state.selectedItem ? state.selectedItem.textValue : placeholder}
               {...tid}
@@ -267,7 +274,7 @@ export function ChipSelectField<O, V extends Value>(
                 {...clearFocusProps}
                 css={{
                   ...Css.prPx(4).borderRadius("0 16px 16px 0").outline0.$,
-                  "&:hover": Css.bgGray400.$,
+                  "&:hover": chipHoverStyles,
                   ...(isClearFocused ? Css.boxShadow(`0px 0px 0px 2px rgba(3,105,161,1)`).$ : {}),
                 }}
                 onClick={() => {
@@ -277,7 +284,7 @@ export function ChipSelectField<O, V extends Value>(
                 aria-label="Remove"
                 {...tid.clearButton}
               >
-                <Icon icon="x" inc={typeScale === "xs" ? 2 : undefined} />
+                <Icon icon="x" color={Palette.Gray600} inc={typeScale === "xs" ? 2 : undefined} />
               </button>
             )}
           </div>

--- a/src/inputs/ChipTextField.stories.tsx
+++ b/src/inputs/ChipTextField.stories.tsx
@@ -1,8 +1,10 @@
 import { action } from "@storybook/addon-actions";
+import { Meta } from "@storybook/react";
+import { waitFor, within } from "@storybook/test";
 import { useState } from "react";
-import { PresentationProvider } from "src/components";
 import { Css } from "src/Css";
 import { ChipTextField } from "src/inputs/ChipTextField";
+import { newStory } from "src/utils/sb";
 
 export default {
   component: ChipTextField,
@@ -12,33 +14,39 @@ export default {
       url: "https://www.figma.com/file/aWUE4pPeUTgrYZ4vaTYZQU/%E2%9C%A8Beam-Design-System?node-id=34522%3A101241",
     },
   },
-};
+} as Meta;
 
-export function Example() {
-  const [value, setValue] = useState("Add new");
-  const [value2, setValue2] = useState("Add new");
-  return (
-    <div>
-      <h1 css={Css.xl.$}>Default</h1>
-      <ChipTextField
-        value={value}
-        label="Chip Field"
-        onChange={setValue}
-        onFocus={action("onFocus")}
-        onBlur={action("onBlur")}
-        required
-      />
-      <h1 css={Css.mt3.xl.$}>Within PresentationProvider with smaller Font Size set to 'xs'</h1>
-      <PresentationProvider fieldProps={{ typeScale: "xs" }}>
+export const DefaultChip = newStory(
+  () => {
+    const [value, setValue] = useState("Add new");
+
+    return (
+      <div css={Css.df.gap1.bgWhite.p2.$}>
         <ChipTextField
-          value={value2}
+          value={value}
           label="Chip Field"
-          onChange={setValue2}
+          onChange={setValue}
           onFocus={action("onFocus")}
           onBlur={action("onBlur")}
           required
         />
-      </PresentationProvider>
-    </div>
-  );
-}
+        <ChipTextField
+          value={value}
+          label="Focused"
+          onChange={setValue}
+          onFocus={action("onFocus")}
+          onBlur={action("onBlur")}
+          autoFocus
+        />
+      </div>
+    );
+  },
+  {
+    play: async ({ canvasElement }) => {
+      const canvas = within(canvasElement);
+      return waitFor(async () => {
+        await canvas.getByText("Focused").focus();
+      });
+    },
+  },
+);

--- a/src/inputs/ChipTextField.stories.tsx
+++ b/src/inputs/ChipTextField.stories.tsx
@@ -1,9 +1,9 @@
 import { action } from "@storybook/addon-actions";
 import { Meta } from "@storybook/react";
 import { waitFor, within } from "@storybook/test";
-import { useState } from "react";
 import { Css } from "src/Css";
 import { ChipTextField } from "src/inputs/ChipTextField";
+import { noop } from "src/utils";
 import { newStory } from "src/utils/sb";
 
 export default {
@@ -18,22 +18,20 @@ export default {
 
 export const DefaultChip = newStory(
   () => {
-    const [value, setValue] = useState("Add new");
-
     return (
       <div css={Css.df.gap1.bgWhite.p2.$}>
         <ChipTextField
-          value={value}
+          value="Add new"
           label="Chip Field"
-          onChange={setValue}
+          onChange={noop}
           onFocus={action("onFocus")}
           onBlur={action("onBlur")}
           required
         />
         <ChipTextField
-          value={value}
+          value={"Focused"}
           label="Focused"
-          onChange={setValue}
+          onChange={noop}
           onFocus={action("onFocus")}
           onBlur={action("onBlur")}
           autoFocus

--- a/src/inputs/ChipTextField.test.tsx
+++ b/src/inputs/ChipTextField.test.tsx
@@ -27,16 +27,16 @@ describe("ChipTextField", () => {
 
     // When firing the events on the input, then expect the callbacks to be invoked
     focus(r.chipField);
-    expect(onFocus).toBeCalledTimes(1);
+    expect(onFocus).toHaveBeenCalledTimes(1);
 
     fireEvent.blur(r.chipField);
-    expect(onBlur).toBeCalledTimes(1);
+    expect(onBlur).toHaveBeenCalledTimes(1);
 
     fireEvent.keyDown(r.chipField, { key: "Enter" });
-    expect(onEnter).toBeCalledTimes(1);
+    expect(onEnter).toHaveBeenCalledTimes(1);
 
     fireEvent.input(r.chipField, { target: { textContent: "New Value" } });
-    expect(onChange).toBeCalledWith("New Value");
+    expect(onChange).toHaveBeenCalledWith("New Value");
   });
 
   it("removes focus from input and calls onBlur when pressing escape", async () => {
@@ -51,7 +51,7 @@ describe("ChipTextField", () => {
     // Then the element should no longer have focus
     expect(r.chipField).not.toHaveFocus();
     // And onBlur should have been called
-    expect(onBlur).toBeCalledTimes(1);
+    expect(onBlur).toHaveBeenCalledTimes(1);
   });
 
   it("does not removes focus or call onBlur from input when pressing escape disabled", async () => {
@@ -66,6 +66,6 @@ describe("ChipTextField", () => {
     // Then the element should still have focus
     expect(r.chipField).toHaveFocus();
     // And onBlur should not be called
-    expect(onBlur).not.toBeCalled();
+    expect(onBlur).not.toHaveBeenCalled();
   });
 });

--- a/src/inputs/ChipTextField.tsx
+++ b/src/inputs/ChipTextField.tsx
@@ -1,5 +1,6 @@
 import { KeyboardEvent, useEffect, useRef, useState } from "react";
 import { useFocus } from "react-aria";
+import { chipBaseStyles } from "src/components";
 import { usePresentationContext } from "src/components/PresentationContext";
 import { Css } from "src/Css";
 import { maybeCall, useTestIds } from "src/utils";
@@ -52,7 +53,6 @@ export function ChipTextField(props: ChipTextFieldProps) {
   });
 
   const fieldRef = useRef<HTMLSpanElement>(null);
-  const typeScale = fieldProps?.typeScale ?? "sm";
 
   useEffect(
     () => {
@@ -89,8 +89,9 @@ export function ChipTextField(props: ChipTextFieldProps) {
       }}
       {...focusProps}
       css={{
-        ...Css[typeScale].dib.br16.pl1.pxPx(10).pyPx(2).gray900.bgGray300.outline0.mwPx(32).$,
-        ...(isFocused ? Css.bshFocus.$ : {}),
+        ...chipBaseStyles(fieldProps?.compact),
+        ...Css.mwPx(32).outline0.$,
+        ...(isFocused && Css.bshFocus.$),
       }}
       {...tid}
     >

--- a/src/inputs/internal/ListBoxChip.tsx
+++ b/src/inputs/internal/ListBoxChip.tsx
@@ -10,7 +10,7 @@ export function ListBoxChip({ label }: ListBoxChipProps) {
   const { fieldProps } = usePresentationContext();
 
   return (
-    <span css={{ ...chipBaseStyles(fieldProps?.compact), ...Css.lineClamp1.wbba.$ }} title={label}>
+    <span css={{ ...chipBaseStyles(fieldProps?.compact), ...Css.truncate.dib.$ }} title={label}>
       {label}
     </span>
   );

--- a/src/inputs/internal/ListBoxChip.tsx
+++ b/src/inputs/internal/ListBoxChip.tsx
@@ -1,3 +1,4 @@
+import { chipBaseStyles } from "src/components";
 import { usePresentationContext } from "src/components/PresentationContext";
 import { Css } from "src/Css";
 
@@ -9,10 +10,7 @@ export function ListBoxChip({ label }: ListBoxChipProps) {
   const { fieldProps } = usePresentationContext();
 
   return (
-    <span
-      css={Css[fieldProps?.typeScale ?? "sm"].tal.bgGray300.gray900.br16.pxPx(10).pyPx(2).lineClamp1.wbba.$}
-      title={label}
-    >
+    <span css={{ ...chipBaseStyles(fieldProps?.compact), ...Css.lineClamp1.wbba.$ }} title={label}>
       {label}
     </span>
   );


### PR DESCRIPTION
## [Figma Design](https://www.figma.com/design/aWUE4pPeUTgrYZ4vaTYZQU/%E2%9C%A8Beam-Component-Library?node-id=34522-101243&m=dev)

### Chip
* Adds shared base styles for the Chip and ToggleChip components
* Uses some lighter background colors


### ToggleChip
* Adds an optional icon on the left of the text
* Makes the x icon background match the rest of the chip 


![image](https://github.com/user-attachments/assets/63eac69d-1e82-4f12-9517-1230a7fb9b56)

### ChipSelectField 
* Updates bg colors and X icon color
<img width="890" alt="image" src="https://github.com/user-attachments/assets/ffb94f99-7b7b-4b08-913e-d55d8c5f06b6" />
