### PR TITLE
feat: add BeamOverlays for modal and drawer app context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ In camelCase utility files (e.g. `formatDocumentTitle.ts`), put **types first**,
 
 ## Comments
 
-- **JSDoc:** Keep exported symbols to **one or two lines**. State purpose, not implementation; point to `docs/` for full contracts (e.g. [`docs/layouts.md`](docs/layouts.md)).
+- **JSDoc:** Keep exported symbols to **one or two lines**. State purpose, not implementation; point to `docs/` for full contracts (e.g. [`docs/layouts.md`](docs/layouts.md), [`docs/overlays.md`](docs/overlays.md)).
 - **Inline comments:** Use for non-obvious logic near the code. Keep them **short** — one line when possible.
 - **Avoid:** Multi-paragraph JSDoc, restating what the code already says, and duplicating docs that live elsewhere.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ _To see the latest designs, check out the [Figma](https://www.figma.com/file/aWU
 
 Standard **app shell** composition (global nav + body, sidebar + content, page header + body) is implemented as **`NavbarLayout`**, **`SideNavLayout`**, and **`PageHeaderLayout`** from this package. Source lives in **`src/layouts/`** (sibling of `src/components/`). Full setup and composition rules: [`docs/layouts.md`](docs/layouts.md) — also published in the npm package at `node_modules/@homebound/beam/docs/layouts.md`.
 
+## Global overlays (Modal & SuperDrawer)
+
+Apps using `useModal` or `useSuperDrawer` should mount **`<BeamOverlays />`** inside **`BeamProvider`**, below app-wide context providers, so overlay content can access context defined by ancestral providers. Setup and placement rules: [`docs/overlays.md`](docs/overlays.md) — also at `node_modules/@homebound/beam/docs/overlays.md`.
+
 ## Getting Started
 
 ```bash

--- a/docs/overlays.md
+++ b/docs/overlays.md
@@ -1,0 +1,51 @@
+# Beam global overlays (Modal & SuperDrawer)
+
+This document is the **canonical contract** for mounting Beam's global overlays so modal and super-drawer content can use app React context. It ships with the `@homebound/beam` package for consuming apps.
+
+## Rules (normative)
+
+1. **Wrap the app in `BeamProvider`** — Required for `useModal`, `useSuperDrawer`, snackbars, and other Beam globals.
+2. **Mount `<BeamOverlays />` once per `BeamProvider`** — Place it **inside** `BeamProvider`, **below** app-wide providers whose context overlay content should read.
+3. **Do not mount multiple `BeamOverlays`** — A second instance logs a dev warning and can render duplicate modals.
+4. **Route-scoped context still requires props** — Providers mounted only on a page or route do not wrap `BeamOverlays` unless you restructure the tree. Pass that data into `openModal` / `openInDrawer` content explicitly.
+
+## Why this exists
+
+`useModal` and `useSuperDrawer` render a **single global** Modal and SuperDrawer. Without `BeamOverlays`, Beam mounts them as **React siblings** of your app `children`. Content opened via `openModal({ content })` is then **outside** providers nested under `children`, so app context hooks in overlay content see default values.
+
+This is a **React tree** issue, not a DOM portal issue. Portals change where nodes paint in the DOM; they do not change which providers wrap overlay content in React.
+
+## Setup
+
+```tsx
+import { BeamOverlays, BeamProvider } from "@homebound/beam";
+
+<BeamProvider>
+  <AppWideProviders>
+    {children}
+    <BeamOverlays />
+  </AppWideProviders>
+</BeamProvider>;
+```
+
+`AppWideProviders` is whatever wraps most of your app — auth, data clients, feature config, etc. Mount `<BeamOverlays />` as a **descendant** of each provider whose context modals and drawers should see, typically as the last child alongside `{children}`.
+
+Providers that call `useModal` or `useSuperDrawer` must remain **inside** `BeamProvider`. Providers scoped to a single route usually wrap only that route's `{children}`; overlay content on those screens still needs props unless you hoist those providers above `<BeamOverlays />`.
+
+## Fallback (optional adoption)
+
+If an app does **not** mount `BeamOverlays`, `BeamProvider` will render Modal and SuperDrawer at the legacy sibling position. Existing modals keep working; app-wide context in overlay content remains unavailable until `BeamOverlays` is added.
+
+## Consuming apps
+
+After install, this file is available at:
+
+`node_modules/@homebound/beam/docs/overlays.md`
+
+Add a pointer in the app's agent/onboarding docs, e.g.:
+
+> Global modals/drawers: mount `<BeamOverlays />` per `@homebound/beam/docs/overlays.md`.
+
+## GitHub (browse without install)
+
+`https://github.com/homebound-team/beam/blob/main/docs/overlays.md`

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "dist",
     "!dist/**/*.{stories,test}.*",
     "!dist/setupTests.*",
-    "docs/layout-shells.md"
+    "docs/layout-shells.md",
+    "docs/overlays.md"
   ],
   "engines": {
     "node": "~22.14.0"
@@ -30,7 +31,8 @@
     },
     "./Css.json": "./dist/Css.json",
     "./index.css": "./dist/index.css",
