### PR TITLE
feat: Teach GridTableLayout and TableActions to be layout aware

### DIFF
--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -42,8 +42,7 @@ tables) uses the document scrollbars while chrome stays in place:
 - `NavbarLayout` measures and publishes the navbar height (`--beam-navbar-layout-height`).
 - `SideNavLayout` publishes its rail width (`--beam-side-nav-layout-width`) for sticky column offsets.
 - `PageHeaderLayout` reads those and publishes its own height (`--beam-page-header-layout-height`).
-- `GridTable` reads these vars so its sticky header sits below the navbar + page header and its sticky
-  columns sit right of the side nav rail.
+- `GridTableLayout` — **inside `DocumentScrollLayoutProvider`** (e.g. under `NavbarLayout` / `PageHeaderLayout`): when filters, search, or edit-columns are shown, measures and publishes the table actions toolbar height (`--beam-table-actions-height`), pins table actions with the other document-scroll chrome, and renders the table inline for document scroll. **`GridTable`** reads these vars so its sticky header sits below the navbar + page header + table actions and its sticky columns sit right of the side nav rail. **Outside document-scroll layouts**, `GridTableLayout` does not publish that var or pin table actions; it wraps the table in **`ScrollableParent` / `ScrollableContent`** (with `virtualized` when `as="virtual"`) so scrolling stays in the legacy page scroll region.
 
 The exported var-name constants (`beamNavbarLayoutHeightVar`, etc.) are available for advanced sticky
 chrome inside a page body.

--- a/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
@@ -1,39 +1,16 @@
 import { checkboxFilter } from "src/components/Filters";
 import { actionColumn, column, numericColumn } from "src/components/Table/utils/columns";
 import { simpleHeader } from "src/components/Table/utils/simpleHelpers";
+import { DocumentScrollLayoutProvider } from "src/layouts/DocumentScrollLayoutContext";
+import { beamTableActionsHeightVar } from "src/layouts/layoutVars";
 import { noop } from "src/utils";
 import { click, render, tableSnapshot, withRouter } from "src/utils/rtl";
+import { vi } from "vitest";
 import {
   GridTableLayout as GridTableLayoutComponent,
   GridTableLayoutProps,
   useGridTableLayoutState,
 } from "./GridTableLayout";
