### PR TITLE
feat: add scrollable footer

### DIFF
--- a/src/components/Layout/Layout.stories.tsx
+++ b/src/components/Layout/Layout.stories.tsx
@@ -5,12 +5,14 @@ import { TabsWithContent, TabWithContent } from "src/components/Tabs";
 import { Css, Palette } from "src/Css";
 import { FormLines } from "src/forms";
 import {
+  Button,
   FullBleed,
   GridColumn,
   GridDataRow,
   GridTable,
   PreventBrowserScroll,
   ScrollableContent,
+  ScrollableFooter,
   ScrollableParent,
   simpleHeader,
   SimpleHeaderAndData,
@@ -65,6 +67,23 @@ export function VirtualizedScrolling() {
   return (
     <TestProjectLayout>
       <VirtualizedPage />
+    </TestProjectLayout>
+  );
+}
+
+export function WithFooter() {
+  return (
+    <TestProjectLayout>
+      <TestHeader title="Enter Bid Information" />
+      <ScrollableContent virtualized>
+        <TableExample virtualized numCols={20} numRows={200} />
+      </ScrollableContent>
+      <ScrollableFooter>
+        <div css={Css.df.aic.jcfe.gap2.bgWhite.bt.bcGray200.px3.py2.bshHover.$}>
+          <Button variant="quaternary" size="lg" label="Cancel" onClick={() => {}} />
+          <Button size="lg" label="Save" onClick={() => {}} />
+        </div>
+      </ScrollableFooter>
     </TestProjectLayout>
   );
 }

--- a/src/components/Layout/ScrollableFooter.test.tsx
+++ b/src/components/Layout/ScrollableFooter.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "src/utils/rtl";
+import { ScrollableContent } from "./ScrollableContent";
+import { ScrollableFooter } from "./ScrollableFooter";
+import { ScrollableParent } from "./ScrollableParent";
+
+describe("ScrollableFooter", () => {
+  it("renders ScrollableFooter children in the parent's footer slot alongside ScrollableContent", async () => {
+    const r = await render(
+      <ScrollableParent>
+        <ScrollableContent>
+          <div data-testid="pageContent">Hello World!</div>
+        </ScrollableContent>
+        <ScrollableFooter>
+          <div data-testid="pageFooter">Save</div>
+        </ScrollableFooter>
+      </ScrollableParent>,
+    );
+    expect(r.pageContent).toHaveTextContent("Hello World!");
+    expect(r.pageFooter).toHaveTextContent("Save");
+  });
+
+  it("renders ScrollableFooter children inline if not wrapped in ScrollableParent", async () => {
+    const r = await render(
+      <div>
+        <ScrollableFooter>
+          <div data-testid="pageFooter">Save</div>
+        </ScrollableFooter>
+      </div>,
+    );
+    expect(r.pageFooter).toHaveTextContent("Save");
+  });
+});

--- a/src/components/Layout/ScrollableFooter.tsx
+++ b/src/components/Layout/ScrollableFooter.tsx
@@ -1,0 +1,43 @@
+import { ReactNode, ReactPortal } from "react";
+import { createPortal } from "react-dom";
+import { useScrollableParent } from "src/components/Layout/ScrollableParent";
+
+type ScrollableFooterProps = {
+  children: ReactNode;
+};
+
+/**
+ * Renders content into the `ScrollableParent`'s footer slot — a sibling of the scrollable region
+ * that sits at the bottom of the page. The scroll region above shrinks to make room, so the
+ * last row of a long table is never hidden behind the footer.
+ *
+ * Symmetric with `ScrollableContent`: place it anywhere in the tree below `ScrollableParent`
+ * and it portals to the parent's footer container. Style the children directly (e.g. background,
+ * shadow, padding) — the slot itself adds no visuals.
+ *
+ * Typical usage:
+ * ```tsx
+ * <ScrollableParent>
+ *   <PageHeader />
+ *   <ScrollableContent virtualized>
+ *     <GridTable as="virtual" columns={columns} rows={rows} />
+ *   </ScrollableContent>
+ *   {isEditing && (
+ *     <ScrollableFooter>
+ *       <ActionBar onCancel={...} onSave={...} />
+ *     </ScrollableFooter>
+ *   )}
+ * </ScrollableParent>
+ * ```
+ */
+export function ScrollableFooter(props: ScrollableFooterProps): ReactPortal | JSX.Element {
+  const { children } = props;
+  const { footerEl } = useScrollableParent();
+
+  // Escape hatch for tests / callers without a `ScrollableParent` context.
+  if (!footerEl) {
+    return <>{children}</>;
+  }
+
+  return createPortal(<>{children}</>, footerEl);
+}

--- a/src/components/Layout/ScrollableParent.tsx
+++ b/src/components/Layout/ScrollableParent.tsx
@@ -13,6 +13,7 @@ import { Css, maybeInc, Properties } from "src/Css";
 
 interface ScrollableParentContextProps {
   scrollableEl: HTMLElement | null;
+  footerEl: HTMLElement | null;
   paddingRight: string;
   paddingLeft: string;
   setPortalTick: Dispatch<SetStateAction<number>>;
@@ -20,6 +21,7 @@ interface ScrollableParentContextProps {
 
 const ScrollableParentContext = createContext<ScrollableParentContextProps>({
   scrollableEl: null,
+  footerEl: null,
   paddingRight: "0px",
   paddingLeft: "0px",
   setPortalTick: (v) => {},
@@ -69,11 +71,16 @@ export function ScrollableParent(props: PropsWithChildren<ScrollableParentContex
     el.style.height = "100%";
     return el;
   }, []);
+  // Sibling of the scrollable region; receives `ScrollableFooter` content. Empty when no footer
+  // is portaled, so the layout is identical to today's two-slot version in that case.
+  const footerEl = useMemo(() => document.createElement("div"), []);
   const [, setTick] = useState(0);
   const hasScrollableContent = scrollableEl.childNodes.length > 0;
   const scrollableRef = useRef<HTMLDivElement | null>(null);
+  const footerRef = useRef<HTMLDivElement | null>(null);
   const context: ScrollableParentContextProps = {
     scrollableEl,
+    footerEl,
     paddingLeft,
     paddingRight,
     setPortalTick: setTick,
@@ -82,6 +89,10 @@ export function ScrollableParent(props: PropsWithChildren<ScrollableParentContex
   useEffect(() => {
     scrollableRef.current!.appendChild(scrollableEl);
   }, [scrollableEl]);
+
+  useEffect(() => {
+    footerRef.current!.appendChild(footerEl);
+  }, [footerEl]);
 
   return (
     <ScrollableParentContext.Provider value={context}>
@@ -101,6 +112,9 @@ export function ScrollableParent(props: PropsWithChildren<ScrollableParentContex
         </div>
         {/* Set fg1 to take up the remaining space in the viewport.*/}
         <div css={Css.fg1.oa.$} ref={scrollableRef} />
+        {/* Sibling slot for `ScrollableFooter`. fs0 keeps it at its natural height so the
+         * scrollable region above shrinks instead of the footer being clipped. */}
+        <div css={Css.fs0.$} ref={footerRef} />
       </Tag>
     </ScrollableParentContext.Provider>
   );

--- a/src/components/Layout/index.ts
+++ b/src/components/Layout/index.ts
@@ -4,4 +4,5 @@ export * from "./GridTableLayout/GridTableLayout";
 export * from "./PreventBrowserScroll";
 export * from "./RightPaneLayout";
 export * from "./ScrollableContent";
+export * from "./ScrollableFooter";
 export * from "./ScrollableParent";


### PR DESCRIPTION
### Description

Adds a `ScrollableFooter` layout primitive that portals content into a new sibling slot below ScrollableParent's scrollable region, so action bars (Save/Cancel, etc.) sit at the bottom of the page without overlapping the last row of long/virtualized tables.

### Screenshot

https://60466f7d43c37c0021788867-wqfjtbkqqy.chromatic.com/?path=/story/components-layout--with-footer

<img width="1699" height="835" alt="image" src="https://github.com/user-attachments/assets/189ba772-f946-450b-8e0d-c0447a377c6e" />
