### PR TITLE
feat: add preventTooltip opt-out to IconButton and Avatar

### DIFF
--- a/src/components/Avatar/Avatar.test.tsx
+++ b/src/components/Avatar/Avatar.test.tsx
@@ -20,6 +20,16 @@ describe(Avatar, () => {
     expect(r.avatar.textContent).toBe("FML");
   });
 
+  it("shows a tooltip with the name by default", async () => {
+    const r = await render(<Avatar src="test" name="Test" />);
+    expect(r.tooltip).toBeInTheDocument();
+  });
+
+  it("renders no tooltip when preventTooltip is set", async () => {
+    const r = await render(<Avatar src="test" name="Test" preventTooltip />);
+    expect(r.query.tooltip).toBeNull();
+  });
+
   // Note: not testing the `onError` case as jsdom does not request external resources.
   // Instead relying on Storybook to demonstrate fallback
   // See https://github.com/jsdom/jsdom/issues/1816#issuecomment-310106280

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -9,10 +9,10 @@ export interface AvatarProps {
   name?: string;
   size?: AvatarSize;
   showName?: boolean;
-  disableTooltip?: boolean;
+  preventTooltip?: boolean;
 }
 
-export function Avatar({ src, name, size = "md", showName = false, disableTooltip = false, ...others }: AvatarProps) {
+export function Avatar({ src, name, size = "md", showName = false, preventTooltip = false, ...others }: AvatarProps) {
   const tid = useTestIds(others, "avatar");
   const px = sizeToPixel[size];
   const [showFallback, setShowFallback] = useState(src === undefined);
@@ -40,7 +40,7 @@ export function Avatar({ src, name, size = "md", showName = false, disableToolti
       <span css={Css.typography(sizeToTypeScale[size]).$}>{name}</span>
     </div>
   ) : (
-    maybeTooltip({ title: disableTooltip ? undefined : name, children: img, placement: "top" })
+    maybeTooltip({ title: preventTooltip ? undefined : name, children: img, placement: "top" })
   );
 }
 

--- a/src/components/Avatar/AvatarButton.test.tsx
+++ b/src/components/Avatar/AvatarButton.test.tsx
@@ -55,6 +55,13 @@ describe(AvatarButton, () => {
     // Given a button with no tooltip, but a name defined
     const r = await render(<AvatarButton src="test" name="Test" onClick={() => {}} />);
     // Then the tooltip is correctly displayed
-    expect(r.test_button.closest("[data-testid='tooltip']")).toHaveAttribute("title", "Test");
+    expect(r.tooltip).toHaveAttribute("title", "Test");
+  });
+
+  it("renders no tooltip when preventTooltip is set", async () => {
+    // Given a button with a name but preventTooltip set
+    const r = await render(<AvatarButton src="test" name="Test" preventTooltip onClick={() => {}} />);
+    // Then no tooltip is rendered in the DOM
+    expect(r.query.tooltip).toBeNull();
   });
 });

--- a/src/components/Avatar/AvatarButton.tsx
+++ b/src/components/Avatar/AvatarButton.tsx
@@ -32,6 +32,7 @@ export function AvatarButton(props: AvatarButtonProps) {
     openInNew,
     forceFocusStyles = false,
     __storyState,
+    preventTooltip = false,
     ...avatarProps
   } = props;
   const isDisabled = !!disabled;
