### PR TITLE
feat: [P-2225] Add horizontal layout option to RadioGroupField

### DIFF
--- a/src/inputs/RadioGroupField.stories.tsx
+++ b/src/inputs/RadioGroupField.stories.tsx
@@ -294,3 +294,23 @@ export function HelperText() {
     />
   );
 }
+
+export function HorizontalLayout() {
+  const [state, setState] = useState<string | undefined>("a");
+  return (
+    <FormLines width="md">
+      <RadioGroupField
+        label="Estimate Type"
+        layout="horizontal"
+        value={state}
+        onChange={setState}
+        options={[
+          { label: "Temporary", value: "a" },
+          { label: "Lot Determined", value: "b" },
+        ]}
+        onBlur={action("onBlur")}
+        onFocus={action("onFocus")}
+      />
+    </FormLines>
+  );
+}

--- a/src/inputs/RadioGroupField.stories.tsx
+++ b/src/inputs/RadioGroupField.stories.tsx
@@ -296,7 +296,7 @@ export function HelperText() {
 }
 
 export function HorizontalLayout() {
-  const [state, setState] = useState<string | undefined>("a");
+  const [state, setState] = useState<string | undefined>("option-1");
   return (
     <FormLines width="md">
       <RadioGroupField
@@ -305,9 +305,18 @@ export function HorizontalLayout() {
         value={state}
         onChange={setState}
         options={[
-          { label: "Temporary", value: "a" },
-          { label: "Lot Determined", value: "b" },
+          { label: "Option 1", value: "option-1" },
+          { label: "Option 2", value: "option-2" },
         ]}
+        onBlur={action("onBlur")}
+        onFocus={action("onFocus")}
+      />
+      <RadioGroupField
+        label="Many Options"
+        layout="horizontal"
+        value={state}
+        onChange={setState}
+        options={Array.from({ length: 25 }, (_, i) => ({ label: `Option ${i + 1}`, value: `option-${i + 1}` }))}
         onBlur={action("onBlur")}
         onFocus={action("onFocus")}
       />

--- a/src/inputs/RadioGroupField.test.tsx
+++ b/src/inputs/RadioGroupField.test.tsx
@@ -49,4 +49,24 @@ describe("RadioGroupField", () => {
     expect(tooltip).toBeInTheDocument();
     expect(tooltip).toHaveAttribute("title", "some reason");
   });
+
+  it("supports horizontal layout", async () => {
+    const r = await render(
+      <RadioGroupField
+        label="Favorite cheese"
+        layout="horizontal"
+        value="a"
+        onChange={() => {}}
+        options={[
+          { value: "a", label: "Asiago" },
+          { value: "b", label: "Burratta" },
+        ]}
+      />,
+    );
+    // Selection still works in horizontal layout.
+    click(r.favoriteCheese_b);
+    // The flex container that wraps the option labels uses row direction.
+    const optionsContainer = r.container.querySelector(`[data-testid="favoriteCheese_a"]`)!.closest("div")!;
+    expect(optionsContainer).toHaveStyle({ "flex-direction": "row" });
+  });
 });

--- a/src/inputs/RadioGroupField.tsx
+++ b/src/inputs/RadioGroupField.tsx
@@ -85,7 +85,7 @@ export function RadioGroupField<K extends string>(props: RadioGroupFieldProps<K>
     <div css={Css.df.fdc.gap1.aifs.if(labelStyle === "left").fdr.gap2.jcsb.$}>
       <Label label={label} {...labelProps} {...tid.label} hidden={labelStyle === "hidden"} />
       <div {...radioGroupProps}>
-        <div css={Css.df.if(layout === "horizontal").fdr.fww.gap3.else.fdc.$}>
+        <div css={Css.df.if(layout === "horizontal").fdr.fww.gap3.else.fdc.gap1.$}>
           {options.map((option) => {
             return (
               <Fragment key={option.value}>
@@ -98,7 +98,6 @@ export function RadioGroupField<K extends string>(props: RadioGroupFieldProps<K>
                       option={option}
                       state={state}
                       isOptionDisabled={!!option.disabled}
-                      layout={layout}
                       {...otherProps}
                       {...tid[option.value]}
                     />
@@ -124,7 +123,6 @@ function Radio<K extends string>(props: {
   // react-aria uses a WeakMap keyed by the state object identity to store radio group
   // metadata, so spreading state into a new object breaks the lookup.
   isOptionDisabled?: boolean;
-  layout?: RadioGroupFieldLayout;
   onBlur?: () => void;
   onFocus?: () => void;
 }) {
@@ -133,7 +131,6 @@ function Radio<K extends string>(props: {
     option: { description, label, value },
     state,
     isOptionDisabled,
-    layout = "vertical",
     ...others
   } = props;
 
@@ -152,17 +149,7 @@ function Radio<K extends string>(props: {
   const { hoverProps, isHovered } = useHover({ isDisabled: disabled });
 
   return (
-    // In vertical layout, each option uses `mb1` for stacking spacing.
-    // In horizontal layout, spacing comes from the parent flex `gap`, so we skip `mb1`.
-    <label
-      css={
-        Css.df.cursorPointer
-          .if(layout === "vertical")
-          .mb1.if(disabled)
-          .add("cursor", "initial").$
-      }
-      {...hoverProps}
-    >
+    <label css={Css.df.cursorPointer.if(disabled).add("cursor", "initial").$} {...hoverProps}>
       <input
         type="radio"
         ref={ref}

--- a/src/inputs/RadioGroupField.tsx
+++ b/src/inputs/RadioGroupField.tsx
@@ -85,7 +85,7 @@ export function RadioGroupField<K extends string>(props: RadioGroupFieldProps<K>
     <div css={Css.df.fdc.gap1.aifs.if(labelStyle === "left").fdr.gap2.jcsb.$}>
       <Label label={label} {...labelProps} {...tid.label} hidden={labelStyle === "hidden"} />
       <div {...radioGroupProps}>
-        <div css={Css.df.if(layout === "horizontal").fdr.gap3.else.fdc.$}>
+        <div css={Css.df.if(layout === "horizontal").fdr.fww.gap3.else.fdc.$}>
           {options.map((option) => {
             return (
               <Fragment key={option.value}>

--- a/src/inputs/RadioGroupField.tsx
+++ b/src/inputs/RadioGroupField.tsx
@@ -24,6 +24,8 @@ export type RadioFieldOption<K extends string> = {
   disabled?: boolean | ReactNode;
 };
 
+export type RadioGroupFieldLayout = "vertical" | "horizontal";
+
 export type RadioGroupFieldProps<K extends string> = {
   /** The label for the choice itself, i.e. "Favorite Cheese". */
   label: string;
@@ -38,6 +40,8 @@ export type RadioGroupFieldProps<K extends string> = {
   helperText?: string | ReactNode;
   onBlur?: () => void;
   onFocus?: () => void;
+  /** Direction of the options. Defaults to "vertical". */
+  layout?: RadioGroupFieldLayout;
 } & Pick<PresentationFieldProps, "labelStyle">;
 
 /**
@@ -48,7 +52,18 @@ export type RadioGroupFieldProps<K extends string> = {
  * TODO: Add hover (non selected and selected) styles
  */
 export function RadioGroupField<K extends string>(props: RadioGroupFieldProps<K>) {
-  const { label, labelStyle, value, onChange, options, disabled = false, errorMsg, helperText, ...otherProps } = props;
+  const {
+    label,
+    labelStyle,
+    value,
+    onChange,
+    options,
+    disabled = false,
+    errorMsg,
+    helperText,
+    layout = "vertical",
+    ...otherProps
+  } = props;
 
   // useRadioGroupState uses a random group name, so use our name
   const name = useMemo(() => `radio-group-${++nextNameId}`, []);
@@ -70,26 +85,29 @@ export function RadioGroupField<K extends string>(props: RadioGroupFieldProps<K>
     <div css={Css.df.fdc.gap1.aifs.if(labelStyle === "left").fdr.gap2.jcsb.$}>
       <Label label={label} {...labelProps} {...tid.label} hidden={labelStyle === "hidden"} />
       <div {...radioGroupProps}>
-        {options.map((option) => {
-          return (
-            <Fragment key={option.value}>
-              {maybeTooltip({
-                title: resolveTooltip(option.disabled),
-                placement: "bottom",
-                children: (
-                  <Radio
-                    parentId={name}
-                    option={option}
-                    state={state}
-                    isOptionDisabled={!!option.disabled}
-                    {...otherProps}
-                    {...tid[option.value]}
-                  />
-                ),
-              })}
-            </Fragment>
-          );
-        })}
+        <div css={Css.df.if(layout === "horizontal").fdr.gap3.else.fdc.$}>
+          {options.map((option) => {
+            return (
+              <Fragment key={option.value}>
+                {maybeTooltip({
+                  title: resolveTooltip(option.disabled),
+                  placement: "bottom",
+                  children: (
+                    <Radio
+                      parentId={name}
+                      option={option}
+                      state={state}
+                      isOptionDisabled={!!option.disabled}
+                      layout={layout}
+                      {...otherProps}
+                      {...tid[option.value]}
+                    />
+                  ),
+                })}
+              </Fragment>
+            );
+          })}
+        </div>
         {errorMsg && <ErrorMessage errorMsg={errorMsg} {...tid.errorMsg} />}
         {helperText && <HelperText helperText={helperText} />}
       </div>
@@ -106,6 +124,7 @@ function Radio<K extends string>(props: {
   // react-aria uses a WeakMap keyed by the state object identity to store radio group
   // metadata, so spreading state into a new object breaks the lookup.
   isOptionDisabled?: boolean;
+  layout?: RadioGroupFieldLayout;
   onBlur?: () => void;
   onFocus?: () => void;
 }) {
@@ -114,6 +133,7 @@ function Radio<K extends string>(props: {
     option: { description, label, value },
     state,
     isOptionDisabled,
+    layout = "vertical",
     ...others
   } = props;
 
@@ -132,7 +152,17 @@ function Radio<K extends string>(props: {
   const { hoverProps, isHovered } = useHover({ isDisabled: disabled });
 
   return (
-    <label css={Css.df.cursorPointer.mb1.if(disabled).add("cursor", "initial").$} {...hoverProps}>
+    // In vertical layout, each option uses `mb1` for stacking spacing.
+    // In horizontal layout, spacing comes from the parent flex `gap`, so we skip `mb1`.
+    <label
+      css={
+        Css.df.cursorPointer
+          .if(layout === "vertical")
+          .mb1.if(disabled)
+          .add("cursor", "initial").$
+      }
+      {...hoverProps}
+    >
       <input
         type="radio"
         ref={ref}


### PR DESCRIPTION
### [P-2225](https://linear.app/homebound-team/issue/P-2225)

Adds a `layout` prop to `RadioGroupField` so options can render side-by-side instead of stacked. Defaults to `"vertical"` to preserve existing behavior.