### PR TITLE
feat: Add groups to TreeSelectField.

### DIFF
--- a/src/inputs/TreeSelectField/TreeOption.tsx
+++ b/src/inputs/TreeSelectField/TreeOption.tsx
@@ -10,12 +10,12 @@ import { LeveledOption, NestedOption } from "src/inputs/TreeSelectField/utils";
 import { Value, valueToKey } from "src/inputs/Value";
 import { useTestIds } from "src/utils";
 
-interface TreeOptionProps<O> {
+type TreeOptionProps<O> = {
   item: Node<LeveledOption<O>>;
   state: ListState<O>;
   contrast?: boolean;
   allowCollapsing?: boolean;
-}
+};
 /** Represents a single option within a ListBox - used by SelectField, MultiSelectField, and TreeSelectField */
 export function TreeOption<O>(props: TreeOptionProps<O>) {
   const { item, state, contrast = false, allowCollapsing = true } = props;
@@ -35,7 +35,7 @@ export function TreeOption<O>(props: TreeOptionProps<O>) {
 
   // TODO: validate this eslint-disable with https://app.shortcut.com/homebound-team/story/40045
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const { collapsedKeys, setCollapsedKeys, getOptionValue } = useTreeSelectFieldProvider<O, Value>();
+  const { collapsedKeys, setCollapsedKeys, getOptionValue, groupKeys } = useTreeSelectFieldProvider<O, Value>();
 
   // TODO: validate this eslint-disable with https://app.shortcut.com/homebound-team/story/40045
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -44,6 +44,15 @@ export function TreeOption<O>(props: TreeOptionProps<O>) {
     state,
     ref,
   );
+  const isGroup = groupKeys.includes(item.key);
+  const canCollapse = allowCollapsing && !!option.children?.length;
+
+  function toggleCollapsed() {
+    if (!canCollapse) return;
+    setCollapsedKeys((prevKeys) =>
+      collapsedKeys.includes(item.key) ? prevKeys.filter((k) => k !== item.key) : [...prevKeys, item.key],
+    );
+  }
 
   // If this item is not selected, then determine if some of its children are selected to show the indeterminate state.
   // Note: If `isSelected` will be true if all of the children were selected. That auto-parent-selection happens in the `onSelect` callback in TreeSelectField.
@@ -59,24 +68,28 @@ export function TreeOption<O>(props: TreeOptionProps<O>) {
   return (
     <li
       {...hoverProps}
+      onClick={(e) => {
+        if (!isGroup) return;
+        e.preventDefault();
+        e.stopPropagation();
+        toggleCollapsed();
+      }}
       css={{
         ...Css.df.aic.jcsb.gap1.pl2.mh("42px").outline0.cursorPointer.sm.plPx(16 + level * 8).$,
         ...listItemStyles.item,
-        ...(isHovered && !isDisabled ? listItemStyles.hover : {}),
-        ...(isFocused ? listItemStyles.focus : {}),
-        ...(isDisabled ? listItemStyles.disabled : {}),
+        ...(isHovered && (!isDisabled || isGroup) ? listItemStyles.hover : {}),
+        ...(isFocused && !isGroup ? listItemStyles.focus : {}),
+        ...(isDisabled && !isGroup ? listItemStyles.disabled : {}),
       }}
     >
       {allowCollapsing && (
         <span css={Css.wPx(18).fs0.df.aic.$}>
-          {option.children && option.children?.length > 0 && (
+          {canCollapse && (
             <button
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                setCollapsedKeys((prevKeys) =>
-                  collapsedKeys.includes(item.key) ? prevKeys.filter((k) => k !== item.key) : [...prevKeys, item.key],
-                );
+                toggleCollapsed();
                 return false;
               }}
               css={Css.br4.hPx(16).wPx(16).bgTransparent.onHover.bgGray300.$}
@@ -88,12 +101,14 @@ export function TreeOption<O>(props: TreeOptionProps<O>) {
         </span>
       )}
       <span css={Css.df.aic.gap1.h100.fg1.py1.pr2.$} ref={ref} {...optionProps} data-label={item.textValue}>
-        <StyledCheckbox
-          isDisabled={isDisabled}
-          isSelected={isSelected}
-          isIndeterminate={isIndeterminate}
-          {...tid[item.key.toString()]}
-        />
+        {!isGroup && (
+          <StyledCheckbox
+            isDisabled={isDisabled}
+            isSelected={isSelected}
+            isIndeterminate={isIndeterminate}
+            {...tid[item.key.toString()]}
+          />
+        )}
         <div css={Css.pl1.$}>{item.rendered}</div>
       </span>
     </li>

--- a/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
@@ -6,7 +6,7 @@ import { Value } from "src/inputs/index";
 import { TreeSelectField, TreeSelectFieldProps } from "src/inputs/TreeSelectField/TreeSelectField";
 import { NestedOption } from "src/inputs/TreeSelectField/utils";
 import { HasIdAndName } from "src/types";
-import { zeroTo } from "src/utils/sb";
+import { newStory, zeroTo } from "src/utils/sb";
 import { action } from "storybook/actions";
 import { within } from "storybook/test";
 
@@ -160,54 +160,33 @@ export const Contrast = Template.bind({});
 // @ts-ignore
 Contrast.args = { compact: true, contrast: true };
 
-export function OpenMenu() {
-  const options: NestedOption<HasIdAndName>[] = zeroTo(3).map((dIdx) => ({
-    id: `d:${dIdx}`,
-    name: `Development ${dIdx}`,
-    children: zeroTo(2).map((cIdx) => ({
-      id: `c:${cIdx}:d:${dIdx}`,
-      name: `Cohort ${cIdx}`,
-      children: zeroTo(2).map((pIdx) => ({
-        id: `p:${pIdx}:c:${cIdx}:d:${dIdx}`,
-        name: `Project ${pIdx}`,
+export const OpenMenu = newStory(
+  () => {
+    const options: NestedOption<HasIdAndName>[] = zeroTo(3).map((dIdx) => ({
+      id: `d:${dIdx}`,
+      name: `Development ${dIdx}`,
+      children: zeroTo(2).map((cIdx) => ({
+        id: `c:${cIdx}:d:${dIdx}`,
+        name: `Cohort ${cIdx}`,
+        children: zeroTo(2).map((pIdx) => ({
+          id: `p:${pIdx}:c:${cIdx}:d:${dIdx}`,
+          name: `Project ${pIdx}`,
+        })),
       })),
-    })),
-  }));
+    }));
 
-  return <TestTreeSelectField values={[]} options={options} label="Nested options" placeholder="Select a project" />;
-}
-OpenMenu.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
-  const canvas = within(canvasElement);
-  canvas.getByTestId("toggleListBox").click();
-};
+    return <TestTreeSelectField values={[]} options={options} label="Nested options" placeholder="Select a project" />;
+  },
+  {
+    play: async ({ canvasElement }) => {
+      const canvas = within(canvasElement);
+      canvas.getByTestId("toggleListBox").click();
+    },
+  },
+);
 
 export function AsyncOptions() {
-  const options: NestedOption<HasIdAndName>[] = [
-    {
-      id: "baseball",
-      name: "Baseball",
-      children: [
-        { id: "mlb", name: "MLB" },
-        { id: "milb", name: "Minor League Baseball" },
-      ],
-    },
-    {
-      id: "basketball",
-      name: "Basketball",
-      children: [
-        { id: "nba", name: "NBA" },
-        { id: "wnba", name: "WNBA" },
-      ],
-    },
-    {
-      id: "football",
-      name: "Football",
-      children: [
-        { id: "nfl", name: "NFL" },
-        { id: "xfl", name: "XFL" },
-      ],
-    },
-  ];
+  const options = getLeagueOptions();
   const initialOption = [options[0]];
 
   return (
@@ -227,6 +206,36 @@ export function AsyncOptions() {
     />
   );
 }
+
+export function GroupOptions() {
+  return (
+    <TestTreeSelectField
+      values={["mlb", "nba"]}
+      options={getLeagueOptions()}
+      groupOptions={["baseball", "basketball"]}
+      label="Favorite League"
+      placeholder="Select a league"
+    />
+  );
+}
+
+export const GroupOptionsOpen = newStory(
+  () => (
+    <TestTreeSelectField
+      values={["mlb", "nba"]}
+      options={getLeagueOptions()}
+      groupOptions={["baseball", "basketball"]}
+      label="Favorite League"
+      placeholder="Select a league"
+    />
+  ),
+  {
+    play: ({ canvasElement }) => {
+      const canvas = within(canvasElement);
+      canvas.getByTestId("toggleListBox").click();
+    },
+  },
+);
 
 export function Interactive() {
   const options: NestedOption<HasIdAndName>[] = zeroTo(3).map((dIdx) => ({
@@ -279,4 +288,33 @@ function TestTreeSelectField<T extends HasIdAndName, V extends Value>(
       getOptionValue={(o) => o.id}
     />
   );
+}
+
+function getLeagueOptions(): NestedOption<HasIdAndName>[] {
+  return [
+    {
+      id: "baseball",
+      name: "Baseball",
+      children: [
+        { id: "mlb", name: "MLB" },
+        { id: "milb", name: "Minor League Baseball" },
+      ],
+    },
+    {
+      id: "basketball",
+      name: "Basketball",
+      children: [
+        { id: "nba", name: "NBA" },
+        { id: "wnba", name: "WNBA" },
+      ],
+    },
+    {
+      id: "football",
+      name: "Football",
+      children: [
+        { id: "nfl", name: "NFL" },
+        { id: "xfl", name: "XFL" },
+      ],
+    },
+  ];
 }

--- a/src/inputs/TreeSelectField/TreeSelectField.test.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.test.tsx
@@ -536,6 +536,64 @@ describe("TreeSelectField", () => {
     expect(r.getByRole("option", { name: "NBA" })).toHaveAttribute("aria-disabled", "true");
   });
 
+  it("renders group options as non-selectable text and toggles them from the row click", async () => {
+    // Given a TreeSelectField with group options
+    const onSelect = vi.fn() as any;
+    const r = await render(
+      <TreeSelectField
+        onSelect={onSelect}
+        values={[]}
+        options={getNestedOptions()}
+        groupOptions={["basketball"]}
+        label="Favorite League"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+
+    // When opening the options
+    click(r.favoriteLeague);
+
+    // Then the group option renders without a checkbox
+    expect(r.query.treeOption_basketball_checkbox).not.toBeInTheDocument();
+
+    // And clicking the row does not select it
+    click(r.getByRole("option", { name: "Basketball" }));
+    expect(onSelect).not.toHaveBeenCalled();
+
+    // But it does collapse and expand its children
+    expect(r.queryByRole("option", { name: "NBA" })).toBeFalsy();
+    click(r.getByRole("option", { name: "Basketball" }));
+    expect(r.getByRole("option", { name: "NBA" })).toBeVisible();
+  });
+
+  it("does not auto-select group options when all of their children are selected", async () => {
+    // Given a TreeSelectField with a group option
+    const onSelect = vi.fn() as any;
+    const r = await render(
+      <TreeSelectField
+        onSelect={onSelect}
+        values={[]}
+        options={getNestedOptions()}
+        groupOptions={["basketball"]}
+        label="Favorite League"
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+
+    // When selecting all of the group's children
+    click(r.favoriteLeague);
+    click(r.getByRole("option", { name: "NBA" }));
+    click(r.getByRole("option", { name: "WNBA" }));
+
+    // Then the group itself is still not selected
+    expect(r.getByRole("option", { name: "Basketball" })).toHaveAttribute("aria-selected", "false");
+    // And the callback returns the children as the top-level selections
+    expect(onSelect.mock.calls[1][0].leaf.values).toEqual(["nba", "wnba"]);
+    expect(onSelect.mock.calls[1][0].root.values).toEqual(["nba", "wnba"]);
+  });
+
   it("selects all matching options when there are duplicates and only the child is passed as values", async () => {
     // Given the multiple parents with duplicate children
     const options: NestedOption<HasIdAndName>[] = [

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -74,6 +74,7 @@ export type TreeSelectFieldProps<O, V extends Value> = {
    * @default root */
   chipDisplay?: "all" | "leaf" | "root";
   disabledOptions?: V[];
+  groupOptions?: V[];
 } & BeamFocusableProps &
   PresentationFieldProps;
 
@@ -95,6 +96,7 @@ export function TreeSelectField<O, V extends Value>(
   } = props;
 
   const [collapsedKeys, setCollapsedKeys] = useState<AriaKey[]>([]);
+  const groupKeys = useMemo(() => props.groupOptions?.map((option) => valueToKey(option)) ?? [], [props.groupOptions]);
 
   useEffect(() => {
     setCollapsedKeys(
@@ -112,10 +114,10 @@ export function TreeSelectField<O, V extends Value>(
   }, [options, defaultCollapsed]);
 
   const contextValue = useMemo<CollapsedChildrenState<O, V>>(
-    () => ({ collapsedKeys, setCollapsedKeys, getOptionValue }),
+    () => ({ collapsedKeys, setCollapsedKeys, getOptionValue, groupKeys }),
     // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [collapsedKeys, setCollapsedKeys],
+    [collapsedKeys, setCollapsedKeys, groupKeys],
   );
 
   return (
@@ -135,19 +137,21 @@ export function TreeSelectField<O, V extends Value>(
 }
 
 export function useTreeSelectFieldProvider<O, V extends Value>() {
-  return useContext(CollapsedContext);
+  return useContext(CollapsedContext) as CollapsedChildrenState<O, V>;
 }
 
 type CollapsedChildrenState<O, V extends Value> = {
   collapsedKeys: AriaKey[];
   setCollapsedKeys: Dispatch<SetStateAction<AriaKey[]>>;
   getOptionValue: (opt: O) => V;
+  groupKeys: AriaKey[];
 };
 // create the context to hold the collapsed state, default should be false
 export const CollapsedContext = React.createContext<CollapsedChildrenState<any, any>>({
   collapsedKeys: [],
   setCollapsedKeys: () => {},
   getOptionValue: () => ({}) as any,
+  groupKeys: [],
 });
 
 function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, V>) {
@@ -165,13 +169,16 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
     contrast = false,
     nothingSelectedText = "",
     onSelect,
-    defaultCollapsed = false,
+    defaultCollapsed: _defaultCollapsed = false,
     placeholder,
     fullWidth = fieldProps?.fullWidth ?? false,
     chipDisplay = "root",
     disabledOptions,
+    groupOptions: _groupOptions,
     ...otherProps
   } = props;
+
+  void _defaultCollapsed;
 
   const isDisabled = !!disabled;
   const isReadOnly = !!readOnly;
@@ -179,10 +186,13 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
   const { contains } = useFilter({ sensitivity: "base" });
 
   const { collapsedKeys } = useTreeSelectFieldProvider();
+  const groupKeys = useMemo(() => _groupOptions?.map((option) => valueToKey(option)) ?? [], [_groupOptions]);
+  const groupKeySet = useMemo<Set<AriaKey>>(() => new Set(groupKeys), [groupKeys]);
 
   // `disabledKeys` from ComboBoxState does not support additional meta for showing a disabled reason to the user
   // This lookup map helps us cleanly prune out the optional reason text, then access it further down the component tree
   const disabledOptionsWithReasons = Object.fromEntries(disabledOptions?.map(disabledOptionToKeyedTuple) ?? []);
+  const disabledKeys = [...new Set<AriaKey>([...Object.keys(disabledOptionsWithReasons), ...groupKeys])];
 
   const initTreeFieldState: () => TreeFieldState<O> = useCallback(() => {
     // Figure out which options should be considered selected.
@@ -200,11 +210,12 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
       }),
     );
 
-    function selectOptionAndAllChildren(maybeParent: NestedOption<O>): string[] {
+    function selectOptionAndAllChildren(maybeParent: NestedOption<O>): AriaKey[] {
       // Check if the maybeParent has children, if so, return those as selected keys
       // Do in a recursive way so that children may have children
+      const key = valueToKey(getOptionValue(maybeParent));
       return [
-        valueToKey(getOptionValue(maybeParent)),
+        ...(groupKeySet.has(key) ? [] : [key]),
         ...(maybeParent.children?.flatMap(selectOptionAndAllChildren) ?? []),
       ];
     }
@@ -212,15 +223,16 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
     // It is possible that all the children of a parent were considered selected `values`, but the parent wasn't included in the `values` array.
     // In this case, the parent also should be considered a selected option.
     function areAllChildrenSelected(maybeParent: NestedOption<O>): boolean {
-      const isSelected = selectedKeys.has(valueToKey(getOptionValue(maybeParent)));
+      const key = valueToKey(getOptionValue(maybeParent));
+      const isSelected = selectedKeys.has(key);
       // If already selected, or the options does not have children, then return its current state.
       if (isSelected || !maybeParent.children || maybeParent.children.length === 0) return isSelected;
 
       // If we do have children, then check if all children are selected.
       // if all are selected, then push this parent to the selectedKeys
       const areAllSelected = maybeParent.children.every(areAllChildrenSelected);
-      if (areAllSelected) {
-        selectedKeys.add(valueToKey(getOptionValue(maybeParent)));
+      if (areAllSelected && !groupKeySet.has(key)) {
+        selectedKeys.add(key);
       }
       return areAllSelected;
     }
@@ -243,10 +255,9 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
           ? selectedOptions.filter((o) => !o.children || o.children.length === 0).map(getOptionLabel)
           : selectedOptions.map(getOptionLabel);
 
-    const filteredOptions = initialOptions.flatMap((o) => levelOptions(o, 0, false, collapsedKeys, getOptionValue));
-
     return {
       selectedKeys: [...selectedKeys],
+      searchValue: undefined,
       inputValue:
         selectedOptions.length === 1
           ? getOptionLabel([...selectedOptions][0])
@@ -255,7 +266,6 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
             : selectedOptions.length === 0
               ? nothingSelectedText
               : "",
-      filteredOptions,
       selectedOptions,
       allOptions: initialOptions,
       selectedOptionsLabels,
@@ -270,7 +280,7 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
     isReadOnly,
     nothingSelectedText,
     getOptionValue,
-    collapsedKeys,
+    groupKeySet,
   ]);
 
   // Initialize the TreeFieldState
@@ -299,75 +309,47 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getOptionValue, initTreeFieldState, values]);
 
-  // React to collapsed keys and update the filtered options
-  const reactToCollapse = useRef(false);
-  useEffect(
-    () => {
-      // Do not run this effect on first render. Otherwise we'd be triggering a re-render on first render.
-      if (reactToCollapse.current) {
-        setFieldState(({ allOptions, inputValue, ...others }) => ({
-          allOptions,
-          inputValue,
-          ...others,
-          filteredOptions: allOptions.flatMap((o) =>
-            levelOptions(o, 0, inputValue.length > 0, collapsedKeys, getOptionValue).filter(([option]) =>
-              contains(getOptionLabel(option), inputValue),
-            ),
-          ),
-        }));
-      }
-      reactToCollapse.current = true;
-    },
-    // Only react to collapseKey changes. Other deps should be stable (`contains`, `getOptionLabel`, `getOptionValue`).
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [collapsedKeys],
+  const filteredOptions = useMemo(
+    () =>
+      getFilteredOptions(
+        fieldState.allOptions,
+        fieldState.searchValue,
+        collapsedKeys,
+        contains,
+        getOptionLabel,
+        getOptionValue,
+      ),
+    [fieldState.allOptions, fieldState.searchValue, collapsedKeys, contains, getOptionLabel, getOptionValue],
   );
 
   // Update the filtered options when the input value changes
-  const onInputChange = useCallback(
-    (inputValue: string) => {
-      setFieldState((prevState) => {
-        return {
-          ...prevState,
-          inputValue,
-          allowCollapsing: inputValue.length === 0,
-          filteredOptions: prevState.allOptions.flatMap((o) =>
-            levelOptions(o, 0, inputValue.length > 0, collapsedKeys, getOptionValue).filter(([option]) =>
-              contains(getOptionLabel(option), inputValue),
-            ),
-          ),
-        };
-      });
-    },
-    [collapsedKeys, contains, getOptionLabel, getOptionValue],
-  );
+  const onInputChange = useCallback((inputValue: string) => {
+    setFieldState((prevState) => {
+      return {
+        ...prevState,
+        inputValue,
+        searchValue: inputValue.length === 0 ? undefined : inputValue,
+        allowCollapsing: inputValue.length === 0,
+      };
+    });
+  }, []);
 
   // Handle loading of the options in the case that they are loaded via a Promise.
   const maybeInitLoad = useCallback(
-    async (
-      options: NestedOptionsOrLoad<O>,
-      fieldState: TreeFieldState<O>,
-      setFieldState: React.Dispatch<React.SetStateAction<TreeFieldState<O>>>,
-    ) => {
+    async (options: NestedOptionsOrLoad<O>, setFieldState: React.Dispatch<React.SetStateAction<TreeFieldState<O>>>) => {
       if (!Array.isArray(options)) {
         setFieldState((prevState) => ({ ...prevState, optionsLoading: true }));
         const loadedOptions = (await options.load()).options;
-        const filteredOptions = loadedOptions.flatMap((o) =>
-          levelOptions(o, 0, fieldState.inputValue.length > 0, collapsedKeys, getOptionValue).filter(([option]) =>
-            contains(getOptionLabel(option), fieldState.inputValue),
-          ),
-        );
 
         // Ensure the `unset` option is prepended to the top of the list if `unsetLabel` was provided
         setFieldState((prevState) => ({
           ...prevState,
-          filteredOptions,
           allOptions: loadedOptions,
           optionsLoading: false,
         }));
       }
     },
-    [collapsedKeys, contains, getOptionLabel, getOptionValue],
+    [],
   );
 
   // Only on the first open of the listbox, we want to load the options if they haven't been loaded yet.
@@ -376,7 +358,7 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
     if (firstOpen.current && isOpen) {
       // TODO: verify this eslint ignore
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      maybeInitLoad(options, fieldState, setFieldState);
+      maybeInitLoad(options, setFieldState);
       firstOpen.current = false;
     }
     if (isOpen) {
@@ -384,7 +366,8 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
       setFieldState((prevState) => ({
         ...prevState,
         inputValue: "",
-        filteredOptions: prevState.allOptions.flatMap((o) => levelOptions(o, 0, false, collapsedKeys, getOptionValue)),
+        searchValue: undefined,
+        allowCollapsing: true,
       }));
     }
   }
@@ -402,11 +385,11 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
 
   const comboBoxProps = {
     ...otherProps,
-    disabledKeys: Object.keys(disabledOptionsWithReasons),
+    disabledKeys,
     placeholder: !values || values.length === 0 ? placeholder : "",
     label: props.label,
     inputValue: fieldState.inputValue,
-    items: fieldState.filteredOptions,
+    items: filteredOptions,
     isDisabled,
     isReadOnly,
     onInputChange,
@@ -437,6 +420,8 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
           setFieldState((prevState) => ({
             ...prevState,
             inputValue: nothingSelectedText,
+            searchValue: undefined,
+            allowCollapsing: true,
             selectedKeys: [],
             selectedOptions: [],
           }));
@@ -467,18 +452,19 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
                   // remove children that are disabled
                   return !state.disabledKeys.has(childKey);
                 });
-              [key, ...childrenKeys].forEach(addedKeys.add, addedKeys);
+              [...(groupKeySet.has(key) ? [] : [key]), ...childrenKeys].forEach(addedKeys.add, addedKeys);
             }
 
             // If this was a child that was selected, then see if every other child is also selected, and if so, consider the parent selected.
             // Walk up the parents and determine their state.
-            for (const parent of parents.reverse()) {
-              const allChecked = parent.children?.every((child) => {
-                const childKey = valueToKey(getOptionValue(child));
-                return addedKeys.has(childKey) || existingKeys.has(childKey) || state.disabledKeys.has(childKey);
-              });
-              if (allChecked) {
-                addedKeys.add(valueToKey(getOptionValue(parent)));
+            const selectionKeys = new Set([...existingKeys, ...addedKeys]);
+            for (const parent of [...parents].reverse()) {
+              const parentKey = valueToKey(getOptionValue(parent));
+              if (isOptionFullySelected(parent, selectionKeys, state.disabledKeys, groupKeySet, getOptionValue)) {
+                if (!groupKeySet.has(parentKey)) {
+                  addedKeys.add(parentKey);
+                  selectionKeys.add(parentKey);
+                }
               }
             }
           }
@@ -539,7 +525,7 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
           ...prevState,
           // Since we reset the list of options upon selection changes, then set the `inputValue` to empty string to reflect that.
           inputValue: "",
-          filteredOptions: initialOptions.flatMap((o) => levelOptions(o, 0, false, collapsedKeys, getOptionValue)),
+          searchValue: undefined,
           selectedKeys: [...selectedKeys],
           selectedOptions,
           selectedOptionsLabels:
@@ -574,7 +560,7 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
             : selectedOptions.length === 0
               ? nothingSelectedText
               : "",
-        filteredOptions: initialOptions.flatMap((o) => levelOptions(o, 0, false, collapsedKeys, getOptionValue)),
+        searchValue: undefined,
         allowCollapsing: true,
       }));
     }
@@ -714,4 +700,41 @@ function getTopLevelSelections<O, V extends Value>(
   // If this element has no children, then look through the children for top level selected options.
   if (o.children) return [...o.children.flatMap((c) => getTopLevelSelections(c, selectedKeys, getOptionValue))];
   return [];
+}
+
+function getFilteredOptions<O, V extends Value>(
+  allOptions: NestedOption<O>[],
+  searchValue: string | undefined,
+  collapsedKeys: AriaKey[],
+  contains: (string: string, substring: string) => boolean,
+  getOptionLabel: (o: O) => string,
+  getOptionValue: (o: O) => V,
+): LeveledOption<O>[] {
+  return allOptions.flatMap((option) =>
+    levelOptions(option, 0, !!searchValue, collapsedKeys, getOptionValue).filter(([nestedOption]) =>
+      searchValue ? contains(getOptionLabel(nestedOption), searchValue) : true,
+    ),
+  );
+}
+
+function isOptionFullySelected<O, V extends Value>(
+  option: NestedOption<O>,
+  selectedKeys: Set<AriaKey>,
+  disabledKeys: Set<AriaKey>,
+  groupKeys: Set<AriaKey>,
+  getOptionValue: (o: O) => V,
+): boolean {
+  const key = valueToKey(getOptionValue(option));
+  if (groupKeys.has(key)) {
+    return option.children?.length
+      ? option.children.every((child) =>
+          isOptionFullySelected(child, selectedKeys, disabledKeys, groupKeys, getOptionValue),
+        )
+      : false;
+  }
+  if (selectedKeys.has(key) || disabledKeys.has(key)) return true;
+  if (!option.children || option.children.length === 0) return false;
+  return option.children.every((child) =>
+    isOptionFullySelected(child, selectedKeys, disabledKeys, groupKeys, getOptionValue),
+  );
 }

--- a/src/inputs/TreeSelectField/utils.ts
+++ b/src/inputs/TreeSelectField/utils.ts
@@ -10,7 +10,7 @@ export type LeveledOption<O> = [NestedOption<O>, number];
 
 export type TreeFieldState<O> = {
   inputValue: string;
-  filteredOptions: LeveledOption<O>[];
+  searchValue?: string;
   selectedKeys: AriaKey[];
   selectedOptions: NestedOption<O>[];
   /** These are the labels of the top-level selected values

--- a/src/inputs/internal/VirtualizedOptions.tsx
+++ b/src/inputs/internal/VirtualizedOptions.tsx
@@ -61,14 +61,18 @@ export function VirtualizedOptions<O>(props: VirtualizedOptionsProps<O>) {
   return (
     <Virtuoso
       ref={virtuosoRef}
-      key={items.length}
       totalListHeightChanged={onListHeightChange}
       totalCount={items.length}
       {...(process.env.NODE_ENV === "test"
         ? {
-            // We don't really need to set this, but it's handy for tests, which would
-            // otherwise render just 1 row. A better way to do this would be to jest.mock
-            // out Virtuoso with an impl that just rendered everything, but doing this for now.
+            // In tests, we render all rows so assertions can see expands/async-loaded items. However,
+            // the `initialItemCount` (next prop) is only applied on amount, so we set `key={items.length}`
+            // to force a remount when our list changes -- and we only want/need this in tests, b/c otherwise
+            // in production a Virtuoso remount causes visible flashing.
+            key: items.length,
+            // We don't really need to set this, but it's handy for tests, which would otherwise render
+            // just 1 row. A better way to do this would be to jest.mock out Virtuoso with an impl that
+            // just rendered everything, but doing this for now.
             initialItemCount: items.length,
           }
         : {


### PR DESCRIPTION
For grouping items w/o wanting the groups themselves to be selectable:

<img width="1848" height="1240" alt="image" src="https://github.com/user-attachments/assets/d917fb12-07d8-4cef-a275-07de78522e37" />
