### PR TITLE
feat: [SC-68262] Grid table layout

### DIFF
--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -30,7 +30,7 @@ export function GridTableLayout() {
       filterDefs,
       storageKey: "grid-table-layout",
     },
-    useSearch: "client",
+    search: "client",
   });
 
   return (
@@ -63,7 +63,7 @@ export function QueryTableLayout() {
       filterDefs,
       storageKey: "grid-table-layout",
     },
-    useSearch: "server",
+    search: "server",
   });
 
   // In this example, we set up a server-side search that uses the `searchString` from the layout state.

--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -1,0 +1,82 @@
+import { Meta } from "@storybook/react";
+import { useMemo } from "react";
+import { checkboxFilter, multiFilter } from "src/components/Filters";
+import { GridColumn } from "src/components/Table/types";
+import { simpleHeader, SimpleHeaderAndData } from "src/components/Table/utils/simpleHelpers";
+import { withBeamDecorator, withRouter } from "src/utils/sb";
+import { GridTableLayout as GridTableLayoutComponent, useGridTableLayoutState } from "./GridTableLayout";
+
+export default {
+  component: GridTableLayout,
+  decorators: [withBeamDecorator, withRouter()],
+} satisfies Meta;
+
+type Data = { name: string | undefined; value: number | undefined };
+type Row = SimpleHeaderAndData<Data>;
+
+export function GridTableLayout() {
+  const nameColumn: GridColumn<Row> = { header: "Name", data: ({ name }) => name };
+  const valueColumn: GridColumn<Row> = { header: "Value", data: ({ value }) => value };
+  const actionColumn: GridColumn<Row> = { header: "Action", data: () => <div>Actions</div> };
+
+  const filterDefs = useMemo(() => {
+    return {
+      primary: multiFilter({
+        options: [
+          { value: "primary", label: "Primary" },
+          { value: "secondary", label: "Secondary" },
+        ],
+        getOptionLabel: (tp) => tp.label,
+        getOptionValue: (tp) => tp.value,
+        label: "Preference",
+      }),
+      status: multiFilter({
+        options: [
+          { label: "Active", value: "active" },
+          { label: "Inactive", value: "inactive" },
+        ],
+        getOptionLabel: (cs) => cs.label,
+        getOptionValue: (cs) => cs.value,
+        label: "Status",
+      }),
+      needsRevision: checkboxFilter({
+        label: "Needs Revision",
+      }),
+    };
+  }, []);
+
+  const tableState = useGridTableLayoutState({
+    persistedFilter: {
+      filterDefs,
+      storageKey: "grid-table-layout",
+    },
+    useSearch: "client",
+  });
+
+  const { data } = useExampleQuery({ filter: tableState.filter });
+
+  return (
+    <GridTableLayoutComponent
+      pageTitle="Grid Table Layout Example"
+      breadcrumb={[
+        { href: "/", label: "Home" },
+        { href: "/", label: "Sub Page" },
+      ]}
+      tableState={tableState}
+      gridTableProps={{
+        columns: [nameColumn, valueColumn, actionColumn],
+        rows: [simpleHeader, ...data.map((d) => ({ kind: "data" as const, id: d.id, data: d }))],
+      }}
+    />
+  );
+}
+
+function useExampleQuery({ filter }: { filter: Record<string, unknown> }) {
+  return {
+    data: [
+      { id: "1", name: "a", value: 1 },
+      { id: "2", name: "b", value: 2 },
+      { id: "3", name: "c", value: 3 },
+    ],
+  };
+}

--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -7,8 +7,9 @@ import { withBeamDecorator, withRouter } from "src/utils/sb";
 import { GridTableLayout as GridTableLayoutComponent, useGridTableLayoutState } from "./GridTableLayout";
 
 export default {
-  component: GridTableLayout,
+  component: GridTableLayoutComponent,
   decorators: [withBeamDecorator, withRouter()],
+  parameters: { layout: "fullscreen" },
 } satisfies Meta;
 
 type Data = { name: string | undefined; value: number | undefined };

--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -1,9 +1,12 @@
 import { Meta } from "@storybook/react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { checkboxFilter, multiFilter } from "src/components/Filters";
