### PR TITLE
feat: Adding an outline variant to the IconButton component

### DIFF
--- a/src/components/IconButton.stories.tsx
+++ b/src/components/IconButton.stories.tsx
@@ -88,6 +88,10 @@ export const Circle = Template.bind({});
 // @ts-ignore
 Circle.args = { circle: true };
 
+export const Outline = Template.bind({});
+// @ts-ignore
+Outline.args = { outline: true };
+
 export function WithTooltip() {
   return (
     <div css={Css.dg.fdc.gap2.jcfs.$}>
@@ -140,13 +144,13 @@ export function IconButtonLink() {
 
 /** Hover styled version of the IconButton — uses a scoped stylesheet to force hover styles for visual testing. */
 function HoveredIconButton(args: IconButtonStoryArgs) {
-  const { storyContrast = false, circle, ...iconArgs } = args;
-  const bg = storyContrast ? Palette.Gray700 : circle ? Palette.Blue100 : Palette.Gray200;
-  const borderColor = circle ? Palette.Blue200 : undefined;
+  const { storyContrast = false, circle, outline, ...iconArgs } = args;
+  const bg = storyContrast ? Palette.Gray700 : circle || outline ? Palette.Blue100 : Palette.Gray200;
+  const borderColor = circle || outline ? Palette.Blue200 : undefined;
   const hoverBlock = (
     <div className="hovered-icon-button">
       <style>{`.hovered-icon-button button { background-color: ${bg};${borderColor ? ` border-color: ${borderColor};` : ""} }`}</style>
-      <IconButton {...iconArgs} circle={circle} active={circle} />
+      <IconButton {...iconArgs} circle={circle} outline={outline} active={circle} />
     </div>
   );
   return storyContrast ? <ContrastScope>{hoverBlock}</ContrastScope> : hoverBlock;

--- a/src/components/IconButton.stories.tsx
+++ b/src/components/IconButton.stories.tsx
@@ -86,11 +86,11 @@ Contrast.args = { storyContrast: true };
 
 export const Circle = Template.bind({});
 // @ts-ignore
-Circle.args = { circle: true };
+Circle.args = { variant: "circle" };
 
 export const Outline = Template.bind({});
 // @ts-ignore
-Outline.args = { outline: true };
+Outline.args = { variant: "outline" };
 
 export function WithTooltip() {
   return (
@@ -144,13 +144,15 @@ export function IconButtonLink() {
 
 /** Hover styled version of the IconButton — uses a scoped stylesheet to force hover styles for visual testing. */
 function HoveredIconButton(args: IconButtonStoryArgs) {
-  const { storyContrast = false, circle, outline, ...iconArgs } = args;
-  const bg = storyContrast ? Palette.Gray700 : circle || outline ? Palette.Blue100 : Palette.Gray200;
-  const borderColor = circle || outline ? Palette.Blue200 : undefined;
+  const { storyContrast = false, variant = "default", ...iconArgs } = args;
+  const isCircle = variant === "circle";
+  const isOutline = variant === "outline";
+  const bg = storyContrast ? Palette.Gray700 : isCircle || isOutline ? Palette.Blue100 : Palette.Gray200;
+  const borderColor = isCircle || isOutline ? Palette.Blue200 : undefined;
   const hoverBlock = (
     <div className="hovered-icon-button">
       <style>{`.hovered-icon-button button { background-color: ${bg};${borderColor ? ` border-color: ${borderColor};` : ""} }`}</style>
-      <IconButton {...iconArgs} circle={circle} outline={outline} active={circle} />
+      <IconButton {...iconArgs} variant={variant} active={isCircle} />
     </div>
   );
   return storyContrast ? <ContrastScope>{hoverBlock}</ContrastScope> : hoverBlock;

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -35,6 +35,8 @@ export type IconButtonProps = {
    * for screen readers without showing the tooltip. An explicit `tooltip` or disabled reason still shows.
    */
   preventTooltip?: boolean;
+  /** Whether to display the square variant */
+  outline?: boolean;
 } & BeamButtonProps &
   BeamFocusableProps;
 
@@ -58,6 +60,7 @@ export function IconButton(props: IconButtonProps) {
     forceFocusStyles = false,
     label,
     preventTooltip = false,
+    outline = false,
   } = props;
   const isDisabled = !!disabled;
   const ariaProps = { onPress, isDisabled, autoFocus, ...menuTriggerProps };
@@ -77,14 +80,14 @@ export function IconButton(props: IconButtonProps) {
   const styles = useMemo(
     () => ({
       ...iconButtonStylesReset,
-      ...(circle ? iconButtonCircle : compact ? iconButtonCompact : iconButtonNormal),
-      ...(isHovered && (circle ? iconButtonCircleStylesHover : iconButtonTokenHover)),
+      ...(circle ? iconButtonCircle : compact ? iconButtonCompact : outline ? iconButtonOutline : iconButtonNormal),
+      ...(isHovered && (circle || outline ? iconButtonCircleStylesHover : iconButtonTokenHover)),
       ...(isFocusVisible || forceFocusStyles ? (circle ? iconButtonCircleStylesFocus : iconButtonStylesFocus) : {}),
-      ...(active && (circle ? activeStylesCircle : iconButtonTokenHover)),
+      ...(active && (circle || outline ? activeStylesCircle : iconButtonTokenHover)),
       ...(isDisabled && iconButtonStylesDisabled),
       ...(bgColor && Css.bgColor(bgColor).$),
     }),
-    [isHovered, isFocusVisible, isDisabled, compact, circle, active, bgColor, forceFocusStyles],
+    [isHovered, isFocusVisible, isDisabled, compact, circle, active, bgColor, forceFocusStyles, outline],
   );
   const iconColor = circle ? circleIconColor : defaultIconColor;
 
@@ -129,6 +132,7 @@ const iconButtonStylesReset = Css.bcTransparent.bss.bgTransparent.cursorPointer.
 const iconButtonNormal = Css.hPx(28).wPx(28).br8.bw2.$;
 const iconButtonCompact = Css.hPx(18).wPx(18).br4.bw1.$;
 const iconButtonCircle = Css.br100.wPx(48).hPx(48).bcGray300.ba.bw1.df.jcc.aic.$;
+const iconButtonOutline = Css.br8.wPx(48).hPx(40).pxPx(12).py1.bcGray300.ba.bw1.df.jcc.aic.$;
 /** Semantic hover fill; contrast is driven by `--b-*` when inside {@link ContrastScope}. */
 const iconButtonTokenHover = Css.bgColor(Tokens.NeutralFillHoverStrong).$;
 export const iconButtonStylesHover = Css.bgGray200.$;

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -10,6 +10,8 @@ import { noop } from "src/utils";
 import { getButtonOrLink } from "src/utils/getInteractiveElement";
 import { useTestIds } from "src/utils/useTestIds";
 
+export type IconButtonVariant = "default" | "circle" | "outline";
+
 export type IconButtonProps = {
   /** The icon to use within the button. */
   icon: IconProps["icon"];
@@ -22,8 +24,8 @@ export type IconButtonProps = {
   buttonRef?: RefObject<HTMLButtonElement>;
   /** Whether to show a 16x16px version of the IconButton */
   compact?: boolean;
-  /** Whether to display the circle variant */
-  circle?: boolean;
+  /** Visual variant of the button. Defaults to "default". */
+  variant?: IconButtonVariant;
   /** Indicates that the button is active/selected */
   active?: boolean;
   /** Denotes if this button is used to download a resource. Uses the anchor tag with the `download` attribute */
@@ -35,8 +37,6 @@ export type IconButtonProps = {
    * for screen readers without showing the tooltip. An explicit `tooltip` or disabled reason still shows.
    */
   preventTooltip?: boolean;
-  /** Whether to display the square variant */
-  outline?: boolean;
 } & BeamButtonProps &
   BeamFocusableProps;
 
@@ -55,12 +55,11 @@ export function IconButton(props: IconButtonProps) {
     openInNew,
     active = false,
     compact = false,
-    circle = false,
+    variant = "default",
     download = false,
     forceFocusStyles = false,
     label,
     preventTooltip = false,
-    outline = false,
   } = props;
   const isDisabled = !!disabled;
   const ariaProps = { onPress, isDisabled, autoFocus, ...menuTriggerProps };
@@ -77,19 +76,21 @@ export function IconButton(props: IconButtonProps) {
   const { hoverProps, isHovered } = useHover(ariaProps);
   const testIds = useTestIds(props, icon);
 
+  const isCircle = variant === "circle";
+  const isOutline = variant === "outline";
   const styles = useMemo(
     () => ({
       ...iconButtonStylesReset,
-      ...(circle ? iconButtonCircle : compact ? iconButtonCompact : outline ? iconButtonOutline : iconButtonNormal),
-      ...(isHovered && (circle || outline ? iconButtonCircleStylesHover : iconButtonTokenHover)),
-      ...(isFocusVisible || forceFocusStyles ? (circle ? iconButtonCircleStylesFocus : iconButtonStylesFocus) : {}),
-      ...(active && (circle || outline ? activeStylesCircle : iconButtonTokenHover)),
+      ...(isCircle ? iconButtonCircle : isOutline ? iconButtonOutline : compact ? iconButtonCompact : iconButtonNormal),
+      ...(isHovered && (isCircle || isOutline ? iconButtonCircleStylesHover : iconButtonTokenHover)),
+      ...(isFocusVisible || forceFocusStyles ? (isCircle ? iconButtonCircleStylesFocus : iconButtonStylesFocus) : {}),
+      ...(active && (isCircle || isOutline ? activeStylesCircle : iconButtonTokenHover)),
       ...(isDisabled && iconButtonStylesDisabled),
       ...(bgColor && Css.bgColor(bgColor).$),
     }),
-    [isHovered, isFocusVisible, isDisabled, compact, circle, active, bgColor, forceFocusStyles, outline],
+    [isHovered, isFocusVisible, isDisabled, compact, isCircle, isOutline, active, bgColor, forceFocusStyles],
   );
-  const iconColor = circle ? circleIconColor : defaultIconColor;
+  const iconColor = isCircle ? circleIconColor : defaultIconColor;
 
   const buttonAttrs = {
     ...testIds,
@@ -108,12 +109,12 @@ export function IconButton(props: IconButtonProps) {
         color ||
         (isDisabled
           ? Tokens.TextDisabled
-          : circle && (isHovered || active || isFocusVisible)
+          : isCircle && (isHovered || active || isFocusVisible)
             ? defaultIconColor
             : iconColor)
       }
       bgColor={bgColor}
-      inc={compact ? 2 : circle ? 2.5 : inc}
+      inc={compact ? 2 : isCircle ? 2.5 : inc}
     />
   );
 

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -133,7 +133,7 @@ const iconButtonStylesReset = Css.bcTransparent.bss.bgTransparent.cursorPointer.
 const iconButtonNormal = Css.hPx(28).wPx(28).br8.bw2.$;
 const iconButtonCompact = Css.hPx(18).wPx(18).br4.bw1.$;
 const iconButtonCircle = Css.br100.wPx(48).hPx(48).bcGray300.ba.bw1.df.jcc.aic.$;
-const iconButtonOutline = Css.br8.wPx(48).hPx(40).pxPx(12).py1.bcGray300.ba.bw1.df.jcc.aic.$;
+const iconButtonOutline = Css.br8.wPx(48).hPx(40).bcGray300.ba.bw1.df.jcc.aic.$;
 /** Semantic hover fill; contrast is driven by `--b-*` when inside {@link ContrastScope}. */
 const iconButtonTokenHover = Css.bgColor(Tokens.NeutralFillHoverStrong).$;
 export const iconButtonStylesHover = Css.bgGray200.$;

--- a/src/components/Layout/TableReviewLayout/TableReviewLayout.tsx
+++ b/src/components/Layout/TableReviewLayout/TableReviewLayout.tsx
@@ -132,7 +132,7 @@ export function TableReviewLayout<R extends Kinded, X extends Only<GridTableXss,
               <div css={Css.absolute.topPx(-32).df.fdc.aic.leftPx(-24).z1.$}>
                 <IconButton
                   bgColor={Palette.White}
-                  circle
+                  variant="circle"
                   icon="x"
                   inc={3.5}
                   onClick={handleClosePanel}

--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -58,7 +58,7 @@ export function RightSidebar({ content, headerHeightPx }: RightSidebarProps) {
                 <div css={Css.absolute.leftPx(-24).top0.df.fdc.aic.$}>
                   <IconButton
                     bgColor={Palette.White}
-                    circle
+                    variant="circle"
                     onClick={() => setSelectedIcon(undefined)}
                     icon="x"
                     inc={3.5}
@@ -100,7 +100,7 @@ function IconButtonList({ content, selectedIcon, onIconClick }: IconButtonListPr
         <IconButton
           // selectedIcon is added to key to reset the active state
           key={`${icon}-${selectedIcon}`}
-          circle
+          variant="circle"
           active={icon === selectedIcon}
           onClick={() => onIconClick(icon)}
           icon={icon}


### PR DESCRIPTION
## IconButton Outline Variant

Similar to circle. Will likely be used for buttons on mobile screens quite a bit.