### PR TITLE
feat: Using Outline variant in FilterDropdown Menu & Adding endAdornment to IconButton

### DIFF
--- a/src/components/Filters/FilterDropdownMenu.tsx
+++ b/src/components/Filters/FilterDropdownMenu.tsx
@@ -5,7 +5,7 @@ import { Filter, FilterDefs, FilterImpls, filterTestIdPrefix, updateFilter } fro
 import { Icon } from "src/components/Icon";
 import { IconButton } from "src/components/IconButton";
 import { ToggleChip } from "src/components/ToggleChip";
-import { Css, Palette, Tokens } from "src/Css";
+import { Css, Palette } from "src/Css";
 import { useBreakpoint } from "src/hooks";
 import { SelectField } from "src/inputs/SelectField";
 import { TextField } from "src/inputs/TextField";
@@ -120,7 +120,6 @@ function FilterDropdownMenu<F extends Record<string, unknown>, G extends Value =
           label="Search"
           onClick={() => setSearchIsOpen(!searchIsOpen)}
           active={searchIsOpen}
-          bgColor={Tokens.Surface}
           {...testId.searchButton}
         />
       )}
@@ -133,7 +132,6 @@ function FilterDropdownMenu<F extends Record<string, unknown>, G extends Value =
           label="Filter"
           active={isOpen}
           onClick={() => setIsOpen(!isOpen)}
-          bgColor={Tokens.Surface}
           {...testId.button}
         />
       )}

--- a/src/components/Filters/FilterDropdownMenu.tsx
+++ b/src/components/Filters/FilterDropdownMenu.tsx
@@ -133,7 +133,6 @@ function FilterDropdownMenu<F extends Record<string, unknown>, G extends Value =
           label="Filter"
           active={isOpen}
           onClick={() => setIsOpen(!isOpen)}
-          endAdornment={activeFilterCount > 0 ? <CountBadge count={activeFilterCount} /> : undefined}
           bgColor={Tokens.Surface}
           {...testId.button}
         />

--- a/src/components/Filters/FilterDropdownMenu.tsx
+++ b/src/components/Filters/FilterDropdownMenu.tsx
@@ -3,8 +3,9 @@ import { Button } from "src/components/Button";
 import { CountBadge } from "src/components/CountBadge";
 import { Filter, FilterDefs, FilterImpls, filterTestIdPrefix, updateFilter } from "src/components/Filters";
 import { Icon } from "src/components/Icon";
+import { IconButton } from "src/components/IconButton";
 import { ToggleChip } from "src/components/ToggleChip";
-import { Css, Palette } from "src/Css";
+import { Css, Palette, Tokens } from "src/Css";
 import { useBreakpoint } from "src/hooks";
 import { SelectField } from "src/inputs/SelectField";
 import { TextField } from "src/inputs/TextField";
@@ -113,28 +114,41 @@ function FilterDropdownMenu<F extends Record<string, unknown>, G extends Value =
 
       {/* Small screen: search icon button inline with filter button */}
       {sm && hasSearch && (
-        <Button
-          label=""
-          aria-label="Search"
+        <IconButton
+          variant="outline"
           icon="search"
+          label="Search"
           onClick={() => setSearchIsOpen(!searchIsOpen)}
           active={searchIsOpen}
-          variant="secondaryBlack"
+          bgColor={Tokens.Surface}
           {...testId.searchButton}
         />
       )}
 
