### PR TITLE
feat: [APP-1545] Update Pinned GridTable Row Colors

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -659,7 +659,7 @@ export function InteractiveGroupRowPinning() {
             <span css={Css.xsSb.$}>{data.name}</span>
             <IconButton
               icon="pin"
-              active={isPinned}
+              color={isPinned ? Palette.Blue600 : undefined}
               label={isPinned ? "Unpin group" : "Pin group"}
               onClick={() => ids.forEach((id) => (isPinned ? api.unpinRow(id) : api.pinRow(id)))}
             />

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1067,8 +1067,8 @@ describe("GridTable", () => {
       expect(cell(r, 1, 0)).toHaveTextContent("bar");
       expect(cell(r, 2, 0)).toHaveTextContent("foo");
       expect(cell(r, 3, 0)).toHaveTextContent("zaz");
-      // And the pinned row gets the green highlight (`Green50` = #ecfdf5)
-      expect(cell(r, 1, 0)).toHaveStyle({ backgroundColor: Palette.Green50 });
+      // And the pinned row gets the blue highlight (`Blue50`)
+      expect(cell(r, 1, 0)).toHaveStyle({ backgroundColor: Palette.Blue50 });
     });
 
     it("keeps a pinned row visible even when a filter would hide it", async () => {

--- a/src/components/Table/TableStyles.tsx
+++ b/src/components/Table/TableStyles.tsx
@@ -91,7 +91,7 @@ export type GridStyle = {
   keptGroupRowCss?: Properties;
   /** Defines styles for the last row `keptGroup` to provide separation from the rest of the table */
   keptLastRowCss?: Properties;
-  /** Applied to every cell of a runtime-pinned row — the green highlight for the pinned section. */
+  /** Applied to every cell of a runtime-pinned row — the blue highlight for the pinned section. */
   pinnedRowCss?: Properties;
 };
 
@@ -212,9 +212,9 @@ function memoizedTableStyles() {
         rowHoverColor: Palette.Blue50,
         keptGroupRowCss: Css.bgYellow100.gray900.xsSb.df.aic.$,
         keptLastRowCss: Css.boxShadow("inset 0px -14px 8px -11px rgba(63,63,63,.18)").$,
-        // Pinned rows get a green highlight; the standard `betweenRowsCss` bottom border (not a
+        // Pinned rows get a blue highlight; the standard `betweenRowsCss` bottom border (not a
         // shadow) already separates the pinned section from the body.
-        pinnedRowCss: Css.bgColor(Palette.Green50).$,
+        pinnedRowCss: Css.bgColor(Palette.Blue50).$,
       };
     }
 

--- a/src/components/Table/components/PinToggle.tsx
+++ b/src/components/Table/components/PinToggle.tsx
@@ -22,7 +22,7 @@ export function PinToggle({ rowId }: PinToggleProps) {
     <IconButton
       {...tid[rowId]}
       icon="pin"
-      bgColor={isPinned ? Palette.Green300 : undefined}
+      color={isPinned ? Palette.Blue600 : undefined}
       label={isPinned ? "Unpin row" : "Pin row"}
       onClick={() => tableState.togglePinned(rowId)}
     />

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -377,7 +377,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
             ...(isGridCellContent(maybeContent) && maybeContent.css ? maybeContent.css : {}),
             // Apply kept last row styling per-cell
             ...(isLastKeptRow && style.keptLastRowCss),
-            // Apply the green highlight to every runtime-pinned row's cells (wins over `isActive`)
+            // Apply the blue highlight to every runtime-pinned row's cells (wins over `isActive`)
             ...(pinned && style.pinnedRowCss),
             // Apply cell highlight styles to active cell and hover
             ...Css.if(applyCellHighlight && isCellActive).br4.boxShadow(`inset 0 0 0 1px ${Palette.Blue700}`).$,


### PR DESCRIPTION
Swaps out green pinned `GridTable` row styles for blue
<img width="1623" height="276" alt="image" src="https://github.com/user-attachments/assets/b1e30850-4bf7-40aa-8e83-a04eff68ee2c" />


https://www.figma.com/design/z8KoZW6FQoSUkE6arpgMcQ/Personalization-Group-Management-Improvements--BP-?node-id=4422-45385&m=dev