### PR TITLE
feat: Put IconButton.label in a tooltip.

### DIFF
--- a/src/components/IconButton.stories.tsx
+++ b/src/components/IconButton.stories.tsx
@@ -63,6 +63,10 @@ function Template(args: IconButtonProps) {
           <h2>Colored</h2>
           <IconButton {...args} color={Palette.Red700} />
         </div>
+        <div>
+          <h2>Labeled</h2>
+          <IconButton {...args} label="Download" />
+        </div>
       </div>
     </div>
   );

--- a/src/components/IconButton.test.tsx
+++ b/src/components/IconButton.test.tsx
@@ -5,6 +5,11 @@ import { click, render, withRouter } from "src/utils/rtl";
 import { useTestIds } from "src/utils/useTestIds";
 
 describe("IconButton", () => {
+  it("can add tooltips", async () => {
+    const r = await render(<IconButton icon="trash" label="Move to trash" onClick={noop} />);
+    expect(r.tooltip).toHaveAttribute("title", "Move to trash");
+  });
+
   it("can have a data-testid", async () => {
     const r = await render(<IconButton icon="trash" data-testid="remove" onClick={noop} />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("remove");

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -114,7 +114,7 @@ export function IconButton(props: IconButtonProps) {
 
   // If we're disabled b/c of a non-boolean ReactNode, or the caller specified tooltip text, then show it in a tooltip
   return maybeTooltip({
-    title: resolveTooltip(disabled, tooltip),
+    title: resolveTooltip(disabled ?? label, tooltip),
     placement: "top",
     children: getButtonOrLink(buttonContent, onPress, buttonAttrs, openInNew, download),
   });


### PR DESCRIPTION
Instead of a manual Tooltip wrapper:

```
              <Tooltip title={`Download ${trade.tradePartner.name} bid`} placement="top">
                <IconButton icon="download" onClick={onDownloadTemplate} color={Palette.Blue600} />
```

We can get it for free by just setting label.