### PR TITLE
fix: Fix weird style issues when env banner overflows

### DIFF
--- a/src/components/EnvironmentBanner/EnvironmentBanner.tsx
+++ b/src/components/EnvironmentBanner/EnvironmentBanner.tsx
@@ -126,9 +126,11 @@ function getEnvironmentBannerConfig(
 /** Rounded bottom-edge cutout via box-shadow; `side` controls horizontal shadow offset. */
 function getInvertedCorner(side: "left" | "right", bgColorVar: string): ReactNode {
   const invertedCornerRadiusPx = 12;
-  const shell = Css.absolute.bottomPx(-invertedCornerRadiusPx).sqPx(invertedCornerRadiusPx).add("pointerEvents", "none")
-    .z1.$;
-  const outerPosition = side === "left" ? Css.left0.$ : Css.rightPx(invertedCornerRadiusPx).$;
+  const shell = Css.absolute.oh
+    .bottomPx(-invertedCornerRadiusPx)
+    .sqPx(invertedCornerRadiusPx)
+    .add("pointerEvents", "none").z1.$;
+  const outerPosition = side === "left" ? Css.left0.$ : Css.right0.$;
   const shadowXOffset = side === "left" ? -invertedCornerRadiusPx : invertedCornerRadiusPx;
 
   return (
@@ -138,7 +140,8 @@ function getInvertedCorner(side: "left" | "right", bgColorVar: string): ReactNod
           Css.h("200%")
             .w("200%")
             .absolute.add("borderRadius", "50%")
-            .boxShadow(`${shadowXOffset}px -${invertedCornerRadiusPx}px 0 0 ${bgColorVar}`).$
+            .boxShadow(`${shadowXOffset}px -${invertedCornerRadiusPx}px 0 0 ${bgColorVar}`)
+            .if(side === "right").right0.$
         }
       />
     </div>


### PR DESCRIPTION
Before | After
-- | -- 
<img width="687" height="114" alt="Screenshot 2026-06-23 at 8 49 09 AM" src="https://github.com/user-attachments/assets/67e16a91-5435-45db-a78e-7e7a5c29a271" /> | <img width="664" height="91" alt="Screenshot 2026-06-23 at 8 48 49 AM" src="https://github.com/user-attachments/assets/47b60a78-2233-47ac-839a-f61cab321fbc" />

