### PR TITLE
feat: add onEnter callback param for SelectField

### DIFF
--- a/src/inputs/SelectField.test.tsx
+++ b/src/inputs/SelectField.test.tsx
@@ -493,6 +493,51 @@ describe("SelectFieldTest", () => {
     expect(onSelect.mock.calls[2][0]).toBe(undefined);
   });
 
+  it("calls onEnter when pressing Enter with typed text and no keyboard-focused list item", async () => {
+    // Given a SelectField with onEnter
+    const onEnter = vi.fn();
+    const r = await render(
+      <TestSelectField
+        label="Age"
+        value={undefined}
+        options={options}
+        getOptionLabel={(o) => o.name}
+        getOptionValue={(o) => o.id}
+        onEnter={onEnter}
+      />,
+    );
+    // When we type and press Enter without arrowing to a list item
+    focus(r.age);
+    fireEvent.change(r.age, { target: { value: "New Value" } });
+    fireEvent.keyDown(r.age, { key: "Enter", code: "Enter" });
+    // Then onEnter is called with the trimmed input value
+    expect(onEnter).toHaveBeenCalledTimes(1);
+    expect(onEnter).toHaveBeenCalledWith("New Value");
+  });
+
+  it("does not call onEnter when a list item is keyboard-focused", async () => {
+    // Given a SelectField with onEnter
+    const onEnter = vi.fn();
+    const r = await render(
+      <TestSelectField
+        label="Age"
+        value={undefined}
+        options={options}
+        getOptionLabel={(o) => o.name}
+        getOptionValue={(o) => o.id}
+        onEnter={onEnter}
+      />,
+    );
+    // When we type, arrow to an option, and press Enter
+    focus(r.age);
+    fireEvent.change(r.age, { target: { value: "One" } });
+    fireEvent.keyDown(r.age, { key: "ArrowDown", code: "ArrowDown" });
+    fireEvent.keyDown(r.age, { key: "Enter", code: "Enter" });
+    // Then onEnter is not called and the focused option is selected instead
+    expect(onEnter).not.toHaveBeenCalled();
+    expect(r.age).toHaveValue("One");
+  });
+
   it("allows to add a new option", async () => {
     // Given a SelectField
     const onAddNew = vi.fn();

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -66,6 +66,11 @@ export type ComboBoxBaseProps<O, V extends Value> = {
   /* Only supported on single Select fields */
   onAddNew?: (v: string) => void;
   /**
+   * Called when Enter is pressed in the filter input with typed text and no keyboard-focused list item.
+   * Only supported on single Select fields.
+   */
+  onEnter?: (inputValue: string) => void;
+  /**
    * When true (default), options are sorted alphabetically by their label.
    * Set to false to maintain the original order of options.
    */
@@ -102,6 +107,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
     fullWidth = fieldProps?.fullWidth ?? false,
     onSearch,
     onAddNew,
+    onEnter,
     autoSort = true,
     ...otherProps
   } = props;
@@ -387,6 +393,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
         borderless={borderless}
         tooltip={resolveTooltip(disabled, undefined, readOnly)}
         resetField={resetField}
+        onEnter={multiselect ? undefined : onEnter}
       />
       {state.isOpen && (
         <Popover

--- a/src/inputs/internal/ComboBoxInput.tsx
+++ b/src/inputs/internal/ComboBoxInput.tsx
@@ -47,6 +47,8 @@ type ComboBoxInputProps<O, V extends Value> = {
   isTree?: boolean;
   /* Allows input to wrap to multiple lines */
   multiline?: boolean;
+  /** Only supported on single Select fields. See ComboBoxBaseProps.onEnter. */
+  onEnter?: (inputValue: string) => void;
 } & PresentationFieldProps;
 
 export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V>) {
@@ -71,6 +73,7 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
     inputRef,
     inputWrapRef,
     multiline = false,
+    onEnter,
     ...otherProps
   } = props;
 
@@ -103,7 +106,27 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
     value: inputProps.value,
   });
 
-  return (
+  function onEnterKeyDownCapture(e: React.KeyboardEvent) {
+    if (!onEnter) return;
+    if (e.key !== "Enter") return;
+    if (inputProps.readOnly || inputProps.disabled) return;
+    if (!(e.target instanceof HTMLInputElement)) return;
+
+    const input = e.target;
+
+    // User arrowed to a dropdown row — let react-aria select that option (including "Add New").
+    if (input.getAttribute("aria-activedescendant")) return;
+
+    const typedValue = input.value.trim();
+    if (!typedValue) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+    onEnter(typedValue);
+    input.blur();
+  }
+
+  const field = (
     <TextFieldBase
       {...otherProps}
       {...multilineProps}
@@ -246,6 +269,8 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
       }}
     />
   );
+
+  return onEnter ? <div onKeyDownCapture={onEnterKeyDownCapture}>{field}</div> : field;
 }
 
 function SelectedOptionBullets({ labels = [] }: { labels: string[] | undefined }) {


### PR DESCRIPTION
Added an optional onEnter callback to SelectField (via ComboBoxBase / ComboBoxInput) so consumers can handle Enter in the filter input when no dropdown row is keyboard-focused.

React Aria’s combobox reverts typed text on Enter when the menu is open but nothing in the list has focus (aria-activedescendant is unset). That breaks flows like type-then-Enter to create or commit a custom value. This wires Enter through Beam instead of requiring app-level onKeyDownCapture workarounds.

When **onEnter** is set:

- Enter with non-empty trimmed input and no keyboard-focused list item → calls onEnter(inputValue) and blurs the field
- Enter when the user has arrowed to a list row (including “Add New”) → normal selection; onEnter is not called
- Disabled/read-only fields are ignored
- Single-select only (MultiSelectField is unchanged)