### PR TITLE
feat: [SC-70480] Enable Banner/Snackbar in FormPageLayout

### DIFF
--- a/src/components/Layout/FormPageLayout.stories.tsx
+++ b/src/components/Layout/FormPageLayout.stories.tsx
@@ -11,7 +11,14 @@ import {
   boundTextField,
 } from "src/forms";
 import { AuthorInput } from "src/forms/formStateDomain";
-import { Css, FormPageLayout as FormPageLayoutComponent, FormSectionConfig, TextField } from "src/index";
+import {
+  Css,
+  FormPageLayout as FormPageLayoutComponent,
+  FormSectionConfig,
+  TextField,
+  useSnackbar,
+  useToast,
+} from "src/index";
 import { noop } from "src/utils";
 import { withBeamDecorator, withDimensions, withRouter } from "src/utils/sb";
 
@@ -26,13 +33,21 @@ export function FormPageLayout() {
     config: formConfig,
     init: { input: { firstName: "John", middleInitial: "C", lastName: "Doe" } },
   });
+  const { showToast } = useToast();
+  const { triggerNotice } = useSnackbar();
 
   return (
     <FormPageLayoutComponent
       pageTitle="Detail Title"
       submitAction={{ label: "Save", onClick: noop }}
-      cancelAction={{ label: "Cancel", onClick: noop }}
-      tertiaryAction={{ label: "Tertiary Test", onClick: noop }}
+      cancelAction={{
+        label: "Cancel",
+        onClick: () => showToast({ message: "Cancel Action Triggered", type: "warning" }),
+      }}
+      tertiaryAction={{
+        label: "Tertiary Test",
+        onClick: () => triggerNotice({ message: "Tertiary Action Triggered" }),
+      }}
       breadCrumb={[
         { label: "Breadcrumb A", href: "/breadcrumb-a" },
         { label: "Breadcrumb B", href: "/breadcrumb-b" },
@@ -52,13 +67,21 @@ export function SingleColumn() {
     config: formConfig,
     init: { input: { firstName: "John", middleInitial: "C", lastName: "Doe" } },
   });
+  const { showToast } = useToast();
+  const { triggerNotice } = useSnackbar();
 
   return (
     <FormPageLayoutComponent
       pageTitle="Detail Title"
       submitAction={{ label: "Save", onClick: noop }}
-      cancelAction={{ label: "Cancel", onClick: noop }}
-      tertiaryAction={{ label: "Tertiary Test", onClick: noop }}
+      cancelAction={{
+        label: "Cancel",
+        onClick: () => showToast({ message: "Cancel Action Triggered", type: "warning" }),
+      }}
+      tertiaryAction={{
+        label: "Tertiary Test",
+        onClick: () => triggerNotice({ message: "Tertiary Action Triggered" }),
+      }}
       breadCrumb={[
         { label: "Breadcrumb A", href: "/breadcrumb-a" },
         { label: "Breadcrumb B", href: "/breadcrumb-b" },

--- a/src/components/Layout/FormPageLayout.tsx
+++ b/src/components/Layout/FormPageLayout.tsx
@@ -9,6 +9,7 @@ import { useDebouncedCallback } from "use-debounce";
 import { Button, ButtonProps } from "../Button";
 import { Icon, IconKey } from "../Icon";
 import { RIGHT_SIDEBAR_MIN_WIDTH, RightSidebar, SidebarContentProps } from "../RightSidebar";
+import { Toast } from "../Toast/Toast";
 import { HeaderBreadcrumb, PageHeaderBreadcrumbs } from "./PageHeaderBreadcrumbs";
 
 type FormSection<F> = {
@@ -42,7 +43,6 @@ const maxContentWidthPx = 1600;
 
 function FormPageLayoutComponent<F>(props: FormPageLayoutProps<F>) {
   const { formSections, formState, rightSideBar } = props;
-
   const tids = useTestIds(props, "formPageLayout");
 
   // Create a ref for each section here so we can coordinate both the `scrollIntoView`
@@ -89,7 +89,8 @@ function PageHeader<F>(props: FormPageLayoutProps<F>) {
   const tids = useTestIds(props);
 
   return (
-    <header css={Css.gr(1).gc("1 / 4").sticky.top0.hPx(headerHeightPx).bgWhite.z5.$} {...tids}>
+    <header css={Css.gr(1).gc("1 / 4").sticky.top0.bgWhite.z5.$} {...tids}>
+      <Toast />
       <div css={Css.py2.px3.df.jcsb.aic.$}>
         <div>
           {breadCrumb && <PageHeaderBreadcrumbs breadcrumb={breadCrumb} />}

--- a/src/components/Layout/FormPageLayout.tsx
+++ b/src/components/Layout/FormPageLayout.tsx
@@ -10,6 +10,7 @@ import { Button, ButtonProps } from "../Button";
 import { Icon, IconKey } from "../Icon";
 import { RIGHT_SIDEBAR_MIN_WIDTH, RightSidebar, SidebarContentProps } from "../RightSidebar";
 import { Toast } from "../Toast/Toast";
+import { useToastContext } from "../Toast/ToastContext";
 import { HeaderBreadcrumb, PageHeaderBreadcrumbs } from "./PageHeaderBreadcrumbs";
 
 type FormSection<F> = {
@@ -85,11 +86,11 @@ export const FormPageLayout = React.memo(FormPageLayoutComponent) as typeof Form
 
 function PageHeader<F>(props: FormPageLayoutProps<F>) {
   const { pageTitle, breadCrumb, submitAction, cancelAction, tertiaryAction, formState } = props;
-
+  const { notice } = useToastContext();
   const tids = useTestIds(props);
 
   return (
-    <header css={Css.gr(1).gc("1 / 4").sticky.top0.bgWhite.z5.$} {...tids}>
+    <header css={Css.gr(1).gc("1 / 4").sticky.top0.bgWhite.z5.if(!notice).hPx(headerHeightPx).$} {...tids}>
       <Toast />
       <div css={Css.py2.px3.df.jcsb.aic.$}>
         <div>

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -12,6 +12,7 @@ export function Snackbar({ notices, offset }: SnackbarProps) {
   return (
     <div
       {...tid.snackbarWrapper}
+      // Using z9999 to ensure notifications appear above all other UI elements, including FormPageLayout
       css={Css.fixed.z9999.bottomPx(offset.bottom ?? defaultOffset.bottom).left3.df.fdc.aifs.gapPx(12).$}
     >
       {notices.map((data) => (

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -12,7 +12,7 @@ export function Snackbar({ notices, offset }: SnackbarProps) {
   return (
     <div
       {...tid.snackbarWrapper}
-      css={Css.fixed.z999.bottomPx(offset.bottom ?? defaultOffset.bottom).left3.df.fdc.aifs.gapPx(12).$}
+      css={Css.fixed.z9999.bottomPx(offset.bottom ?? defaultOffset.bottom).left3.df.fdc.aifs.gapPx(12).$}
     >
       {notices.map((data) => (
         <SnackbarNotice key={data.id} {...data} />


### PR DESCRIPTION
### Description 

`FormPageLayout` is displayed as a full-screen modal, which prevents notifications from being visible during user actions (via `Snackbar`) or query errors (via `BannerNotice`). We need to add support for both types of notifications.

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/d161b4da-8274-4d1c-a7f2-063542e65058" />

