### PR TITLE
feat: Support setting document.title from PageHeader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,10 @@ Match the existing conventions when adding files:
 - **Utility / constant modules** — camelCase: `zIndices.ts`, `layoutVars.ts`.
 - Co-locate `*.test.tsx` and `*.stories.tsx` beside the file they cover.
 
+## Utility modules
+
+In camelCase utility files (e.g. `formatDocumentTitle.ts`), put **types first**, then the **primary exported function** the file exists for, then other exports and private helpers. Do not bury the main export below unrelated helpers.
+
 ## Comments
 
 - **JSDoc:** Keep exported symbols to **one or two lines**. State purpose, not implementation; point to `docs/` for full contracts (e.g. [`docs/layouts.md`](docs/layouts.md)).
@@ -36,7 +40,7 @@ After editing a test file, run `yarn lint:fix:files` on that path (see **Linting
 
 ### Structure
 
-- Follow Given/When/Then with clear comments when it helps readability.
+- **Given/When/Then:** In each `it` block, use `// Given …` for setup, `// When …` for the action (render, click, rerender, etc.), and `// Then …` before assertions. Omit `When` only when there is no separate action step after setup. See [`PageHeaderLayout.test.tsx`](src/layouts/PageHeaderLayout/PageHeaderLayout.test.tsx).
 - Each test should focus on one behavior; cover happy path and important edge cases.
 - Use descriptive `it` names.
 - **Inline test data:** Define props, items, and other fixtures **inside the `it` body** when only that test needs them. Extract a shared factory only when **multiple tests** need the same shape and duplicating it would hurt maintainability.

--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, MutableRefObject, PropsWithChildren, useContext, useMemo, useReducer, useRef } from "react";
 import { OverlayProvider } from "react-aria";
 import { AutoSaveStatusProvider } from "src/components/AutoSaveStatus/index";
+import { DocumentTitleConfig, DocumentTitleProvider } from "src/components/DocumentTitle";
 import { Modal, ModalProps } from "src/components/Modal/Modal";
 import { PresentationContextProps, PresentationProvider } from "src/components/PresentationContext";
 import { SnackbarProvider } from "src/components/Snackbar/SnackbarContext";
@@ -12,7 +13,7 @@ import { RightPaneProvider } from "./Layout";
 import { ToastProvider } from "./Toast/ToastContext";
 
 /** The internal state of our Beam context; see useModal and useSuperDrawer for the public APIs. */