-import { GridColumn } from "src/components/Table/types";
-import { simpleHeader, SimpleHeaderAndData } from "src/components/Table/utils/simpleHelpers";
-import { withBeamDecorator, withRouter } from "src/utils/sb";
+import { GridDataRow } from "src/components/Table";
+import { collapseColumn, column, numericColumn, selectColumn } from "src/components/Table/utils/columns";
+import { simpleHeader } from "src/components/Table/utils/simpleHelpers";
+import { noop } from "src/utils";
+import { withBeamDecorator, withRouter, zeroTo } from "src/utils/sb";
+import { TestProjectLayout } from "../Layout.stories";
 import { GridTableLayout as GridTableLayoutComponent, useGridTableLayoutState } from "./GridTableLayout";
 
 export default {
@@ -12,41 +15,17 @@ export default {
   parameters: { layout: "fullscreen" },
 } satisfies Meta;
 
-type Data = { name: string | undefined; value: number | undefined };
-type Row = SimpleHeaderAndData<Data>;
+type Data = { name: string | undefined; value: number | undefined; status: string; priority: number };
+type HeaderRow = { kind: "header"; id: string; data: undefined };
+type ParentRow = { kind: "parent"; id: string; data: Data; children: GridDataRow<Row>[] };
+type DataRow = { kind: "data"; id: string; data: Data };
+type Row = HeaderRow | ParentRow | DataRow;
 
 export function GridTableLayout() {
-  const nameColumn: GridColumn<Row> = { header: "Name", data: ({ name }) => name };
-  const valueColumn: GridColumn<Row> = { header: "Value", data: ({ value }) => value };
-  const actionColumn: GridColumn<Row> = { header: "Action", data: () => <div>Actions</div> };
+  const filterDefs = useMemo(() => getFilterDefs(), []);
+  const columns = useMemo(() => getColumns(), []);
 
-  const filterDefs = useMemo(() => {
-    return {
-      primary: multiFilter({
-        options: [
-          { value: "primary", label: "Primary" },
-          { value: "secondary", label: "Secondary" },
-        ],
-        getOptionLabel: (tp) => tp.label,
-        getOptionValue: (tp) => tp.value,
-        label: "Preference",
-      }),
-      status: multiFilter({
-        options: [
-          { label: "Active", value: "active" },
-          { label: "Inactive", value: "inactive" },
-        ],
-        getOptionLabel: (cs) => cs.label,
-        getOptionValue: (cs) => cs.value,
-        label: "Status",
-      }),
-      needsRevision: checkboxFilter({
-        label: "Needs Revision",
-      }),
-    };
-  }, []);
-
-  const tableState = useGridTableLayoutState({
+  const layoutState = useGridTableLayoutState({
     persistedFilter: {
       filterDefs,
       storageKey: "grid-table-layout",
@@ -54,30 +33,200 @@ export function GridTableLayout() {
     useSearch: "client",
   });
 
-  const { data } = useExampleQuery({ filter: tableState.filter });
+  return (
+    <TestProjectLayout>
+      <GridTableLayoutComponent
+        pageTitle="Grid Table Layout Example"
+        breadcrumb={[
+          { href: "/", label: "Home" },
+          { href: "/", label: "Sub Page" },
+        ]}
+        layoutState={layoutState}
+        tableProps={{
+          columns: [collapseColumn<Row>(), selectColumn<Row>(), ...columns],
+          rows: [simpleHeader, ...makeNestedRows(3)],
+          sorting: { on: "client", initial: [columns[1].id!, "ASC"] },
+        }}
+        primaryAction={{ label: "Primary Action", onClick: noop }}
+        secondaryAction={{ label: "Secondary Action", onClick: noop }}
+        tertiaryAction={{ label: "Tertiary Action", onClick: noop }}
+      />
+    </TestProjectLayout>
+  );
+}
+
+export function QueryTableLayout() {
+  const filterDefs = useMemo(() => getFilterDefs(), []);
+
+  const layoutState = useGridTableLayoutState({
+    persistedFilter: {
+      filterDefs,
+      storageKey: "grid-table-layout",
+    },
+    useSearch: "server",
+  });
+
+  // In this example, we set up a server-side search that uses the `searchString` from the layout state.
+  // in combination with the "QueryTable" behavior for loading/error states.
+  const query = useExampleQuery({ filter: { ...layoutState.filter, search: layoutState.searchString } });
+  const columns = useMemo(() => getColumns(), []);
 
   return (
-    <GridTableLayoutComponent
-      pageTitle="Grid Table Layout Example"
-      breadcrumb={[
-        { href: "/", label: "Home" },
-        { href: "/", label: "Sub Page" },
-      ]}
-      tableState={tableState}
-      gridTableProps={{
-        columns: [nameColumn, valueColumn, actionColumn],
-        rows: [simpleHeader, ...data.map((d) => ({ kind: "data" as const, id: d.id, data: d }))],
-      }}
-    />
+    <TestProjectLayout>
+      <GridTableLayoutComponent
+        pageTitle="Query Table Layout Example"
+        breadcrumb={[
+          { href: "/", label: "Home" },
+          { href: "/", label: "Sub Page" },
+        ]}
+        layoutState={layoutState}
+        tableProps={{
+          columns: [collapseColumn<Row>(), selectColumn<Row>(), ...columns],
+          query,
+          createRows: (data) => [
+            simpleHeader,
+            ...(data?.map((row) => ({ kind: "data" as const, id: row.id, data: row })) ?? []),
+          ],
+          sorting: { on: "client", initial: [columns[1].id!, "ASC"] },
+        }}
+        primaryAction={{ label: "Primary Action", onClick: noop }}
+      />
+    </TestProjectLayout>
   );
 }
 
 function useExampleQuery({ filter }: { filter: Record<string, unknown> }) {
+  const filterString = JSON.stringify(filter);
+
+  const [loading, setLoading] = useState(true);
+  const [data, setData] =
+    useState<Array<{ id: string; name: string; value: number; status: string; priority: number }>>();
+
+  useEffect(() => {
+    setLoading(true);
+    const timer = setTimeout(() => {
+      setData([
+        { id: "1", name: "a", value: 1, status: "active", priority: 1 },
+        { id: "2", name: "b", value: 2, status: "inactive", priority: 2 },
+        { id: "3", name: "c", value: 3, status: "active", priority: 3 },
+      ]);
+      setLoading(false);
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [filterString]);
+
   return {
-    data: [
-      { id: "1", name: "a", value: 1 },
-      { id: "2", name: "b", value: 2 },
-      { id: "3", name: "c", value: 3 },
-    ],
+    data,
+    loading,
   };
+}
+
+function getFilterDefs() {
+  return {
+    primary: multiFilter({
+      options: [
+        { value: "primary", label: "Primary" },
+        { value: "secondary", label: "Secondary" },
+      ],
+      getOptionLabel: (tp) => tp.label,
+      getOptionValue: (tp) => tp.value,
+      label: "Preference",
+    }),
+    status: multiFilter({
+      options: [
+        { label: "Active", value: "active" },
+        { label: "Inactive", value: "inactive" },
+      ],
+      getOptionLabel: (cs) => cs.label,
+      getOptionValue: (cs) => cs.value,
+      label: "Status",
+    }),
+    needsRevision: checkboxFilter({
+      label: "Needs Revision",
+    }),
+  };
+}
+
+function getColumns() {
+  const nameColumn = column<Row>({
+    header: () => "Name",
+    parent: (row) => ({ content: row.name, value: row.name }),
+    data: (row) => row.name,
+    mw: "200px",
+  });
+  const valueColumn = numericColumn<Row>({
+    header: () => "Value",
+    parent: (row) => ({ content: row.value, value: row.value }),
+    data: (row) => row.value,
+    mw: "100px",
+  });
+  const statusColumn = column<Row>({
+    header: () => "Status",
+    parent: (row) => ({ content: row.status, value: row.status }),
+    data: (row) => row.status,
+    mw: "100px",
+  });
+  const priorityColumn = numericColumn<Row>({
+    header: () => "Priority",
+    parent: (row) => ({ content: row.priority, value: row.priority }),
+    data: (row) => row.priority,
+    mw: "100px",
+  });
+  const actionColumn = column<Row>({
+    header: () => "Action",
+    parent: () => ({ content: <div>Actions</div>, value: "" }),
+    data: () => <div>Actions</div>,
+    clientSideSort: false,
+    w: "100px",
+  });
+
+  return [nameColumn, valueColumn, statusColumn, priorityColumn, actionColumn];
+}
+
+function makeNestedRows(repeat: number = 1): GridDataRow<Row>[] {
+  let parentId = 0;
+  return zeroTo(repeat).flatMap((i) => {
+    const p1 = `p${parentId++}`;
+    const p2 = `p${parentId++}`;
+    const p3 = `p${parentId++}`;
+    const prefix = i === 0 ? "" : `${i}.`;
+    return [
+      {
+        kind: "parent",
+        id: p1,
+        data: { name: `parent ${prefix}1`, value: 100, status: "active", priority: 1 },
+        children: [
+          {
+            kind: "data",
+            id: `${p1}c1`,
+            data: { name: `child ${prefix}p1c1`, value: 50, status: "active", priority: 2 },
+          },
+          {
+            kind: "data",
+            id: `${p1}c2`,
+            data: { name: `child ${prefix}p1c2`, value: 30, status: "inactive", priority: 1 },
+          },
+        ],
+      },
+      {
+        kind: "parent",
+        id: p2,
+        data: { name: `parent ${prefix}2`, value: 200, status: "inactive", priority: 2 },
+        children: [
+          {
+            kind: "data",
+            id: `${p2}c1`,
+            data: { name: `child ${prefix}p2c1`, value: 100, status: "active", priority: 3 },
+          },
+        ],
+      },
+      {
+        kind: "parent",
+        id: p3,
+        data: { name: `parent ${prefix}3`, value: 150, status: "active", priority: 3 },
+        children: [],
+      },
+    ];
+  });
 }

--- a/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
@@ -1,0 +1,153 @@
+import { checkboxFilter } from "src/components/Filters";
+import { actionColumn, column, numericColumn } from "src/components/Table/utils/columns";
+import { simpleHeader } from "src/components/Table/utils/simpleHelpers";
+import { noop } from "src/utils";
+import { render, tableSnapshot, withRouter } from "src/utils/rtl";
+import { QueryParamProvider } from "use-query-params";
+import {
+  GridTableLayout as GridTableLayoutComponent,
+  GridTableLayoutProps,
+  useGridTableLayoutState,
+} from "./GridTableLayout";
+
+type Data = { name: string | undefined; value: number | undefined };
+type HeaderRow = { kind: "header"; id: string; data: undefined };
+type DataRow = { kind: "data"; id: string; data: Data };
+type Row = HeaderRow | DataRow;
+
+// Because we also want to test the use of the useGridTableLayoutState hook, we need create a wrapper component
+type TestWrapperProps = Omit<GridTableLayoutProps<any, Row, any, any>, "layoutState"> & {
+  layoutStateProps: Parameters<typeof useGridTableLayoutState>[0];
+};
+function TestWrapper(props: TestWrapperProps) {
+  const layoutState = useGridTableLayoutState(props.layoutStateProps);
+  return <GridTableLayoutComponent {...props} layoutState={layoutState} />;
+}
+
+const columns = [
+  column<Row>({ header: () => "Name", data: (row) => row.name, id: "name" }),
+  numericColumn<Row>({ header: () => "Value", data: (row) => row.value, id: "value" }),
+  actionColumn<Row>({ header: () => "Action", data: () => <div>Actions</div>, id: "action" }),
+];
+
+const rows: Row[] = [
+  { kind: "data", id: "1", data: { name: "Alpha", value: 10 } },
+  { kind: "data", id: "2", data: { name: "Beta", value: 20 } },
+  { kind: "data", id: "3", data: { name: "Gamma", value: 30 } },
+];
+
+describe("GridTableLayout", () => {
+  it("renders with static rows", async () => {
+    // Given a GridTableLayout with static rows and search and filter config
+    const r = await render(
+      <QueryParamProvider>
+        <TestWrapper
+          layoutStateProps={{
+            persistedFilter: {
+              filterDefs: {
+                needsRevision: checkboxFilter({
+                  label: "Needs Revision",
+                }),
+              },
+              storageKey: "test",
+            },
+            useSearch: "client",
+          }}
+          pageTitle="Grid Table Layout Example"
+          breadcrumb={[
+            { href: "/", label: "Home" },
+            { href: "/", label: "Sub Page" },
+          ]}
+          tableProps={{
+            columns,
+            rows: [simpleHeader, ...rows],
+          }}
+          primaryAction={{ label: "Primary Action", onClick: noop }}
+          secondaryAction={{ label: "Secondary Action", onClick: noop }}
+          tertiaryAction={{ label: "Tertiary Action", onClick: noop }}
+        />
+      </QueryParamProvider>,
+      withRouter(),
+    );
+
+    // We expect the Header to be rendered
+    expect(r.pageTitle).toHaveTextContent("Grid Table Layout Example");
+    expect(r.primaryAction).toBeInTheDocument();
+    expect(r.secondaryAction).toBeInTheDocument();
+    expect(r.tertiaryAction).toBeInTheDocument();
+    expect(r.pageHeaderBreadcrumbs_navLink_0).toHaveTextContent("Home");
+    expect(r.pageHeaderBreadcrumbs_navLink_1).toHaveTextContent("Sub Page");
+
+    // And the table actions to be rendered
+    expect(r.search).toHaveValue("");
+    expect(r.filter_needsRevision).not.toBeChecked();
+
+    // And the table content to be rendered
+    expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+      "
+      | Name  | Value | Action  |
+      | ----- | ----- | ------- |
+      | Alpha | 10    | Actions |
+      | Beta  | 20    | Actions |
+      | Gamma | 30    | Actions |
+      "
+    `);
+  });
+
+  it("renders with query table", async () => {
+    // When the table is rendered with a query
+    const r = await render(
+      <QueryParamProvider>
+        <TestWrapper
+          layoutStateProps={{
+            persistedFilter: {
+              filterDefs: {
+                needsRevision: checkboxFilter({
+                  label: "Needs Revision",
+                }),
+              },
+              storageKey: "test",
+            },
+            // And no search config
+          }}
+          pageTitle="Query Table Layout Example"
+          breadcrumb={[
+            { href: "/", label: "Home" },
+            { href: "/", label: "Sub Page" },
+          ]}
+          tableProps={{
+            columns,
+            query: {
+              data: [
+                { id: "1", name: "Delta", value: 100 },
+                { id: "2", name: "Epsilon", value: 200 },
+              ],
+              loading: false,
+            },
+            createRows: (data) => [
+              simpleHeader,
+              ...(data?.map((row: Data & { id: string }) => ({ kind: "data", id: row.id, data: row })) ?? []),
+            ],
+          }}
+          primaryAction={{ label: "Primary Action", onClick: noop }}
+        />
+      </QueryParamProvider>,
+      withRouter(),
+    );
+
+    // And the search to not be rended
+    expect(r.query.search).not.toBeInTheDocument();
+    // But the filter still is
+    expect(r.filter_needsRevision).not.toBeChecked();
+
+    // And the table content to be rendered
+    expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+      "
+      | Name    | Value | Action  |
+      | ------- | ----- | ------- |
+      | Delta   | 100   | Actions |
+      | Epsilon | 200   | Actions |
+      "
+    `);
+  });
+});

--- a/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
@@ -51,7 +51,7 @@ describe("GridTableLayout", () => {
               },
               storageKey: "test",
             },
-            useSearch: "client",
+            search: "client",
           }}
           pageTitle="Grid Table Layout Example"
           breadcrumb={[

--- a/src/components/Layout/GridTableLayout/GridTableLayout.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.tsx
@@ -1,123 +1,217 @@
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
+import { Button, ButtonProps } from "src/components/Button";
 import { Filters } from "src/components/Filters/Filters";
 import { Icon } from "src/components/Icon";
+import { GridDataRow } from "src/components/Table";
 import { GridTable, GridTableProps } from "src/components/Table/GridTable";
 import { TableActions } from "src/components/Table/TableActions";
 import { GridTableXss, Kinded } from "src/components/Table/types";
 import { Css, Only, Palette } from "src/Css";
-import { usePersistedFilter, UsePersistedFilterProps } from "src/hooks";
+import { useBreakpoint, useGroupBy, usePersistedFilter, UsePersistedFilterProps } from "src/hooks";
 import { TextField } from "src/inputs/TextField";
 import { useTestIds } from "src/utils";
 import { useDebounce } from "use-debounce";
+import { StringParam, useQueryParams } from "use-query-params";
 import { FullBleed } from "../FullBleed";
 import { HeaderBreadcrumb, PageHeaderBreadcrumbs } from "../PageHeaderBreadcrumbs";
 import { ScrollableContent } from "../ScrollableContent";
+import { QueryResult, QueryTable, QueryTableProps } from "./QueryTable";
+
+type ActionButtonProps = Pick<ButtonProps, "onClick" | "label" | "disabled" | "tooltip">;
+
+type OmittedTableProps = "filter" | "stickyHeader" | "style" | "rows";
+
+// To wrap the `QueryTable` behavior, we allow a user to pass in EITHER `rows` OR `query` + `createRows` to opt-in to the QueryTable behavior
+type BaseTableProps<R extends Kinded, X extends Only<GridTableXss, X>> = Omit<GridTableProps<R, X>, OmittedTableProps>;
+type GridTablePropsWithRows<R extends Kinded, X extends Only<GridTableXss, X>> = BaseTableProps<R, X> & {
+  rows: GridTableProps<R, X>["rows"];
+  query?: never;
+  createRows?: never;
+};
+type QueryTablePropsWithQuery<R extends Kinded, X extends Only<GridTableXss, X>, QData> = BaseTableProps<R, X> & {
+  query: QueryResult<QData>;
+  createRows: (data: QData | undefined) => GridDataRow<R>[];
+  getPageInfo?: (data: QData) => { hasNextPage: boolean };
+  emptyFallback?: string;
+  keepHeaderWhenLoading?: boolean;
+  rows?: never;
+};
+function isGridTableProps<R extends Kinded, X extends Only<GridTableXss, X>, QData>(
+  props: GridTablePropsWithRows<R, X> | QueryTablePropsWithQuery<R, X, QData>,
+): props is GridTablePropsWithRows<R, X> {
+  return "rows" in props;
+}
 
 export type GridTableLayoutProps<
   F extends Record<string, unknown>,
   R extends Kinded,
   X extends Only<GridTableXss, X>,
+  QData,
 > = {
   pageTitle: string;
+  tableProps: GridTablePropsWithRows<R, X> | QueryTablePropsWithQuery<R, X, QData>;
   breadcrumb?: HeaderBreadcrumb | HeaderBreadcrumb[];
-  gridTableProps: GridTableProps<R, X>;
-  tableState?: ReturnType<typeof useGridTableLayoutState<F>>;
+  layoutState?: ReturnType<typeof useGridTableLayoutState<F>>;
+  primaryAction?: ActionButtonProps;
+  secondaryAction?: ActionButtonProps;
+  tertiaryAction?: ActionButtonProps;
 };
 
-export function GridTableLayout<F extends Record<string, unknown>, R extends Kinded, X extends Only<GridTableXss, X>>(
-  props: GridTableLayoutProps<F, R, X>,
-) {
-  const { pageTitle, breadcrumb, gridTableProps, tableState } = props;
-  const { filterState, searchState } = tableState ?? {};
+/**
+ * A layout component that combines a table with a header, actions buttons and filters.
+ *
+ * This component can render either a `GridTable` or wrapped `QueryTable` based on the provided props:
+ *
+ * - For static data or custom handled loading states, use `rows` to pass in the data directly:
+ * ```tsx
+ * <GridTableLayout
+ *   tableProps={{
+ *     rows: [...],
+ *     columns: [...],
+ *   }}
+ * />
+ * ```
+ *
+ * - To take advantage of data/loading/error states directly from an Apollo query, use `query` and `createRows`:
+ * ```tsx
+ * <GridTableLayout
+ *   tableProps={{
+ *     query,
+ *     createRows: (data) => [...],
+ *     columns: [...],
+ *   }}
+ * />
+ * ```
+ */
+function GridTableLayoutComponent<
+  F extends Record<string, unknown>,
+  R extends Kinded,
+  X extends Only<GridTableXss, X>,
+  QData,
+>(props: GridTableLayoutProps<F, R, X, QData>) {
+  const { pageTitle, breadcrumb, tableProps, layoutState, primaryAction, secondaryAction, tertiaryAction } = props;
 
-  const clientSearch = searchState?.useSearch === "client" ? searchState.searchString : undefined;
-  const showTableActions = filterState || searchState;
+  const clientSearch = layoutState?.useSearch === "client" ? layoutState.searchString : undefined;
+  const showTableActions = layoutState?.filterDefs || layoutState?.useSearch;
+  const isVirtualized = tableProps.as === "virtual";
 
-  const tids = useTestIds({}, "gridTableLayout");
+  const breakpoints = useBreakpoint();
 
   return (
     <>
-      <Header pageTitle={pageTitle} breadcrumb={breadcrumb} {...tids} />
-      <div css={Css.px2.$}>
-        {showTableActions && (
-          <TableActions>
-            {searchState && <SearchBox onSearch={searchState.setSearchString} />}
-
-            {filterState && (
-              <Filters
-                filterDefs={filterState.filterDefs}
-                filter={filterState.filter}
-                onChange={filterState.setFilter}
-              />
-            )}
-          </TableActions>
+      <Header
+        pageTitle={pageTitle}
+        breadcrumb={breadcrumb}
+        primaryAction={primaryAction}
+        secondaryAction={secondaryAction}
+        tertiaryAction={tertiaryAction}
+      />
+      {showTableActions && (
+        <TableActions onlyRight={!layoutState?.useSearch}>
+          {layoutState?.useSearch && <SearchBox onSearch={layoutState.setSearchString} />}
+          {layoutState?.filterDefs && (
+            <Filters
+              filterDefs={layoutState.filterDefs}
+              filter={layoutState.filter}
+              onChange={layoutState.setFilter}
+              groupBy={layoutState.groupBy}
+              numberOfInlineFilters={breakpoints.mdAndDown ? 2 : undefined}
+            />
+          )}
+        </TableActions>
+      )}
+      <ScrollableContent virtualized={isVirtualized}>
+        {isGridTableProps(tableProps) ? (
+          <GridTable {...tableProps} filter={clientSearch} style={{ allWhite: true }} stickyHeader />
+        ) : (
+          <QueryTable
+            {...(tableProps as QueryTableProps<R, QData, X>)}
+            filter={clientSearch}
+            style={{ allWhite: true }}
+            stickyHeader
+          />
         )}
-        <ScrollableContent virtualized={gridTableProps.as === "virtual"}>
-          <GridTable {...gridTableProps} filter={clientSearch} style={{ allWhite: true }} />
-        </ScrollableContent>
-      </div>
+      </ScrollableContent>
     </>
   );
 }
 
+export const GridTableLayout = React.memo(GridTableLayoutComponent) as typeof GridTableLayoutComponent;
+
+/**
+ * A wrapper around standard filter, grouping and search state hooks.
+ * * `client` search will use the built-in grid table search functionality.
+ * * `server` search will return `searchString` as a debounced search string to query the server.
+ */
 export function useGridTableLayoutState<F extends Record<string, unknown>>({
   persistedFilter,
   useSearch,
+  groupBy: maybeGroupBy,
 }: {
-  persistedFilter: UsePersistedFilterProps<F>;
+  persistedFilter?: UsePersistedFilterProps<F>;
   useSearch?: "client" | "server";
+  groupBy?: Record<string, string>;
 }) {
-  const { filter, setFilter } = usePersistedFilter<F>(persistedFilter);
+  // Because we can't conditionally render a hook, we still call it with a fallback value.
+  const filterFallback = { filterDefs: {}, storageKey: "unset-filter" } as UsePersistedFilterProps<F>;
+  const { filter, setFilter } = usePersistedFilter<F>(persistedFilter ?? filterFallback);
+  const groupBy = useGroupBy(maybeGroupBy ?? { none: "none" });
+
   const [searchString, setSearchString] = useState<string | undefined>("");
 
   return {
-    filterState: { filter, setFilter, filterDefs: persistedFilter.filterDefs },
-    searchState: { searchString, setSearchString, useSearch },
-    // Duplicated for easier destructuring
     filter,
+    setFilter,
+    filterDefs: persistedFilter?.filterDefs,
     searchString,
+    setSearchString,
+    useSearch,
+    groupBy: maybeGroupBy ? groupBy : undefined,
   };
 }
 
 type HeaderProps = {
   pageTitle: string;
   breadcrumb?: HeaderBreadcrumb | HeaderBreadcrumb[];
+  primaryAction?: ActionButtonProps;
+  secondaryAction?: ActionButtonProps;
+  tertiaryAction?: ActionButtonProps;
 };
 
 function Header(props: HeaderProps) {
-  const { pageTitle, breadcrumb } = props;
+  const { pageTitle, breadcrumb, primaryAction, secondaryAction, tertiaryAction } = props;
   const tids = useTestIds(props);
 
   return (
     <FullBleed>
-      <header css={{ ...Css.p3.mb3.mhPx(50).bgWhite.$ }} {...tids.header}>
-        {breadcrumb && <PageHeaderBreadcrumbs breadcrumb={breadcrumb} />}
-        <h1 css={Css.xl2Sb.mt2.$} {...tids.pageTitle}>
-          {pageTitle}
-        </h1>
+      <header css={{ ...Css.p3.mb3.mhPx(50).bgWhite.df.jcsb.aic.$ }} {...tids.header}>
+        <div>
+          {breadcrumb && <PageHeaderBreadcrumbs breadcrumb={breadcrumb} />}
+          <h1 css={Css.xl2Sb.mt1.$} {...tids.pageTitle}>
+            {pageTitle}
+          </h1>
+        </div>
+        {/* Flex wrap reverse and justify flex end allows the buttons to wrap naturally/responsively on smaller screens */}
+        <div css={Css.df.fwr.jcfe.gap1.$}>
+          {tertiaryAction && <Button {...tertiaryAction} variant="tertiary" />}
+          {secondaryAction && <Button {...secondaryAction} variant="secondary" />}
+          {primaryAction && <Button {...primaryAction} />}
+        </div>
       </header>
     </FullBleed>
   );
 }
 
-type SearchBoxProps = {
-  onSearch(filter: string): void;
-  clearable?: boolean;
-  updateQueryString?: boolean;
-};
+function SearchBox({ onSearch }: { onSearch(filter: string): void }) {
+  const [{ search: initialValue }, setQueryParams] = useQueryParams({ search: StringParam });
+  const [value, setValue] = useState<string>(initialValue || "");
 
-function SearchBox(props: SearchBoxProps) {
-  const { onSearch, clearable, updateQueryString = true } = props;
-  // const [{ search: initialValue }, setQs] = useZodQueryString(searchSchema);
-  const [value, setValue] = useState<string>("");
-
-  // const tid = useTestIds(props, "searchBox");
   const [debouncedSearch] = useDebounce(value, 300);
 
-  // TODO: figure out query strings
   useEffect(() => {
     onSearch(debouncedSearch);
-  }, [debouncedSearch, onSearch, updateQueryString]);
+    setQueryParams({ search: debouncedSearch || undefined }, "replaceIn");
+  }, [debouncedSearch, onSearch, setQueryParams]);
 
   return (
     <div css={Css.wPx(244).$}>
@@ -127,9 +221,8 @@ function SearchBox(props: SearchBoxProps) {
         value={value}
         onChange={(v) => setValue(v ?? "")}
         placeholder={"Search"}
-        clearable={clearable}
+        clearable
         startAdornment={<Icon icon="search" color={Palette.Gray700} />}
-        // {...tid}
       />
     </div>
   );

--- a/src/components/Layout/GridTableLayout/GridTableLayout.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.tsx
@@ -36,21 +36,27 @@ export function GridTableLayout<F extends Record<string, unknown>, R extends Kin
   const tids = useTestIds({}, "gridTableLayout");
 
   return (
-    <div>
+    <>
       <Header pageTitle={pageTitle} breadcrumb={breadcrumb} {...tids} />
-      {showTableActions && (
-        <TableActions>
-          {searchState && <SearchBox onSearch={searchState.setSearchString} />}
+      <div css={Css.px2.$}>
+        {showTableActions && (
+          <TableActions>
+            {searchState && <SearchBox onSearch={searchState.setSearchString} />}
 
-          {filterState && (
-            <Filters filterDefs={filterState.filterDefs} filter={filterState.filter} onChange={filterState.setFilter} />
-          )}
-        </TableActions>
-      )}
-      <ScrollableContent virtualized={gridTableProps.as === "virtual"}>
-        <GridTable {...gridTableProps} filter={clientSearch} style={{ allWhite: true }} />
-      </ScrollableContent>
-    </div>
+            {filterState && (
+              <Filters
+                filterDefs={filterState.filterDefs}
+                filter={filterState.filter}
+                onChange={filterState.setFilter}
+              />
+            )}
+          </TableActions>
+        )}
+        <ScrollableContent virtualized={gridTableProps.as === "virtual"}>
+          <GridTable {...gridTableProps} filter={clientSearch} style={{ allWhite: true }} />
+        </ScrollableContent>
+      </div>
+    </>
   );
 }
 

--- a/src/components/Layout/GridTableLayout/GridTableLayout.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.tsx
@@ -91,8 +91,8 @@ function GridTableLayoutComponent<
 >(props: GridTableLayoutProps<F, R, X, QData>) {
   const { pageTitle, breadcrumb, tableProps, layoutState, primaryAction, secondaryAction, tertiaryAction } = props;
 
-  const clientSearch = layoutState?.useSearch === "client" ? layoutState.searchString : undefined;
-  const showTableActions = layoutState?.filterDefs || layoutState?.useSearch;
+  const clientSearch = layoutState?.search === "client" ? layoutState.searchString : undefined;
+  const showTableActions = layoutState?.filterDefs || layoutState?.search;
   const isVirtualized = tableProps.as === "virtual";
 
   const breakpoints = useBreakpoint();
@@ -107,8 +107,8 @@ function GridTableLayoutComponent<
         tertiaryAction={tertiaryAction}
       />
       {showTableActions && (
-        <TableActions onlyRight={!layoutState?.useSearch}>
-          {layoutState?.useSearch && <SearchBox onSearch={layoutState.setSearchString} />}
+        <TableActions onlyRight={!layoutState?.search}>
+          {layoutState?.search && <SearchBox onSearch={layoutState.setSearchString} />}
           {layoutState?.filterDefs && (
             <Filters
               filterDefs={layoutState.filterDefs}
@@ -145,11 +145,11 @@ export const GridTableLayout = React.memo(GridTableLayoutComponent) as typeof Gr
  */
 export function useGridTableLayoutState<F extends Record<string, unknown>>({
   persistedFilter,
-  useSearch,
+  search,
   groupBy: maybeGroupBy,
 }: {
   persistedFilter?: UsePersistedFilterProps<F>;
-  useSearch?: "client" | "server";
+  search?: "client" | "server";
   groupBy?: Record<string, string>;
 }) {
   // Because we can't conditionally render a hook, we still call it with a fallback value.
@@ -165,7 +165,7 @@ export function useGridTableLayoutState<F extends Record<string, unknown>>({
     filterDefs: persistedFilter?.filterDefs,
     searchString,
     setSearchString,
-    useSearch,
+    search,
     groupBy: maybeGroupBy ? groupBy : undefined,
   };
 }

--- a/src/components/Layout/GridTableLayout/GridTableLayout.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useState } from "react";
+import { Filters } from "src/components/Filters/Filters";
+import { Icon } from "src/components/Icon";
+import { GridTable, GridTableProps } from "src/components/Table/GridTable";
+import { TableActions } from "src/components/Table/TableActions";
+import { GridTableXss, Kinded } from "src/components/Table/types";
+import { Css, Only, Palette } from "src/Css";
+import { usePersistedFilter, UsePersistedFilterProps } from "src/hooks";
+import { TextField } from "src/inputs/TextField";
+import { useTestIds } from "src/utils";
+import { useDebounce } from "use-debounce";
+import { FullBleed } from "../FullBleed";
+import { HeaderBreadcrumb, PageHeaderBreadcrumbs } from "../PageHeaderBreadcrumbs";
+import { ScrollableContent } from "../ScrollableContent";
+
+export type GridTableLayoutProps<
+  F extends Record<string, unknown>,
+  R extends Kinded,
+  X extends Only<GridTableXss, X>,
+> = {
+  pageTitle: string;
+  breadcrumb?: HeaderBreadcrumb | HeaderBreadcrumb[];
+  gridTableProps: GridTableProps<R, X>;
+  tableState?: ReturnType<typeof useGridTableLayoutState<F>>;
+};
+
+export function GridTableLayout<F extends Record<string, unknown>, R extends Kinded, X extends Only<GridTableXss, X>>(
+  props: GridTableLayoutProps<F, R, X>,
+) {
+  const { pageTitle, breadcrumb, gridTableProps, tableState } = props;
+  const { filterState, searchState } = tableState ?? {};
+
+  const clientSearch = searchState?.useSearch === "client" ? searchState.searchString : undefined;
+  const showTableActions = filterState || searchState;
+
+  const tids = useTestIds({}, "gridTableLayout");
+
+  return (
+    <div>
+      <Header pageTitle={pageTitle} breadcrumb={breadcrumb} {...tids} />
+      {showTableActions && (
+        <TableActions>
+          {searchState && <SearchBox onSearch={searchState.setSearchString} />}
+
+          {filterState && (
+            <Filters filterDefs={filterState.filterDefs} filter={filterState.filter} onChange={filterState.setFilter} />
+          )}
+        </TableActions>
+      )}
+      <ScrollableContent virtualized={gridTableProps.as === "virtual"}>
+        <GridTable {...gridTableProps} filter={clientSearch} style={{ allWhite: true }} />
+      </ScrollableContent>
+    </div>
+  );
+}
+
+export function useGridTableLayoutState<F extends Record<string, unknown>>({
+  persistedFilter,
+  useSearch,
+}: {
+  persistedFilter: UsePersistedFilterProps<F>;
+  useSearch?: "client" | "server";
+}) {
+  const { filter, setFilter } = usePersistedFilter<F>(persistedFilter);
+  const [searchString, setSearchString] = useState<string | undefined>("");
+
+  return {
+    filterState: { filter, setFilter, filterDefs: persistedFilter.filterDefs },
+    searchState: { searchString, setSearchString, useSearch },
+    // Duplicated for easier destructuring
+    filter,
+    searchString,
+  };
+}
+
+type HeaderProps = {
+  pageTitle: string;
+  breadcrumb?: HeaderBreadcrumb | HeaderBreadcrumb[];
+};
+
+function Header(props: HeaderProps) {
+  const { pageTitle, breadcrumb } = props;
+  const tids = useTestIds(props);
+
+  return (
+    <FullBleed>
+      <header css={{ ...Css.p3.mb3.mhPx(50).bgWhite.$ }} {...tids.header}>
+        {breadcrumb && <PageHeaderBreadcrumbs breadcrumb={breadcrumb} />}
+        <h1 css={Css.xl2Sb.mt2.$} {...tids.pageTitle}>
+          {pageTitle}
+        </h1>
+      </header>
+    </FullBleed>
+  );
+}
+
+type SearchBoxProps = {
+  onSearch(filter: string): void;
+  clearable?: boolean;
+  updateQueryString?: boolean;
+};
+
+function SearchBox(props: SearchBoxProps) {
+  const { onSearch, clearable, updateQueryString = true } = props;
+  // const [{ search: initialValue }, setQs] = useZodQueryString(searchSchema);
+  const [value, setValue] = useState<string>("");
+
+  // const tid = useTestIds(props, "searchBox");
+  const [debouncedSearch] = useDebounce(value, 300);
+
+  // TODO: figure out query strings
+  useEffect(() => {
+    onSearch(debouncedSearch);
+  }, [debouncedSearch, onSearch, updateQueryString]);
+
+  return (
+    <div css={Css.wPx(244).$}>
+      <TextField
+        label="Search"
+        labelStyle="hidden"
+        value={value}
+        onChange={(v) => setValue(v ?? "")}
+        placeholder={"Search"}
+        clearable={clearable}
+        startAdornment={<Icon icon="search" color={Palette.Gray700} />}
+        // {...tid}
+      />
+    </div>
+  );
+}

--- a/src/components/Layout/GridTableLayout/QueryTable.tsx
+++ b/src/components/Layout/GridTableLayout/QueryTable.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from "react";
+import { LoadingSkeleton, LoadingSkeletonProps } from "src/components/LoadingSkeleton";
+import { GridDataRow } from "src/components/Table/components/Row";
+import { GridTable, GridTableProps } from "src/components/Table/GridTable";
+import { GridTableXss, Kinded } from "src/components/Table/types";
+import { Only } from "src/Css";
+
+export type QueryResult<QData> = {
+  loading: boolean;
+  error?: { message: string };
+  data?: QData;
+};
+
+export type QueryTableProps<R extends Kinded, QData, X> = Omit<GridTableProps<R, X>, "rows" | "fallback"> & {
+  query: QueryResult<QData>;
+  emptyFallback?: string;
+  /** Creates the rows given the data; needs to accept undefined so we can create the header row. */
+  createRows: (data: QData | undefined) => GridDataRow<R>[];
+  getPageInfo?: (data: QData) => {
+    hasNextPage: boolean;
+  };
+  keepHeaderWhenLoading?: boolean;
+};
+
+/**
+ * An adaption of GridTable that binds directly to an Apollo QueryResult.
+ *
+ * This handles the data/loading/error states internally within the table, i.e. we'll show a fallbackMessage
+ * for loading/error states, instead of the entire table blinking in/out.
+ */
+export function QueryTable<R extends Kinded, QData, X extends Only<GridTableXss, X> = any>(
+  props: QueryTableProps<R, QData, X>,
+) {
+  const { emptyFallback, query, createRows, getPageInfo, columns, keepHeaderWhenLoading, ...others } = props;
+
+  // Always call createRows to get the header, even if we're loading/error'd. We do force data=undefined
+  // if loading/error though b/c while making/loading a 2nd query, Apollo will keep the 1st query's data.
+  // This is arguably a better UX if we could show a spinner-new-results-coming-soon + the
+  // old-results-are-still-here at the same time.
+  const data = query.loading || query.error ? undefined : query.data;
+  const rows = useMemo(() => createRows(data), [createRows, data]);
+
+  // Detect our `pageInfo` response pattern
+  const hasNextPage = data && getPageInfo && getPageInfo(data).hasNextPage;
+  const infoMessage = hasNextPage ? "Too many rows" : undefined;
+
+  // loading/error/empty can all use the one fallback prop.
+  const fallbackMessage = query.loading ? "Loading…" : query.error ? `Error: ${query.error.message}` : emptyFallback;
+
+  const headers = rows.filter((row) => row.kind === "header");
+
+  return query.loading ? (
+    <div>
+      {keepHeaderWhenLoading ? (
+        <GridTable {...{ columns, ...others }} rows={headers} fallbackMessage={fallbackMessage} />
+      ) : (
+        <LoadingTable columns={columns.length} />
+      )}
+    </div>
+  ) : (
+    <GridTable {...{ rows, columns, fallbackMessage, infoMessage, ...others }} />
+  );
+}
+
+export type LoadingTableProps = Pick<LoadingSkeletonProps, "columns">;
+
+function LoadingTable(props: LoadingTableProps) {
+  const { columns } = props;
+  return (
+    <>
+      {/* Header row */}
+      <LoadingSkeleton rows={1} columns={1} />
+      {/* Line Item rows - default to 5 rows/columns */}
+      <LoadingSkeleton rows={5} columns={columns ?? 5} />
+    </>
+  );
+}

--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -275,7 +275,7 @@ function TestLayout({ children }: ChildrenOnly) {
   );
 }
 
-function TestProjectLayout({ children }: ChildrenOnly) {
+export function TestProjectLayout({ children }: ChildrenOnly) {
   return (
     <PreventBrowserScroll>
       <TestTopNav />

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -1,5 +1,6 @@
 export * from "./FormPageLayout";
 export * from "./FullBleed";
+export * from "./GridTableLayout/GridTableLayout";
 export * from "./PreventBrowserScroll";
 export * from "./RightPaneLayout";
 export * from "./ScrollableContent";

--- a/src/hooks/usePersistedFilter.ts
+++ b/src/hooks/usePersistedFilter.ts
@@ -4,7 +4,7 @@ import { useSessionStorage } from "src/hooks";
 import { safeEntries, safeKeys } from "src/utils";
 import { JsonParam, useQueryParams } from "use-query-params";
 
-interface UsePersistedFilterProps<F> {
+export interface UsePersistedFilterProps<F> {
   filterDefs: FilterDefs<F>;
   storageKey: string;
 }


### PR DESCRIPTION
A layout component that combines a table with a header, actions buttons and filters. Story for this branch: https://sc-68262-table-page-layout--60466f7d43c37c0021788867.chromatic.com/?path=/story/components-layout-gridtablelayout--query-table-layout

This component can render either a `GridTable` or wrapped `QueryTable` based on the provided props:
 - For static data or custom handled loading states, use `rows` to pass in the data directly:
```tsx
<GridTableLayout
  tableProps={{
    rows: [...],
    columns: [...],
  }}
/>
```
 - To take advantage of data/loading/error states directly from an Apollo query, use `query` and `createRows`:
```tsx
<GridTableLayout
  tableProps={{
    query,
    createRows: (data) => [...],
    columns: [...],
  }}
/>
```

- For filtering, search and group by, this component is also intended to be used with the `useGridTableLayoutState` which  combines the various hooks into a single prop while also providing access to the filter/search states to the parent component:
```tsx
  const layoutState = useGridTableLayoutState({
    persistedFilter: {
      filterDefs,
      storageKey: "grid-table-layout",
    },
    search: "client",
  });

  const query = useExampleQuery({ filter: { ...layoutState.filter, search: layoutState.searchString } });


return <GridTableLayout
  tableProps={{...}}
  layoutState={layoutState}
/>
```