### PR TITLE
feat: Query Table Infinite Scroll Support

### DIFF
--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -173,43 +173,6 @@ export function QueryTableLayout() {
   );
 }
 
-export function WithPagination() {
-  const filterDefs = useMemo(() => getFilterDefs(), []);
-  const columns = useMemo(() => getColumns(), []);
-
-  const layoutState = useGridTableLayoutState({
-    persistedFilter: {
-      filterDefs,
-      storageKey: "grid-table-layout",
-    },
-    search: "client",
-    pagination: {
-      pageSizes: [25, 50, 100, 500],
-      storageKey: "grid-table-pagination",
-    },
-  });
-
-  return (
-    <TestProjectLayout>
-      <GridTableLayoutComponent
-        pageTitle="Grid Table With Pagination"
-        breadCrumb={[
-          { href: "/", label: "Home" },
-          { href: "/", label: "Product Offerings" },
-        ]}
-        layoutState={layoutState}
-        totalCount={543}
-        tableProps={{
-          columns,
-          rows: [simpleHeader, ...makeNestedRows(10)],
-          sorting: { on: "client", initial: [columns[0].id!, "ASC"] },
-        }}
-        primaryAction={{ label: "Add Product", onClick: noop }}
-      />
-    </TestProjectLayout>
-  );
-}
-
 export function WithoutHeader() {
   const columns = useMemo(() => getColumns(false), []);
 
@@ -349,8 +312,18 @@ export function WithInfiniteScroll() {
 }
 
 export function WithQueryTableInfiniteScroll() {
-  const query = useExamplePaginatedQuery({ filter: {} });
   const columns = useMemo(() => getColumns(false), []);
+  const filterDefs = useMemo(() => getFilterDefs(), []);
+
+  const layoutState = useGridTableLayoutState({
+    persistedFilter: {
+      filterDefs,
+      storageKey: "grid-table-layout",
+    },
+    search: "client",
+  });
+
+  const query = useExamplePaginatedQuery({ filter: layoutState.filter });
 
   return (
     <TestProjectLayout>
@@ -366,6 +339,7 @@ export function WithQueryTableInfiniteScroll() {
           ],
           infiniteScroll: { pageSize: 50 },
         }}
+        layoutState={layoutState}
       />
     </TestProjectLayout>
   );
@@ -398,11 +372,11 @@ function useExampleQuery({ filter }: { filter: Record<string, unknown> }) {
   };
 }
 