-export interface BeamContextState {
+export type BeamContextState = {
   modalState: MutableRefObject<ModalProps | undefined>;
   modalCanCloseChecks: MutableRefObject<CheckFn[]>;
   /** The div for ModalHeader to portal into. */
@@ -29,7 +30,7 @@ export interface BeamContextState {
   drawerCanCloseDetailsChecks: MutableRefObject<CanCloseCheck[][]>;
   /** The div for SuperDrawerHeader to portal into. */
   sdHeaderDiv: HTMLDivElement;
-}
+};
 
 /** This is only exported internally, for useModal and useSuperDrawer, it's not a public API. */
 export const BeamContext = createContext<BeamContextState>({
@@ -44,9 +45,11 @@ export const BeamContext = createContext<BeamContextState>({
   sdHeaderDiv: undefined!,
 });
 
-interface BeamProviderProps extends PropsWithChildren<PresentationContextProps> {}
+type BeamProviderProps = {
+  documentTitleConfig?: DocumentTitleConfig;
+} & PropsWithChildren<PresentationContextProps>;
 
-export function BeamProvider({ children, ...presentationProps }: BeamProviderProps) {
+export function BeamProvider({ children, documentTitleConfig, ...presentationProps }: BeamProviderProps) {
   // We want the identity of these to be stable, b/c they end up being used as dependencies
   // in both useModal's and useSuperDrawer's return values, which means the end-application's
   // dependencies as well, i.e. things like GridTable rowStyles will memoize on openInDrawer.
@@ -85,24 +88,32 @@ export function BeamProvider({ children, ...presentationProps }: BeamProviderPro
     };
   }, [modalBodyDiv, modalFooterDiv, modalHeaderDiv, sdHeaderDiv]);
 
+  const beamTree = (
+    <PresentationProvider {...presentationProps}>
+      <RightPaneProvider>
+        <AutoSaveStatusProvider>
+          <SnackbarProvider>
+            {/* OverlayProvider is required for Modals generated via React-Aria */}
+            <ToastProvider>
+              <OverlayProvider>
+                {children}
+                {modalRef.current && <Modal {...modalRef.current} />}
+              </OverlayProvider>
+              <SuperDrawer />
+            </ToastProvider>
+          </SnackbarProvider>
+        </AutoSaveStatusProvider>
+      </RightPaneProvider>
+    </PresentationProvider>
+  );
+
   return (
     <BeamContext.Provider value={{ ...context }}>
-      <PresentationProvider {...presentationProps}>
-        <RightPaneProvider>
-          <AutoSaveStatusProvider>
-            <SnackbarProvider>
-              {/* OverlayProvider is required for Modals generated via React-Aria */}
-              <ToastProvider>
-                <OverlayProvider>
-                  {children}
-                  {modalRef.current && <Modal {...modalRef.current} />}
-                </OverlayProvider>
-                <SuperDrawer />
-              </ToastProvider>
-            </SnackbarProvider>
-          </AutoSaveStatusProvider>
-        </RightPaneProvider>
-      </PresentationProvider>
+      {documentTitleConfig ? (
+        <DocumentTitleProvider {...documentTitleConfig}>{beamTree}</DocumentTitleProvider>
+      ) : (
+        beamTree
+      )}
     </BeamContext.Provider>
   );
 }

--- a/src/components/DocumentTitle/DocumentTitleContext.tsx
+++ b/src/components/DocumentTitle/DocumentTitleContext.tsx
@@ -1,0 +1,21 @@
+import { createContext, PropsWithChildren, useContext, useMemo } from "react";
+import type { AppEnvironment } from "src/components/EnvironmentBanner/EnvironmentBanner";
+
+export type DocumentTitleConfig = {
+  env: AppEnvironment;
+  suffix?: string;
+};
+
+const DocumentTitleContext = createContext<DocumentTitleConfig | undefined>(undefined);
+
+export function DocumentTitleProvider(props: PropsWithChildren<DocumentTitleConfig>) {
+  const { children, env, suffix } = props;
+  const value = useMemo(() => ({ env, suffix }), [env, suffix]);
+
+  return <DocumentTitleContext.Provider value={value}>{children}</DocumentTitleContext.Provider>;
+}
+
+/** Used by {@link useDocumentTitle}. */
+export function useDocumentTitleConfig(): DocumentTitleConfig | undefined {
+  return useContext(DocumentTitleContext);
+}

--- a/src/components/DocumentTitle/formatDocumentTitle.test.ts
+++ b/src/components/DocumentTitle/formatDocumentTitle.test.ts
@@ -1,0 +1,79 @@
+import { formatDocumentTitle, joinDocumentTitleSegments } from "src/components/DocumentTitle/formatDocumentTitle";
+
+describe("formatDocumentTitle", () => {
+  it("joins page title and suffix", () => {
+    // Given prod env with a page title and app suffix
+    // When formatting the document title
+    const result = formatDocumentTitle({
+      env: "prod",
+      pageTitle: "Projects",
+      suffix: "Blueprint | Homebound",
+    });
+
+    // Then the page title and suffix are joined
+    expect(result).toBe("Projects | Blueprint | Homebound");
+  });
+
+  it("includes env prefix for non-prod", () => {
+    // Given a non-prod env with a page title and app suffix
+    // When formatting the document title
+    const result = formatDocumentTitle({
+      env: "qa",
+      pageTitle: "Schedule | 123 Sesame St",
+      suffix: "Blueprint | Homebound",
+    });
+
+    // Then the env prefix is included
+    expect(result).toBe("[QA] Schedule | 123 Sesame St | Blueprint | Homebound");
+  });
+
+  it("returns env prefix and app suffix when page title is omitted", () => {
+    // Given local env and app suffix with no page title
+    // When formatting the document title
+    const result = formatDocumentTitle({
+      env: "local",
+      suffix: "Blueprint | Homebound",
+    });
+
+    // Then only the env prefix and app suffix are returned
+    expect(result).toBe("[LOCAL] Blueprint | Homebound");
+  });
+
+  it("returns an empty string for prod with no suffix and no page title", () => {
+    // Given prod env with no page title or suffix
+    // When formatting the document title
+    const result = formatDocumentTitle({ env: "prod" });
+
+    // Then the result is empty
+    expect(result).toBe("");
+  });
+});
+
+describe("joinDocumentTitleSegments", () => {
+  it("joins non-empty segments", () => {
+    // Given multiple page title segments
+    // When joining them
+    const result = joinDocumentTitleSegments("Schedule", "123 Sesame St");
+
+    // Then they are separated by the document title separator
+    expect(result).toBe("Schedule | 123 Sesame St");
+  });
+
+  it("omits undefined and blank segments", () => {
+    // Given a mix of valid and empty segments
+    // When joining them
+    const result = joinDocumentTitleSegments("Schedule", undefined, "");
+
+    // Then only the valid segment remains
+    expect(result).toBe("Schedule");
+  });
+
+  it("returns undefined when all segments are empty", () => {
+    // Given only empty segments
+    // When joining them
+    const result = joinDocumentTitleSegments(undefined, "");
+
+    // Then no page title is produced
+    expect(result).toBeUndefined();
+  });
+});

--- a/src/components/DocumentTitle/formatDocumentTitle.ts
+++ b/src/components/DocumentTitle/formatDocumentTitle.ts
@@ -1,0 +1,32 @@
+import type { AppEnvironment } from "src/components/EnvironmentBanner/EnvironmentBanner";
+
+type FormatDocumentTitleInput = {
+  env: AppEnvironment;
+  pageTitle?: string;
+  suffix?: string;
+};
+
+/** Builds `document.title` from env prefix, optional page title, and optional app suffix. */
+export function formatDocumentTitle(input: FormatDocumentTitleInput): string {
+  const prefix = getDocumentTitleEnvPrefix(input.env);
+
+  if (input.pageTitle) {
+    return input.suffix ? `${prefix}${input.pageTitle} | ${input.suffix}` : `${prefix}${input.pageTitle}`;
+  }
+
+  if (input.suffix) {
+    return `${prefix}${input.suffix}`;
+  }
+
+  return prefix.trimEnd();
+}
+
+/** Joins page-level title segments for {@link useDocumentTitle}. */
+export function joinDocumentTitleSegments(...segments: (string | undefined)[]): string | undefined {
+  const parts = segments.filter((segment): segment is string => segment != null && segment.length > 0);
+  return parts.length > 0 ? parts.join(" | ") : undefined;
+}
+
+function getDocumentTitleEnvPrefix(env: AppEnvironment): string {
+  return env === "prod" ? "" : `[${env.toUpperCase()}] `;
+}

--- a/src/components/DocumentTitle/index.ts
+++ b/src/components/DocumentTitle/index.ts
@@ -1,0 +1,3 @@
+export { DocumentTitleProvider } from "src/components/DocumentTitle/DocumentTitleContext";
+export type { DocumentTitleConfig } from "src/components/DocumentTitle/DocumentTitleContext";
+export { joinDocumentTitleSegments } from "src/components/DocumentTitle/formatDocumentTitle";

--- a/src/components/PageHeader.test.tsx
+++ b/src/components/PageHeader.test.tsx
@@ -1,3 +1,4 @@
+import { BeamProvider } from "src/components/BeamContext";
 import { Button } from "src/components/Button";
 import { PageHeader } from "src/components/PageHeader";
 import { Tab } from "src/components/Tabs";
@@ -5,10 +6,42 @@ import { noop } from "src/utils";
 import { render, withRouter } from "src/utils/rtl";
 
 describe("PageHeader", () => {
+  beforeEach(() => {
+    document.title = "";
+  });
+
   it("renders", async () => {
     const r = await render(<PageHeader title="Test Title" />);
     expect(r.pageHeader).toBeInTheDocument();
     expect(r.pageHeader_title.textContent).toEqual("Test Title");
+  });
+
+  it("sets document.title when BeamProvider documentTitleConfig is configured", async () => {
+    // Given BeamProvider with documentTitleConfig and a PageHeader
+    // When rendered
+    await render(
+      <BeamProvider documentTitleConfig={{ env: "local", suffix: "Blueprint | Homebound" }}>
+        <PageHeader title="Projects" />
+      </BeamProvider>,
+      { omitBeamContext: true },
+    );
+
+    // Then document.title includes the env prefix, page title, and app suffix
+    expect(document.title).toBe("[LOCAL] Projects | Blueprint | Homebound");
+  });
+
+  it("includes documentTitleSuffix in document.title only", async () => {
+    // Given a PageHeader with documentTitleSuffix inside BeamProvider
+    const r = await render(
+      <BeamProvider documentTitleConfig={{ env: "qa", suffix: "Blueprint | Homebound" }}>
+        <PageHeader title="Schedule" documentTitleSuffix="123 Sesame St" />
+      </BeamProvider>,
+      { omitBeamContext: true },
+    );
+
+    // Then the suffix appears in document.title but not the visible heading
+    expect(document.title).toBe("[QA] Schedule | 123 Sesame St | Blueprint | Homebound");
+    expect(r.pageHeader_title.textContent).toBe("Schedule");
   });
 
   it("renders with right slot", async () => {

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,19 +1,23 @@
 import { ReactNode } from "react";
 import { RouteTabsProps, Tabs, TabsContentXss, TabsProps } from "src/components/Tabs";
 import { Css, Only, Tokens } from "src/Css";
+import { useDocumentTitle } from "src/hooks/useDocumentTitle";
 import { useTestIds } from "src/utils";
 
-export interface PageHeaderProps<V extends string, X> {
-  title: ReactNode;
+export type PageHeaderProps<V extends string, X> = {
+  title: string;
+  /** Extra segment(s) for `document.title` only; not shown in the visible page heading. */
+  documentTitleSuffix?: string;
   rightSlot?: ReactNode;
   tabs?:
     | Omit<TabsProps<V, X>, "contentXss" | "omitFullBleedPadding" | "includeBottomBorder">
     | Omit<RouteTabsProps<V, X>, "contentXss" | "omitFullBleedPadding" | "includeBottomBorder">;
-}
+};
 
 export function PageHeader<V extends string, X extends Only<TabsContentXss, X>>(props: PageHeaderProps<V, X>) {
-  const { title, rightSlot, tabs, ...otherProps } = props;
+  const { title, documentTitleSuffix, rightSlot, tabs, ...otherProps } = props;
   const tid = useTestIds(otherProps, "pageHeader");
+  useDocumentTitle(title, documentTitleSuffix);
 
   return (
     <header {...tid} css={Css.df.fdc.pt3.pr3.pl3.bb.bc(Tokens.SurfaceSeparator).bgColor(Tokens.Surface).$}>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -23,6 +23,7 @@ export * from "./ContrastScope";
 export * from "./Copy";
 export * from "./CountBadge";
 export * from "./DnDGrid";
+export * from "./DocumentTitle";
 export * from "./EnvironmentBanner/EnvironmentBanner";
 export type { AppEnvironment, EnvironmentBannerProps, ImpersonatedUser } from "./EnvironmentBanner/EnvironmentBanner";
 export { setEnvironmentFavicon } from "./EnvironmentBanner/setEnvironmentFavicon";

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from "./useBreakpoint";
 export * from "./useComputed";
 export * from "./useContentOverflow";
+export * from "./useDocumentTitle";
 export * from "./useFilter";
 export * from "./useGroupBy";
 export * from "./useHover";

--- a/src/hooks/useDocumentTitle.test.tsx
+++ b/src/hooks/useDocumentTitle.test.tsx
@@ -1,0 +1,134 @@
+import { renderHook } from "@testing-library/react";
+import { DocumentTitleProvider } from "src/components/DocumentTitle/DocumentTitleContext";
+import { PageHeader } from "src/components/PageHeader";
+import { useDocumentTitle } from "src/hooks/useDocumentTitle";
+import { render } from "src/utils/rtl";
+
+describe("useDocumentTitle", () => {
+  beforeEach(() => {
+    document.title = "";
+  });
+
+  it("sets document.title with env prefix and suffix", () => {
+    // Given a DocumentTitleProvider with local env and app suffix
+    // When the hook registers a page title
+    renderHook(() => useDocumentTitle("Potato"), {
+      wrapper: ({ children }) => (
+        <DocumentTitleProvider env="local" suffix="Blueprint | Homebound">
+          {children}
+        </DocumentTitleProvider>
+      ),
+    });
+
+    // Then document.title includes the env prefix, page title, and app suffix
+    expect(document.title).toBe("[LOCAL] Potato | Blueprint | Homebound");
+  });
+
+  it("joins variadic title segments before applying app suffix", () => {
+    // Given a DocumentTitleProvider and multiple page title segments
+    // When the hook registers the joined page title
+    renderHook(() => useDocumentTitle("Schedule", "123 Sesame St"), {
+      wrapper: ({ children }) => (
+        <DocumentTitleProvider env="qa" suffix="Blueprint | Homebound">
+          {children}
+        </DocumentTitleProvider>
+      ),
+    });
+
+    // Then document.title includes all segments plus the app suffix
+    expect(document.title).toBe("[QA] Schedule | 123 Sesame St | Blueprint | Homebound");
+  });
+
+  it("omits env prefix in production", () => {
+    // Given a DocumentTitleProvider in prod
+    // When the hook registers a page title
+    renderHook(() => useDocumentTitle("Potato"), {
+      wrapper: ({ children }) => (
+        <DocumentTitleProvider env="prod" suffix="Blueprint | Homebound">
+          {children}
+        </DocumentTitleProvider>
+      ),
+    });
+
+    // Then document.title omits the env prefix
+    expect(document.title).toBe("Potato | Blueprint | Homebound");
+  });
+
+  it("updates document.title when the title changes", () => {
+    // Given a DocumentTitleProvider and an initial page title
+    const { rerender } = renderHook(({ title }) => useDocumentTitle(title), {
+      initialProps: { title: "Potato" },
+      wrapper: ({ children }) => (
+        <DocumentTitleProvider env="local" suffix="Blueprint | Homebound">
+          {children}
+        </DocumentTitleProvider>
+      ),
+    });
+
+    expect(document.title).toBe("[LOCAL] Potato | Blueprint | Homebound");
+
+    // When the page title changes
+    rerender({ title: "Carrot" });
+
+    // Then document.title reflects the new page title
+    expect(document.title).toBe("[LOCAL] Carrot | Blueprint | Homebound");
+  });
+
+  it("falls back to env prefix and app suffix on unmount", () => {
+    // Given a registered page title
+    const { unmount } = renderHook(() => useDocumentTitle("Potato"), {
+      wrapper: ({ children }) => (
+        <DocumentTitleProvider env="local" suffix="Blueprint | Homebound">
+          {children}
+        </DocumentTitleProvider>
+      ),
+    });
+
+    expect(document.title).toBe("[LOCAL] Potato | Blueprint | Homebound");
+
+    // When the hook unmounts
+    unmount();
+
+    // Then document.title falls back to env prefix and app suffix only
+    expect(document.title).toBe("[LOCAL] Blueprint | Homebound");
+  });
+
+  it("sets document.title from PageHeader when a provider is present", async () => {
+    // Given a PageHeader inside a DocumentTitleProvider
+    // When rendered
+    await render(
+      <DocumentTitleProvider env="local" suffix="Blueprint | Homebound">
+        <PageHeader title="Projects" />
+      </DocumentTitleProvider>,
+      { omitBeamContext: true },
+    );
+
+    // Then document.title is set via PageHeader
+    expect(document.title).toBe("[LOCAL] Projects | Blueprint | Homebound");
+  });
+
+  it("includes documentTitleSuffix in the browser tab title", async () => {
+    // Given a PageHeader with documentTitleSuffix
+    const r = await render(
+      <DocumentTitleProvider env="qa" suffix="Blueprint | Homebound">
+        <PageHeader title="Schedule" documentTitleSuffix="123 Sesame St" />
+      </DocumentTitleProvider>,
+      { omitBeamContext: true },
+    );
+
+    // Then the suffix appears in document.title but not the visible heading
+    expect(document.title).toBe("[QA] Schedule | 123 Sesame St | Blueprint | Homebound");
+    expect(r.pageHeader_title.textContent).toBe("Schedule");
+  });
+
+  it("leaves document.title unchanged when PageHeader renders without a provider", async () => {
+    // Given an existing document.title and no DocumentTitleProvider
+    document.title = "Initial title";
+
+    // When PageHeader renders
+    await render(<PageHeader title="Projects" />, { omitBeamContext: true });
+
+    // Then document.title is unchanged
+    expect(document.title).toBe("Initial title");
+  });
+});

--- a/src/hooks/useDocumentTitle.tsx
+++ b/src/hooks/useDocumentTitle.tsx
@@ -1,0 +1,22 @@
+import { useLayoutEffect } from "react";
+import { useDocumentTitleConfig } from "src/components/DocumentTitle/DocumentTitleContext";
+import { formatDocumentTitle, joinDocumentTitleSegments } from "src/components/DocumentTitle/formatDocumentTitle";
+
+/** Sets `document.title` from joined segments plus provider env prefix and app suffix. */
+export function useDocumentTitle(...titleSegments: (string | undefined)[]): void {
+  const config = useDocumentTitleConfig();
+  const pageTitle = joinDocumentTitleSegments(...titleSegments);
+
+  useLayoutEffect(() => {
+    if (!config || !pageTitle || typeof document === "undefined") {
+      return;
+    }
+
+    document.title = formatDocumentTitle({ ...config, pageTitle });
+
+    return () => {
+      // Reset on unmount. Expect next page to set its own title, but in case it doesn't we don't persist the previous title.
+      document.title = formatDocumentTitle(config);
+    };
+  }, [config, pageTitle]);
+}


### PR DESCRIPTION
Whenever using the `PageHeader` or `PageHeaderLayout` components, then the document title would get set for free via the `PageHeader` component.
Examples:

Results in: **[QA] Product Offerings | Blueprint | Homebound**
```
<BeamContext 
  documentTitleConfig={{
    env: "qa", // Sets environment prefix
    suffix: "Blueprint | Homebound",
  }}
>
  <PageHeader title="Product Offerings" />
</BeamContext>
```

Results in: **Schedule | 123 Sesame St | Blueprint | Homebound**
```
<BeamContext 
  documentTitleConfig={{
    env: "prod", // Prod env does not apply a prefix
    suffix: "Blueprint | Homebound",
  }}
>
  <PageHeader title="Schedule" documentTitleSuffix="123 Sesame St" />
</BeamContext>
```