-    "./docs/layout-shells.md": "./docs/layout-shells.md"
+    "./docs/layout-shells.md": "./docs/layout-shells.md",
+    "./docs/overlays.md": "./docs/overlays.md"
   },
   "scripts": {
     "start": "yarn storybook",

--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -131,7 +131,8 @@ export function BeamProvider({ children, documentTitleConfig, ...presentationPro
               <ToastProvider>
                 <OverlayProvider>
                   {children}
-                  {!hasOverlayHost && <BeamOverlaysContent /> // fallback for Overlays when opted-out of <BeamOverlays>}
+                  {/* Fallback overlay content for apps that don't mount BeamOverlays */}
+                  {!hasOverlayHost && <BeamOverlaysContent />}
                 </OverlayProvider>
               </ToastProvider>
             </SnackbarProvider>

--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -1,11 +1,22 @@
-import { createContext, MutableRefObject, PropsWithChildren, useContext, useMemo, useReducer, useRef } from "react";
+import {
+  createContext,
+  MutableRefObject,
+  PropsWithChildren,
+  useCallback,
+  useContext,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 import { OverlayProvider } from "react-aria";
 import { AutoSaveStatusProvider } from "src/components/AutoSaveStatus/index";
+import { BeamOverlaysContent } from "src/components/BeamOverlaysContent";
 import { DocumentTitleConfig, DocumentTitleProvider } from "src/components/DocumentTitle";
-import { Modal, ModalProps } from "src/components/Modal/Modal";
+import { ModalProps } from "src/components/Modal/Modal";
+import { OverlayHostContext, OverlayHostContextValue } from "src/components/OverlayHostContext";
 import { PresentationContextProps, PresentationProvider } from "src/components/PresentationContext";
 import { SnackbarProvider } from "src/components/Snackbar/SnackbarContext";
-import { SuperDrawer } from "src/components/SuperDrawer/SuperDrawer";
 import { ContentStack } from "src/components/SuperDrawer/useSuperDrawer";
 import { CanCloseCheck, CheckFn } from "src/types";
 import { EmptyRef } from "src/utils/index";
@@ -49,6 +60,7 @@ type BeamProviderProps = {
   documentTitleConfig?: DocumentTitleConfig;
 } & PropsWithChildren<PresentationContextProps>;
 
+/** Root provider for Beam globals. See [`docs/overlays.md`](../../docs/overlays.md) for {@link BeamOverlays} placement. */
 export function BeamProvider({ children, documentTitleConfig, ...presentationProps }: BeamProviderProps) {
   // We want the identity of these to be stable, b/c they end up being used as dependencies
   // in both useModal's and useSuperDrawer's return values, which means the end-application's
@@ -88,23 +100,45 @@ export function BeamProvider({ children, documentTitleConfig, ...presentationPro
     };
   }, [modalBodyDiv, modalFooterDiv, modalHeaderDiv, sdHeaderDiv]);
 
+  const [overlayHostCount, setOverlayHostCount] = useState(0);
+  const hasOverlayHost = overlayHostCount > 0;
+
+  const registerOverlayHost = useCallback(() => {
+    setOverlayHostCount((count) => {
+      if (process.env.NODE_ENV !== "production" && count >= 1) {
+        console.warn("BeamOverlays: multiple overlay hosts mounted; mount BeamOverlays once per BeamProvider.");
+      }
+      return count + 1;
+    });
+  }, []);
+
+  const unregisterOverlayHost = useCallback(() => {
+    setOverlayHostCount((count) => Math.max(0, count - 1));
+  }, []);
+
+  const overlayHostContext = useMemo<OverlayHostContextValue>(
+    () => ({ registerOverlayHost, unregisterOverlayHost }),
+    [registerOverlayHost, unregisterOverlayHost],
+  );
+
   const beamTree = (
-    <PresentationProvider {...presentationProps}>
-      <RightPaneProvider>
-        <AutoSaveStatusProvider>
-          <SnackbarProvider>
-            {/* OverlayProvider is required for Modals generated via React-Aria */}
-            <ToastProvider>
-              <OverlayProvider>
-                {children}
-                {modalRef.current && <Modal {...modalRef.current} />}
-              </OverlayProvider>
-              <SuperDrawer />
-            </ToastProvider>
-          </SnackbarProvider>
-        </AutoSaveStatusProvider>
-      </RightPaneProvider>
-    </PresentationProvider>
+    <OverlayHostContext.Provider value={overlayHostContext}>
+      <PresentationProvider {...presentationProps}>
+        <RightPaneProvider>
+          <AutoSaveStatusProvider>
+            <SnackbarProvider>
+              {/* OverlayProvider is required for Modals generated via React-Aria */}
+              <ToastProvider>
+                <OverlayProvider>
+                  {children}
+                  {!hasOverlayHost && <BeamOverlaysContent />}
+                </OverlayProvider>
+              </ToastProvider>
+            </SnackbarProvider>
+          </AutoSaveStatusProvider>
+        </RightPaneProvider>
+      </PresentationProvider>
+    </OverlayHostContext.Provider>
   );
 
   return (

--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -131,7 +131,7 @@ export function BeamProvider({ children, documentTitleConfig, ...presentationPro
               <ToastProvider>
                 <OverlayProvider>
                   {children}
-                  {!hasOverlayHost && <BeamOverlaysContent />}
+                  {!hasOverlayHost && <BeamOverlaysContent /> // fallback for Overlays when opted-out of <BeamOverlays>}
                 </OverlayProvider>
               </ToastProvider>
             </SnackbarProvider>

--- a/src/components/BeamOverlays.test.tsx
+++ b/src/components/BeamOverlays.test.tsx
@@ -1,0 +1,71 @@
+import { createContext, useContext, useEffect } from "react";
+import { BeamProvider } from "src/components/BeamContext";
+import { BeamOverlays } from "src/components/BeamOverlays";
+import { useModal } from "src/components/Modal/useModal";
+import { render } from "src/utils/rtl";
+
+describe("BeamOverlays", () => {
+  it("lets modal content access providers mounted above BeamOverlays", async () => {
+    // Given a provider wrapping routes and BeamOverlays
+    const TestContext = createContext("missing");
+
+    function ModalContent() {
+      const value = useContext(TestContext);
+      return <div data-testid="modalContextValue">{value}</div>;
+    }
+
+    function TestApp() {
+      const { openModal } = useModal();
+      useEffect(() => {
+        openModal({ content: <ModalContent /> });
+      }, [openModal]);
+      return null;
+    }
+
+    // When opening a modal via BeamOverlays placed below the provider
+    const r = await render(
+      <BeamProvider>
+        <TestContext.Provider value="from-provider">
+          <TestApp />
+          <BeamOverlays />
+        </TestContext.Provider>
+      </BeamProvider>,
+      { omitBeamContext: true },
+    );
+
+    // Then modal content sees the provider context
+    expect(r.modalContextValue).toHaveTextContent("from-provider");
+  });
+
+  it("falls back to BeamProvider overlays when BeamOverlays is not mounted", async () => {
+    // Given a provider that does not wrap BeamProvider's fallback overlay mount
+    const TestContext = createContext("missing");
+
+    function ModalContent() {
+      const value = useContext(TestContext);
+      return <div data-testid="modalContextValue">{value}</div>;
+    }
+
+    function TestApp() {
+      const { openModal } = useModal();
+      useEffect(() => {
+        openModal({ content: <ModalContent /> });
+      }, [openModal]);
+      return null;
+    }
+
+    const r = await render(
+      <BeamProvider>
+        <TestContext.Provider value="from-provider">
+          <TestApp />
+        </TestContext.Provider>
+      </BeamProvider>,
+      { omitBeamContext: true },
+    );
+
+    // Then the modal still opens via fallback
+    expect(r.modal).toBeTruthy();
+    // And it does not inherit providers nested only in children
+    expect(r.modalContextValue).toHaveTextContent("missing");
+  });
+});

--- a/src/components/BeamOverlays.tsx
+++ b/src/components/BeamOverlays.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { BeamOverlaysContent } from "src/components/BeamOverlaysContent";
+import { useOverlayHostContext } from "src/components/OverlayHostContext";
+
+/**
+ * Mount point for Beam's global Modal and SuperDrawer overlays.
+ * Full setup: [`docs/overlays.md`](../../docs/overlays.md).
+ */
+export function BeamOverlays() {
+  const { registerOverlayHost, unregisterOverlayHost } = useOverlayHostContext();
+
+  useEffect(() => {
+    registerOverlayHost();
+    return unregisterOverlayHost;
+  }, [registerOverlayHost, unregisterOverlayHost]);
+
+  return <BeamOverlaysContent />;
+}

--- a/src/components/BeamOverlaysContent.tsx
+++ b/src/components/BeamOverlaysContent.tsx
@@ -1,0 +1,14 @@
+import { useBeamContext } from "src/components/BeamContext";
+import { Modal } from "src/components/Modal/Modal";
+import { SuperDrawer } from "src/components/SuperDrawer/SuperDrawer";
+
+/** Renders the global Modal and SuperDrawer; used by {@link BeamOverlays} and BeamProvider fallback. */
+export function BeamOverlaysContent() {
+  const { modalState } = useBeamContext();
+  return (
+    <>
+      {modalState.current && <Modal {...modalState.current} />}
+      <SuperDrawer />
+    </>
+  );
+}

--- a/src/components/OverlayHostContext.tsx
+++ b/src/components/OverlayHostContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext } from "react";
+
+export type OverlayHostContextValue = {
+  registerOverlayHost: () => void;
+  unregisterOverlayHost: () => void;
+};
+
+export const OverlayHostContext = createContext<OverlayHostContextValue | null>(null);
+
+export function useOverlayHostContext(): OverlayHostContextValue {
+  const context = useContext(OverlayHostContext);
+  if (!context) {
+    throw new Error("BeamOverlays must be rendered inside BeamProvider");
+  }
+  return context;
+}

--- a/src/components/SuperDrawer/SuperDrawer.stories.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.stories.tsx
@@ -352,14 +352,14 @@ export function HiddenControls() {
   );
 }
 
-interface TestDrawerContentProps {
+type TestDrawerContentProps = {
   book: Book;
   hasActions?: boolean;
   title: string;
   leftContent?: ReactNode;
   rightContent?: ReactNode;
   hideControls?: boolean;
-}
+};
 
 /** Example component to render inside the SuperDrawer */
 function TestDrawerContent(props: TestDrawerContentProps) {

--- a/src/components/SuperDrawer/SuperDrawer.test.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.test.tsx
@@ -1,0 +1,88 @@
+import { useEffect } from "react";
+import { BeamProvider } from "src/components/BeamContext";
+import { BeamOverlays } from "src/components/BeamOverlays";
+import { ButtonMenu } from "src/components/ButtonMenu";
+import { SuperDrawerContent } from "src/components/SuperDrawer";
+import { SuperDrawerHeader } from "src/components/SuperDrawer/components/SuperDrawerHeader";
+import { useSuperDrawer } from "src/components/SuperDrawer/useSuperDrawer";
+import { noop } from "src/utils";
+import { click, render } from "src/utils/rtl";
+
+describe("SuperDrawer nested overlays", () => {
+  it("opens a ButtonMenu inside SuperDrawer via BeamProvider fallback", async () => {
+    // Given a SuperDrawer with a menu trigger, using BeamProvider fallback overlays
+    const r = await render(
+      <BeamProvider>
+        <DrawerWithMenuApp />
+      </BeamProvider>,
+      { omitBeamContext: true },
+    );
+
+    // Then the drawer is open
+    expect(r.superDrawer).toBeTruthy();
+
+    // When opening the menu inside the drawer
+    click(r.drawerMenu);
+
+    // Then menu items render above the drawer scrim
+    expect(r.drawerMenu_optionA).toBeInTheDocument();
+
+    // When selecting an item
+    click(r.drawerMenu_optionA);
+
+    // Then the menu closes
+    expect(r.query.drawerMenu_optionA).toBeNull();
+  });
+
+  it("opens a ButtonMenu inside SuperDrawer via BeamOverlays", async () => {
+    // Given a SuperDrawer with a menu trigger, using an explicit BeamOverlays host
+    const r = await render(
+      <BeamProvider>
+        <DrawerWithMenuApp />
+        <BeamOverlays />
+      </BeamProvider>,
+      { omitBeamContext: true },
+    );
+
+    // Then the drawer is open
+    expect(r.superDrawer).toBeTruthy();
+
+    // When opening the menu inside the drawer
+    click(r.drawerMenu);
+
+    // Then menu items render above the drawer scrim
+    expect(r.drawerMenu_optionA).toBeInTheDocument();
+
+    // When selecting an item
+    click(r.drawerMenu_optionA);
+
+    // Then the menu closes
+    expect(r.query.drawerMenu_optionA).toBeNull();
+  });
+});
+
+function DrawerWithMenuApp() {
+  const { openInDrawer } = useSuperDrawer();
+
+  useEffect(() => {
+    openInDrawer({
+      content: (
+        <>
+          <SuperDrawerHeader title="Drawer with menu" />
+          <SuperDrawerContent>
+            <ButtonMenu
+              data-testid="drawerMenu"
+              trigger={{ label: "Actions" }}
+              items={[
+                { label: "Option A", onClick: noop },
+                { label: "Option B", onClick: noop },
+              ]}
+            />
+          </SuperDrawerContent>
+        </>
+      ),
+    });
+  }, [openInDrawer]);
+
+  return null;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -13,6 +13,7 @@ export * from "./Avatar";
 export * from "./Banner";
 export type { BannerProps } from "./Banner";
 export { BeamProvider } from "./BeamContext";
+export { BeamOverlays } from "./BeamOverlays";
 export * from "./Button";
 export * from "./ButtonDatePicker";
 export * from "./ButtonGroup";

--- a/src/utils/rtl.tsx
+++ b/src/utils/rtl.tsx
@@ -6,10 +6,10 @@ import { BeamProvider } from "src";
 export * from "./rtlUtils";
 export { _withRouter as withRouter };
 
-interface RenderOpts {
+type RenderOpts = {
   at?: { url: string; route?: string };
   omitBeamContext?: boolean;
-}
+};
 
 export function render(
   component: ReactElement,
@@ -27,8 +27,9 @@ export function render(
 ): Promise<RenderResult & Record<string, HTMLElement>> {
   let wrappers: Wrapper[];
   if (wrapperOrOpts && "wrap" in wrapperOrOpts) {
-    // They passed at least single wrapper + maybe more.
-    // We put `withBeamRTL` first so that any `withApollo`s wrap outside of beam, so in-drawer/in-modal content has apollo
+    // withBeamRTL is innermost; wrappers passed here wrap outside BeamProvider.
+    // For overlay context (feature flags, Apollo), nest providers inside BeamProvider
+    // and mount BeamOverlays below them — see docs/overlays.md.
     wrappers = [withBeamRTL, wrapperOrOpts as Wrapper, ...otherWrappers];
   } else if (wrapperOrOpts) {
     const { omitBeamContext, at } = wrapperOrOpts;
@@ -43,7 +44,7 @@ export function render(
   return rtlRender(component, { wrappers, wait: true });
 }
 
-/** RTL wrapper for Beam's SuperDrawer/Modal context. */
+/** RTL wrapper for Beam's SuperDrawer/Modal context (BeamProvider fallback overlays). */
 export const withBeamRTL: Wrapper = {
   wrap: (c) => <BeamProvider>{c}</BeamProvider>,
 };

--- a/src/utils/sb.tsx
+++ b/src/utils/sb.tsx
@@ -1,6 +1,6 @@
 import { type Decorator, type StoryObj } from "@storybook/react-vite";
 import { ReactNode } from "react";
-import { BeamProvider } from "src/components";
+import { BeamOverlays, BeamProvider } from "src/components";
 import { Css, Properties } from "src/Css";
 import { withRouter as rtlWithRouter } from "src/utils/rtl";
 import type { InitialViewportKeys, MINIMAL_VIEWPORTS } from "storybook/viewport";
@@ -64,10 +64,11 @@ export function zeroTo(n: number): number[] {
   return [...Array(n).keys()];
 }
 
-/** Storybook decorator utility to wrap a story with a SuperDrawer context */
+/** Storybook decorator: BeamProvider + BeamOverlays (see docs/overlays.md). */
 export const withBeamDecorator: Decorator = (Story) => (
   <BeamProvider>
     <Story />
+    <BeamOverlays />
   </BeamProvider>
 );
 


### PR DESCRIPTION
## Summary
- Adds `BeamOverlays`, an opt-in mount point that apps can place inside `BeamProvider` below app-wide context providers so `openModal` / `openInDrawer` content can use those hooks.
- `BeamProvider` keeps backwards-compatible fallback overlay rendering when `BeamOverlays` is not mounted.
- Documents setup in `docs/overlays.md` and ships it in the npm package.

## Test plan
- [x] `npx vitest run src/components/BeamOverlays.test.tsx`
- [x] `npx vitest run src/components/SuperDrawer/SuperDrawer.test.tsx`
- [x] `npx vitest run src/components/Modal/useModal.test.tsx`
- [ ] Blueprint follow-up: mount `<BeamOverlays />` in `AppProviders` after Beam release