### PR TITLE
feat: Page Header

### DIFF
--- a/src/components/PageHeader.stories.tsx
+++ b/src/components/PageHeader.stories.tsx
@@ -1,7 +1,6 @@
 import { Meta } from "@storybook/react-vite";
 import { Button } from "src/components/Button";
 import { PageHeader } from "src/components/PageHeader";
-import { Css } from "src/Css";
 import { action } from "storybook/actions";
 
 export default {
@@ -13,20 +12,14 @@ export default {
 } as Meta;
 
 export function NoRightSlot() {
-  return (
-    <div css={Css.bgWhite.$}>
-      <PageHeader title="Test Title" />
-    </div>
-  );
+  return <PageHeader title="Test Title" />;
 }
 
 export function WithRightSlot() {
   return (
-    <div css={Css.bgWhite.$}>
-      <PageHeader
-        title="Test Title"
-        rightSlot={<Button label="Test Action" variant="primary" onClick={action("clicked")} />}
-      />
-    </div>
+    <PageHeader
+      title="Test Title"
+      rightSlot={<Button label="Test Action" variant="primary" onClick={action("clicked")} />}
+    />
   );
 }

--- a/src/components/PageHeader.stories.tsx
+++ b/src/components/PageHeader.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta } from "@storybook/react-vite";
+import { Button } from "src/components/Button";
 import { PageHeader } from "src/components/PageHeader";
 import { Css } from "src/Css";