-      {/* Filter button (only rendered when filterDefs are provided) */}
-      {hasFilters && (
+      {/* Small screen: filter icon button with optional active count badge */}
+      {sm && hasFilters && (
+        <IconButton
+          variant="outline"
+          icon="filter"
+          label="Filter"
+          active={isOpen}
+          onClick={() => setIsOpen(!isOpen)}
+          endAdornment={activeFilterCount > 0 ? <CountBadge count={activeFilterCount} /> : undefined}
+          bgColor={Tokens.Surface}
+          {...testId.button}
+        />
+      )}
+
+      {/* Large screen: full filter button with label, badge, and chevron */}
+      {!sm && hasFilters && (
         <Button
-          label={sm ? "" : "Filter"}
-          aria-label="Filter"
+          label="Filter"
           icon="filter"
           size="md"
           endAdornment={
             <div css={Css.df.aic.gap1.$}>
               {activeFilterCount > 0 && <CountBadge count={activeFilterCount} />}
-              <Icon xss={Css.if(sm).visuallyHidden.$} icon={isOpen ? "chevronUp" : "chevronDown"} />
+              <Icon icon={isOpen ? "chevronUp" : "chevronDown"} />
             </div>
           }
           variant="secondaryBlack"

--- a/src/components/IconButton.stories.tsx
+++ b/src/components/IconButton.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react-vite";
-import { ContrastScope, CountBadge, Css, IconButton, IconButtonProps, Icons, Palette } from "src";
+import { ContrastScope, Css, IconButton, IconButtonProps, Icons, Palette } from "src";
 import { noop } from "src/utils";
 import { withRouter } from "src/utils/sb";
 import { action } from "storybook/actions";
@@ -37,7 +37,6 @@ type IconButtonStoryArgs = IconButtonProps & { storyContrast?: boolean };
 
 function Template(args: IconButtonStoryArgs) {
   const { storyContrast = false, ...iconArgs } = args;
-  const { variant } = iconArgs;
   const surface = (
     <div css={Css.if(storyContrast).bgGray800.white.$}>
       <h1 css={Css.xl2.mbPx(30).$}>Icon Only Button</h1>
@@ -70,13 +69,6 @@ function Template(args: IconButtonStoryArgs) {
           <h2>Labeled</h2>
           <IconButton {...iconArgs} label="Download" />
         </div>
-        {(variant === "circle" || variant === "outline") && (
-          <div>
-            <h2>With End Adornment</h2>
-            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-            <IconButton {...iconArgs} variant={variant} endAdornment={<CountBadge count={3} />} />
-          </div>
-        )}
       </div>
     </div>
   );
@@ -160,8 +152,7 @@ function HoveredIconButton(args: IconButtonStoryArgs) {
   const hoverBlock = (
     <div className="hovered-icon-button">
       <style>{`.hovered-icon-button button { background-color: ${bg};${borderColor ? ` border-color: ${borderColor};` : ""} }`}</style>
-      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <IconButton {...(iconArgs as any)} variant={variant} active={isCircle} />
+      <IconButton {...iconArgs} variant={variant} active={isCircle} />
     </div>
   );
   return storyContrast ? <ContrastScope>{hoverBlock}</ContrastScope> : hoverBlock;

--- a/src/components/IconButton.stories.tsx
+++ b/src/components/IconButton.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react-vite";
-import { ContrastScope, Css, IconButton, IconButtonProps, Icons, Palette } from "src";
+import { ContrastScope, CountBadge, Css, IconButton, IconButtonProps, Icons, Palette } from "src";
 import { noop } from "src/utils";
 import { withRouter } from "src/utils/sb";
 import { action } from "storybook/actions";
@@ -37,6 +37,7 @@ type IconButtonStoryArgs = IconButtonProps & { storyContrast?: boolean };
 
 function Template(args: IconButtonStoryArgs) {
   const { storyContrast = false, ...iconArgs } = args;
+  const { variant } = iconArgs;
   const surface = (
     <div css={Css.if(storyContrast).bgGray800.white.$}>
       <h1 css={Css.xl2.mbPx(30).$}>Icon Only Button</h1>
@@ -69,6 +70,13 @@ function Template(args: IconButtonStoryArgs) {
           <h2>Labeled</h2>
           <IconButton {...iconArgs} label="Download" />
         </div>
+        {(variant === "circle" || variant === "outline") && (
+          <div>
+            <h2>With End Adornment</h2>
+            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+            <IconButton {...iconArgs} variant={variant} endAdornment={<CountBadge count={3} />} />
+          </div>
+        )}
       </div>
     </div>
   );
@@ -152,7 +160,8 @@ function HoveredIconButton(args: IconButtonStoryArgs) {
   const hoverBlock = (
     <div className="hovered-icon-button">
       <style>{`.hovered-icon-button button { background-color: ${bg};${borderColor ? ` border-color: ${borderColor};` : ""} }`}</style>
-      <IconButton {...iconArgs} variant={variant} active={isCircle} />
+      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+      <IconButton {...(iconArgs as any)} variant={variant} active={isCircle} />
     </div>
   );
   return storyContrast ? <ContrastScope>{hoverBlock}</ContrastScope> : hoverBlock;

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -133,7 +133,8 @@ const iconButtonStylesReset = Css.bcTransparent.bss.bgTransparent.cursorPointer.
 const iconButtonNormal = Css.hPx(28).wPx(28).br8.bw2.$;
 const iconButtonCompact = Css.hPx(18).wPx(18).br4.bw1.$;
 const iconButtonCircle = Css.br100.wPx(48).hPx(48).bcGray300.ba.bw1.df.jcc.aic.$;
-const iconButtonOutline = Css.br8.wPx(48).hPx(40).bcGray300.ba.bw1.df.jcc.aic.$;
+const iconButtonOutline = Css.br8.wPx(48).hPx(40).bgColor(Tokens.Surface).bc(Tokens.SurfaceSeparator).ba.bw1.df.jcc
+  .aic.$;
 /** Semantic hover fill; contrast is driven by `--b-*` when inside {@link ContrastScope}. */
 const iconButtonTokenHover = Css.bgColor(Tokens.NeutralFillHoverStrong).$;
 export const iconButtonStylesHover = Css.bgGray200.$;

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,5 +1,5 @@
 import { AriaButtonProps } from "@react-types/button";
-import { RefObject, useMemo } from "react";
+import { ReactNode, RefObject, useMemo } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
 import { BeamColor } from "src/colors";
 import { Icon, IconProps, maybeTooltip, navLink, resolveTooltip } from "src/components";
@@ -10,7 +10,9 @@ import { noop } from "src/utils";
 import { getButtonOrLink } from "src/utils/getInteractiveElement";
 import { useTestIds } from "src/utils/useTestIds";
 
-export type IconButtonVariant = "default" | "circle" | "outline";
+type IconButtonVariantProps =
+  | { variant?: "default"; endAdornment?: never }
+  | { variant: "circle" | "outline"; endAdornment?: ReactNode };
 
 export type IconButtonProps = {
   /** The icon to use within the button. */
@@ -24,8 +26,6 @@ export type IconButtonProps = {
   buttonRef?: RefObject<HTMLButtonElement>;
   /** Whether to show a 16x16px version of the IconButton */
   compact?: boolean;
-  /** Visual variant of the button. Defaults to "default". */
-  variant?: IconButtonVariant;
   /** Indicates that the button is active/selected */
   active?: boolean;
   /** Denotes if this button is used to download a resource. Uses the anchor tag with the `download` attribute */
@@ -37,7 +37,8 @@ export type IconButtonProps = {
    * for screen readers without showing the tooltip. An explicit `tooltip` or disabled reason still shows.
    */
   preventTooltip?: boolean;
-} & BeamButtonProps &
+} & IconButtonVariantProps &
+  BeamButtonProps &
   BeamFocusableProps;
 
 export function IconButton(props: IconButtonProps) {
@@ -60,6 +61,7 @@ export function IconButton(props: IconButtonProps) {
     forceFocusStyles = false,
     label,
     preventTooltip = false,
+    endAdornment,
   } = props;
   const isDisabled = !!disabled;
   const ariaProps = { onPress, isDisabled, autoFocus, ...menuTriggerProps };
@@ -81,14 +83,33 @@ export function IconButton(props: IconButtonProps) {
   const styles = useMemo(
     () => ({
       ...iconButtonStylesReset,
-      ...(isCircle ? iconButtonCircle : isOutline ? iconButtonOutline : compact ? iconButtonCompact : iconButtonNormal),
+      ...(isCircle
+        ? iconButtonCircle
+        : isOutline
+          ? endAdornment
+            ? iconButtonOutlineWithAdornment
+            : iconButtonOutline
+          : compact
+            ? iconButtonCompact
+            : iconButtonNormal),
       ...(isHovered && (isCircle || isOutline ? iconButtonCircleStylesHover : iconButtonTokenHover)),
       ...(isFocusVisible || forceFocusStyles ? (isCircle ? iconButtonCircleStylesFocus : iconButtonStylesFocus) : {}),
       ...(active && (isCircle || isOutline ? activeStylesCircle : iconButtonTokenHover)),
       ...(isDisabled && iconButtonStylesDisabled),
       ...(bgColor && Css.bgColor(bgColor).$),
     }),
-    [isHovered, isFocusVisible, isDisabled, compact, isCircle, isOutline, active, bgColor, forceFocusStyles],
+    [
+      isHovered,
+      isFocusVisible,
+      isDisabled,
+      compact,
+      isCircle,
+      isOutline,
+      active,
+      bgColor,
+      forceFocusStyles,
+      endAdornment,
+    ],
   );
   const iconColor = isCircle ? circleIconColor : defaultIconColor;
 
@@ -103,19 +124,22 @@ export function IconButton(props: IconButtonProps) {
     "aria-label": label,
   };
   const buttonContent = (
-    <Icon
-      icon={icon}
-      color={
-        color ||
-        (isDisabled
-          ? Tokens.TextDisabled
-          : isCircle && (isHovered || active || isFocusVisible)
-            ? defaultIconColor
-            : iconColor)
-      }
-      bgColor={bgColor}
-      inc={compact ? 2 : isCircle ? 2.5 : inc}
-    />
+    <>
+      <Icon
+        icon={icon}
+        color={
+          color ||
+          (isDisabled
+            ? Tokens.TextDisabled
+            : isCircle && (isHovered || active || isFocusVisible)
+              ? defaultIconColor
+              : iconColor)
+        }
+        bgColor={bgColor}
+        inc={compact ? 2 : isCircle ? 2.5 : inc}
+      />
+      {endAdornment}
+    </>
   );
 
   // If we're disabled b/c of a non-boolean ReactNode, or the caller specified tooltip text, then show it in a tooltip.
@@ -134,6 +158,7 @@ const iconButtonNormal = Css.hPx(28).wPx(28).br8.bw2.$;
 const iconButtonCompact = Css.hPx(18).wPx(18).br4.bw1.$;
 const iconButtonCircle = Css.br100.wPx(48).hPx(48).bcGray300.ba.bw1.df.jcc.aic.$;
 const iconButtonOutline = Css.br8.wPx(48).hPx(40).bcGray300.ba.bw1.df.jcc.aic.$;
+const iconButtonOutlineWithAdornment = Css.br8.mwPx(48).hPx(40).bcGray300.ba.bw1.df.aic.gap1.px2.$;
 /** Semantic hover fill; contrast is driven by `--b-*` when inside {@link ContrastScope}. */
 const iconButtonTokenHover = Css.bgColor(Tokens.NeutralFillHoverStrong).$;
 export const iconButtonStylesHover = Css.bgGray200.$;

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,5 +1,5 @@
 import { AriaButtonProps } from "@react-types/button";
-import { ReactNode, RefObject, useMemo } from "react";
+import { RefObject, useMemo } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
 import { BeamColor } from "src/colors";
 import { Icon, IconProps, maybeTooltip, navLink, resolveTooltip } from "src/components";
@@ -10,9 +10,7 @@ import { noop } from "src/utils";
 import { getButtonOrLink } from "src/utils/getInteractiveElement";
 import { useTestIds } from "src/utils/useTestIds";
 
-type IconButtonVariantProps =
-  | { variant?: "default"; endAdornment?: never }
-  | { variant: "circle" | "outline"; endAdornment?: ReactNode };
+export type IconButtonVariant = "default" | "circle" | "outline";
 
 export type IconButtonProps = {
   /** The icon to use within the button. */
@@ -26,6 +24,8 @@ export type IconButtonProps = {
   buttonRef?: RefObject<HTMLButtonElement>;
   /** Whether to show a 16x16px version of the IconButton */
   compact?: boolean;
+  /** Visual variant of the button. Defaults to "default". */
+  variant?: IconButtonVariant;
   /** Indicates that the button is active/selected */
   active?: boolean;
   /** Denotes if this button is used to download a resource. Uses the anchor tag with the `download` attribute */
@@ -37,8 +37,7 @@ export type IconButtonProps = {
    * for screen readers without showing the tooltip. An explicit `tooltip` or disabled reason still shows.
    */
   preventTooltip?: boolean;
-} & IconButtonVariantProps &
-  BeamButtonProps &
+} & BeamButtonProps &
   BeamFocusableProps;
 
 export function IconButton(props: IconButtonProps) {
@@ -61,7 +60,6 @@ export function IconButton(props: IconButtonProps) {
     forceFocusStyles = false,
     label,
     preventTooltip = false,
-    endAdornment,
   } = props;
   const isDisabled = !!disabled;
   const ariaProps = { onPress, isDisabled, autoFocus, ...menuTriggerProps };
@@ -83,33 +81,14 @@ export function IconButton(props: IconButtonProps) {
   const styles = useMemo(
     () => ({
       ...iconButtonStylesReset,
-      ...(isCircle
-        ? iconButtonCircle
-        : isOutline
-          ? endAdornment
-            ? iconButtonOutlineWithAdornment
-            : iconButtonOutline
-          : compact
-            ? iconButtonCompact
-            : iconButtonNormal),
+      ...(isCircle ? iconButtonCircle : isOutline ? iconButtonOutline : compact ? iconButtonCompact : iconButtonNormal),
       ...(isHovered && (isCircle || isOutline ? iconButtonCircleStylesHover : iconButtonTokenHover)),
       ...(isFocusVisible || forceFocusStyles ? (isCircle ? iconButtonCircleStylesFocus : iconButtonStylesFocus) : {}),
       ...(active && (isCircle || isOutline ? activeStylesCircle : iconButtonTokenHover)),
       ...(isDisabled && iconButtonStylesDisabled),
       ...(bgColor && Css.bgColor(bgColor).$),
     }),
-    [
-      isHovered,
-      isFocusVisible,
-      isDisabled,
-      compact,
-      isCircle,
-      isOutline,
-      active,
-      bgColor,
-      forceFocusStyles,
-      endAdornment,
-    ],
+    [isHovered, isFocusVisible, isDisabled, compact, isCircle, isOutline, active, bgColor, forceFocusStyles],
   );
   const iconColor = isCircle ? circleIconColor : defaultIconColor;
 
@@ -124,22 +103,19 @@ export function IconButton(props: IconButtonProps) {
     "aria-label": label,
   };
   const buttonContent = (
-    <>
-      <Icon
-        icon={icon}
-        color={
-          color ||
-          (isDisabled
-            ? Tokens.TextDisabled
-            : isCircle && (isHovered || active || isFocusVisible)
-              ? defaultIconColor
-              : iconColor)
-        }
-        bgColor={bgColor}
-        inc={compact ? 2 : isCircle ? 2.5 : inc}
-      />
-      {endAdornment}
-    </>
+    <Icon
+      icon={icon}
+      color={
+        color ||
+        (isDisabled
+          ? Tokens.TextDisabled
+          : isCircle && (isHovered || active || isFocusVisible)
+            ? defaultIconColor
+            : iconColor)
+      }
+      bgColor={bgColor}
+      inc={compact ? 2 : isCircle ? 2.5 : inc}
+    />
   );
 
   // If we're disabled b/c of a non-boolean ReactNode, or the caller specified tooltip text, then show it in a tooltip.
@@ -158,7 +134,6 @@ const iconButtonNormal = Css.hPx(28).wPx(28).br8.bw2.$;
 const iconButtonCompact = Css.hPx(18).wPx(18).br4.bw1.$;
 const iconButtonCircle = Css.br100.wPx(48).hPx(48).bcGray300.ba.bw1.df.jcc.aic.$;
 const iconButtonOutline = Css.br8.wPx(48).hPx(40).bcGray300.ba.bw1.df.jcc.aic.$;
-const iconButtonOutlineWithAdornment = Css.br8.mwPx(48).hPx(40).bcGray300.ba.bw1.df.aic.gap1.px2.$;
 /** Semantic hover fill; contrast is driven by `--b-*` when inside {@link ContrastScope}. */
 const iconButtonTokenHover = Css.bgColor(Tokens.NeutralFillHoverStrong).$;
 export const iconButtonStylesHover = Css.bgGray200.$;


### PR DESCRIPTION
## `IconButton` outline variant in `FilterDropdownMenu` and adding `endAdornment` to `IconButton`

This PR has the `GridTableLayout` actually use the outline variant `IconButton` by updating `FilterDropdownMenu` to use them. This does also update the `IconButton` by adding `endAdornment` to `IconButton` for outline and circle variants only, as the filter button really felt like they needed them for showing currently active filters for consistency with the normal button

Note: This did not add the end adornment to the IconButton. Will incorporate that either through [this pr](https://github.com/homebound-team/beam/pull/1273) or a future one