@@ -75,15 +76,15 @@ export function AvatarButton(props: AvatarButtonProps) {
 
   const content = (
     <>
-      <Avatar {...avatarProps} {...tid} disableTooltip />
+      <Avatar {...avatarProps} {...tid} preventTooltip />
       {isPressed && <span css={pressedOverlayCss} />}
     </>
   );
 
-  // If we're disabled b/c of a non-boolean ReactNode, or the caller specified tooltip text, then show it in a tooltip
+  // If we're disabled b/c of a non-boolean ReactNode, or the caller specified tooltip text, then show it in a tooltip.
+  // Unless opted out via `preventTooltip`, the avatar's `name` is also surfaced as the tooltip.
   return maybeTooltip({
-    // Default the tooltip to the avatar's name, if defined.
-    title: resolveTooltip(disabled, tooltip ?? avatarProps.name),
+    title: resolveTooltip(disabled, tooltip ?? (preventTooltip ? undefined : avatarProps.name)),
     placement: "top",
     // Disable the auto-tooltip in Avatar to prevent nested tooltips which can cause issues with interactions
     children: getButtonOrLink(content, onPress, buttonAttrs, openInNew),

--- a/src/components/ButtonMenu.test.tsx
+++ b/src/components/ButtonMenu.test.tsx
@@ -107,6 +107,26 @@ describe("ButtonMenu", () => {
     expect(r.tooltip).toHaveAttribute("title", "Tooltip");
   });
 
+  // OverlayTrigger forwards `preventTooltip` from an avatar trigger through to AvatarButton.
+  it("shows the avatar name as a tooltip by default", async () => {
+    const r = await render(
+      <ButtonMenu trigger={{ src: "test", name: "Test" }} items={[{ label: "Option A", onClick: noop }]} />,
+      withRouter(),
+    );
+    expect(r.tooltip).toHaveAttribute("title", "Test");
+  });
+
+  it("renders no tooltip on an avatar trigger when preventTooltip is set", async () => {
+    const r = await render(
+      <ButtonMenu
+        trigger={{ src: "test", name: "Test", preventTooltip: true }}
+        items={[{ label: "Option A", onClick: noop }]}
+      />,
+      withRouter(),
+    );
+    expect(r.query.tooltip).toBeNull();
+  });
+
   it("handles selecting button menu items", async () => {
     // Given two menu items that can be selected
     function TestComponent() {

--- a/src/components/IconButton.test.tsx
+++ b/src/components/IconButton.test.tsx
@@ -10,6 +10,11 @@ describe("IconButton", () => {
     expect(r.tooltip).toHaveAttribute("title", "Move to trash");
   });
 
+  it("renders no tooltip when preventTooltip is set", async () => {
+    const r = await render(<IconButton icon="trash" label="Move to trash" preventTooltip onClick={noop} />);
+    expect(r.query.tooltip).toBeNull();
+  });
+
   it("can have a data-testid", async () => {
     const r = await render(<IconButton icon="trash" data-testid="remove" onClick={noop} />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("remove");

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -30,6 +30,11 @@ export type IconButtonProps = {
   download?: boolean;
   /** Provides label for screen readers - Will become a required soon */
   label?: string;
+  /**
+   * By default the `label` is also surfaced as a hover tooltip. Set this to keep the `aria-label`
+   * for screen readers without showing the tooltip. An explicit `tooltip` or disabled reason still shows.
+   */
+  preventTooltip?: boolean;
 } & BeamButtonProps &
   BeamFocusableProps;
 
@@ -52,6 +57,7 @@ export function IconButton(props: IconButtonProps) {
     download = false,
     forceFocusStyles = false,
     label,
+    preventTooltip = false,
   } = props;
   const isDisabled = !!disabled;
   const ariaProps = { onPress, isDisabled, autoFocus, ...menuTriggerProps };
@@ -108,9 +114,10 @@ export function IconButton(props: IconButtonProps) {
     />
   );
 
-  // If we're disabled b/c of a non-boolean ReactNode, or the caller specified tooltip text, then show it in a tooltip
+  // If we're disabled b/c of a non-boolean ReactNode, or the caller specified tooltip text, then show it in a tooltip.
+  // Unless opted out via `preventTooltip`, the `label` is also surfaced as the tooltip.
   return maybeTooltip({
-    title: resolveTooltip(disabled ?? label, tooltip),
+    title: resolveTooltip(disabled ?? (preventTooltip ? undefined : label), tooltip),
     placement: "top",
     children: getButtonOrLink(buttonContent, onPress, buttonAttrs, openInNew, download),
   });

--- a/src/components/internal/OverlayTrigger.tsx
+++ b/src/components/internal/OverlayTrigger.tsx
@@ -16,7 +16,7 @@ import { defaultTestId } from "src/utils/defaultTestId";
 
 type TextButtonTriggerProps = Pick<ButtonProps, "label" | "variant" | "size" | "icon">;
 type IconButtonTriggerProps = Pick<IconButtonProps, "icon" | "color" | "compact" | "inc">;
-type AvatarButtonTriggerProps = Pick<AvatarButtonProps, "src" | "name" | "size">;
+type AvatarButtonTriggerProps = Pick<AvatarButtonProps, "src" | "name" | "size" | "preventTooltip">;
 type NavLinkButtonTriggerProps = {
   navLabel: string;
 } & Pick<NavLinkProps, "active" | "variant" | "icon">;


### PR DESCRIPTION
IconButton and AvatarButton surface their `label`/`name` as a hover tooltip by default. Add a `preventTooltip` prop to keep the `aria-label` for screen readers without the tooltip (an explicit `tooltip` or disabled reason still shows). 
Renames Avatar/AvatarButton's existing `disableTooltip` to `preventTooltip` for consistency, and to disambiguate from the existing tooltips that show when an element is considered "disabled"