### PR TITLE
fix: add toast to table review layout;

### DIFF
--- a/src/components/Layout/FormPageLayout.stories.tsx
+++ b/src/components/Layout/FormPageLayout.stories.tsx
@@ -1,6 +1,7 @@
 import { ObjectConfig, required, useFormState } from "@homebound/form-state";
 import { Meta } from "@storybook/react-vite";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useToast } from "src/components/Toast/useToast";
 import {
   boundCheckboxField,
   boundDateField,
@@ -19,7 +20,6 @@ import {
   TextField,
   Tooltip,
   useSnackbar,
-  useToast,
 } from "src/index";
 import { noop } from "src/utils";
 import { withBeamDecorator, withDimensions, withRouter } from "src/utils/sb";
@@ -241,6 +241,32 @@ const singleColumnConfig: FormSectionConfig<AuthorInput> = [
   },
   { rows: [{ firstName: boundTextField() }] },
 ];
+
+function WithToastWrapper() {
+  const formState = useFormState({
+    config: formConfig,
+    init: { input: { firstName: "John", middleInitial: "C", lastName: "Doe" } },
+  });
+  const { showToast } = useToast();
+  useEffect(() => {
+    showToast({ type: "error", message: "Validation failed: something went wrong while saving." });
+  }, [showToast]);
+
+  return (
+    <FormPageLayoutComponent
+      pageTitle="Detail Title"
+      submitAction={{ label: "Save", onClick: noop }}
+      cancelAction={{ label: "Cancel", onClick: noop }}
+      breadCrumb={[{ label: "Breadcrumb A", href: "/breadcrumb-a" }]}
+      formSections={formSections}
+      formState={formState}
+    />
+  );
+}
+
+export function WithToastVisible() {
+  return <WithToastWrapper />;
+}
 
 function CommentComponent() {
   const [comment, setComment] = useState<string | undefined>(undefined);

--- a/src/components/Layout/FormPageLayout.tsx
+++ b/src/components/Layout/FormPageLayout.tsx
@@ -67,7 +67,7 @@ function FormPageLayoutComponent<F>(props: FormPageLayoutProps<F>) {
     // since this layout will be replacing most superdrawers/sidebars, we keep the listing mounted below to preserve the users's
     // scroll position & filters
     // Adding "align-items: start" allows "position: sticky" to work within a grid for the sidebars
-    <div css={Css.fixed.top0.bottom0.left0.right0.z(1000).oya.bgWhite.df.jcc.aifs.$} {...tids}>
+    <div css={Css.fixed.top0.bottom0.left0.right0.z(zIndices.pageOverlay).oya.bgWhite.df.jcc.aifs.$} {...tids}>
       <div css={Css.w100.maxwPx(maxContentWidthPx).dg.gtc(gridColumns).gtr("auto 1fr").cg3.ais.$}>
         <PageHeader {...props} {...tids.pageHeader} />
         <LeftNav sectionsWithRefs={sectionsWithRefs} {...tids} />

--- a/src/components/Layout/TableReviewLayout/TableReviewLayout.stories.tsx
+++ b/src/components/Layout/TableReviewLayout/TableReviewLayout.stories.tsx
@@ -1,9 +1,10 @@
 import { Meta } from "@storybook/react-vite";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Button } from "src/components/Button";
 import { GridDataRow } from "src/components/Table";
 import { column } from "src/components/Table/utils/columns";
 import { simpleHeader } from "src/components/Table/utils/simpleHelpers";
+import { useToast } from "src/components/Toast/useToast";
 import { Css } from "src/Css";
 import { withBeamDecorator, withDimensions, withRouter } from "src/utils/sb";
 import { SidePanelProps, TableReviewLayout as TableReviewLayoutComponent } from "./TableReviewLayout";
@@ -344,6 +345,28 @@ export function EmptyState() {
       }
     />
   );