-
-type Data = { name: string | undefined; value: number | undefined };
-type HeaderRow = { kind: "header"; id: string; data: undefined };
-type DataRow = { kind: "data"; id: string; data: Data };
-type Row = HeaderRow | DataRow;
-
-// Because we also want to test the use of the useGridTableLayoutState hook, we need create a wrapper component
-type TestWrapperProps = Omit<GridTableLayoutProps<any, Row, any, any>, "layoutState"> & {
-  layoutStateProps: Parameters<typeof useGridTableLayoutState>[0];
-};
-function TestWrapper(props: TestWrapperProps) {
-  const layoutState = useGridTableLayoutState(props.layoutStateProps);
-  return <GridTableLayoutComponent {...props} layoutState={layoutState} />;
-}
-
-const columns = [
-  column<Row>({ header: () => "Name", data: (row) => row.name, id: "name", name: "Name" }),
-  numericColumn<Row>({ header: () => "Value", data: (row) => row.value, id: "value", name: "Value" }),
-  actionColumn<Row>({ header: () => "Action", data: () => <div>Actions</div>, id: "action", name: "Action" }),
-];
-
-const rows: Row[] = [
-  { kind: "data", id: "1", data: { name: "Alpha", value: 10 } },
-  { kind: "data", id: "2", data: { name: "Beta", value: 20 } },
-  { kind: "data", id: "3", data: { name: "Gamma", value: 30 } },
-];
 
 describe("GridTableLayout", () => {
   it("renders with static rows", async () => {
@@ -57,8 +34,8 @@ describe("GridTableLayout", () => {
           { href: "/", label: "Sub Page" },
         ]}
         tableProps={{
-          columns,
-          rows: [simpleHeader, ...rows],
+          columns: getColumns(),
+          rows: [simpleHeader, ...getRows()],
         }}
         totalCount={100}
         primaryAction={{ label: "Primary Action", onClick: noop }}
@@ -113,7 +90,7 @@ describe("GridTableLayout", () => {
           { href: "/", label: "Sub Page" },
         ]}
         tableProps={{
-          columns,
+          columns: getColumns(),
           query: {
             data: [
               { id: "1", name: "Delta", value: 100 },
@@ -158,8 +135,8 @@ describe("GridTableLayout", () => {
           hideEditColumns={true}
           totalCount={100}
           tableProps={{
-            columns,
-            rows: [simpleHeader, ...rows],
+            columns: getColumns(),
+            rows: [simpleHeader, ...getRows()],
           }}
         />,
         withRouter(),
@@ -180,7 +157,7 @@ describe("GridTableLayout", () => {
           totalCount={100}
           tableProps={{
             columns: columnsWithoutId,
-            rows: [simpleHeader, ...rows],
+            rows: [simpleHeader, ...getRows()],
           }}
         />,
         withRouter(),
@@ -202,7 +179,7 @@ describe("GridTableLayout", () => {
           totalCount={100}
           tableProps={{
             columns: columnsWithoutName,
-            rows: [simpleHeader, ...rows],
+            rows: [simpleHeader, ...getRows()],
           }}
         />,
         withRouter(),
@@ -226,7 +203,7 @@ describe("GridTableLayout", () => {
           totalCount={100}
           tableProps={{
             columns: columnsWithoutId,
-            rows: [simpleHeader, ...rows],
+            rows: [simpleHeader, ...getRows()],
           }}
         />,
         withRouter(),
@@ -250,8 +227,8 @@ describe("GridTableLayout", () => {
           hideEditColumns
           totalCount={500}
           tableProps={{
-            columns,
-            rows: [simpleHeader, ...rows],
+            columns: getColumns(),
+            rows: [simpleHeader, ...getRows()],
           }}
         />,
         withRouter(),
@@ -275,8 +252,8 @@ describe("GridTableLayout", () => {
           hideEditColumns
           totalCount={500}
           tableProps={{
-            columns,
-            rows: [simpleHeader, ...rows],
+            columns: getColumns(),
+            rows: [simpleHeader, ...getRows()],
           }}
         />,
         withRouter(),
@@ -305,8 +282,8 @@ describe("GridTableLayout", () => {
           hideEditColumns
           totalCount={500}
           tableProps={{
-            columns,
-            rows: [simpleHeader, ...rows],
+            columns: getColumns(),
+            rows: [simpleHeader, ...getRows()],
           }}
         />,
         withRouter(),
@@ -325,15 +302,15 @@ describe("GridTableLayout", () => {
   });
 
   describe("view toggle", () => {
-    it("should not display a view toggle if renderContent is undefined", async () => {
+    it("should not display a view toggle if withCardView is undefined", async () => {
       const r = await render(
         <TestWrapper
           layoutStateProps={{}}
           pageTitle="Test"
           totalCount={100}
           tableProps={{
-            columns,
-            rows: [simpleHeader, ...rows],
+            columns: getColumns(),
+            rows: [simpleHeader, ...getRows()],
           }}
         />,
         withRouter(),
@@ -342,32 +319,133 @@ describe("GridTableLayout", () => {
       // Then ViewToggleButton is not rendered
       expect(r.query.viewToggleButton).not.toBeInTheDocument();
     });
+
+    it("should display view toggle if withCardView is defined", async () => {
+      const Content = () => <span data-testid="cardContent">Content</span>;
+
+      const r = await render(
+        <TestWrapper
+          layoutStateProps={{}}
+          pageTitle="Test"
+          totalCount={100}
+          tableProps={{
+            columns: getColumns(),
+            rows: [simpleHeader, ...getRows()],
+          }}
+          withCardView={<Content />}
+        />,
+        withRouter(),
+      );
+
+      expect(r.viewToggleButton).toBeInTheDocument();
+      expect(r.query.cardContent).not.toBeInTheDocument();
+
+      click(r.viewToggleButton);
+      click(r.viewToggleButton_card);
+
+      expect(r.cardContent).toBeInTheDocument();
+    });
   });
 
-  it("should display view toggle if renderContent is defined", async () => {
-    const Content = () => <span data-testid="cardContent">Content</span>;
+  describe("document scroll layout", () => {
+    it("sets table actions height CSS var inside DocumentScrollLayoutProvider", async () => {
+      const rectSpy = vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+        height: 40,
+        width: 800,
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        bottom: 40,
+        right: 800,
+        toJSON: () => ({}),
+      } as DOMRect);
 
-    const r = await render(
-      <TestWrapper
-        layoutStateProps={{}}
-        pageTitle="Test"
-        totalCount={100}
-        tableProps={{
-          columns,
-          rows: [simpleHeader, ...rows],
-        }}
-        withCardView={<Content />}
-      />,
-      withRouter(),
-    );
+      try {
+        // Given a GridTableLayout with filters inside a document-scroll layout
+        // When the layout mounts
+        const r = await render(
+          <DocumentScrollLayoutProvider>
+            <TestWrapper
+              layoutStateProps={getFilterLayoutStateProps("document-scroll-test")}
+              hideEditColumns
+              tableProps={{
+                columns: getColumns(),
+                rows: [simpleHeader, ...getRows()],
+              }}
+            />
+          </DocumentScrollLayoutProvider>,
+          withRouter(),
+        );
 
-    // Then ViewToggleButton is not rendered
-    expect(r.viewToggleButton).toBeInTheDocument();
-    expect(r.query.cardContent).not.toBeInTheDocument();
+        // Then the table actions height var is set for sticky column header coordination
+        expect(r.tableWrapper.style.getPropertyValue(beamTableActionsHeightVar)).toBe("40px");
+      } finally {
+        rectSpy.mockRestore();
+      }
+    });
 
-    click(r.viewToggleButton);
-    click(r.viewToggleButton_card);
+    it("does not set table actions height CSS var outside DocumentScrollLayoutProvider", async () => {
+      // Given a GridTableLayout with filters but no document-scroll layout
+      // When the layout mounts
+      const r = await render(
+        <TestWrapper
+          layoutStateProps={getFilterLayoutStateProps("legacy-layout-test")}
+          hideEditColumns
+          tableProps={{
+            columns: getColumns(),
+            rows: [simpleHeader, ...getRows()],
+          }}
+        />,
+        withRouter(),
+      );
 
-    expect(r.cardContent).toBeInTheDocument();
+      // Then the table actions height var is not set
+      expect(r.tableWrapper.style.getPropertyValue(beamTableActionsHeightVar)).toBe("");
+    });
+
+    function getFilterLayoutStateProps(storageKey: string) {
+      return {
+        persistedFilter: {
+          filterDefs: {
+            needsRevision: checkboxFilter({
+              label: "Needs Revision",
+            }),
+          },
+          storageKey,
+        },
+        search: "client" as const,
+      };
+    }
   });
 });
+
+type Data = { name: string | undefined; value: number | undefined };
+type HeaderRow = { kind: "header"; id: string; data: undefined };
+type DataRow = { kind: "data"; id: string; data: Data };
+type Row = HeaderRow | DataRow;
+
+// Because we also want to test the use of the useGridTableLayoutState hook, we need create a wrapper component
+type TestWrapperProps = Omit<GridTableLayoutProps<any, Row, any, any>, "layoutState"> & {
+  layoutStateProps: Parameters<typeof useGridTableLayoutState>[0];
+};
+function TestWrapper(props: TestWrapperProps) {
+  const layoutState = useGridTableLayoutState(props.layoutStateProps);
+  return <GridTableLayoutComponent {...props} layoutState={layoutState} />;
+}
+
+function getColumns() {
+  return [
+    column<Row>({ header: () => "Name", data: (row) => row.name, id: "name", name: "Name" }),
+    numericColumn<Row>({ header: () => "Value", data: (row) => row.value, id: "value", name: "Value" }),
+    actionColumn<Row>({ header: () => "Action", data: () => <div>Actions</div>, id: "action", name: "Action" }),
+  ];
+}
+
+function getRows(): Row[] {
+  return [
+    { kind: "data", id: "1", data: { name: "Alpha", value: 10 } },
+    { kind: "data", id: "2", data: { name: "Beta", value: 20 } },
+    { kind: "data", id: "3", data: { name: "Gamma", value: 30 } },
+  ];
+}

--- a/src/components/Layout/GridTableLayout/GridTableLayout.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.tsx
@@ -1,4 +1,5 @@
-import React, { ReactNode, useEffect, useMemo, useState } from "react";
+import { useResizeObserver } from "@react-aria/utils";
+import React, { ReactNode, RefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ScrollableContent } from "src/components";
 import { Button } from "src/components/Button";
 import { ButtonMenu, ButtonMenuProps } from "src/components/ButtonMenu";
@@ -10,9 +11,17 @@ import { GridTable } from "src/components/Table/GridTable";
 import { GridTableApiImpl } from "src/components/Table/GridTableApi";
 import { TableActions } from "src/components/Table/TableActions";
 import { GridTableXss, Kinded } from "src/components/Table/types";
-import { Css, Only } from "src/Css";
+import { Css, Only, Tokens } from "src/Css";
 import { useComputed, useGroupBy, usePersistedFilter, UsePersistedFilterProps, useSessionStorage } from "src/hooks";
-import { useTestIds } from "src/utils";
+import { useDocumentScrollLayout } from "src/layouts/DocumentScrollLayoutContext";
+import {
+  beamTableActionsHeightVar,
+  documentScrollChromeLeft,
+  documentScrollChromeWidth,
+  stickyNavAndHeaderOffset,
+} from "src/layouts/layoutVars";
+import { noop, useTestIds } from "src/utils";
+import { zIndices } from "src/utils/zIndices";
 import { FullBleed } from "../FullBleed";
 import { ActionButtonProps, BaseQueryTableProps, GridTablePropsWithRows, isGridTableProps } from "../layoutTypes";
 import { HeaderBreadcrumb, PageHeaderBreadcrumbs } from "../PageHeaderBreadcrumbs";
@@ -119,8 +128,12 @@ function GridTableLayoutComponent<
   );
   const [view, setView] = useState<TableView>(defaultView);
   const clientSearch = layoutState?.search === "client" ? layoutState.searchString : undefined;
-  const showTableActions = layoutState?.filterDefs || layoutState?.search || hasHideableColumns || !!withCardView;
+  const showTableActions = !!(layoutState?.filterDefs || layoutState?.search || hasHideableColumns || withCardView);
   const isVirtualized = tableProps.as === "virtual";
+  const inDocumentScrollLayout = useDocumentScrollLayout();
+  const tableActionsRef = useRef<HTMLDivElement>(null);
+  const tableWrapperRef = useRef<HTMLDivElement>(null);
+  useSetTableActionsHeight(tableWrapperRef, tableActionsRef, inDocumentScrollLayout && showTableActions);
 
   // Sync API changes back to persisted state when persistedColumns is provided
   const visibleColumnIds = useComputed(() => api.getVisibleColumnIds(), [api]);
@@ -131,6 +144,100 @@ function GridTableLayoutComponent<
   }, [visibleColumnIds, layoutState]);
 
   const visibleColumnsStorageKey = layoutState?.persistedColumnsStorageKey;
+
+  const tableActionsEl = (
+    <TableActions
+      right={
+        (hasHideableColumns || withCardView) && (
+          <div css={Css.df.gap1.$}>
+            {hasHideableColumns && (
+              <EditColumnsButton
+                columns={columns}
+                api={api}
+                tooltip="Display columns"
+                trigger={{ icon: "kanban", size: "md", label: "", variant: "secondaryBlack" }}
+                {...tid.editColumnsButton}
+              />
+            )}
+            {withCardView && <ViewToggleButton view={view} onChange={setView} />}
+          </div>
+        )
+      }
+      xss={Css.pt3.if(inDocumentScrollLayout).pl3.pr3.$}
+    >
+      {layoutState && (layoutState.filterDefs || layoutState.search) && (
+        <FilterDropdownMenu
+          filterDefs={layoutState.filterDefs}
+          filter={layoutState.filter}
+          onChange={layoutState.setFilter}
+          groupBy={layoutState.groupBy}
+          searchProps={layoutState.search ? { onSearch: layoutState.setSearchString } : undefined}
+        />
+      )}
+    </TableActions>
+  );
+
+  const tableBody = (
+    <>
+      {view === "card" && withCardView ? (
+        withCardView
+      ) : isGridTableProps(tableProps) ? (
+        <GridTable
+          {...tableProps}
+          api={api}
+          filter={clientSearch}
+          style={{ allWhite: true }}
+          stickyHeader
+          disableColumnResizing={false}
+          visibleColumnsStorageKey={visibleColumnsStorageKey}
+        />
+      ) : (
+        <QueryTable
+          {...(tableProps as QueryTableProps<R, QData, X>)}
+          api={api}
+          filter={clientSearch}
+          style={{ allWhite: true }}
+          stickyHeader
+          disableColumnResizing={false}
+          visibleColumnsStorageKey={visibleColumnsStorageKey}
+        />
+      )}
+      {layoutState && totalCount !== undefined && (
+        <Pagination
+          page={[layoutState.page, layoutState._pagination.setPage]}
+          totalCount={totalCount}
+          pageSizes={layoutState._pagination.pageSizes}
+          {...tid.pagination}
+        />
+      )}
+    </>
+  );
+
+  const tableScrollContent = (
+    <>
+      {showTableActions && (
+        <div
+          ref={tableActionsRef}
+          css={
+            Css.if(inDocumentScrollLayout)
+              .transitionTop.sticky.top(stickyNavAndHeaderOffset())
+              .left(documentScrollChromeLeft())
+              .w(documentScrollChromeWidth())
+              .z(zIndices.tableActions)
+              .bgColor(Tokens.Surface).$
+          }
+          {...tid.stickyContent}
+        >
+          {tableActionsEl}
+        </div>
+      )}
+      {inDocumentScrollLayout ? (
+        tableBody
+      ) : (
+        <ScrollableContent virtualized={isVirtualized}>{tableBody}</ScrollableContent>
+      )}
+    </>
+  );
 
   return (
     <>
@@ -144,67 +251,10 @@ function GridTableLayoutComponent<
           actionMenu={actionMenu}
         />
       )}
-      {showTableActions && (
-        <TableActions
-          right={
-            <div css={Css.df.gap1.$}>
-              {hasHideableColumns && (
-                <EditColumnsButton
-                  columns={columns}
-                  api={api}
-                  tooltip="Display columns"
-                  trigger={{ icon: "kanban", size: "md", label: "", variant: "secondaryBlack" }}
-                  {...tid.editColumnsButton}
-                />
-              )}
-              {withCardView && <ViewToggleButton view={view} onChange={setView} />}
-            </div>
-          }
-        >
-          {layoutState && (layoutState.filterDefs || layoutState.search) && (
-            <FilterDropdownMenu
-              filterDefs={layoutState.filterDefs}
-              filter={layoutState.filter}
-              onChange={layoutState.setFilter}
-              groupBy={layoutState.groupBy}
-              searchProps={layoutState.search ? { onSearch: layoutState.setSearchString } : undefined}
-            />
-          )}
-        </TableActions>
-      )}
-      <ScrollableContent virtualized={isVirtualized}>
-        {view === "card" && withCardView ? (
-          withCardView
-        ) : isGridTableProps(tableProps) ? (
-          <GridTable
-            {...tableProps}
-            api={api}
-            filter={clientSearch}
-            style={{ allWhite: true }}
-            stickyHeader
-            disableColumnResizing={false}
-            visibleColumnsStorageKey={visibleColumnsStorageKey}
-          />
-        ) : (
-          <QueryTable
-            {...(tableProps as QueryTableProps<R, QData, X>)}
-            api={api}
-            filter={clientSearch}
-            style={{ allWhite: true }}
-            stickyHeader
-            disableColumnResizing={false}
-            visibleColumnsStorageKey={visibleColumnsStorageKey}
-          />
-        )}
-        {layoutState && totalCount !== undefined && (
-          <Pagination
-            page={[layoutState.page, layoutState._pagination.setPage]}
-            totalCount={totalCount}
-            pageSizes={layoutState._pagination.pageSizes}
-            {...tid.pagination}
-          />
-        )}
-      </ScrollableContent>
+      {/* Wrapper sets --beam-table-actions-height so GridTable's sticky header can read it. */}
+      <div ref={tableWrapperRef} css={Css.display("contents").$} {...tid.tableWrapper}>
+        {tableScrollContent}
+      </div>
     </>
   );
 }
@@ -307,13 +357,47 @@ type HeaderProps = {
   actionMenu?: ActionButtonMenuProps;
 };
 
+/** Sets `--beam-table-actions-height` on the table wrapper so the sticky header can read it without re-rendering children. */
+function useSetTableActionsHeight(
+  tableWrapperRef: RefObject<HTMLElement | null>,
+  tableActionsRef: RefObject<HTMLElement | null>,
+  enabled: boolean,
+) {
+  const syncHeightVar = useCallback(() => {
+    const tableWrapper = tableWrapperRef.current;
+    if (!tableWrapper) return;
+
+    if (!enabled) {
+      tableWrapper.style.removeProperty(beamTableActionsHeightVar);
+      return;
+    }
+
+    const height = tableActionsRef.current ? Math.round(tableActionsRef.current.getBoundingClientRect().height) : 0;
+
+    if (height > 0) {
+      tableWrapper.style.setProperty(beamTableActionsHeightVar, `${height}px`);
+    } else {
+      tableWrapper.style.removeProperty(beamTableActionsHeightVar);
+    }
+  }, [enabled, tableActionsRef, tableWrapperRef]);
+
+  useResizeObserver({ ref: tableActionsRef, onResize: enabled ? syncHeightVar : noop });
+  useLayoutEffect(() => {
+    syncHeightVar();
+    const tableWrapper = tableWrapperRef.current;
+    return () => {
+      tableWrapper?.style.removeProperty(beamTableActionsHeightVar);
+    };
+  }, [tableWrapperRef, syncHeightVar]);
+}
+
 function Header(props: HeaderProps) {
   const { pageTitle, breadCrumb, primaryAction, secondaryAction, tertiaryAction, actionMenu } = props;
   const tids = useTestIds(props);
 
   return (
     <FullBleed>
-      <header css={{ ...Css.p3.mb3.mhPx(50).bgWhite.df.jcsb.aic.$ }} {...tids.header}>
+      <header css={{ ...Css.p3.mhPx(50).bgWhite.df.jcsb.aic.$ }} {...tids.header}>
         <div>
           {breadCrumb && <PageHeaderBreadcrumbs breadcrumb={breadCrumb} />}
           <h1 css={Css.xl2.mt1.$} {...tids.pageTitle}>

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -4,10 +4,12 @@ import { GridDataRow } from "src/components/Table/components/Row";
 import { GridTable, OnRowSelect, setRunningInJest } from "src/components/Table/GridTable";
 import { GridTableApi, GridTableApiImpl, useGridTableApi } from "src/components/Table/GridTableApi";
 import { defaultStyle, RowStyles } from "src/components/Table/TableStyles";
-import { GridColumn } from "src/components/Table/types";
+import { GridColumn, GridColumnWithId } from "src/components/Table/types";
 import {
   actionColumn,
+  calcColumnLayout,
   calcColumnSizes,
+  collapseColumn,
   column,
   generateColumnId,
   selectColumn,
@@ -1067,6 +1069,53 @@ describe("GridTable", () => {
         ]).join(" "),
       ).toEqual("300px ((100% - 0% - 300px) * (2 / 2))");
     });
+
+    it("expands content width when fr mw mins and % columns exceed measured table width", () => {
+      // Given columns whose mw mins and % widths exceed a narrow probe width
+      const columns = getExpandTestColumns();
+      const tableWidth = 643;
+
+      // When sizing columns in a document-scroll layout
+      const { contentWidth } = calcColumnLayout(columns, tableWidth, undefined, [], undefined, true);
+
+      // Then the resolved content width expands beyond the probe
+      expect(contentWidth).toBe(698);
+    });
+
+    it("does not expand content width on the legacy column layout path", () => {
+      // Given columns that would expand in document-scroll mode
+      const columns = getLegacyGateColumns();
+      const tableWidth = 643;
+
+      // When sizing columns outside a document-scroll layout
+      const legacy = calcColumnLayout(columns, tableWidth, undefined, [], undefined, false);
+
+      // Then content width stays at the probe and column sizes match a single calcColumnSizes pass
+      expect(legacy.contentWidth).toBe(643);
+      expect(legacy.columnSizes).toEqual(calcColumnSizes(columns, tableWidth, undefined, [], undefined));
+    });
+
+    function getExpandTestColumns() {
+      return [
+        collapseColumn(),
+        selectColumn(),
+        column({ id: "name", mw: "200px" }),
+        column({ id: "value", mw: "100px" }),
+        column({ id: "status", w: "20%", mw: "100px" }),
+        column({ id: "priority", mw: "80px" }),
+        actionColumn({ id: "action", w: "100px", mw: "80px" }),
+      ] as GridColumnWithId<any>[];
+    }
+
+    function getLegacyGateColumns() {
+      return [
+        collapseColumn(),
+        selectColumn(),
+        column({ id: "name", mw: "200px" }),
+        column({ id: "status", w: "20%", mw: "100px" }),
+        actionColumn({ id: "action", w: "100px", mw: "80px" }),
+      ] as GridColumnWithId<any>[];
+    }
   });
 
   it("throws error if column min-width definition is set with a non-px value", async () => {

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -42,7 +42,7 @@ import { Css, Only } from "src/Css";
 import { useComputed } from "src/hooks";
 import { useRenderCount } from "src/hooks/useRenderCount";
 import { useDocumentScrollLayout } from "src/layouts/DocumentScrollLayoutContext";
-import { stickyNavAndHeaderOffset } from "src/layouts/layoutVars";
+import { stickyTableHeaderOffset } from "src/layouts/layoutVars";
 import { isPromise } from "src/utils";
 import { zIndices } from "src/utils/zIndices";
 import type { GridDataRow, GridRowKind } from "./components/Row";
@@ -296,6 +296,7 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
 
   const style = resolveStyles(maybeStyle);
   const { tableState } = api;
+  const inDocumentScrollLayout = useDocumentScrollLayout();
 
   tableState.onRowSelect = onRowSelect;
 
@@ -331,7 +332,7 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
 
   // Our column sizes use either `w` or `expandedWidth`, so see which columns are currently expanded
   const expandedColumnIds: string[] = useComputed(() => tableState.expandedColumnIds, [tableState]);
-  const { columnSizes, tableWidth, resizedWidths, setResizedWidth, setResizedWidths, resetColumnWidths } =
+  const { columnSizes, tableWidth, contentWidth, resizedWidths, setResizedWidth, setResizedWidths, resetColumnWidths } =
     useSetupColumnSizes(
       style,
       columns,
@@ -339,6 +340,7 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
       expandedColumnIds,
       visibleColumnsStorageKey,
       disableColumnResizing,
+      inDocumentScrollLayout,
     );
 
   // Store resetColumnWidths on the API instance so it can be called from EditColumnsButton
@@ -579,12 +581,22 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
     [tableState, tableContainerRef],
   );
 
+  // Document-scroll layouts may need a wider table shell than the resize probe when mw/% columns require it.
+  const tableStyle = useMemo(() => {
+    if (!inDocumentScrollLayout || contentWidth === undefined || tableWidth === undefined) return style;
+
+    const minWidthPx = Math.max(style.minWidthPx ?? 0, contentWidth);
+    if (minWidthPx === style.minWidthPx) return style;
+
+    return { ...style, minWidthPx };
+  }, [contentWidth, inDocumentScrollLayout, style, tableWidth]);
+
   return (
     <TableStateContext.Provider value={rowStateContext}>
       <PresentationProvider fieldProps={fieldProps} wrap={style?.presentationSettings?.wrap}>
-        <div ref={resizeRef} css={getTableRefWidthStyles(as === "virtual")} />
+        <div ref={resizeRef} css={getTableRefWidthStyles(as === "virtual", inDocumentScrollLayout)} />
         {renders[_as](
-          style,
+          tableStyle,
           id,
           columns,
           visibleDataRows,
@@ -647,7 +659,11 @@ function renderDiv<R extends Kinded>(
     >
       {/* Table Head */}
       <div
-        css={Css.if(stickyHeader).sticky.top(stickyNavAndHeaderOffset(stickyOffset)).z(zIndices.tableStickyHeader).$}
+        css={
+          Css.if(stickyHeader)
+            .sticky.transitionTop.top(stickyTableHeaderOffset(stickyOffset))
+            .z(zIndices.tableStickyHeader).$
+        }
       >
         {tableHeadRows}
       </div>
@@ -706,7 +722,11 @@ function renderTable<R extends Kinded>(
       data-testid={id}
     >
       <thead
-        css={Css.if(stickyHeader).sticky.top(stickyNavAndHeaderOffset(stickyOffset)).z(zIndices.tableStickyHeader).$}
+        css={
+          Css.if(stickyHeader)
+            .sticky.transitionTop.top(stickyTableHeaderOffset(stickyOffset))
+            .z(zIndices.tableStickyHeader).$
+        }
       >
         {tableHeadRows}
       </thead>
@@ -820,10 +840,12 @@ function renderVirtual<R extends Kinded>(
           <div
             {...props}
             ref={ref as MutableRefObject<HTMLDivElement>}
+            css={Css.transitionTop.$}
             style={{
               ...props.style,
+              ...(style.minWidthPx !== undefined ? { minWidth: style.minWidthPx } : {}),
               zIndex: zIndices.tableStickyHeader,
-              top: stickyNavAndHeaderOffset(stickyOffset),
+              top: stickyTableHeaderOffset(stickyOffset),
             }}
           />
         )),
@@ -871,7 +893,7 @@ function renderVirtual<R extends Kinded>(
               // Ensure the fallback message is the same width as the table
               <div
                 css={{
-                  ...getTableRefWidthStyles(true),
+                  ...getTableRefWidthStyles(true, inDocumentScrollLayout),
                   ...(keptSelectedRows.length === 0 && style.firstBodyRowCss),
                   ...(visibleDataRows.length === 0 && style.lastRowCss),
                 }}

--- a/src/components/Table/TableActions.tsx
+++ b/src/components/Table/TableActions.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
-import { Css, Margin, Only, Xss } from "src/Css";
+import { Css, Margin, Only, Padding, Xss } from "src/Css";
 
-type TableActionsXss = Xss<Margin>;
+type TableActionsXss = Xss<Margin | Padding>;
 
 interface TableActionsProps<X> {
   xss?: X;

--- a/src/components/Table/hooks/useSetupColumnSizes.ts
+++ b/src/components/Table/hooks/useSetupColumnSizes.ts
@@ -3,7 +3,7 @@ import { MutableRefObject, useCallback, useEffect, useRef, useState } from "reac
 import { GridStyle } from "src/components/Table/TableStyles";
 import { ResizedWidths, useColumnResizing } from "src/components/Table/hooks/useColumnResizing";
 import { GridColumnWithId, Kinded } from "src/components/Table/types";
-import { calcColumnSizes } from "src/components/Table/utils/columns";
+import { calcColumnLayout } from "src/components/Table/utils/columns";
 import { useDebouncedCallback } from "use-debounce";
 
 /**
@@ -32,9 +32,13 @@ export function useSetupColumnSizes<R extends Kinded>(
   expandedColumnIds: string[],
   visibleColumnsStorageKey: string | undefined,
   disableColumnResizing: boolean,
+  inDocumentScrollLayout: boolean,
 ): {
   columnSizes: string[];
+  /** Container width from the resize probe (unchanged when content expands). */
   tableWidth: number | undefined;
+  /** Row width required by column defs; only expands beyond probe in document-scroll layouts. */
+  contentWidth: number | undefined;
   resizedWidths: ResizedWidths;
   setResizedWidth: (columnId: string, width: number) => void;
   setResizedWidths: (widths: ResizedWidths | ((prev: ResizedWidths) => ResizedWidths)) => void;
@@ -50,20 +54,30 @@ export function useSetupColumnSizes<R extends Kinded>(
   // which is used internally by `useDebounce`, so the frozen clock means the callback is never called.
   const calculateImmediately = useRef<boolean>(true);
   const [tableWidth, setTableWidth] = useState<number | undefined>();
+  const [contentWidth, setContentWidth] = useState<number | undefined>();
+  const [columnSizes, setColumnSizes] = useState<string[]>(
+    () =>
+      calcColumnLayout(columns, undefined, style.minWidthPx, expandedColumnIds, resizedWidths, inDocumentScrollLayout)
+        .columnSizes,
+  );
   // Track previous table width to detect container resize
   const prevTableWidthRef = useRef<number | undefined>(tableWidth);
 
-  // Calc our initial/first render sizes where we won't have a width yet
-  const [columnSizes, setColumnSizes] = useState<string[]>(
-    calcColumnSizes(columns, tableWidth, style.minWidthPx, expandedColumnIds, resizedWidths),
-  );
-
-  const setTableAndColumnWidths = useCallback(
-    (width: number) => {
-      setTableWidth(width);
-      setColumnSizes(calcColumnSizes(columns, width, style.minWidthPx, expandedColumnIds, resizedWidths));
+  const applyColumnLayout = useCallback(
+    (probeWidth: number) => {
+      const layout = calcColumnLayout(
+        columns,
+        probeWidth,
+        style.minWidthPx,
+        expandedColumnIds,
+        resizedWidths,
+        inDocumentScrollLayout,
+      );
+      setTableWidth(probeWidth);
+      setContentWidth(layout.contentWidth);
+      setColumnSizes(layout.columnSizes);
     },
-    [setTableWidth, setColumnSizes, columns, style, expandedColumnIds, resizedWidths],
+    [columns, style.minWidthPx, expandedColumnIds, resizedWidths, inDocumentScrollLayout],
   );
 
   // Scale resized column widths when container width changes
@@ -103,15 +117,15 @@ export function useSetupColumnSizes<R extends Kinded>(
     () => {
       if (!calculateImmediately.current) {
         const width = resizeRef.current?.clientWidth;
-        width && setTableAndColumnWidths(width);
+        width && applyColumnLayout(width);
       }
     },
     // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [columns, resizedWidths, setTableAndColumnWidths],
+    [columns, resizedWidths, applyColumnLayout],
   );
 
-  const setTableAndColumnWidthsDebounced = useDebouncedCallback(setTableAndColumnWidths, 100);
+  const applyColumnLayoutDebounced = useDebouncedCallback(applyColumnLayout, 100);
 
   const onResize = useCallback(
     () => {
@@ -119,18 +133,26 @@ export function useSetupColumnSizes<R extends Kinded>(
       if (target && target.clientWidth !== tableWidth) {
         if (calculateImmediately.current) {
           calculateImmediately.current = false;
-          setTableAndColumnWidths(target.clientWidth);
+          applyColumnLayout(target.clientWidth);
         } else {
-          setTableAndColumnWidthsDebounced(target.clientWidth);
+          applyColumnLayoutDebounced(target.clientWidth);
         }
       }
     },
     // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [tableWidth, setTableAndColumnWidths, setTableAndColumnWidthsDebounced],
+    [tableWidth, applyColumnLayout, applyColumnLayoutDebounced],
   );
 
   useResizeObserver({ ref: resizeRef, onResize });
 
-  return { columnSizes, tableWidth, resizedWidths, setResizedWidth, setResizedWidths, resetColumnWidths };
+  return {
+    columnSizes,
+    tableWidth,
+    contentWidth,
+    resizedWidths,
+    setResizedWidth,
+    setResizedWidths,
+    resetColumnWidths,
+  };
 }

--- a/src/components/Table/utils/columns.tsx
+++ b/src/components/Table/utils/columns.tsx
@@ -99,11 +99,11 @@ export function parseWidthToPx(widthStr: string | undefined, tableWidth: number 
   if (!widthStr) return null;
 
   if (widthStr.endsWith("px")) {
-    const parsed = parseInt(widthStr.replace("px", ""), 10);
+    const parsed = parseFloat(widthStr.replace("px", ""));
     return isNaN(parsed) ? null : parsed;
   }
 
-  if (widthStr.endsWith("%") && tableWidth) {
+  if (widthStr.endsWith("%") && tableWidth !== undefined) {
     const percent = parseFloat(widthStr.replace("%", ""));
     if (isNaN(percent)) return null;
     return Math.round((percent / 100) * tableWidth);
@@ -113,6 +113,61 @@ export function parseWidthToPx(widthStr: string | undefined, tableWidth: number 
   // These should never happen since we've run calcColumnSizes already resolved to px
   // by the time resizing happens
   return null;
+}
+
+/** Sum resolved column sizes in px; returns null when any size is still a calc() expression. */
+export function sumColumnSizesPx(columnSizes: string[], tableWidth: number | undefined): number | null {
+  if (tableWidth === undefined) return null;
+
+  let sum = 0;
+  for (const size of columnSizes) {
+    const px = parseWidthToPx(size, tableWidth);
+    if (px === null) return null;
+    sum += px;
+  }
+
+  return sum;
+}
+
+/** Split resolved column sizes into fixed px vs row-relative % portions. */
+function sumColumnSizeParts(columnSizes: string[]): { pxSum: number; percentSum: number; hasCalc: boolean } {
+  let pxSum = 0;
+  let percentSum = 0;
+  let hasCalc = false;
+
+  for (const size of columnSizes) {
+    if (size.endsWith("px")) {
+      pxSum += parseFloat(size.replace("px", ""));
+    } else if (size.endsWith("%")) {
+      percentSum += parseFloat(size.replace("%", ""));
+    } else {
+      hasCalc = true;
+    }
+  }
+
+  return { pxSum, percentSum, hasCalc };
+}
+
+/** Table content width: at least the measured container and a self-consistent width for literal % columns. */
+export function resolveTableContentWidth(
+  tableWidth: number | undefined,
+  columnSizes: string[],
+  minWidthPx: number = 0,
+): number | undefined {
+  if (tableWidth === undefined) return undefined;
+
+  const { pxSum, percentSum, hasCalc } = sumColumnSizeParts(columnSizes);
+
+  // fixedPx + (percent/100) * rowWidth = rowWidth  →  rowWidth = fixedPx / (1 - percent/100)
+  if (!hasCalc && percentSum > 0 && percentSum < 100) {
+    const selfConsistent = pxSum / (1 - percentSum / 100);
+    return Math.max(tableWidth, minWidthPx, Math.ceil(selfConsistent));
+  }
+
+  const sum = sumColumnSizesPx(columnSizes, tableWidth);
+  if (sum === null) return undefined;
+
+  return Math.max(tableWidth, sum, minWidthPx);
 }
 
 /**
@@ -229,6 +284,50 @@ export function calcColumnSizes<R extends Kinded>(
   });
 
   return sizes;
+}
+
+export type ColumnLayoutResult = {
+  columnSizes: string[];
+  /** Row width required by column defs; equals probe width when no expansion (or legacy path). */
+  contentWidth: number | undefined;
+};
+
+/** Size columns for a measured container; resolves content width when in a document-scroll layout. */
+export function calcColumnLayout<R extends Kinded>(
+  columns: GridColumnWithId<R>[],
+  probeWidth: number | undefined,
+  tableMinWidthPx: number = 0,
+  expandedColumnIds: string[],
+  resizedWidths: ResizedWidths | undefined,
+  inDocumentScrollLayout: boolean,
+): ColumnLayoutResult {
+  if (probeWidth === undefined) {
+    return {
+      columnSizes: calcColumnSizes(columns, undefined, tableMinWidthPx, expandedColumnIds, resizedWidths),
+      contentWidth: undefined,
+    };
+  }
+
+  if (!inDocumentScrollLayout) {
+    return {
+      columnSizes: calcColumnSizes(columns, probeWidth, tableMinWidthPx, expandedColumnIds, resizedWidths),
+      contentWidth: probeWidth,
+    };
+  }
+
+  // Pass 1: size columns assuming the row width equals the measured container (probe).
+  let columnSizes = calcColumnSizes(columns, probeWidth, tableMinWidthPx, expandedColumnIds, resizedWidths);
+
+  // Literal % columns and mw floors can require a row wider than the probe.
+  const contentWidth = resolveTableContentWidth(probeWidth, columnSizes, tableMinWidthPx) ?? probeWidth;
+
+  // Re-run fr→px at the content width when expansion is meaningful; literal % columns stay as-is.
+  // Skip re-run when expansion is ≤1px (rounding noise from % resolution at the probe).
+  if (contentWidth > probeWidth + 1) {
+    columnSizes = calcColumnSizes(columns, contentWidth, tableMinWidthPx, expandedColumnIds, resizedWidths);
+  }
+
+  return { columnSizes, contentWidth };
 }
 
 /** Assign column ids if missing. */

--- a/src/components/Table/utils/utils.tsx
+++ b/src/components/Table/utils/utils.tsx
@@ -8,6 +8,7 @@ import { GridRowApi } from "src/components/Table/GridTableApi";
 import { GridStyle } from "src/components/Table/TableStyles";
 import { GridCellAlignment, GridColumnBorder, GridColumnWithId, Kinded, RenderAs } from "src/components/Table/types";
 import { Css, Palette, Properties } from "src/Css";
+import { documentScrollChromeWidth } from "src/layouts/layoutVars";
 import { getButtonOrLink } from "src/utils/getInteractiveElement";
 
 /** If a column def return just string text for a given row, apply some default styling. */
@@ -305,8 +306,15 @@ export function recursivelyGetContainingRow<R extends Kinded>(
   return undefined;
 }
 
-export function getTableRefWidthStyles(isVirtual: boolean) {
-  // If virtualized take some pixels off the width to accommodate when virtuoso's scrollbar is introduced.
-  // Otherwise a horizontal scrollbar will _always_ appear once the vertical scrollbar is needed
-  return Css.w100.if(isVirtual).w("calc(100% - 20px)").$;
+export function getTableRefWidthStyles(isVirtual: boolean, inDocumentScrollLayout: boolean = false) {
+  // When using document-scroll, utilize the documentScrollChromeWidth to get the available width on the page for it.
+  if (inDocumentScrollLayout) {
+    return Css.w(documentScrollChromeWidth()).$;
+  }
+  // Nested scrolling virtual tables reserve space for Virtuoso / ScrollableParent vertical scrollbars.
+  if (isVirtual) {
+    return Css.w("calc(100% - 20px)").$;
+  }
+  // Otherwise, use the full width of the container (nested scroll, non-virtual tables)
+  return Css.w100.$;
 }

--- a/src/layouts/NavbarLayout/NavbarLayout.stories.tsx
+++ b/src/layouts/NavbarLayout/NavbarLayout.stories.tsx
@@ -1,15 +1,21 @@
 import { Meta } from "@storybook/react-vite";
+import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import { AppNavItems } from "src/components/AppNav/AppNavItems";
 import type { AppNavItem } from "src/components/AppNav/appNavTypes";
 import { Button } from "src/components/Button";
+import { checkboxFilter, multiFilter } from "src/components/Filters";
 import { HomeboundLogo } from "src/components/HomeboundLogo";
+import { GridTableLayout, useGridTableLayoutState } from "src/components/Layout/GridTableLayout/GridTableLayout";
 import type { NavbarProps, NavbarUser } from "src/components/Navbar/Navbar";
+import { GridDataRow } from "src/components/Table";
+import { collapseColumn, column, numericColumn, selectColumn } from "src/components/Table/utils/columns";
+import { simpleHeader } from "src/components/Table/utils/simpleHelpers";
 import { Css, Tokens } from "src/Css";
 import { NavbarLayout } from "src/layouts/NavbarLayout";
 import { PageHeaderLayout } from "src/layouts/PageHeaderLayout";
 import { SideNavLayout } from "src/layouts/SideNavLayout/SideNavLayout";
-import { viewportModes, withBeamDecorator, withRouter } from "src/utils/sb";
+import { viewportModes, withBeamDecorator, withRouter, zeroTo } from "src/utils/sb";
 import { TableExample } from "src/utils/sbComponents";
 import { action } from "storybook/actions";
 
@@ -58,6 +64,45 @@ export const ComposedWithoutSideNav = () => (
     </PageHeaderLayout>
   </NavbarLayout>
 );
+
+/**
+ * `NavbarLayout` → `PageHeaderLayout` → `GridTableLayout` without a side nav. Page title and actions live in
+ * `PageHeaderLayout`; filters and search live in `GridTableLayout` (no `pageTitle`). The virtualized table uses
+ * document scroll so the navbar and page header auto-hide on scroll-down and the sticky table header pins below them.
+ */
+export function ComposedGridTableWithoutSideNav() {
+  const filterDefs = useMemo(() => getGridTableFilterDefs(), []);
+  const columns = useMemo(() => getGridTableColumns(), []);
+
+  const layoutState = useGridTableLayoutState({
+    persistedFilter: {
+      filterDefs,
+      storageKey: "navbar-layout-grid-table",
+    },
+    search: "client",
+  });
+
+  return (
+    <NavbarLayout navbar={createNavbar()}>
+      <PageHeaderLayout
+        pageHeader={{
+          title: "Projects",
+          rightSlot: <Button label="Action" onClick={() => {}} />,
+        }}
+      >
+        <GridTableLayout
+          layoutState={layoutState}
+          tableProps={{
+            as: "virtual",
+            columns,
+            rows: [simpleHeader, ...makeGridTableNestedRows(20)],
+            sorting: { on: "client", initial: [columns[1].id!, "ASC"] },
+          }}
+        />
+      </PageHeaderLayout>
+    </NavbarLayout>
+  );
+}
 
 function createNavbar(): NavbarProps {
   return {
@@ -108,4 +153,139 @@ function sideNavItems(): AppNavItem[] {
       ],
     },
   ];
+}
+
+type GridTableData = { name: string | undefined; value: number | undefined; status: string; priority: number };
+type GridTableHeaderRow = { kind: "header"; id: string; data: undefined };
+type GridTableParentRow = { kind: "parent"; id: string; data: GridTableData; children: GridDataRow<GridTableRow>[] };
+type GridTableDataRow = { kind: "data"; id: string; data: GridTableData };
+type GridTableRow = GridTableHeaderRow | GridTableParentRow | GridTableDataRow;
+
+function getGridTableFilterDefs() {
+  return {
+    primary: multiFilter({
+      options: [
+        { value: "primary", label: "Primary" },
+        { value: "secondary", label: "Secondary" },
+      ],
+      getOptionLabel: (tp) => tp.label,
+      getOptionValue: (tp) => tp.value,
+      label: "Preference",
+    }),
+    status: multiFilter({
+      options: [
+        { label: "Active", value: "active" },
+        { label: "Inactive", value: "inactive" },
+      ],
+      getOptionLabel: (cs) => cs.label,
+      getOptionValue: (cs) => cs.value,
+      label: "Status",
+    }),
+    needsRevision: checkboxFilter({
+      label: "Needs Revision",
+    }),
+  };
+}
+
+function getGridTableColumns() {
+  const nameColumn = column<GridTableRow>({
+    id: "name-col",
+    name: "Name",
+    header: () => ({ content: "Name" }),
+    parent: (row) => ({ content: row.name, value: row.name }),
+    data: (row) => ({ content: row.name }),
+    mw: "200px",
+  });
+  const valueColumn = numericColumn<GridTableRow>({
+    id: "value-col",
+    name: "Value",
+    header: () => ({ content: "Value" }),
+    parent: (row) => ({ content: row.value, value: row.value }),
+    data: (row) => ({ content: row.value }),
+    mw: "100px",
+  });
+  const statusColumn = column<GridTableRow>({
+    id: "status-col",
+    name: "Status",
+    header: () => ({ content: "Status" }),
+    parent: (row) => ({ content: row.status, value: row.status }),
+    data: (row) => ({ content: row.status }),
+    w: "20%",
+    mw: "100px",
+  });
+  const priorityColumn = numericColumn<GridTableRow>({
+    id: "priority-col",
+    name: "Priority",
+    header: () => ({ content: "Priority" }),
+    parent: (row) => ({ content: row.priority, value: row.priority }),
+    data: (row) => ({ content: row.priority }),
+    mw: "80px",
+  });
+  const actionColumn = column<GridTableRow>({
+    id: "action-col",
+    name: "Action",
+    header: () => ({ content: "Action" }),
+    parent: () => ({ content: <div>Actions</div>, value: "" }),
+    data: () => ({ content: <div>Actions</div> }),
+    clientSideSort: false,
+    w: "100px",
+    mw: "80px",
+  });
+
+  return [
+    collapseColumn<GridTableRow>(),
+    selectColumn<GridTableRow>(),
+    nameColumn,
+    valueColumn,
+    statusColumn,
+    priorityColumn,
+    actionColumn,
+  ];
+}
+
+function makeGridTableNestedRows(repeat: number = 1): GridDataRow<GridTableRow>[] {
+  let parentId = 0;
+  return zeroTo(repeat).flatMap((i) => {
+    const p1 = `p${parentId++}`;
+    const p2 = `p${parentId++}`;
+    const p3 = `p${parentId++}`;
+    const prefix = i === 0 ? "" : `${i}.`;
+    return [
+      {
+        kind: "parent",
+        id: p1,
+        data: { name: `parent ${prefix}1`, value: 100, status: "active", priority: 1 },
+        children: [
+          {
+            kind: "data",
+            id: `${p1}c1`,
+            data: { name: `child ${prefix}p1c1`, value: 50, status: "active", priority: 2 },
+          },
+          {
+            kind: "data",
+            id: `${p1}c2`,
+            data: { name: `child ${prefix}p1c2`, value: 30, status: "inactive", priority: 1 },
+          },
+        ],
+      },
+      {
+        kind: "parent",
+        id: p2,
+        data: { name: `parent ${prefix}2`, value: 200, status: "inactive", priority: 2 },
+        children: [
+          {
+            kind: "data",
+            id: `${p2}c1`,
+            data: { name: `child ${prefix}p2c1`, value: 100, status: "active", priority: 3 },
+          },
+        ],
+      },
+      {
+        kind: "parent",
+        id: p3,
+        data: { name: `parent ${prefix}3`, value: 150, status: "active", priority: 3 },
+        children: [],
+      },
+    ];
+  });
 }

--- a/src/layouts/PageHeaderLayout/PageHeaderLayout.tsx
+++ b/src/layouts/PageHeaderLayout/PageHeaderLayout.tsx
@@ -6,10 +6,10 @@ import { useTestIds } from "src/utils";
 import { zIndices } from "src/utils/zIndices";
 import { DocumentScrollLayoutProvider } from "../DocumentScrollLayoutContext";
 import {
-  beamLayoutViewportWidthVar,
   beamNavbarLayoutHeightVar,
   beamPageHeaderLayoutHeightVar,
-  beamSideNavLayoutWidthVar,
+  documentScrollChromeLeft,
+  documentScrollChromeWidth,
 } from "../layoutVars";
 import { useNavbarLayoutHeight } from "../NavbarLayout/NavbarLayoutHeightContext";
 import { useAutoHideOnScroll } from "../useAutoHideOnScroll";
@@ -45,8 +45,8 @@ export function PageHeaderLayout<V extends string, X extends Only<TabsContentXss
   const cssVars: Record<string, string> | undefined =
     headerHeight > 0 && headerOccupiesPosition ? { [beamPageHeaderLayoutHeightVar]: `${headerHeight}px` } : undefined;
 
-  const headerLeft = `var(${beamSideNavLayoutWidthVar}, 0px)`;
-  const headerWidth = `calc(var(${beamLayoutViewportWidthVar}, 100vw) - var(${beamSideNavLayoutWidthVar}, 0px))`;
+  const headerLeft = documentScrollChromeLeft();
+  const headerWidth = documentScrollChromeWidth();
   const outerTop = `var(${beamNavbarLayoutHeightVar}, 0px)`;
 
   const innerCss =

--- a/src/layouts/index.ts
+++ b/src/layouts/index.ts
@@ -6,6 +6,11 @@ export {
   beamNavbarLayoutHeightVar,
   beamPageHeaderLayoutHeightVar,
   beamSideNavLayoutWidthVar,
+  beamTableActionsHeightVar,
+  documentScrollChromeLeft,
+  documentScrollChromeWidth,
+  stickyNavAndHeaderOffset,
+  stickyTableHeaderOffset,
 } from "./layoutVars";
 export { NavbarLayout } from "./NavbarLayout";
 export type { NavbarLayoutProps } from "./NavbarLayout";

--- a/src/layouts/layoutVars.test.ts
+++ b/src/layouts/layoutVars.test.ts
@@ -1,6 +1,17 @@
-import { stickyNavAndHeaderOffset } from "src/layouts/layoutVars";
+import { documentScrollChromeWidth, stickyNavAndHeaderOffset, stickyTableHeaderOffset } from "src/layouts/layoutVars";
 
 describe("layoutVars", () => {
+  describe("documentScrollChromeWidth", () => {
+    it("spans the viewport width beside the side nav rail", () => {
+      // Given the document scroll chrome width helper
+      // When computing the width expression
+      const result = documentScrollChromeWidth();
+
+      // Then it subtracts the side nav rail from the layout viewport width
+      expect(result).toBe("calc(var(--beam-layout-viewport-width, 100vw) - var(--beam-side-nav-layout-width, 0px))");
+    });
+  });
+
   describe("stickyNavAndHeaderOffset", () => {
     it("sums the nav + header height vars with a 0 base by default", () => {
       // Given the default base offset
@@ -21,6 +32,19 @@ describe("layoutVars", () => {
       // Then the base is included in the calc expression
       expect(result).toBe(
         "calc(12px + var(--beam-navbar-layout-height, 0px) + var(--beam-page-header-layout-height, 0px))",
+      );
+    });
+  });
+
+  describe("stickyTableHeaderOffset", () => {
+    it("sums the nav + header + table actions height vars with a 0 base by default", () => {
+      // Given the default base offset
+      // When computing the sticky offset
+      const result = stickyTableHeaderOffset();
+
+      // Then the nav, header, and table actions height vars are summed with a 0px base
+      expect(result).toBe(
+        "calc(0px + var(--beam-navbar-layout-height, 0px) + var(--beam-page-header-layout-height, 0px) + var(--beam-table-actions-height, 0px))",
       );
     });
   });

--- a/src/layouts/layoutVars.ts
+++ b/src/layouts/layoutVars.ts
@@ -13,7 +13,25 @@ export const beamLayoutViewportHeightVar = "--beam-layout-viewport-height";
 /** Side nav rail width (px) for horizontal sticky offsets. */
 export const beamSideNavLayoutWidthVar = "--beam-side-nav-layout-width";
 
+/** Table actions toolbar height (px) while pinned in document-scroll layouts. */
+export const beamTableActionsHeightVar = "--beam-table-actions-height";
+
+/** `left` for document-scroll sticky chrome (below side nav when present). */
+export function documentScrollChromeLeft(): string {
+  return `var(${beamSideNavLayoutWidthVar}, 0px)`;
+}
+
+/** `width` for document-scroll sticky chrome spanning the visible viewport beside the side nav. */
+export function documentScrollChromeWidth(): string {
+  return `calc(var(${beamLayoutViewportWidthVar}, 100vw) - var(${beamSideNavLayoutWidthVar}, 0px))`;
+}
+
 /** `top` offset below auto-hiding navbar + page header (each var collapses to `0` when scrolled away). */
 export function stickyNavAndHeaderOffset(basePx = 0): string {
   return `calc(${basePx}px + var(${beamNavbarLayoutHeightVar}, 0px) + var(${beamPageHeaderLayoutHeightVar}, 0px))`;
+}
+
+/** `top` offset for sticky table column headers (navbar + page header + table actions). */
+export function stickyTableHeaderOffset(basePx = 0): string {
+  return `calc(${basePx}px + var(${beamNavbarLayoutHeightVar}, 0px) + var(${beamPageHeaderLayoutHeightVar}, 0px) + var(${beamTableActionsHeightVar}, 0px))`;
 }

--- a/src/layouts/useAutoHideOnScroll.test.tsx
+++ b/src/layouts/useAutoHideOnScroll.test.tsx
@@ -100,6 +100,20 @@ describe("useAutoHideOnScroll", () => {
     expect(r.atTop).toHaveTextContent("true");
   });
 
+  it("does not reveal when document height changes", async () => {
+    // Given the chrome is hidden mid-page
+    const r = await render(<Harness />);
+    scrollTo(r.spacer, 0, { scrollHeight: 2000 });
+    scrollTo(r.spacer, 300, { scrollHeight: 2000 });
+    expect(r.state).toHaveTextContent("hidden");
+
+    // When the page grows at the same scroll position (would reveal on scroll-up otherwise)
+    scrollTo(r.spacer, 250, { scrollHeight: 4000 });
+
+    // Then the chrome stays hidden
+    expect(r.state).toHaveTextContent("hidden");
+  });
+
   it("uses getTopOffset (not 0) as the static / atTop threshold", async () => {
     // Given a placeholder below a 100px top offset (e.g. below a navbar)
     const r = await render(<Harness topOffset={100} />);
@@ -142,14 +156,19 @@ function Harness({ enabled = true, topOffset }: { enabled?: boolean; topOffset?:
 }
 
 /** Fakes document scroll; `anchorTop` positions the placeholder, `maxScroll` controls the atBottom check. */
-function scrollTo(spacer: HTMLElement, y: number, opts: { maxScroll?: number; anchorTop?: number } = {}) {
+function scrollTo(
+  spacer: HTMLElement,
+  y: number,
+  opts: { maxScroll?: number; anchorTop?: number; scrollHeight?: number } = {},
+) {
   const maxScroll = opts.maxScroll ?? 1_000_000;
   const anchorTop = opts.anchorTop ?? 0;
   const clientHeight = 800;
+  const scrollHeight = opts.scrollHeight ?? maxScroll + clientHeight;
   Object.defineProperty(window, "scrollY", { value: y, configurable: true });
   Object.defineProperty(document.documentElement, "clientHeight", { value: clientHeight, configurable: true });
   Object.defineProperty(document.documentElement, "scrollHeight", {
-    value: maxScroll + clientHeight,
+    value: scrollHeight,
     configurable: true,
   });
   const top = anchorTop - y;

--- a/src/layouts/useAutoHideOnScroll.ts
+++ b/src/layouts/useAutoHideOnScroll.ts
@@ -1,4 +1,4 @@
-import { type RefObject, useEffect, useRef, useState } from "react";
+import { type RefObject, useLayoutEffect, useRef, useState } from "react";
 
 /**
  * Auto-hide chrome positioning: `static` (in flow), `hidden` (fixed above viewport), `revealed` (fixed at top).
@@ -15,27 +15,38 @@ export type AutoHideResult = {
 /** Scroll distance before committing to fixed positioning. Exported for tests. */
 export const THRESHOLD = 80;
 
+function getInitialAutoHideState(): { state: AutoHideState; atTop: boolean } {
+  if (typeof window === "undefined" || window.scrollY <= 0) {
+    return { state: "static", atTop: true };
+  }
+  // Mid-page reload — assume hidden until spacer geometry syncs in layout effect.
+  return { state: "hidden", atTop: false };
+}
+
 export function useAutoHideOnScroll(
   spacerRef: RefObject<HTMLElement | null>,
   enabled: boolean,
   /** Viewport-y when `revealed`; defaults to `0`. Read each scroll (tracks dynamic parent chrome). */
   getTopOffset?: () => number,
 ): AutoHideResult {
-  const [state, setState] = useState<AutoHideState>("static");
-  const stateRef = useRef<AutoHideState>("static");
-  const [atTop, setAtTop] = useState(true);
-  const atTopRef = useRef(true);
+  const initial = getInitialAutoHideState();
+  const [state, setState] = useState<AutoHideState>(initial.state);
+  const stateRef = useRef<AutoHideState>(initial.state);
+  const [atTop, setAtTop] = useState(initial.atTop);
+  const atTopRef = useRef(initial.atTop);
   // Ref avoids re-subscribing the scroll listener when callers pass an unmemoized callback.
   const getTopOffsetRef = useRef(getTopOffset);
   getTopOffsetRef.current = getTopOffset;
   // +Infinity so the first scroll reads as "up" (deep-link / scroll restore can land in `revealed`).
   const lastScrollY = useRef(Number.POSITIVE_INFINITY);
+  const lastScrollHeight = useRef(0);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!enabled) {
       stateRef.current = "static";
       atTopRef.current = true;
       lastScrollY.current = Number.POSITIVE_INFINITY;
+      lastScrollHeight.current = 0;
       setState("static");
       setAtTop(true);
       return;
@@ -52,9 +63,32 @@ export function useAutoHideOnScroll(
       }
     };
 
+    /** Document height changed — derive state from spacer position only; never reveal chrome. */
+    const autoHideStateOnLayoutChange = (
+      rect: DOMRect,
+      topOffset: number,
+    ): { next: AutoHideState; nextAtTop: boolean } => {
+      const nextAtTop = rect.top >= topOffset;
+      let next = stateRef.current;
+
+      if (nextAtTop) {
+        next = "static";
+      } else if (rect.bottom < -THRESHOLD && next !== "revealed") {
+        // Layout-driven scroll (e.g. when table rows are expanded, or rows filtered) — never reveal; pin hidden when past threshold.
+        next = "hidden";
+      }
+
+      return { next, nextAtTop };
+    };
+
     const updateAutoHideState = () => {
       const el = spacerRef.current;
       if (!el) return;
+
+      const doc = document.documentElement;
+      const currentScrollHeight = doc.scrollHeight;
+      const scrollHeightChanged = lastScrollHeight.current !== 0 && currentScrollHeight !== lastScrollHeight.current;
+      lastScrollHeight.current = currentScrollHeight;
 
       // Top of page (or iOS rubber-band overscroll) — stay in flow.
       if (window.scrollY <= 0) {
@@ -63,16 +97,23 @@ export function useAutoHideOnScroll(
         return;
       }
 
-      const rect = el.getBoundingClientRect();
       const currentY = window.scrollY;
+      const rect = el.getBoundingClientRect();
+      const topOffset = getTopOffsetRef.current?.() ?? 0;
+
+      // Document height changed — resync scrollY baseline; apply geometry only (never reveal).
+      if (scrollHeightChanged) {
+        lastScrollY.current = currentY;
+        const { next, nextAtTop } = autoHideStateOnLayoutChange(rect, topOffset);
+        commit(next, nextAtTop);
+        return;
+      }
+
       const dy = currentY - lastScrollY.current;
       lastScrollY.current = currentY;
 
-      const topOffset = getTopOffsetRef.current?.() ?? 0;
-      const nextAtTop = rect.top >= topOffset;
-
-      const doc = document.documentElement;
       const atBottom = currentY >= doc.scrollHeight - doc.clientHeight;
+      const nextAtTop = rect.top >= topOffset;
 
       let next: AutoHideState = stateRef.current;
       if (nextAtTop) {

--- a/src/utils/zIndices.ts
+++ b/src/utils/zIndices.ts
@@ -10,6 +10,7 @@ export const zIndices = {
   tableExpandableTitle: 20,
   tableStickyColumn: 30,
   tableStickyHeader: 40,
+  tableActions: 45,
 
   // Page chrome - ensure these items sit above the table
   scrollShadow: 50,


### PR DESCRIPTION
GridTableLayout and TableActions can now smartly be sticky when in NavbarLayout and within PageHeaderLayout. Required also teaching GridTable to adjust some things when in a layout with document level scrolling. Also needed to adjust some ways we calculate columns to avoid unnecessary scroll bars