### PR TITLE
feat: allow custom radio group name

### DIFF
--- a/src/inputs/RadioGroupField.test.tsx
+++ b/src/inputs/RadioGroupField.test.tsx
@@ -50,18 +50,18 @@ describe("RadioGroupField", () => {
     expect(tooltip).toHaveAttribute("title", "some reason");
   });
 
-  it("can have a group name", async () => {
+  it("can provide a custom group name", async () => {
     const r = await render(
       <>
         <RadioGroupField
-          name="favorite-cheese-group"
+          unsupportedNameHack="favorite-cheese-group"
           label="cheese option 1"
           value="a"
           onChange={() => {}}
           options={[{ value: "a", label: "Asiago" }]}
         />
         <RadioGroupField
-          name="favorite-cheese-group"
+          unsupportedNameHack="favorite-cheese-group"
           label="cheese option 2"
           value="b"
           onChange={() => {}}

--- a/src/inputs/RadioGroupField.tsx
+++ b/src/inputs/RadioGroupField.tsx
@@ -38,8 +38,8 @@ export interface RadioGroupFieldProps<K extends string> extends Pick<Presentatio
   helperText?: string | ReactNode;
   onBlur?: () => void;
   onFocus?: () => void;
-  /** The group name for the radio group. */
-  name?: string;
+  /** The group name for the radio group. Only for legacy pages with custom layouts - avoid using this. */
+  unsupportedNameHack?: string;
 }
 
 /**
@@ -59,12 +59,12 @@ export function RadioGroupField<K extends string>(props: RadioGroupFieldProps<K>
     disabled = false,
     errorMsg,
     helperText,
-    name,
+    unsupportedNameHack,
     ...otherProps
   } = props;
   // We use a group name so that the radio group is logically grouped together
   // Allows for externally grouped radios when `name` is provided multiple times
-  const groupName = useMemo(() => name ?? `radio-group-${++nextNameId}`, [name]);
+  const groupName = useMemo(() => unsupportedNameHack ?? `radio-group-${++nextNameId}`, [unsupportedNameHack]);
   const state = useRadioGroupState({
     name: groupName,
     value,


### PR DESCRIPTION
This PR adds support to provide a `name` prop to the `RadioGroupField` component.

By default, the underlying <input type="radio"> element requires a name attribute in order to be logically grouped with other radios. Without name, each radio is treated as independent, meaning multiple radios can be selected at the same time instead of behaving as a mutually exclusive set.

This fixes some situations where the `RadioGroupField` is rendered individually for a parent group.