### PR TITLE
fix: Update select card description font size

### DIFF
--- a/src/inputs/SelectCard/GridSelectCard.stories.tsx
+++ b/src/inputs/SelectCard/GridSelectCard.stories.tsx
@@ -57,20 +57,6 @@ export function States() {
   );
 }
 
-/** Mix of cards with and without descriptions in one row. */
-export function MixedDescriptions() {
-  const description = "Slots share the same options, but each slot can have its own selection.";
-
-  return (
-    <div css={{ ...Css.wPx(640).$, ...getSelectCardOptionsCss("grid", true) }}>
-      <GridSelectCardWrapper label="Single" icon="single" description={description} selected />
-      <GridSelectCardWrapper label="Math" icon="abacus" />
-      <GridSelectCardWrapper label="Package" icon="package" description="Selections come in preconfigured bundles." />
-      <GridSelectCardWrapper label="Finance" icon="dollar" />
-    </div>
-  );
-}
-
 type GridSelectCardWrapperProps = Omit<GridSelectCardProps, "inputProps">;
 
 function GridSelectCardWrapper(props: GridSelectCardWrapperProps) {

--- a/src/inputs/SelectCard/GridSelectCard.tsx
+++ b/src/inputs/SelectCard/GridSelectCard.tsx
@@ -42,7 +42,7 @@ export function GridSelectCard(props: GridSelectCardProps) {
       <Icon icon={icon} inc={4} color={isDisabled ? Tokens.OnSurfaceDisabled : Tokens.OnSurface} />
       <span css={Css.df.fdc.gap("4px").w100.$}>
         <span css={Css.smSb.if(isDisabled).gray600.$}>{label}</span>
-        {description && <span css={Css.xs.color(Tokens.OnSurface).if(isDisabled).gray600.$}>{description}</span>}
+        {description && <span css={Css.sm.color(Tokens.OnSurface).if(isDisabled).gray600.$}>{description}</span>}
       </span>
     </SelectCardShell>
   );

--- a/src/inputs/SelectCard/ListSelectCard.tsx
+++ b/src/inputs/SelectCard/ListSelectCard.tsx
@@ -48,7 +48,7 @@ export function ListSelectCard(props: SelectCardItemProps) {
         )}
         <span css={Css.smSb.color(Tokens.OnSurface).if(isDisabled).gray600.$}>{label}</span>
       </div>
-      {description && <span css={Css.ml3.xs.color(Tokens.OnSurface).if(isDisabled).gray600.$}>{description}</span>}
+      {description && <span css={Css.ml3.sm.color(Tokens.OnSurface).if(isDisabled).gray600.$}>{description}</span>}
     </SelectCardShell>
   );
 }


### PR DESCRIPTION
Also removes "Mixed Descriptions" storybook example as we'd never actually mix cards with and without descriptions.