+import { action } from "storybook/actions";
 
 export default {
   component: PageHeader,
@@ -21,7 +23,10 @@ export function NoRightSlot() {
 export function WithRightSlot() {
   return (
     <div css={Css.bgWhite.$}>
-      <PageHeader title="Test Title" rightSlot={<span>Right Slot</span>} />
+      <PageHeader
+        title="Test Title"
+        rightSlot={<Button label="Test Action" variant="primary" onClick={action("clicked")} />}
+      />
     </div>
   );
 }

--- a/src/components/PageHeader.stories.tsx
+++ b/src/components/PageHeader.stories.tsx
@@ -1,0 +1,27 @@
+import { Meta } from "@storybook/react-vite";
+import { PageHeader } from "src/components/PageHeader";
+import { Css } from "src/Css";
+
+export default {
+  component: PageHeader,
+  parameters: {
+    type: "figma",
+    url: "https://www.figma.com/design/yJcdAYy1rqkxTTNhUQnjjU/H2-2026-Beam-Work?m=dev",
+  },
+} as Meta;
+
+export function NoRightSlot() {
+  return (
+    <div css={Css.bgWhite.$}>
+      <PageHeader title="Test Title" />
+    </div>
+  );
+}
+
+export function WithRightSlot() {
+  return (
+    <div css={Css.bgWhite.$}>
+      <PageHeader title="Test Title" rightSlot={<span>Right Slot</span>} />
+    </div>
+  );
+}

--- a/src/components/PageHeader.test.tsx
+++ b/src/components/PageHeader.test.tsx
@@ -5,18 +5,13 @@ import { noop } from "src/utils";
 
 describe("PageHeader", () => {
   it("renders", async () => {
-    const r = await render(<PageHeader title="Test Title" data-testid={"pageHeader"} />);
+    const r = await render(<PageHeader title="Test Title" />);
     expect(r.pageHeader).toBeInTheDocument();
-    expect(r.pageHeader.textContent).toEqual("Test Title");
+    expect(r.pageHeader_title.textContent).toEqual("Test Title");
   });
 
   it("renders with right slot", async () => {
-    const r = await render(
-      <PageHeader
-        title="Test Title"
-        rightSlot={<Button data-testid={"exampleButton"} label="Test Button" onClick={noop} />}
-      />,
-    );
-    expect(r.exampleButton).toBeInTheDocument();
+    const r = await render(<PageHeader title="Test Title" rightSlot={<Button label="Test Button" onClick={noop} />} />);
+    expect(r.testButton).toBeInTheDocument();
   });
 });

--- a/src/components/PageHeader.test.tsx
+++ b/src/components/PageHeader.test.tsx
@@ -1,0 +1,22 @@
+import { render } from "@homebound/rtl-utils";
+import { Button } from "src/components/Button";
+import { PageHeader } from "src/components/PageHeader";
+import { noop } from "src/utils";
+
+describe("PageHeader", () => {
+  it("renders", async () => {
+    const r = await render(<PageHeader title="Test Title" data-testid={"pageHeader"} />);
+    expect(r.pageHeader).toBeInTheDocument();
+    expect(r.pageHeader.textContent).toEqual("Test Title");
+  });
+
+  it("renders with right slot", async () => {
+    const r = await render(
+      <PageHeader
+        title="Test Title"
+        rightSlot={<Button data-testid={"exampleButton"} label="Test Button" onClick={noop} />}
+      />,
+    );
+    expect(r.exampleButton).toBeInTheDocument();
+  });
+});

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,5 +1,6 @@
 import { ReactNode } from "react";
 import { Css, Margin, Only, Xss } from "src/Css";
+import { useTestIds } from "src/utils";
 
 type PageHeaderXss = Margin;
 export interface PageHeaderProps<X> {
@@ -9,10 +10,11 @@ export interface PageHeaderProps<X> {
 }
 
 export function PageHeader<X extends Only<Xss<PageHeaderXss>, X>>(props: PageHeaderProps<X>) {
-  const { title, rightSlot, xss } = props;
+  const { title, rightSlot, xss, ...otherProps } = props;
+  const tid = useTestIds(otherProps);
 
   return (
-    <header css={{ ...Css.df.fdc.pt3.pr3.pl3.$, ...xss }}>
+    <header {...tid} css={{ ...Css.df.fdc.pt3.pr3.pl3.$, ...xss }}>
       <div css={Css.df.jcsb.mb2.w100.aic.$}>
         <div>
           {/* Breadcrumbs here */}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,20 +1,26 @@
 import { ReactNode } from "react";
-import { Margin, Only, Xss } from "src/Css";
+import { Css, Margin, Only, Xss } from "src/Css";
 
 type PageHeaderXss = Margin;
 export interface PageHeaderProps<X> {
-  title: string;
+  title: ReactNode;
   rightSlot?: ReactNode;
   xss?: X;
 }
 
 export function PageHeader<X extends Only<Xss<PageHeaderXss>, X>>(props: PageHeaderProps<X>) {
-  const { title, rightSlot } = props;
+  const { title, rightSlot, xss } = props;
 
   return (
-    <header>
-      <h4>{title}</h4>
-      <div>{rightSlot}</div>
+    <header css={{ ...Css.df.fdc.pt3.pr3.pl3.$, ...xss }}>
+      <div css={Css.df.jcsb.mb2.w100.aic.$}>
+        <div>
+          {/* Breadcrumbs here */}
+          <h2 css={Css.xl.$}>{title}</h2>
+        </div>
+        <div>{rightSlot}</div>
+      </div>
+      {/* Tabs Here */}
     </header>
   );
 }

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from "react";
+import { Margin, Only, Xss } from "src/Css";
+
+type PageHeaderXss = Margin;
+export interface PageHeaderProps<X> {
+  title: string;
+  rightSlot?: ReactNode;
+  xss?: X;
+}
+
+export function PageHeader<X extends Only<Xss<PageHeaderXss>, X>>(props: PageHeaderProps<X>) {
+  const { title, rightSlot } = props;
+
+  return (
+    <header>
+      <h4>{title}</h4>
+      <div>{rightSlot}</div>
+    </header>
+  );
+}

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,24 +1,24 @@
 import { ReactNode } from "react";
-import { Css, Margin, Only, Xss } from "src/Css";
+import { Css, Tokens } from "src/Css";
 import { useTestIds } from "src/utils";
 
-type PageHeaderXss = Margin;
-export interface PageHeaderProps<X> {
+export interface PageHeaderProps {
   title: ReactNode;
   rightSlot?: ReactNode;
-  xss?: X;
 }
 
-export function PageHeader<X extends Only<Xss<PageHeaderXss>, X>>(props: PageHeaderProps<X>) {
-  const { title, rightSlot, xss, ...otherProps } = props;
-  const tid = useTestIds(otherProps);
+export function PageHeader(props: PageHeaderProps) {
+  const { title, rightSlot, ...otherProps } = props;
+  const tid = useTestIds(otherProps, "pageHeader");
 
   return (
-    <header {...tid} css={{ ...Css.df.fdc.pt3.pr3.pl3.$, ...xss }}>
-      <div css={Css.df.jcsb.mb2.w100.aic.$}>
+    <header {...tid} css={Css.df.fdc.pt3.pr3.pl3.bb.bc(Tokens.SurfaceSeparator).$}>
+      <div css={Css.df.jcsb.mb2.w100.gap1.$}>
         <div>
           {/* Breadcrumbs here */}
-          <h2 css={Css.xl.$}>{title}</h2>
+          <h1 {...tid.title} css={Css.xl.$}>
+            {title}
+          </h1>
         </div>
         <div>{rightSlot}</div>
       </div>

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -12,7 +12,7 @@ export function PageHeader(props: PageHeaderProps) {
   const tid = useTestIds(otherProps, "pageHeader");
 
   return (
-    <header {...tid} css={Css.df.fdc.pt3.pr3.pl3.bb.bc(Tokens.SurfaceSeparator).$}>
+    <header {...tid} css={Css.df.fdc.pt3.pr3.pl3.bb.bc(Tokens.SurfaceSeparator).bgColor(Tokens.Surface).$}>
       <div css={Css.df.jcsb.mb2.w100.gap1.$}>
         <div>
           {/* Breadcrumbs here */}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -36,6 +36,7 @@ export * from "./Modal";
 export * from "./Modal/useModal";
 export { NavGroup, NavLink, getNavLinkStyles } from "./NavLinks";
 export type { NavGroupLink, NavGroupProps, NavLinkProps, NavLinkVariant } from "./NavLinks";
+export * from "./PageHeader";
 export * from "./Pagination";
 export { PresentationProvider } from "./PresentationContext";
 export type { InputStylePalette, PresentationFieldProps } from "./PresentationContext";


### PR DESCRIPTION
## Page Header

A new `PageHeader` component added. Currently only supporting a `title` and `rightSlot` property to get what's needed for Product Offerings. Made quick notes and preparation for the breadcrumbs and tabs portions of the component once we get to that stage so it should (hopefully) be an pretty easy add once we get there.