-function useExamplePaginatedQuery({ filter }: { filter: Record<string, unknown> }) {
+function useExamplePaginatedQuery({ filter }: { filter: { status: string[] } }) {
   const filterString = JSON.stringify(filter);
   const pageSize = 50;
 
-  const fakedb = useMemo(
+  const fakeDatabase = useMemo(
     () =>
       zeroTo(200).map((index) => ({
         id: String(index),
@@ -414,6 +388,11 @@ function useExamplePaginatedQuery({ filter }: { filter: Record<string, unknown> 
     [],
   );
 
+  const filteredDatabase = useMemo(
+    () => (filter.status ? fakeDatabase.filter((row) => filter.status.includes(row.status)) : fakeDatabase),
+    [fakeDatabase, filter],
+  );
+
   const [loading, setLoading] = useState(true);
   const [data, setData] =
     useState<Array<{ id: string; name: string; value: number; status: string; priority: number }>>();
@@ -421,21 +400,21 @@ function useExamplePaginatedQuery({ filter }: { filter: Record<string, unknown> 
   useEffect(() => {
     setLoading(true);
     const timer = setTimeout(() => {
-      setData(fakedb.slice(0, pageSize));
+      setData(filteredDatabase.slice(0, pageSize));
       setLoading(false);
     }, 500);
     return () => clearTimeout(timer);
-  }, [filterString, fakedb, pageSize]);
+  }, [filterString, filteredDatabase, pageSize, filter]);
 
   const fetchMore = useCallback(
     async ({ offset, limit }: { offset: number; limit: number }) => {
       return new Promise<{ data: typeof data }>((resolve) => {
         setTimeout(() => {
-          resolve({ data: fakedb.slice(offset, offset + limit) });
+          resolve({ data: filteredDatabase.slice(offset, offset + limit) });
         }, 800);
       });
     },
-    [fakedb],
+    [filteredDatabase],
   );
 
   return { data, loading, fetchMore };

--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -325,6 +325,15 @@ export function WithQueryTableInfiniteScroll() {
 
   const query = useExamplePaginatedQuery({ filter: layoutState.filter });
 
+  const maybeHasMore = useCallback(
+    async (index: number) => {
+      if (query.data?.pageInfo.hasNextPage) {
+        await query.fetchMore({ variables: { page: { offset: index, limit: 50 } } });
+      }
+    },
+    [query],
+  );
+
   return (
     <TestProjectLayout>
       <GridTableLayoutComponent
@@ -335,9 +344,9 @@ export function WithQueryTableInfiniteScroll() {
           columns,
           createRows: (data) => [
             simpleHeader,
-            ...(data?.map((row) => ({ kind: "data" as const, id: row.id, data: row })) ?? []),
+            ...(data?.simpleData.map((row) => ({ kind: "data" as const, id: row.id, data: row })) ?? []),
           ],
-          infiniteScroll: { pageSize: 50 },
+          infiniteScroll: { onEndReached: maybeHasMore },
         }}
         layoutState={layoutState}
       />
@@ -372,6 +381,11 @@ function useExampleQuery({ filter }: { filter: Record<string, unknown> }) {
   };
 }
 
+type ExampleQueryData = {
+  simpleData: Array<{ id: string; name: string; value: number; status: string; priority: number }>;
+  pageInfo: { hasNextPage: boolean };
+};
+
 function useExamplePaginatedQuery({ filter }: { filter: { status: string[] } }) {
   const filterString = JSON.stringify(filter);
   const pageSize = 50;
@@ -394,23 +408,41 @@ function useExamplePaginatedQuery({ filter }: { filter: { status: string[] } }) 
   );
 
   const [loading, setLoading] = useState(true);
-  const [data, setData] =
-    useState<Array<{ id: string; name: string; value: number; status: string; priority: number }>>();
+  const [data, setData] = useState<ExampleQueryData>();
 
   useEffect(() => {
     setLoading(true);
     const timer = setTimeout(() => {
-      setData(filteredDatabase.slice(0, pageSize));
+      console.log(filteredDatabase);
+      setData({
+        simpleData: filteredDatabase.slice(0, pageSize),
+        pageInfo: { hasNextPage: pageSize < filteredDatabase.length },
+      });
       setLoading(false);
     }, 500);
     return () => clearTimeout(timer);
   }, [filterString, filteredDatabase, pageSize, filter]);
 
   const fetchMore = useCallback(
-    async ({ offset, limit }: { offset: number; limit: number }) => {
-      return new Promise<{ data: typeof data }>((resolve) => {
+    async ({
+      variables: {
+        page: { offset, limit },
+      },
+    }: {
+      variables: { page: { offset: number; limit: number } };
+    }) => {
+      return new Promise<boolean>((resolve) => {
         setTimeout(() => {
-          resolve({ data: filteredDatabase.slice(offset, offset + limit) });
+          setData((prev) => {
+            const previousData = prev?.simpleData ?? [];
+
+            return {
+              simpleData: [...previousData, ...filteredDatabase.slice(offset, offset + limit)],
+              pageInfo: { hasNextPage: offset + limit < filteredDatabase.length },
+            };
+          });
+
+          resolve(true);
         }, 800);
       });
     },

--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -281,8 +281,8 @@ export function WithInfiniteScroll() {
       data: {
         name: `row ${i + offset}`,
         value: i + offset,
-        status: Math.floor(Math.random() * 3) > 1 ? "active" : "inactive",
-        priority: Math.floor(Math.random() * 3) + 1,
+        status: i === 0 || i % 3 === 0 ? "active" : "inactive",
+        priority: Math.floor(i % 3) + 1,
         actions: "actions",
       },
     }));
@@ -396,8 +396,8 @@ function useExamplePaginatedQuery({ filter }: { filter: { status: string[] } }) 
         id: String(index),
         name: `Row ${index}`,
         value: index,
-        status: Math.floor(Math.random() * 3) > 1 ? "active" : "inactive",
-        priority: Math.floor(Math.random() * 3) + 1,
+        status: index === 0 || index % 3 === 0 ? "active" : "inactive",
+        priority: Math.floor(index % 3) + 1,
       })),
     [],
   );

--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -142,16 +142,10 @@ export function QueryTableLayout() {
       storageKey: "grid-table-layout",
     },
     search: "server",
-    pagination: {
-      pageSizes: [25, 50, 100],
-      storageKey: "query-table-pagination",
-    },
   });
 
-  // In this example, we set up server-side search and pagination using `searchString` and `page` from the layout state,
-  // in combination with the "QueryTable" behavior for loading/error states.
   const query = useExampleQuery({
-    filter: { ...layoutState.filter, search: layoutState.searchString, page: layoutState.page },
+    filter: { ...layoutState.filter, search: layoutState.searchString },
   });
 
   return (
@@ -162,9 +156,6 @@ export function QueryTableLayout() {
           { href: "/", label: "Home" },
           { href: "/", label: "Sub Page A" },
           { href: "/", label: "Sub Page B" },
-          { href: "/", label: "Sub Page C" },
-          { href: "/", label: "Sub Page D" },
-          { href: "/", label: "Sub Page E" },
         ]}
         layoutState={layoutState}
         tableProps={{
@@ -177,7 +168,6 @@ export function QueryTableLayout() {
           sorting: { on: "client", initial: [columns[1].id!, "ASC"] },
         }}
         primaryAction={{ label: "Primary Action", onClick: noop }}
-        totalCount={100}
       />
     </TestProjectLayout>
   );
@@ -358,6 +348,29 @@ export function WithInfiniteScroll() {
   );
 }
 
+export function WithQueryTableInfiniteScroll() {
+  const query = useExamplePaginatedQuery({ filter: {} });
+  const columns = useMemo(() => getColumns(false), []);
+
+  return (
+    <TestProjectLayout>
+      <GridTableLayoutComponent
+        pageTitle="Query Table with Infinite Scroll"
+        tableProps={{
+          as: "virtual",
+          query,
+          columns,
+          createRows: (data) => [
+            simpleHeader,
+            ...(data?.map((row) => ({ kind: "data" as const, id: row.id, data: row })) ?? []),
+          ],
+          infiniteScroll: { pageSize: 50 },
+        }}
+      />
+    </TestProjectLayout>
+  );
+}
+
 function useExampleQuery({ filter }: { filter: Record<string, unknown> }) {
   const filterString = JSON.stringify(filter);
 
@@ -383,6 +396,49 @@ function useExampleQuery({ filter }: { filter: Record<string, unknown> }) {
     data,
     loading,
   };
+}
+
+function useExamplePaginatedQuery({ filter }: { filter: Record<string, unknown> }) {
+  const filterString = JSON.stringify(filter);
+  const pageSize = 50;
+
+  const fakedb = useMemo(
+    () =>
+      zeroTo(200).map((index) => ({
+        id: String(index),
+        name: `Row ${index}`,
+        value: index,
+        status: Math.floor(Math.random() * 3) > 1 ? "active" : "inactive",
+        priority: Math.floor(Math.random() * 3) + 1,
+      })),
+    [],
+  );
+
+  const [loading, setLoading] = useState(true);
+  const [data, setData] =
+    useState<Array<{ id: string; name: string; value: number; status: string; priority: number }>>();
+
+  useEffect(() => {
+    setLoading(true);
+    const timer = setTimeout(() => {
+      setData(fakedb.slice(0, pageSize));
+      setLoading(false);
+    }, 500);
+    return () => clearTimeout(timer);
+  }, [filterString, fakedb, pageSize]);
+
+  const fetchMore = useCallback(
+    async ({ offset, limit }: { offset: number; limit: number }) => {
+      return new Promise<{ data: typeof data }>((resolve) => {
+        setTimeout(() => {
+          resolve({ data: fakedb.slice(offset, offset + limit) });
+        }, 800);
+      });
+    },
+    [fakedb],
+  );
+
+  return { data, loading, fetchMore };
 }
 
 function getFilterDefs() {

--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -413,7 +413,6 @@ function useExamplePaginatedQuery({ filter }: { filter: { status: string[] } }) 
   useEffect(() => {
     setLoading(true);
     const timer = setTimeout(() => {
-      console.log(filteredDatabase);
       setData({
         simpleData: filteredDatabase.slice(0, pageSize),
         pageInfo: { hasNextPage: pageSize < filteredDatabase.length },

--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react-vite";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { checkboxFilter, multiFilter } from "src/components/Filters";
 import { GridDataRow } from "src/components/Table";
 import { collapseColumn, column, numericColumn, selectColumn } from "src/components/Table/utils/columns";
@@ -317,6 +317,44 @@ export function WithViewToggle() {
       withCardView={tileContent}
       defaultView="card"
     />
+  );
+}
+
+export function WithInfiniteScroll() {
+  const loadRows = useCallback((offset: number) => {
+    return zeroTo(50).map((i) => ({
+      kind: "data" as const,
+      id: String(i + offset),
+      data: {
+        name: `row ${i + offset}`,
+        value: i + offset,
+        status: Math.floor(Math.random() * 3) > 1 ? "active" : "inactive",
+        priority: Math.floor(Math.random() * 3) + 1,
+        actions: "actions",
+      },
+    }));
+  }, []);
+
+  const [data, setData] = useState(loadRows(0));
+  const columns = useMemo(() => getColumns(false), []);
+  const rows = useMemo(() => [simpleHeader, ...data], [data]);
+
+  return (
+    <TestProjectLayout>
+      <GridTableLayoutComponent
+        pageTitle="Grid Table Layout with Infinite Scroll"
+        tableProps={{
+          as: "virtual",
+          rows,
+          columns,
+          infiniteScroll: {
+            onEndReached(index) {
+              setData([...data, ...loadRows(index)]);
+            },
+          },
+        }}
+      />
+    </TestProjectLayout>
   );
 }
 

--- a/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
@@ -38,7 +38,6 @@ describe("GridTableLayout", () => {
           columns: getColumns(),
           rows: [simpleHeader, ...getRows()],
         }}
-        totalCount={100}
         primaryAction={{ label: "Primary Action", onClick: noop }}
         secondaryAction={{ label: "Secondary Action", onClick: noop }}
         tertiaryAction={{ label: "Tertiary Action", onClick: noop }}
@@ -104,7 +103,6 @@ describe("GridTableLayout", () => {
             ...(data?.map((row: Data & { id: string }) => ({ kind: "data", id: row.id, data: row })) ?? []),
           ],
         }}
-        totalCount={100}
         primaryAction={{ label: "Primary Action", onClick: noop }}
       />,
       withRouter(),
@@ -134,7 +132,6 @@ describe("GridTableLayout", () => {
           layoutStateProps={{}}
           pageTitle="Test"
           hideEditColumns={true}
-          totalCount={100}
           tableProps={{
             columns: getColumns(),
             rows: [simpleHeader, ...getRows()],
@@ -155,7 +152,6 @@ describe("GridTableLayout", () => {
         <TestWrapper
           layoutStateProps={{}}
           pageTitle="Test"
-          totalCount={100}
           tableProps={{
             columns: columnsWithoutId,
             rows: [simpleHeader, ...getRows()],
@@ -177,7 +173,6 @@ describe("GridTableLayout", () => {
         <TestWrapper
           layoutStateProps={{}}
           pageTitle="Test"
-          totalCount={100}
           tableProps={{
             columns: columnsWithoutName,
             rows: [simpleHeader, ...getRows()],
@@ -201,7 +196,6 @@ describe("GridTableLayout", () => {
           layoutStateProps={{}}
           pageTitle="Test"
           hideEditColumns={true}
-          totalCount={100}
           tableProps={{
             columns: columnsWithoutId,
             rows: [simpleHeader, ...getRows()],
@@ -214,101 +208,12 @@ describe("GridTableLayout", () => {
     });
   });
 
-  describe("pagination", () => {
-    it("renders pagination when totalCount is provided", async () => {
-      // Given a GridTableLayout with totalCount
-      const r = await render(
-        <TestWrapper
-          layoutStateProps={{
-            pagination: {
-              pageSizes: [100, 500, 1000],
-            },
-          }}
-          pageTitle="Test With Pagination"
-          hideEditColumns
-          totalCount={500}
-          tableProps={{
-            columns: getColumns(),
-            rows: [simpleHeader, ...getRows()],
-          }}
-        />,
-        withRouter(),
-      );
-
-      // Then the pagination component is rendered
-      expect(r.pagination).toBeInTheDocument();
-      expect(r.pagination_pageInfoLabel).toHaveTextContent("1 - 100 of 500");
-    });
-
-    it("updates page state when clicking next", async () => {
-      // Given a GridTableLayout with pagination
-      const r = await render(
-        <TestWrapper
-          layoutStateProps={{
-            pagination: {
-              pageSizes: [100, 500, 1000],
-            },
-          }}
-          pageTitle="Test Pagination Navigation"
-          hideEditColumns
-          totalCount={500}
-          tableProps={{
-            columns: getColumns(),
-            rows: [simpleHeader, ...getRows()],
-          }}
-        />,
-        withRouter(),
-      );
-
-      // Initially on page 1
-      expect(r.pagination_pageInfoLabel).toHaveTextContent("1 - 100 of 500");
-
-      // When clicking next
-      click(r.pagination_nextIcon);
-
-      // Then page 2 is shown
-      expect(r.pagination_pageInfoLabel).toHaveTextContent("101 - 200 of 500");
-    });
-
-    it("updates page size when selecting a new size", async () => {
-      // Given a GridTableLayout with pagination
-      const r = await render(
-        <TestWrapper
-          layoutStateProps={{
-            pagination: {
-              pageSizes: [100, 500, 1000],
-            },
-          }}
-          pageTitle="Test Page Size"
-          hideEditColumns
-          totalCount={500}
-          tableProps={{
-            columns: getColumns(),
-            rows: [simpleHeader, ...getRows()],
-          }}
-        />,
-        withRouter(),
-      );
-
-      // Initially page size is 100
-      expect(r.pagination_pageInfoLabel).toHaveTextContent("1 - 100 of 500");
-
-      // When changing page size to 500
-      click(r.pagination_pageSize);
-      click(r.getByRole("option", { name: "500" }));
-
-      // Then the page info reflects new size
-      expect(r.pagination_pageInfoLabel).toHaveTextContent("1 - 500 of 500");
-    });
-  });
-
   describe("view toggle", () => {
     it("should not display a view toggle if withCardView is undefined", async () => {
       const r = await render(
         <TestWrapper
           layoutStateProps={{}}
           pageTitle="Test"
-          totalCount={100}
           tableProps={{
             columns: getColumns(),
             rows: [simpleHeader, ...getRows()],
@@ -328,7 +233,6 @@ describe("GridTableLayout", () => {
         <TestWrapper
           layoutStateProps={{}}
           pageTitle="Test"
-          totalCount={100}
           tableProps={{
             columns: getColumns(),
             rows: [simpleHeader, ...getRows()],
@@ -355,7 +259,6 @@ describe("GridTableLayout", () => {
         <TestWrapper
           layoutStateProps={{}}
           pageTitle="Test"
-          totalCount={100}
           tableProps={{
             columns: getColumns(),
             rows: [simpleHeader, ...getRows()],
@@ -379,7 +282,6 @@ describe("GridTableLayout", () => {
         <TestWrapper
           layoutStateProps={{}}
           pageTitle="Test"
-          totalCount={100}
           tableProps={{
             columns: getColumns(),
             rows: [simpleHeader, ...getRows()],
@@ -400,7 +302,6 @@ describe("GridTableLayout", () => {
         <TestWrapper
           layoutStateProps={{}}
           pageTitle="Test"
-          totalCount={100}
           tableProps={{
             columns: getColumns(),
             rows: [simpleHeader, ...getRows()],
@@ -420,7 +321,6 @@ describe("GridTableLayout", () => {
         <TestWrapper
           layoutStateProps={{}}
           pageTitle="Test"
-          totalCount={100}
           defaultView="list"
           tableProps={{
             columns: getColumns(),

--- a/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
@@ -1,4 +1,6 @@
+import { act } from "@testing-library/react";
 import { checkboxFilter } from "src/components/Filters";
+import { setRunningInJest } from "src/components/Table/GridTable";
 import { actionColumn, column, numericColumn } from "src/components/Table/utils/columns";
 import { simpleHeader } from "src/components/Table/utils/simpleHelpers";
 import { DocumentScrollLayoutProvider } from "src/layouts/DocumentScrollLayoutContext";
@@ -405,6 +407,39 @@ describe("GridTableLayout", () => {
         search: "client" as const,
       };
     }
+  });
+
+  it("passes infiniteScroll prop to the underlying table", async () => {
+    setRunningInJest();
+    // Given a GridTableLayout with infiniteScroll configured
+    const onEndReached = vi.fn();
+    const r = await render(
+      <TestWrapper
+        layoutStateProps={{ search: "client" as const }}
+        tableProps={{
+          as: "virtual",
+          columns: getColumns(),
+          rows: [simpleHeader, ...getRows()],
+          infiniteScroll: { onEndReached },
+        }}
+      />,
+      withRouter(),
+    );
+    // When the table renders, it should display the rows without error
+    expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+      "
+      | Name  | Value | Action  |
+      | ----- | ----- | ------- |
+      | Alpha | 10    | Actions |
+      | Beta  | 20    | Actions |
+      | Gamma | 30    | Actions |
+      "
+    `);
+    // And onEndReached can be called as Virtuoso would call it at runtime
+    act(() => {
+      onEndReached(3);
+    });
+    expect(onEndReached).toHaveBeenCalledWith(3);
   });
 });
 

--- a/src/components/Layout/GridTableLayout/GridTableLayout.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.tsx
@@ -25,21 +25,20 @@ import { zIndices } from "src/utils/zIndices";
 import { FullBleed } from "../FullBleed";
 import { ActionButtonProps, BaseQueryTableProps, GridTablePropsWithRows, isGridTableProps } from "../layoutTypes";
 import { HeaderBreadcrumb, PageHeaderBreadcrumbs } from "../PageHeaderBreadcrumbs";
-import { QueryTable, QueryTableProps } from "./QueryTable";
+import { QueryInfiniteScroll, QueryTable, QueryTableProps } from "./QueryTable";
 import { usePersistedTableView } from "./usePersistedTableView";
 
 // Omit to force all action button menus to look the same
 type ActionButtonMenuProps = Omit<ButtonMenuProps, "trigger">;
 
-// GridTableLayout-specific query props extend the shared base with pagination/display extras.
-type QueryTablePropsWithQuery<R extends Kinded, X extends Only<GridTableXss, X>, QData> = BaseQueryTableProps<
-  R,
-  X,
-  QData
+// GridTableLayout-specific query props extend the shared base with display extras.
+type QueryTablePropsWithQuery<R extends Kinded, X extends Only<GridTableXss, X>, QData> = Omit<
+  BaseQueryTableProps<R, X, QData>,
+  "infiniteScroll"
 > & {
-  getPageInfo?: (data: QData) => { hasNextPage: boolean };
   emptyFallback?: string;
   keepHeaderWhenLoading?: boolean;
+  infiniteScroll?: QueryInfiniteScroll;
 };
 
 export type GridTableLayoutProps<

--- a/src/components/Layout/GridTableLayout/GridTableLayout.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.tsx
@@ -24,20 +24,20 @@ import { zIndices } from "src/utils/zIndices";
 import { FullBleed } from "../FullBleed";
 import { ActionButtonProps, BaseQueryTableProps, GridTablePropsWithRows, isGridTableProps } from "../layoutTypes";
 import { HeaderBreadcrumb, PageHeaderBreadcrumbs } from "../PageHeaderBreadcrumbs";
-import { QueryInfiniteScroll, QueryTable, QueryTableProps } from "./QueryTable";
+import { QueryTable, QueryTableProps } from "./QueryTable";
 import { usePersistedTableView } from "./usePersistedTableView";
 
 // Omit to force all action button menus to look the same
 type ActionButtonMenuProps = Omit<ButtonMenuProps, "trigger">;
 
 // GridTableLayout-specific query props extend the shared base with display extras.
-type QueryTablePropsWithQuery<R extends Kinded, X extends Only<GridTableXss, X>, QData> = Omit<
-  BaseQueryTableProps<R, X, QData>,
-  "infiniteScroll"
+type QueryTablePropsWithQuery<R extends Kinded, X extends Only<GridTableXss, X>, QData> = BaseQueryTableProps<
+  R,
+  X,
+  QData
 > & {
   emptyFallback?: string;
   keepHeaderWhenLoading?: boolean;
-  infiniteScroll?: QueryInfiniteScroll;
 };
 
 export type GridTableLayoutProps<

--- a/src/components/Layout/GridTableLayout/GridTableLayout.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.tsx
@@ -4,7 +4,6 @@ import { ScrollableContent } from "src/components";
 import { Button } from "src/components/Button";
 import { ButtonMenu, ButtonMenuProps } from "src/components/ButtonMenu";
 import { FilterDropdownMenu } from "src/components/Filters/FilterDropdownMenu";
-import { OffsetAndLimit, Pagination } from "src/components/Pagination";
 import { EditColumnsButton } from "src/components/Table/components/EditColumnsButton";
 import { TableView, ViewToggleButton } from "src/components/Table/components/ViewToggleButton";
 import { GridTable } from "src/components/Table/GridTable";
@@ -57,14 +56,13 @@ export type GridTableLayoutProps<
   secondaryAction?: ActionButtonProps;
   tertiaryAction?: ActionButtonProps;
   hideEditColumns?: boolean;
-  totalCount?: number;
   /** Temporary prop for card views. When provided, shows a view toggle button. Rendered in place of the table when in tile mode. */
   withCardView?: ReactNode;
   defaultView?: TableView;
 };
 
 /**
- * A layout component that combines a table with a header, actions buttons, filters, and pagination.
+ * A layout component that combines a table with a header, actions buttons, filters, and infinite scroll.
  *
  * This component can render either a `GridTable` or wrapped `QueryTable` based on the provided props:
  *
@@ -88,8 +86,6 @@ export type GridTableLayoutProps<
  *   }}
  * />
  * ```
- *
- * Pagination is rendered when `totalCount` is provided. Use `layoutState.page` for server query variables.
  */
 function GridTableLayoutComponent<
   F extends Record<string, unknown>,
@@ -107,7 +103,6 @@ function GridTableLayoutComponent<
     tertiaryAction,
     actionMenu,
     hideEditColumns = false,
-    totalCount,
     withCardView,
     defaultView = "list",
   } = props;
@@ -196,14 +191,6 @@ function GridTableLayoutComponent<
           visibleColumnsStorageKey={visibleColumnsStorageKey}
         />
       )}
-      {layoutState && totalCount !== undefined && (
-        <Pagination
-          page={[layoutState.page, layoutState._pagination.setPage]}
-          totalCount={totalCount}
-          pageSizes={layoutState._pagination.pageSizes}
-          {...tid.pagination}
-        />
-      )}
     </>
   );
 
@@ -264,33 +251,21 @@ function validateColumns(columns: readonly { id?: string; name?: string }[]): vo
   }
 }
 
-/** Configuration for pagination in GridTableLayout */
-export type PaginationConfig = {
-  /** Available page size options */
-  pageSizes?: number[];
-  /** Storage key for persisting page size preference */
-  storageKey?: string;
-};
-
 /**
- * A wrapper around standard filter, grouping, search, and pagination state hooks.
+ * A wrapper around standard filter, grouping, search, and column state hooks.
  * * `client` search will use the built-in grid table search functionality.
  * * `server` search will return `searchString` as a debounced search string to query the server.
- * * Use `pagination` config to customize page sizes or storage key. Use `page` for server query variables.
  */
 export function useGridTableLayoutState<F extends Record<string, unknown>>({
   persistedFilter,
   persistedColumns,
   search,
   groupBy: maybeGroupBy,
-  pagination,
 }: {
   persistedFilter?: UsePersistedFilterProps<F>;
   persistedColumns?: { storageKey: string };
   search?: "client" | "server";
   groupBy?: Record<string, string>;
-  /** Customize pagination page sizes or storage key */
-  pagination?: PaginationConfig;
 }) {
   // Because we can't conditionally render a hook, we still call it with a fallback value.
   const filterFallback = { filterDefs: {}, storageKey: "unset-filter" } as UsePersistedFilterProps<F>;
@@ -305,25 +280,6 @@ export function useGridTableLayoutState<F extends Record<string, unknown>>({
     undefined,
   );
 
-  // Pagination state
-  const paginationFallbackKey = "unset-pagination";
-  const pageSizes = pagination?.pageSizes ?? [100, 500, 1000];
-  const [persistedPageSize, setPersistedPageSize] = useSessionStorage<number>(
-    pagination?.storageKey ?? paginationFallbackKey,
-    100, // default page size
-  );
-
-  const [page, setPage] = useState<OffsetAndLimit>({
-    offset: 0,
-    limit: persistedPageSize,
-  });
-
-  // Persist page size and reset to first page when filters/search change
-  useEffect(() => {
-    if (page.limit !== persistedPageSize) setPersistedPageSize(page.limit);
-    setPage((prev) => (prev.offset === 0 ? prev : { ...prev, offset: 0 }));
-  }, [page.limit, persistedPageSize, setPersistedPageSize, filter, searchString]);
-
   return {
     filter,
     setFilter,
@@ -335,10 +291,6 @@ export function useGridTableLayoutState<F extends Record<string, unknown>>({
     visibleColumnIds: persistedColumns ? visibleColumnIds : undefined,
     setVisibleColumnIds: persistedColumns ? setVisibleColumnIds : undefined,
     persistedColumnsStorageKey: persistedColumns?.storageKey,
-    /** Current page offset/limit - use this for server query variables */
-    page,
-    /** @internal Used by GridTableLayout component */
-    _pagination: { setPage, pageSizes },
   };
 }
 

--- a/src/components/Layout/GridTableLayout/QueryTable.tsx
+++ b/src/components/Layout/GridTableLayout/QueryTable.tsx
@@ -16,9 +16,6 @@ export type QueryTableProps<R extends Kinded, QData, X> = Omit<GridTableProps<R,
   emptyFallback?: string;
   /** Creates the rows given the data; needs to accept undefined so we can create the header row. */
   createRows: (data: QData | undefined) => GridDataRow<R>[];
-  getPageInfo?: (data: QData) => {
-    hasNextPage: boolean;
-  };
   keepHeaderWhenLoading?: boolean;
 };
 
@@ -31,7 +28,7 @@ export type QueryTableProps<R extends Kinded, QData, X> = Omit<GridTableProps<R,
 export function QueryTable<R extends Kinded, QData, X extends Only<GridTableXss, X> = any>(
   props: QueryTableProps<R, QData, X>,
 ) {
-  const { emptyFallback, query, createRows, getPageInfo, columns, keepHeaderWhenLoading, ...others } = props;
+  const { emptyFallback, query, createRows, columns, keepHeaderWhenLoading, ...others } = props;
 
   // Always call createRows to get the header, even if we're loading/error'd. We do force data=undefined
   // if loading/error though b/c while making/loading a 2nd query, Apollo will keep the 1st query's data.
@@ -39,10 +36,6 @@ export function QueryTable<R extends Kinded, QData, X extends Only<GridTableXss,
   // old-results-are-still-here at the same time.
   const data = query.loading || query.error ? undefined : query.data;
   const rows = useMemo(() => createRows(data), [createRows, data]);
-
-  // Detect our `pageInfo` response pattern
-  const hasNextPage = data && getPageInfo && getPageInfo(data).hasNextPage;
-  const infoMessage = hasNextPage ? "Too many rows" : undefined;
 
   // loading/error/empty can all use the one fallback prop.
   const fallbackMessage = query.loading ? "Loading…" : query.error ? `Error: ${query.error.message}` : emptyFallback;
@@ -58,7 +51,7 @@ export function QueryTable<R extends Kinded, QData, X extends Only<GridTableXss,
       )}
     </div>
   ) : (
-    <GridTable {...{ rows, columns, fallbackMessage, infoMessage, ...others }} />
+    <GridTable {...{ rows, columns, fallbackMessage, ...others }} />
   );
 }
 

--- a/src/components/Layout/GridTableLayout/QueryTable.tsx
+++ b/src/components/Layout/GridTableLayout/QueryTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 import { LoadingSkeleton, LoadingSkeletonProps } from "src/components/LoadingSkeleton";
 import type { GridDataRow } from "src/components/Table/components/Row";
 import { GridTable, GridTableProps } from "src/components/Table/GridTable";
@@ -9,35 +9,17 @@ export type QueryResult<QData> = {
   loading: boolean;
   error?: { message: string };
   data?: QData;
-  /**
-   * Optional. When provided alongside `infiniteScroll`, QueryTable will call this as the user
-   * scrolls to the bottom to load the next page. Requires `as="virtual"` on the table.
-   */
-  fetchMore?: (variables: { offset: number; limit: number }) => Promise<{ data?: QData }>;
 };
 
-export type QueryInfiniteScroll = {
-  /** Number of items to load per page. Default: 50 */
-  pageSize?: number;
-  /** Pixels from the bottom to eagerly trigger `fetchMore`. Default: 500px */
-  endOffsetPx?: number;
-};
-
-export type QueryTableProps<R extends Kinded, QData, X> = Omit<
-  GridTableProps<R, X>,
-  "rows" | "fallback" | "infiniteScroll"
-> & {
+export type QueryTableProps<R extends Kinded, QData, X> = Omit<GridTableProps<R, X>, "rows" | "fallback"> & {
   query: QueryResult<QData>;
   emptyFallback?: string;
   /** Creates the rows given the data; needs to accept undefined so we can create the header row. */
   createRows: (data: QData | undefined) => GridDataRow<R>[];
+  getPageInfo?: (data: QData) => {
+    hasNextPage: boolean;
+  };
   keepHeaderWhenLoading?: boolean;
-  /**
-   * Enables infinite scroll. Requires `as="virtual"` and `query.fetchMore` to be provided.
-   * As the user scrolls to the bottom, the next page is fetched and rows are appended.
-   * Rows reset automatically when the query re-fires (e.g. filter change).
-   */
-  infiniteScroll?: QueryInfiniteScroll;
 };
 
 /**
@@ -49,56 +31,23 @@ export type QueryTableProps<R extends Kinded, QData, X> = Omit<
 export function QueryTable<R extends Kinded, QData, X extends Only<GridTableXss, X> = any>(
   props: QueryTableProps<R, QData, X>,
 ) {
-  const { emptyFallback, query, createRows, columns, keepHeaderWhenLoading, infiniteScroll, ...others } = props;
+  const { emptyFallback, query, createRows, getPageInfo, columns, keepHeaderWhenLoading, ...others } = props;
 
   // Always call createRows to get the header, even if we're loading/error'd. We do force data=undefined
   // if loading/error though b/c while making/loading a 2nd query, Apollo will keep the 1st query's data.
+  // This is arguably a better UX if we could show a spinner-new-results-coming-soon + the
+  // old-results-are-still-here at the same time.
   const data = query.loading || query.error ? undefined : query.data;
+  const rows = useMemo(() => createRows(data), [createRows, data]);
 
-  // Infinite scroll: accumulate rows across pages in state.
-  const [accumulatedRows, setAccumulatedRows] = useState<GridDataRow<R>[] | null>(null);
-  const fetchingMoreRef = useRef(false);
-
-  useEffect(() => {
-    // When data changes and we're NOT mid-fetchMore, it's a fresh query result (initial load or
-    // filter reset) — replace accumulated rows entirely.
-    if (!fetchingMoreRef.current) {
-      setAccumulatedRows(createRows(data));
-    }
-  }, [data, createRows]);
-
-  const handleEndReached = useCallback(
-    async (_: number) => {
-      if (!query.fetchMore || !infiniteScroll || !accumulatedRows) return;
-      const offset = accumulatedRows.filter((r) => r.kind !== "header").length;
-      const pageSize = infiniteScroll.pageSize ?? 50;
-      fetchingMoreRef.current = true;
-      try {
-        const result = await query.fetchMore({ offset, limit: pageSize });
-        if (result.data) {
-          const newRows = createRows(result.data).filter((r) => r.kind !== "header");
-          setAccumulatedRows((prev) => [...(prev ?? []), ...newRows]);
-        }
-      } finally {
-        fetchingMoreRef.current = false;
-      }
-    },
-    [query, infiniteScroll, accumulatedRows, createRows],
-  );
+  // Detect our `pageInfo` response pattern
+  const hasNextPage = data && getPageInfo && getPageInfo(data).hasNextPage;
+  const infoMessage = hasNextPage ? "Too many rows" : undefined;
 
   // loading/error/empty can all use the one fallback prop.
   const fallbackMessage = query.loading ? "Loading…" : query.error ? `Error: ${query.error.message}` : emptyFallback;
 
-  const rows = useMemo(() => createRows(data), [createRows, data]);
   const headers = rows.filter((row) => row.kind === "header");
-
-  const infiniteScrollProps =
-    infiniteScroll && query.fetchMore
-      ? { onEndReached: handleEndReached, endOffsetPx: infiniteScroll.endOffsetPx }
-      : undefined;
-
-  // When infinite scroll is active, use accumulated rows (which include all pages).
-  const tableRows = infiniteScroll && accumulatedRows !== null ? accumulatedRows : rows;
 
   return query.loading ? (
     <div>
@@ -109,7 +58,7 @@ export function QueryTable<R extends Kinded, QData, X extends Only<GridTableXss,
       )}
     </div>
   ) : (
-    <GridTable {...{ columns, fallbackMessage, ...others }} rows={tableRows} infiniteScroll={infiniteScrollProps} />
+    <GridTable {...{ rows, columns, fallbackMessage, infoMessage, ...others }} />
   );
 }
 

--- a/src/components/Layout/GridTableLayout/QueryTable.tsx
+++ b/src/components/Layout/GridTableLayout/QueryTable.tsx
@@ -68,7 +68,7 @@ export function QueryTable<R extends Kinded, QData, X extends Only<GridTableXss,
   }, [data, createRows]);
 
   const handleEndReached = useCallback(
-    async (index: number) => {
+    async (_: number) => {
       if (!query.fetchMore || !infiniteScroll || !accumulatedRows) return;
       const offset = accumulatedRows.filter((r) => r.kind !== "header").length;
       const pageSize = infiniteScroll.pageSize ?? 50;

--- a/src/components/Layout/GridTableLayout/QueryTable.tsx
+++ b/src/components/Layout/GridTableLayout/QueryTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { LoadingSkeleton, LoadingSkeletonProps } from "src/components/LoadingSkeleton";
 import type { GridDataRow } from "src/components/Table/components/Row";
 import { GridTable, GridTableProps } from "src/components/Table/GridTable";
@@ -9,17 +9,35 @@ export type QueryResult<QData> = {
   loading: boolean;
   error?: { message: string };
   data?: QData;
+  /**
+   * Optional. When provided alongside `infiniteScroll`, QueryTable will call this as the user
+   * scrolls to the bottom to load the next page. Requires `as="virtual"` on the table.
+   */
+  fetchMore?: (variables: { offset: number; limit: number }) => Promise<{ data?: QData }>;
 };
 
-export type QueryTableProps<R extends Kinded, QData, X> = Omit<GridTableProps<R, X>, "rows" | "fallback"> & {
+export type QueryInfiniteScroll = {
+  /** Number of items to load per page. Default: 50 */
+  pageSize?: number;
+  /** Pixels from the bottom to eagerly trigger `fetchMore`. Default: 500px */
+  endOffsetPx?: number;
+};
+
+export type QueryTableProps<R extends Kinded, QData, X> = Omit<
+  GridTableProps<R, X>,
+  "rows" | "fallback" | "infiniteScroll"
+> & {
   query: QueryResult<QData>;
   emptyFallback?: string;
   /** Creates the rows given the data; needs to accept undefined so we can create the header row. */
   createRows: (data: QData | undefined) => GridDataRow<R>[];
-  getPageInfo?: (data: QData) => {
-    hasNextPage: boolean;
-  };
   keepHeaderWhenLoading?: boolean;
+  /**
+   * Enables infinite scroll. Requires `as="virtual"` and `query.fetchMore` to be provided.
+   * As the user scrolls to the bottom, the next page is fetched and rows are appended.
+   * Rows reset automatically when the query re-fires (e.g. filter change).
+   */
+  infiniteScroll?: QueryInfiniteScroll;
 };
 
 /**
@@ -31,23 +49,56 @@ export type QueryTableProps<R extends Kinded, QData, X> = Omit<GridTableProps<R,
 export function QueryTable<R extends Kinded, QData, X extends Only<GridTableXss, X> = any>(
   props: QueryTableProps<R, QData, X>,
 ) {
-  const { emptyFallback, query, createRows, getPageInfo, columns, keepHeaderWhenLoading, ...others } = props;
+  const { emptyFallback, query, createRows, columns, keepHeaderWhenLoading, infiniteScroll, ...others } = props;
 
   // Always call createRows to get the header, even if we're loading/error'd. We do force data=undefined
   // if loading/error though b/c while making/loading a 2nd query, Apollo will keep the 1st query's data.
-  // This is arguably a better UX if we could show a spinner-new-results-coming-soon + the
-  // old-results-are-still-here at the same time.
   const data = query.loading || query.error ? undefined : query.data;
-  const rows = useMemo(() => createRows(data), [createRows, data]);
 
-  // Detect our `pageInfo` response pattern
-  const hasNextPage = data && getPageInfo && getPageInfo(data).hasNextPage;
-  const infoMessage = hasNextPage ? "Too many rows" : undefined;
+  // Infinite scroll: accumulate rows across pages in state.
+  const [accumulatedRows, setAccumulatedRows] = useState<GridDataRow<R>[] | null>(null);
+  const fetchingMoreRef = useRef(false);
+
+  useEffect(() => {
+    // When data changes and we're NOT mid-fetchMore, it's a fresh query result (initial load or
+    // filter reset) — replace accumulated rows entirely.
+    if (!fetchingMoreRef.current) {
+      setAccumulatedRows(createRows(data));
+    }
+  }, [data, createRows]);
+
+  const handleEndReached = useCallback(
+    async (index: number) => {
+      if (!query.fetchMore || !infiniteScroll || !accumulatedRows) return;
+      const offset = accumulatedRows.filter((r) => r.kind !== "header").length;
+      const pageSize = infiniteScroll.pageSize ?? 50;
+      fetchingMoreRef.current = true;
+      try {
+        const result = await query.fetchMore({ offset, limit: pageSize });
+        if (result.data) {
+          const newRows = createRows(result.data).filter((r) => r.kind !== "header");
+          setAccumulatedRows((prev) => [...(prev ?? []), ...newRows]);
+        }
+      } finally {
+        fetchingMoreRef.current = false;
+      }
+    },
+    [query, infiniteScroll, accumulatedRows, createRows],
+  );
 
   // loading/error/empty can all use the one fallback prop.
   const fallbackMessage = query.loading ? "Loading…" : query.error ? `Error: ${query.error.message}` : emptyFallback;
 
+  const rows = useMemo(() => createRows(data), [createRows, data]);
   const headers = rows.filter((row) => row.kind === "header");
+
+  const infiniteScrollProps =
+    infiniteScroll && query.fetchMore
+      ? { onEndReached: handleEndReached, endOffsetPx: infiniteScroll.endOffsetPx }
+      : undefined;
+
+  // When infinite scroll is active, use accumulated rows (which include all pages).
+  const tableRows = infiniteScroll && accumulatedRows !== null ? accumulatedRows : rows;
 
   return query.loading ? (
     <div>
@@ -58,7 +109,7 @@ export function QueryTable<R extends Kinded, QData, X extends Only<GridTableXss,
       )}
     </div>
   ) : (
-    <GridTable {...{ rows, columns, fallbackMessage, infoMessage, ...others }} />
+    <GridTable {...{ columns, fallbackMessage, ...others }} rows={tableRows} infiniteScroll={infiniteScrollProps} />
   );
 }
 

--- a/src/components/Layout/layoutTypes.ts
+++ b/src/components/Layout/layoutTypes.ts
@@ -3,7 +3,7 @@ import { GridDataRow } from "src/components/Table";
 import { GridTableProps } from "src/components/Table/GridTable";
 import { GridTableXss, Kinded } from "src/components/Table/types";
 import { Only } from "src/Css";
-import { QueryInfiniteScroll, QueryResult } from "./GridTableLayout/QueryTable";
+import { QueryResult } from "./GridTableLayout/QueryTable";
 
 /** Shared action button props used across layout header and panel components. */
 export type ActionButtonProps = Pick<ButtonProps, "onClick" | "label" | "disabled" | "tooltip" | "icon">;
@@ -22,14 +22,10 @@ export type GridTablePropsWithRows<R extends Kinded, X extends Only<GridTableXss
   createRows?: never;
 };
 
-export type BaseQueryTableProps<R extends Kinded, X extends Only<GridTableXss, X>, QData> = Omit<
-  BaseTableProps<R, X>,
-  "infiniteScroll"
-> & {
+export type BaseQueryTableProps<R extends Kinded, X extends Only<GridTableXss, X>, QData> = BaseTableProps<R, X> & {
   query: QueryResult<QData>;
   createRows: (data: QData | undefined) => GridDataRow<R>[];
   rows?: never;
-  infiniteScroll?: QueryInfiniteScroll;
 };
 
 export function isGridTableProps<R extends Kinded, X extends Only<GridTableXss, X>, Q extends { rows?: never }>(

--- a/src/components/Layout/layoutTypes.ts
+++ b/src/components/Layout/layoutTypes.ts
@@ -3,7 +3,7 @@ import { GridDataRow } from "src/components/Table";
 import { GridTableProps } from "src/components/Table/GridTable";
 import { GridTableXss, Kinded } from "src/components/Table/types";
 import { Only } from "src/Css";
-import { QueryResult } from "./GridTableLayout/QueryTable";
+import { QueryInfiniteScroll, QueryResult } from "./GridTableLayout/QueryTable";
 
 /** Shared action button props used across layout header and panel components. */
 export type ActionButtonProps = Pick<ButtonProps, "onClick" | "label" | "disabled" | "tooltip" | "icon">;
@@ -22,10 +22,14 @@ export type GridTablePropsWithRows<R extends Kinded, X extends Only<GridTableXss
   createRows?: never;
 };
 
-export type BaseQueryTableProps<R extends Kinded, X extends Only<GridTableXss, X>, QData> = BaseTableProps<R, X> & {
+export type BaseQueryTableProps<R extends Kinded, X extends Only<GridTableXss, X>, QData> = Omit<
+  BaseTableProps<R, X>,
+  "infiniteScroll"
+> & {
   query: QueryResult<QData>;
   createRows: (data: QData | undefined) => GridDataRow<R>[];
   rows?: never;
+  infiniteScroll?: QueryInfiniteScroll;
 };
 
 export function isGridTableProps<R extends Kinded, X extends Only<GridTableXss, X>, Q extends { rows?: never }>(

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent } from "@testing-library/react";
-import { MutableRefObject, useContext, useMemo, useState } from "react";
+import { MutableRefObject, useCallback, useContext, useMemo, useState } from "react";
 import { GridDataRow } from "src/components/Table/components/Row";
 import { GridTable, OnRowSelect, setRunningInJest } from "src/components/Table/GridTable";
 import { GridTableApi, GridTableApiImpl, useGridTableApi } from "src/components/Table/GridTableApi";
@@ -2536,6 +2536,192 @@ describe("GridTable", () => {
     await render(<GridTable<Row> columns={columns} rows={rows} rowLookup={rowLookup} />);
     // Then we get nothing back
     expect(rowLookup.current!.lookup(r1)).toMatchObject({ data: {} });
+  });
+
+  describe("infinite scroll", () => {
+    it("appends new rows when onEndReached updates state", async () => {
+      setRunningInJest();
+      // Given a stateful Test component that appends rows when onEndReached fires
+      const onEndReachedRef: MutableRefObject<((index: number) => void) | undefined> = { current: undefined };
+      function Test() {
+        const [data, setData] = useState([
+          { kind: "data" as const, id: "1", data: { name: "row 1", value: 1 } },
+          { kind: "data" as const, id: "2", data: { name: "row 2", value: 2 } },
+        ]);
+        const tableRows = useMemo(() => [simpleHeader, ...data], [data]);
+        onEndReachedRef.current = useCallback((index: number) => {
+          if (index === 0) return;
+          setData((prev) => [
+            ...prev,
+            {
+              kind: "data" as const,
+              id: `${prev.length + 1}`,
+              data: { name: `row ${prev.length + 1}`, value: prev.length + 1 },
+            },
+          ]);
+        }, []);
+        return (
+          <GridTable
+            as="virtual"
+            columns={[nameColumn, valueColumn]}
+            rows={tableRows}
+            infiniteScroll={{ onEndReached: onEndReachedRef.current }}
+          />
+        );
+      }
+      const r = await render(<Test />);
+      // When the table initially renders with 2 rows
+      expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+        "
+        | Name  | Value |
+        | ----- | ----- |
+        | row 1 | 1     |
+        | row 2 | 2     |
+        "
+      `);
+      // And onEndReached fires (as Virtuoso's endReached would in production)
+      act(() => {
+        onEndReachedRef.current!(2);
+      });
+      // Then a new row is appended
+      expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+        "
+        | Name  | Value |
+        | ----- | ----- |
+        | row 1 | 1     |
+        | row 2 | 2     |
+        | row 3 | 3     |
+        "
+      `);
+    });
+
+    it("supports async onEndReached and appends rows after resolving", async () => {
+      setRunningInJest();
+      let resolveLoad!: () => void;
+      const onEndReachedRef: MutableRefObject<((index: number) => void | Promise<void>) | undefined> = {
+        current: undefined,
+      };
+      function Test() {
+        const [data, setData] = useState([{ kind: "data" as const, id: "1", data: { name: "row 1", value: 1 } }]);
+        const tableRows = useMemo(() => [simpleHeader, ...data], [data]);
+        onEndReachedRef.current = useCallback(async (index: number) => {
+          if (index === 0) return;
+          // Simulate an async fetch (e.g. fetchMore)
+          await new Promise<void>((resolve) => {
+            resolveLoad = resolve;
+          });
+          setData((prev) => [...prev, { kind: "data" as const, id: "2", data: { name: "row 2", value: 2 } }]);
+        }, []);
+        return (
+          <GridTable
+            as="virtual"
+            columns={[nameColumn, valueColumn]}
+            rows={tableRows}
+            infiniteScroll={{ onEndReached: onEndReachedRef.current }}
+          />
+        );
+      }
+      const r = await render(<Test />);
+      // When onEndReached fires and starts an async fetch
+      // Note: the loading <Loader> footer is not assertable here — it lives inside renderVirtual,
+      // which doesn't mount under setRunningInJest(). Integration tests cover that.
+      void onEndReachedRef.current!(1);
+      await wait();
+
+      // Then rows are unchanged while the fetch is pending
+      expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+        "
+        | Name  | Value |
+        | ----- | ----- |
+        | row 1 | 1     |
+        "
+      `);
+      // When the fetch resolves
+      resolveLoad();
+      await wait();
+      // Then the new row appears
+      expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+        "
+        | Name  | Value |
+        | ----- | ----- |
+        | row 1 | 1     |
+        | row 2 | 2     |
+        "
+      `);
+    });
+
+    it("stops fetching when hasNextPage is false", async () => {
+      setRunningInJest();
+      // Given a stateful component that guards fetches with hasNextPage (mirrors WithQueryTableInfiniteScroll story)
+      const onEndReachedRef: MutableRefObject<((index: number) => void) | undefined> = { current: undefined };
+      function Test() {
+        const [data, setData] = useState([{ kind: "data" as const, id: "1", data: { name: "row 1", value: 1 } }]);
+        const [hasNextPage, setHasNextPage] = useState(true);
+        const tableRows = useMemo(() => [simpleHeader, ...data], [data]);
+        onEndReachedRef.current = useCallback(
+          (index: number) => {
+            if (index === 0 || !hasNextPage) return;
+            setData((prev) => [...prev, { kind: "data" as const, id: "2", data: { name: "row 2", value: 2 } }]);
+            setHasNextPage(false);
+          },
+          [hasNextPage],
+        );
+        return (
+          <GridTable
+            as="virtual"
+            columns={[nameColumn, valueColumn]}
+            rows={tableRows}
+            infiniteScroll={{ onEndReached: onEndReachedRef.current }}
+          />
+        );
+      }
+      const r = await render(<Test />);
+      // When onEndReached fires the first time it loads the next page
+      act(() => {
+        onEndReachedRef.current!(1);
+      });
+      expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+        "
+        | Name  | Value |
+        | ----- | ----- |
+        | row 1 | 1     |
+        | row 2 | 2     |
+        "
+      `);
+      // When onEndReached fires again, hasNextPage is false so nothing changes
+      act(() => {
+        onEndReachedRef.current!(2);
+      });
+      expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+        "
+        | Name  | Value |
+        | ----- | ----- |
+        | row 1 | 1     |
+        | row 2 | 2     |
+        "
+      `);
+    });
+
+    it("accepts endOffsetPx without error", async () => {
+      setRunningInJest();
+      // endOffsetPx controls Virtuoso's increaseViewportBy.bottom — only affects real scroll in production
+      const r = await render(
+        <GridTable
+          as="virtual"
+          columns={[nameColumn, valueColumn]}
+          rows={rows}
+          infiniteScroll={{ onEndReached: vi.fn(), endOffsetPx: 200 }}
+        />,
+      );
+      expect(tableSnapshot(r)).toMatchInlineSnapshot(`
+        "
+        | Name | Value |
+        | ---- | ----- |
+        | foo  | 1     |
+        | bar  | 2     |
+        "
+      `);
+    });
   });
 
   it("supports as=virtual in tests", async () => {


### PR DESCRIPTION
## Query Table Infinite Scroll Support

For GridTableLayout, Infinite Scrolling was already supported via the `infiniteScrolling` prop for the normal grid table usage, but not for the QueryTable usage. This adds the ability to use infinite scrolling with the query table. This also adds stories for both GridTable and QueryTable infinite scrolling.

Lastly, this removes "normal" pagination from GridTableLayout as we want to enforce infinite scrolling in our table layouts.