### PR TITLE
fix: pick the dominant axis on DnDGrid

### DIFF
--- a/src/components/DnDGrid/DnDGrid.tsx
+++ b/src/components/DnDGrid/DnDGrid.tsx
@@ -4,7 +4,7 @@ import { Css, Palette, Properties, useTestIds } from "src";
 import { clearInlineStyles, isDefined, setInlineStyles } from "src/utils";
 import { DnDGridContext } from "./DnDGridContext";
 
-export interface DnDGridProps {
+export type DnDGridProps = {
   children: ReactNode;
   /** CSS Grid styles for the grid container. */
   gridStyles?: GridStyles;
@@ -12,7 +12,7 @@ export interface DnDGridProps {
   activeItemStyles?: Properties;
   /** Returns the new order of the GridItems. */
   onReorder: (items: string[]) => void;
-}
+};
 
 export function DnDGrid(props: DnDGridProps) {
   const { children, gridStyles, onReorder, activeItemStyles } = props;
@@ -113,9 +113,12 @@ export function DnDGrid(props: DnDGridProps) {
       // Figure out if we need to move the placeholder element based on the `dragEl`'s new position.
       if (target instanceof HTMLElement && target !== cloneEl.current && target !== dragEl.current) {
         const targetPos = target.getBoundingClientRect();
-        const isHalfwayPassedTarget =
-          (clientY - targetPos.top) / (targetPos.bottom - targetPos.top) > 0.5 ||
-          (clientX - targetPos.left) / (targetPos.right - targetPos.left) > 0.5;
+        const clonePos = cloneEl.current.getBoundingClientRect();
+        // Pick the axis along which the placeholder and target are most separated, that's the layout's flow direction.
+        const useYAxis = Math.abs(targetPos.top - clonePos.top) >= Math.abs(targetPos.left - clonePos.left);
+        const isHalfwayPassedTarget = useYAxis
+          ? (clientY - targetPos.top) / (targetPos.bottom - targetPos.top) > 0.5
+          : (clientX - targetPos.left) / (targetPos.right - targetPos.left) > 0.5;
 
         // Only insert the placeholder if it's not already in the correct position.
         const shouldInsert =


### PR DESCRIPTION
### [P-2211](https://linear.app/homebound-team/issue/P-2211/beam-fix-drag-and-drop-component)

The drag “passed target” check treated X and Y equally: if the cursor crossed either the bottom half or the right half of a target, it counted as “passed” and triggered “insert after”.

That worked in the existing implementations because items are narrow and dragging naturally moves across X. But in a single-column grid with wide rows and right-side drag handles, the cursor stays in the right half of every target the whole time. The check becomes permanently true, so only “insert after” ever fires. Dragging down works, but dragging up never lands.

The fix chooses a single axis per move based on the dominant displacement between the placeholder and target. Single-column grids use Y, single-row grids use X, and 2D grids use whichever axis changes more.

Before:

https://github.com/user-attachments/assets/aa36e755-8126-4a2d-b061-d0cc0b91776f

After:

https://github.com/user-attachments/assets/aece389a-d159-4436-a57a-b190fd62afd9

## Storybook

* [Before](https://60466f7d43c37c0021788867-kxzpcopueq.chromatic.com/?path=/story/components-table-gridtable--draggable-card-rows)

* [After](https://60466f7d43c37c0021788867-pdjhmwmsjh.chromatic.com/?path=/story/components-table-gridtable--draggable-card-rows)