### PR TITLE
chore: show required suffix on RadioGroupField label

### DIFF
--- a/src/forms/BoundRadioGroupField.test.tsx
+++ b/src/forms/BoundRadioGroupField.test.tsx
@@ -18,6 +18,14 @@ describe("BoundRadioGroupField", () => {
     expect(r.favoriteSport_label).toHaveTextContent("Favorite Sport");
   });
 
+  it("shows the required suffix when the field is required", async () => {
+    // Given a field with a `required` rule
+    const author = createObjectState(formConfig, {});
+    const r = await render(<BoundRadioGroupField field={author.favoriteSport} options={sports} />);
+    // Then the label shows the required suffix
+    expect(r.favoriteSport_label).toHaveTextContent("Favorite Sport *");
+  });
+
   it("trigger onFocus and onBlur callbacks", async () => {
     const onBlur = vi.fn();
     const onFocus = vi.fn();

--- a/src/forms/BoundRadioGroupField.tsx
+++ b/src/forms/BoundRadioGroupField.tsx
@@ -30,6 +30,7 @@ export function BoundRadioGroupField<K extends string>(props: BoundRadioGroupFie
       {() => (
         <RadioGroupField<K>
           label={label}
+          required={field.required}
           value={field.value || undefined}
           onChange={(value) => {
             onChange(value);

--- a/src/inputs/RadioGroupField.stories.tsx
+++ b/src/inputs/RadioGroupField.stories.tsx
@@ -179,6 +179,26 @@ export function OnlyLabels() {
   );
 }
 
+export function Required() {
+  const [state, setState] = useState<string | undefined>();
+  return (
+    <RadioGroupField
+      label="Favorite cheese"
+      required
+      value={state}
+      onChange={setState}
+      options={[
+        { label: "Asiago", value: "a" },
+        { label: "Burratta", value: "b" },
+        { label: "Camembert", value: "c" },
+        { label: "Roquefort", value: "d" },
+      ]}
+      onBlur={action("onBlur")}
+      onFocus={action("onFocus")}
+    />
+  );
+}
+
 export function LabelsAndDescriptions() {
   const [state, setState] = useState<string | undefined>();
   return (

--- a/src/inputs/RadioGroupField.test.tsx
+++ b/src/inputs/RadioGroupField.test.tsx
@@ -50,6 +50,37 @@ describe("RadioGroupField", () => {
     expect(tooltip).toHaveAttribute("title", "some reason");
   });
 
+  it("shows the required suffix on the label when required", async () => {
+    const r = await render(
+      <RadioGroupField
+        label="Favorite cheese"
+        required
+        value="a"
+        onChange={() => {}}
+        options={[
+          { value: "a", label: "Asiago" },
+          { value: "b", label: "Burratta" },
+        ]}
+      />,
+    );
+    expect(r.favoriteCheese_label).toHaveTextContent("Favorite cheese *");
+  });
+
+  it("does not show the required suffix when not required", async () => {
+    const r = await render(
+      <RadioGroupField
+        label="Favorite cheese"
+        value="a"
+        onChange={() => {}}
+        options={[
+          { value: "a", label: "Asiago" },
+          { value: "b", label: "Burratta" },
+        ]}
+      />,
+    );
+    expect(r.favoriteCheese_label).not.toHaveTextContent("*");
+  });
+
   it("supports horizontal layout", async () => {
     const r = await render(
       <RadioGroupField

--- a/src/inputs/RadioGroupField.tsx
+++ b/src/inputs/RadioGroupField.tsx
@@ -6,6 +6,7 @@ import { HelperText } from "src/components/HelperText";
 import { Label } from "src/components/Label";
 import { PresentationFieldProps } from "src/components/PresentationContext";
 import { Css } from "src/Css";
+import { useLabelSuffix } from "src/forms/labelUtils";
 import { ErrorMessage } from "src/inputs/ErrorMessage";
 import { defaultTestId } from "src/utils/defaultTestId";
 import { useTestIds } from "src/utils/useTestIds";
@@ -36,6 +37,8 @@ export type RadioGroupFieldProps<K extends string> = {
   /** The list of options. */
   options: RadioFieldOption<K>[];
   disabled?: boolean;
+  /** Whether the field is required. When true, renders the required suffix (i.e. "*") next to the label. */
+  required?: boolean;
   errorMsg?: string;
   helperText?: string | ReactNode;
   onBlur?: () => void;
@@ -59,6 +62,7 @@ export function RadioGroupField<K extends string>(props: RadioGroupFieldProps<K>
     onChange,
     options,
     disabled = false,
+    required,
     errorMsg,
     helperText,
     layout = "vertical",
@@ -75,15 +79,16 @@ export function RadioGroupField<K extends string>(props: RadioGroupFieldProps<K>
     isReadOnly: false,
   });
   const tid = useTestIds(props, defaultTestId(label));
+  const labelSuffix = useLabelSuffix(required, false);
 
   // We use useRadioGroup b/c it does neat keyboard up/down stuff
-  // TODO: Pass read only, required, error message to useRadioGroup
-  const { labelProps, radioGroupProps } = useRadioGroup({ label, isDisabled: disabled }, state);
+  // TODO: Pass read only, error message to useRadioGroup
+  const { labelProps, radioGroupProps } = useRadioGroup({ label, isDisabled: disabled, isRequired: required }, state);
 
   return (
     // default styling to position `<Label />` above.
     <div css={Css.df.fdc.gap1.aifs.if(labelStyle === "left").fdr.gap2.jcsb.$}>
-      <Label label={label} {...labelProps} {...tid.label} hidden={labelStyle === "hidden"} />
+      <Label label={label} {...labelProps} {...tid.label} suffix={labelSuffix} hidden={labelStyle === "hidden"} />
       <div {...radioGroupProps}>
         <div css={Css.df.if(layout === "horizontal").fdr.fww.gap3.else.fdc.gap1.$}>
           {options.map((option) => {


### PR DESCRIPTION
`RadioGroupField` didn't render the required suffix (e.g. `*`) next to its label like other field components do. This wires it up to match `ToggleChipGroup` and `CheckboxGroup`.

<img width="510" height="327" alt="Screenshot 2026-06-08 at 11 05 27 AM" src="https://github.com/user-attachments/assets/0c045c79-b632-4a08-8d56-a016677ac0dd" />
