### PR TITLE
fix: number field clipboard paste

### DIFF
--- a/src/inputs/NumberField.test.tsx
+++ b/src/inputs/NumberField.test.tsx
@@ -292,6 +292,21 @@ describe("NumberFieldTest", () => {
     expect(lastSet).toEqual(7500);
   });
 
+  it("does not discard pasted values", async () => {
+    // Given a NumberField with a value
+    const r = await render(<TestNumberField label="Cost" type="cents" value={1200} />);
+    expect(r.cost).toHaveValue("$12.00");
+    // When the user focuses, selects all, and pastes a new value
+    const input = r.cost as HTMLInputElement;
+    focus(input);
+    input.setSelectionRange(0, input.value.length);
+    fireEvent.paste(input, { clipboardData: { getData: () => "75" } });
+    fireEvent.blur(input);
+    // Then the pasted value should be retained
+    expect(r.cost).toHaveValue("$75.00");
+    expect(lastSet).toEqual(7500);
+  });
+
   it("respects useGrouping as false", async () => {
     // Given a NumberField with `useGrouping` set to `false`
     const r = await render(<TestNumberField label="Code" useGrouping={false} value={123456} />);

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -142,6 +142,8 @@ export function NumberField(props: NumberFieldProps) {
   // Tracks the last value we sent to the parent via onChange, so the render-time sync
   // can distinguish "echo of user typing" from "genuinely external value change".
   const lastSentRef = useRef<number | undefined>(undefined);
+  // Tracks the value at focus time so we can identify stale blur-commits from react-aria.
+  const focusValueRef = useRef<number | undefined>(undefined);
   // Force re-render after blur so useProps.value picks up the prop value directly (wip=false)
   // and react-aria reformats the input correctly.
   const [, forceRender] = useState(0);
@@ -166,15 +168,16 @@ export function NumberField(props: NumberFieldProps) {
     // // This is called on blur with the final/committed value.
     onChange: (value) => {
       const formatted = formatValue(value, factor, numFractionDigits, numIntegerDigits, positiveOnly);
-      // Suppress react-aria's on-blur commit when it differs from what we already sent.
-      // TextFieldBase.onChange pushes the real-time value; react-aria's commit may be stale
-      // (its controlled value lags behind due to echo-detection preserving cursor position).
-      if (formatted !== lastSentRef.current) return;
+      // Suppress react-aria's on-blur commit only when it's reverting to the stale focus value.
+      // This prevents stale blur-commits from overwriting user edits, while still allowing
+      // paste-originated commits (which produce a value different from the focus value).
+      if (formatted !== lastSentRef.current && formatted === focusValueRef.current) return;
       onChange(formatted);
     },
     onFocus: () => {
       valueRef.current = { wip: true, value: value === undefined ? Number.NaN : value / factor };
       lastSentRef.current = value;
+      focusValueRef.current = value;
     },
     onBlur: () => {
       valueRef.current = { wip: false };


### PR DESCRIPTION
## Summary

Fixes a regression from [#1226](https://github.com/homebound-team/beam/pull/1226) where pasting values into `NumberField` was silently discarded.

PR #1226 added an echo-detection guard (`if (formatted !== lastSentRef.current) return`) to prevent react-aria's stale blur-commits from overwriting user edits. However, when pasting, react-aria calls `commit()` directly via its `onPaste` handler *before* `TextFieldBase.onChange` can update `lastSentRef`, so the guard blocked the legitimate pasted value.

Storybook https://60466f7d43c37c0021788867-ltsykrbklt.chromatic.com/?path=/story/inputs-numberfield--number-field-styles