### PR TITLE
feat: icon badge;

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -15,6 +15,8 @@ export type ButtonProps = {
   variant?: ButtonVariant;
   size?: ButtonSize;
   icon?: IconProps["icon"] | null;
+  /** Shows a small badge overlapping the button's icon (top-right). Omit `count` for a plain dot. */
+  badge?: IconProps["badge"];
   /** Displays contents after the Button's label. Will be ignored for Buttons rendered as a link with an absolute URL */
   endAdornment?: ReactNode;
   /** HTML attributes to apply to the button element when it is being used to trigger a menu. */
@@ -44,6 +46,7 @@ export function Button(props: ButtonProps) {
     forceFocusStyles = false,
     active = false,
     labelInFlight,
+    badge,
     ...otherProps
   } = props;
   const asLink = typeof onPress === "string";
@@ -87,7 +90,7 @@ export function Button(props: ButtonProps) {
 
   const buttonContent = (
     <>
-      {icon && <Icon xss={iconStyles[size]} icon={icon} />}
+      {icon && <Icon xss={iconStyles[size]} icon={icon} badge={badge} />}
       {labelInFlight && asyncInProgress ? labelInFlight : label}
       {(endAdornment || asyncInProgress) && (
         <span css={Css.ml1.$}>{asyncInProgress ? <Loader size={"xs"} /> : endAdornment}</span>

--- a/src/components/CountBadge.tsx
+++ b/src/components/CountBadge.tsx
@@ -1,5 +1,6 @@
 import { BeamColor } from "src/colors";
-import { Css, Only, Palette, Xss } from "src/Css";
+import { Badge } from "src/components/internal/Badge";
+import { Only, Palette, Xss } from "src/Css";
 import { useTestIds } from "src/utils";
 
 type CountBadgeXss = "color";
@@ -22,16 +23,10 @@ export function CountBadge<X extends Only<Xss<CountBadgeXss>, X>>(props: CountBa
 
   if (hideIfZero && count === 0) return null;
 
+  // Use larger size for counts > 100
   return (
-    <span
-      {...tid}
-      css={{
-        ...Css.sqPx(count > 100 ? 18 : 16).$, // Use larger size for counts > 100
-        ...Css.fs0.br100.xs2Sb.df.aic.jcc.bgColor(bgColor).$,
-        ...Css.color(color).$,
-      }}
-    >
+    <Badge {...tid} color={bgColor} textColor={color} sizePx={count > 100 ? 18 : 16}>
       {count}
-    </span>
+    </Badge>
   );
 }

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -1,6 +1,8 @@
 import { DOMProps } from "@react-types/shared";
 import React, { AriaAttributes, ReactNode } from "react";
 import { BeamColor } from "src/colors";
+import { CountBadge } from "src/components/CountBadge";
+import { Badge } from "src/components/internal/Badge";
 import { maybeTooltip } from "src/components/Tooltip";
 import { Css, increment, Margin, Xss } from "src/Css";
 
@@ -15,32 +17,49 @@ export type IconProps = {
   /** Styles overrides */
   xss?: Xss<Margin | "visibility" | "flexShrink">;
   tooltip?: ReactNode;
+  /** Shows a small badge overlapping the icon's top-right. Omit `count` for a plain dot. */
+  badge?: { color: BeamColor; count?: number };
 } & AriaAttributes &
   DOMProps;
 
 export const Icon = React.memo((props: IconProps) => {
-  const { icon, inc = 3, color = "currentColor", bgColor, xss, tooltip, ...other } = props;
+  const { icon, inc = 3, color = "currentColor", bgColor, xss, tooltip, badge, ...other } = props;
   const size = increment(inc);
+  const svg = (
+    <svg
+      aria-hidden={true}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      xmlns="http://www.w3.org/2000/svg"
+      css={{
+        ...Css.fill(color).$,
+        ...(bgColor && Css.bgColor(bgColor).$),
+        ...xss,
+      }}
+      data-icon={icon}
+      {...other}
+    >
+      {Icons[icon]}
+    </svg>
+  );
   return maybeTooltip({
     title: tooltip,
     placement: "top",
-    children: (
-      <svg
-        aria-hidden={true}
-        width={size}
-        height={size}
-        viewBox="0 0 24 24"
-        xmlns="http://www.w3.org/2000/svg"
-        css={{
-          ...Css.fill(color).$,
-          ...(bgColor && Css.bgColor(bgColor).$),
-          ...xss,
-        }}
-        data-icon={icon}
-        {...other}
-      >
-        {Icons[icon]}
-      </svg>
+    children: badge ? (
+      // Overlap a badge on the icon's top-right corner (e.g. a hidden-column count).
+      <span css={Css.relative.dib.add("lineHeight", 0).$}>
+        {svg}
+        <span css={Css.absolute.topPx(-4).right0.$}>
+          {badge.count !== undefined ? (
+            <CountBadge count={badge.count} bgColor={badge.color} />
+          ) : (
+            <Badge color={badge.color} />
+          )}
+        </span>
+      </span>
+    ) : (
+      svg
     ),
   });
 });

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -50,7 +50,7 @@ export const Icon = React.memo((props: IconProps) => {
       // Overlap a badge on the icon's top-right corner (e.g. a hidden-column count).
       <span css={Css.relative.dib.add("lineHeight", 0).$}>
         {svg}
-        <span css={Css.absolute.topPx(-4).right0.$}>
+        <span css={Css.absolute.topPx(-4).$}>
           {badge.count !== undefined ? (
             <CountBadge count={badge.count} bgColor={badge.color} />
           ) : (

--- a/src/components/IconButton.stories.tsx
+++ b/src/components/IconButton.stories.tsx
@@ -92,6 +92,14 @@ export const Outline = Template.bind({});
 // @ts-ignore
 Outline.args = { variant: "outline" };
 
+export const WithBadge = Template.bind({});
+// @ts-ignore
+WithBadge.args = { badge: { color: Palette.Blue700, count: 6 } };
+
+export const WithBadgeContrast = Template.bind({});
+// @ts-ignore
+WithBadgeContrast.args = { storyContrast: true, badge: { color: Palette.Blue700, count: 6 } };
+
 export function WithTooltip() {
   return (
     <div css={Css.dg.fdc.gap2.jcfs.$}>

--- a/src/components/IconButton.test.tsx
+++ b/src/components/IconButton.test.tsx
@@ -1,4 +1,5 @@
 import { IconButton } from "src/components/IconButton";
+import { Palette } from "src/Css";
 import { noop } from "src/utils";
 import { click, render, withRouter } from "src/utils/rtl";
 import { useTestIds } from "src/utils/useTestIds";
@@ -29,6 +30,28 @@ describe("IconButton", () => {
     const testIds = useTestIds({}, "page1");
     const r = await render(<IconButton icon="trash" {...testIds.remove} onClick={noop} />);
     expect(r.firstElement.firstElementChild!.getAttribute("data-testid")).toEqual("page1_remove");
+  });
+
+  it("renders a count badge over the icon", async () => {
+    const r = await render(
+      <IconButton icon="kanban" label="Columns" badge={{ color: Palette.Blue700, count: 6 }} onClick={noop} />,
+    );
+    expect(r.countBadge).toHaveTextContent("6");
+  });
+
+  it("renders a plain dot badge when no count is given", async () => {
+    const r = await render(
+      <IconButton icon="kanban" label="Columns" badge={{ color: Palette.Blue700 }} onClick={noop} />,
+    );
+    // The dot variant renders the base Badge (not a CountBadge)
+    expect(r.badge).toBeInTheDocument();
+    expect(r.query.countBadge).toBeNull();
+  });
+
+  it("renders no badge when badge is omitted", async () => {
+    const r = await render(<IconButton icon="kanban" label="Columns" onClick={noop} />);
+    expect(r.query.badge).toBeNull();
+    expect(r.query.countBadge).toBeNull();
   });
 
   it("fires onClick method", async () => {

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -37,6 +37,8 @@ export type IconButtonProps = {
    * for screen readers without showing the tooltip. An explicit `tooltip` or disabled reason still shows.
    */
   preventTooltip?: boolean;
+  /** Shows a small badge overlapping the icon's top-right. Omit `count` for a plain dot. */
+  badge?: { color: BeamColor; count?: number };
 } & BeamButtonProps &
   BeamFocusableProps;
 
@@ -60,6 +62,7 @@ export function IconButton(props: IconButtonProps) {
     forceFocusStyles = false,
     label,
     preventTooltip = false,
+    badge,
   } = props;
   const isDisabled = !!disabled;
   const ariaProps = { onPress, isDisabled, autoFocus, ...menuTriggerProps };
@@ -115,6 +118,7 @@ export function IconButton(props: IconButtonProps) {
       }
       bgColor={bgColor}
       inc={compact ? 2 : isCircle ? 2.5 : inc}
+      badge={badge}
     />
   );
 

--- a/src/components/Table/components/EditColumnsButton.test.tsx
+++ b/src/components/Table/components/EditColumnsButton.test.tsx
@@ -129,6 +129,34 @@ describe("EditColumnsButton", () => {
     // Then only non-hideable columns remain visible (actions column always visible since canHide: false)
     expect(api.current!.getVisibleColumnIds()).toEqual(["actions"]);
   });
+
+  it("badges the visible hideable-column count, only while some are hidden", async () => {
+    // Given an edit columns button opted into a badge (two hideable columns: name, value)
+    const api: MutableRefObject<GridTableApi<Row> | undefined> = { current: undefined };
+    function Test() {
+      const _api = useGridTableApi<Row>();
+      api.current = _api;
+      return (
+        <>
+          <EditColumnsButton columns={columns} defaultOpen={true} api={_api} />
+          <GridTable columns={columns} rows={[]} api={_api} />
+        </>
+      );
+    }
+    const r = await render(<Test />);
+    // Given all hideable columns are shown, there is no badge
+    expect(r.query.countBadge).toBeFalsy();
+    // When one of the two hideable columns is hidden, the badge shows the visible count (1)
+    click(r.kanban_optionvalue);
+    expect(r.countBadge).toHaveTextContent("1");
+    // When the other is also hidden, the badge shows 0 (still visible because columns are hidden)
+    click(r.kanban_optionname);
+    expect(r.countBadge).toHaveTextContent("0");
+    // When all hideable columns are shown again, the badge disappears
+    click(r.kanban_optionname);
+    click(r.kanban_optionvalue);
+    expect(r.query.countBadge).toBeFalsy();
+  });
 });
 
 type Data = { name: string | undefined; value: number | undefined };

--- a/src/components/Table/components/EditColumnsButton.tsx
+++ b/src/components/Table/components/EditColumnsButton.tsx
@@ -5,7 +5,7 @@ import { Button } from "src/components/Button";
 import { OverlayTrigger, OverlayTriggerProps } from "src/components/internal/OverlayTrigger";
 import { GridTableApi } from "src/components/Table/GridTableApi";
 import { GridColumn, Kinded } from "src/components/Table/types";
-import { Css, Tokens } from "src/Css";
+import { Css, Palette, Tokens } from "src/Css";
 import { useBreakpoint, useComputed } from "src/hooks";
 import { Switch } from "src/inputs";
 import { useTestIds } from "src/utils";
@@ -61,6 +61,11 @@ export function EditColumnsButton<R extends Kinded>(props: EditColumnsButtonProp
     [columns, api],
   );
 
+  // Count of *visible* hideable columns. The badge only appears once at least one hideable column
+  // is hidden, is absent when all columns are shown, and shows 0 when all are hidden.
+  const shownCount = options.filter((o) => selectedValues.includes(o.value)).length;
+  const anyHidden = shownCount < options.length;
+
   return (
     <OverlayTrigger
       {...props}
@@ -69,6 +74,7 @@ export function EditColumnsButton<R extends Kinded>(props: EditColumnsButtonProp
         size: "md",
         label: "",
         variant: "secondaryBlack",
+        ...(anyHidden ? { badge: { color: Palette.Blue700, count: shownCount } } : {}),
       }}
       menuTriggerProps={menuTriggerProps}
       state={state}

--- a/src/components/internal/Badge.tsx
+++ b/src/components/internal/Badge.tsx
@@ -1,0 +1,31 @@
+import { ReactNode } from "react";
+import { BeamColor } from "src/colors";
+import { Css, Palette } from "src/Css";
+import { useTestIds } from "src/utils";
+
+export type BadgeProps = {
+  /** Circle background color. Defaults to Blue700. */
+  color?: BeamColor;
+  /** Content color (e.g. the count text). Defaults to White. */
+  textColor?: BeamColor;
+  /** Diameter in px. Defaults to 16. */
+  sizePx?: number;
+  children?: ReactNode;
+};
+
+/**
+ * Internal base badge: a small colored circle, optionally containing content (e.g. a count).
+ *
+ * `CountBadge` builds on this (always with a count); `Icon` uses it directly for the
+ * no-count "dot" variant. Not part of the public package API.
+ */
+export function Badge(props: BadgeProps) {
+  const { color = Palette.Blue700, textColor = Palette.White, sizePx = 16, children, ...others } = props;
+  // Defaults to "badge"; callers (e.g. CountBadge) can override by passing their own test id.
+  const tid = useTestIds(others, "badge");
+  return (
+    <span {...tid} css={Css.sqPx(sizePx).fs0.br100.xs2Sb.df.aic.jcc.bgColor(color).color(textColor).$}>
+      {children}
+    </span>
+  );
+}

--- a/src/components/internal/OverlayTrigger.tsx
+++ b/src/components/internal/OverlayTrigger.tsx
@@ -14,8 +14,8 @@ import { Css } from "src/Css";
 import { noop, useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
 
-type TextButtonTriggerProps = Pick<ButtonProps, "label" | "variant" | "size" | "icon">;
-type IconButtonTriggerProps = Pick<IconButtonProps, "icon" | "color" | "compact" | "inc">;
+type TextButtonTriggerProps = Pick<ButtonProps, "label" | "variant" | "size" | "icon" | "badge">;
+type IconButtonTriggerProps = Pick<IconButtonProps, "icon" | "color" | "compact" | "inc" | "badge">;
 type AvatarButtonTriggerProps = Pick<AvatarButtonProps, "src" | "name" | "size" | "preventTooltip">;
 type NavLinkButtonTriggerProps = {
   navLabel: string;

--- a/src/components/internal/index.ts
+++ b/src/components/internal/index.ts
@@ -1,3 +1,4 @@
+export * from "./Badge";
 export * from "./DatePicker";
 export * from "./Menu";
 export * from "./MenuItem";


### PR DESCRIPTION
**Badge support on `Icon`, surfaced on `EditColumnsButton`**

- `Icon` gains an optional `badge` (`{ color; count? }`) overlaying in top-right corner.
- `Button` and `IconButton` forward `badge` to their `Icon`, and `OverlayTrigger` trigger configs accept it — needed because `EditColumnsButton`'s trigger is a `Button` (icon + chevron), not an actual `IconButton`.
- `EditColumnsButton` shows a built-in badge of the **visible** hideable-column count, only while some are hidden — absent when all are shown, `0` when all are hidden.


<img width="579" height="213" alt="Screenshot 2026-06-12 at 3 32 11 PM" src="https://github.com/user-attachments/assets/9468d675-ad9c-4c41-8e97-0b93c71ba539" />
<img width="675" height="260" alt="Screenshot 2026-06-12 at 3 32 00 PM" src="https://github.com/user-attachments/assets/dbbd4e05-e1ab-4b1e-901d-ff21c51b0ec5" />