+}
+
+function WithToastWrapper() {
+  const columns = useMemo(() => [column<Row>({ header: "Name", data: ({ name }) => name })], []);
+  const { showToast } = useToast();
+  useEffect(() => {
+    showToast({ type: "error", message: "Validation failed: a takeoff line item already exists at this location." });
+  }, [showToast]);
+
+  return (
+    <TableReviewLayoutComponent
+      pageTitle="Review slot requests"
+      breadCrumb={{ href: "/", label: "The Emerson plan" }}
+      description={description}
+      closeAction={() => {}}
+      tableProps={{ columns, rows }}
+    />
+  );
+}
+
+export function WithToastVisible() {
+  return <WithToastWrapper />;
 }
 
 function Field({ label, value }: { label: string; value: string }) {

--- a/src/components/Layout/TableReviewLayout/TableReviewLayout.tsx
+++ b/src/components/Layout/TableReviewLayout/TableReviewLayout.tsx
@@ -6,6 +6,8 @@ import { GridTable } from "src/components/Table/GridTable";
 import { GridTableXss, Kinded } from "src/components/Table/types";
 import { Css, Only, Palette } from "src/Css";
 import { useTestIds } from "src/utils";
+import { zIndices } from "src/utils/zIndices";
+import { Toast } from "../../Toast/Toast";
 import { QueryTable, QueryTableProps } from "../GridTableLayout/QueryTable";
 import { ActionButtonProps, BaseQueryTableProps, GridTablePropsWithRows, isGridTableProps } from "../layoutTypes";
 import { HeaderBreadcrumb, PageHeaderBreadcrumbs } from "../PageHeaderBreadcrumbs";
@@ -96,8 +98,9 @@ export function TableReviewLayout<R extends Kinded, X extends Only<GridTableXss,
   }
 
   return (
-    <div css={Css.fixed.top0.bottom0.left0.right0.z(1000).bgWhite.df.fdc.$} {...tid}>
+    <div css={Css.fixed.top0.bottom0.left0.right0.z(zIndices.pageOverlay).bgWhite.df.fdc.$} {...tid}>
       <header css={Css.px3.pt3.pb2.fs0.$} {...tid.header}>
+        <Toast />
         <div css={Css.df.jcsb.aic.$}>
           <div>
             {breadCrumb && <PageHeaderBreadcrumbs breadcrumb={breadCrumb} />}

--- a/src/utils/zIndices.ts
+++ b/src/utils/zIndices.ts
@@ -23,7 +23,10 @@ export const zIndices = {
   // snackbar so toasts still land on top.
   sideNav: 100,
 
-  // Top of the stack.
+  // Full-page overlays sit above side-nav and use their own toast internally
+  pageOverlay: 110,
+
+  // Top of stack
   snackbar: 120,
 } as const;
 

--- a/src/utils/zIndices.ts
+++ b/src/utils/zIndices.ts
@@ -23,11 +23,12 @@ export const zIndices = {
   // snackbar so toasts still land on top.
   sideNav: 100,
 
-  // Full-page overlays sit above side-nav and use their own toast internally
-  pageOverlay: 110,
+  // Full-page overlays — high enough to clear consuming-app nav bars (~999).
+  // Both layouts own their Toast internally so it renders inside the overlay header.
+  pageOverlay: 1000,
 
   // Top of stack
-  snackbar: 120,
+  snackbar: 1100,
 } as const;
 
 export type ZIndex = (typeof zIndices)[keyof typeof zIndices];


### PR DESCRIPTION
- Both `TableReviewLayout` and `FormPageLayout` used an arbitrary `z(1000)` index. Replaced it with `pageOverlay: 1000` added to `zIndices`. Sits above BP navbar.
- `TableReviewLayout` now owns its own `<Toast />` inside the header, matching the pattern `FormPageLayout` already had
- Added some `WithToastVisible` stories to both components

<img width="1623" height="634" alt="Screenshot 2026-06-03 at 3 24 52 PM" src="https://github.com/user-attachments/assets/70af3a89-7666-42d1-bd2a-19c750bdf3fc" />


----

This fixes an issue called out in BP accept plan package incoming slot. [APP-1489](https://linear.app/homebound-team/issue/APP-1489/bug-fe-validation-error-banners-do-not-show-in-the-slot-review-ux)