### PR TITLE
feat: mount modals under call-site React context via portal outlet

### DIFF
--- a/codemods/add-use-modal-portal.ts
+++ b/codemods/add-use-modal-portal.ts
@@ -1,0 +1,205 @@
+/**
+ * Codemod: ensure components that call `useModal()` from `@homebound/beam` (or Beam relative
+ * imports) render `{modal.portal}` (or `{alias.portal}`) in the same function body.
+ *
+ * Usage (from a consumer repo, with beam as a sibling):
+ *
+ *   npx jscodeshift -t ../beam/codemods/add-use-modal-portal.ts src \
+ *     --extensions=tsx,ts,jsx,js --parser=tsx
+ *
+ * The transform is conservative:
+ * - Handles `const modal = useModal()`, `const { openModal, ... } = useModal()`, and renames.
+ * - If the hook result is already a single identifier, appends `{ident.portal}` before the
+ *   last return (or at end of function body for arrow-expression conversions).
+ * - If the hook is destructured without `portal`, rewrites to keep a `modal` (or existing)
+ *   binding that includes portal, or adds `portal` to the destructure and renders it.
+ */
+
+export default function transformer(file: any, api: any) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let dirty = false;
+
+  function isUseModalCallee(callee: any): boolean {
+    if (j.Identifier.check(callee) && callee.name === "useModal") return true;
+    if (j.MemberExpression.check(callee) && j.Identifier.check(callee.property) && callee.property.name === "useModal") {
+      return true;
+    }
+    return false;
+  }
+
+  function hasPortalJsx(fnPath: any, portalIdent: string): boolean {
+    return (
+      j(fnPath)
+        .find(j.JSXExpressionContainer)
+        .filter((p: any) => {
+          const expr = p.value.expression;
+          return (
+            j.MemberExpression.check(expr) &&
+            j.Identifier.check(expr.object) &&
+            expr.object.name === portalIdent &&
+            j.Identifier.check(expr.property) &&
+            expr.property.name === "portal"
+          );
+        })
+        .size() > 0
+    );
+  }
+
+  function insertPortalBeforeReturn(fnPath: any, portalIdent: string) {
+    const body = fnPath.value.body;
+    if (!j.BlockStatement.check(body)) {
+      // Arrow with expression body — wrap
+      fnPath.value.body = j.blockStatement([
+        j.returnStatement(
+          j.jsxFragment(j.jsxOpeningFragment(), j.jsxClosingFragment(), [
+            j.jsxExpressionContainer(body),
+            j.jsxExpressionContainer(j.memberExpression(j.identifier(portalIdent), j.identifier("portal"))),
+          ]),
+        ),
+      ]);
+      dirty = true;
+      return;
+    }
+
+    const returns = body.body.filter((s: any) => j.ReturnStatement.check(s));
+    if (returns.length === 0) {
+      body.body.push(
+        j.returnStatement(
+          j.jsxExpressionContainer(j.memberExpression(j.identifier(portalIdent), j.identifier("portal"))),
+        ),
+      );
+      dirty = true;
+      return;
+    }
+
+    // Insert portal into the last return if it's JSX; otherwise append a fragment wrapper.
+    const lastReturn = returns[returns.length - 1];
+    const arg = lastReturn.argument;
+    if (!arg) return;
+
+    const portalExpr = j.jsxExpressionContainer(j.memberExpression(j.identifier(portalIdent), j.identifier("portal")));
+
+    if (j.JSXElement.check(arg) || j.JSXFragment.check(arg)) {
+      if (j.JSXFragment.check(arg)) {
+        arg.children.push(portalExpr);
+      } else {
+        lastReturn.argument = j.jsxFragment(j.jsxOpeningFragment(), j.jsxClosingFragment(), [
+          j.jsxElement(arg.openingElement, arg.closingElement, arg.children),
+          portalExpr,
+        ]);
+      }
+      dirty = true;
+      return;
+    }
+
+    // Return of non-JSX — wrap in fragment
+    lastReturn.argument = j.jsxFragment(j.jsxOpeningFragment(), j.jsxClosingFragment(), [
+      j.jsxExpressionContainer(arg),
+      portalExpr,
+    ]);
+    dirty = true;
+  }
+
+  function processFunction(fnPath: any) {
+    // Find useModal() declarators in this function scope only (not nested functions).
+    const declarators = j(fnPath)
+      .find(j.VariableDeclarator)
+      .filter((p: any) => {
+        // Skip nested function scopes
+        let parent = p.parent;
+        while (parent) {
+          if (
+            parent.node === fnPath.node ||
+            parent.value === fnPath.value
+          ) {
+            break;
+          }
+          if (
+            j.FunctionDeclaration.check(parent.value) ||
+            j.FunctionExpression.check(parent.value) ||
+            j.ArrowFunctionExpression.check(parent.value)
+          ) {
+            return false;
+          }
+          parent = parent.parent;
+        }
+        const init = p.value.init;
+        return init && j.CallExpression.check(init) && isUseModalCallee(init.callee);
+      });
+
+    declarators.forEach((declPath: any) => {
+      const id = declPath.value.id;
+
+      // const modal = useModal()
+      if (j.Identifier.check(id)) {
+        const name = id.name;
+        if (!hasPortalJsx(fnPath, name)) {
+          insertPortalBeforeReturn(fnPath, name);
+        }
+        return;
+      }
+
+      // const { openModal, closeModal } = useModal()
+      if (j.ObjectPattern.check(id)) {
+        const props = id.properties;
+        let portalLocal: string | null = null;
+        let hasPortalProp = false;
+        let hostName = "modal";
+
+        for (const prop of props) {
+          if (!j.Property.check(prop) && !j.ObjectProperty.check(prop)) continue;
+          const key = prop.key;
+          const value = prop.value;
+          if (j.Identifier.check(key) && key.name === "portal") {
+            hasPortalProp = true;
+            portalLocal = j.Identifier.check(value) ? value.name : "portal";
+          }
+        }
+
+        if (!hasPortalProp) {
+          // Prefer renaming to `const modal = useModal()` when destructure is simple enough,
+          // otherwise add `portal` to the pattern.
+          props.push(j.property("init", j.identifier("portal"), j.identifier("portal")));
+          portalLocal = "portal";
+          dirty = true;
+        }
+
+        if (portalLocal && !hasPortalJsx(fnPath, portalLocal === "portal" ? "portal" : portalLocal)) {
+          // For destructured `portal`, JSX is `{portal}` not `{modal.portal}`
+          if (portalLocal === "portal" || hasPortalProp) {
+            // Insert `{portal}` — reuse insert logic with a fake member by wrapping
+            const body = fnPath.value.body;
+            if (j.BlockStatement.check(body)) {
+              const returns = body.body.filter((s: any) => j.ReturnStatement.check(s));
+              const lastReturn = returns[returns.length - 1];
+              if (lastReturn?.argument && (j.JSXElement.check(lastReturn.argument) || j.JSXFragment.check(lastReturn.argument))) {
+                const portalExpr = j.jsxExpressionContainer(j.identifier(portalLocal));
+                if (j.JSXFragment.check(lastReturn.argument)) {
+                  lastReturn.argument.children.push(portalExpr);
+                } else {
+                  const el = lastReturn.argument;
+                  lastReturn.argument = j.jsxFragment(j.jsxOpeningFragment(), j.jsxClosingFragment(), [
+                    j.jsxElement(el.openingElement, el.closingElement, el.children),
+                    portalExpr,
+                  ]);
+                }
+                dirty = true;
+              } else {
+                insertPortalBeforeReturn(fnPath, hostName);
+              }
+            }
+          } else {
+            insertPortalBeforeReturn(fnPath, portalLocal);
+          }
+        }
+      }
+    });
+  }
+
+  root.find(j.FunctionDeclaration).forEach(processFunction);
+  root.find(j.FunctionExpression).forEach(processFunction);
+  root.find(j.ArrowFunctionExpression).forEach(processFunction);
+
+  return dirty ? root.toSource({ quote: "double" }) : file.source;
+}

--- a/codemods/add-use-modal-portal.ts
+++ b/codemods/add-use-modal-portal.ts
@@ -1,6 +1,6 @@
 /**
  * Codemod: ensure components that call `useModal()` from `@homebound/beam` (or Beam relative
- * imports) render `{modal.portal}` (or `{alias.portal}`) in the same function body.
+ * imports) render `{modal.portal}` (or `{alias.portal}` / `{portal}`) in the same function body.
  *
  * Usage (from a consumer repo, with beam as a sibling):
  *
@@ -9,10 +9,11 @@
  *
  * The transform is conservative:
  * - Handles `const modal = useModal()`, `const { openModal, ... } = useModal()`, and renames.
- * - If the hook result is already a single identifier, appends `{ident.portal}` before the
- *   last return (or at end of function body for arrow-expression conversions).
- * - If the hook is destructured without `portal`, rewrites to keep a `modal` (or existing)
- *   binding that includes portal, or adds `portal` to the destructure and renders it.
+ * - Only inserts a portal outlet into JSX returns (element or fragment).
+ * - If the function returns an ObjectExpression (common for wrapper hooks), adds `portal` to
+ *   that object instead of wrapping in a fragment.
+ * - Skips other non-JSX returns (arrays, identifiers, call expressions, etc.) so callers can
+ *   fix those stragglers manually — never wraps them in `<>...</>`.
  */
 
 export default function transformer(file: any, api: any) {
@@ -34,6 +35,9 @@ export default function transformer(file: any, api: any) {
         .find(j.JSXExpressionContainer)
         .filter((p: any) => {
           const expr = p.value.expression;
+          // {portal}
+          if (j.Identifier.check(expr) && expr.name === portalIdent) return true;
+          // {modal.portal}
           return (
             j.MemberExpression.check(expr) &&
             j.Identifier.check(expr.object) &&
@@ -46,75 +50,106 @@ export default function transformer(file: any, api: any) {
     );
   }
 
-  function insertPortalBeforeReturn(fnPath: any, portalIdent: string) {
+  function hasPortalInReturnedObject(fnPath: any): boolean {
     const body = fnPath.value.body;
     if (!j.BlockStatement.check(body)) {
-      // Arrow with expression body — wrap
-      fnPath.value.body = j.blockStatement([
-        j.returnStatement(
-          j.jsxFragment(j.jsxOpeningFragment(), j.jsxClosingFragment(), [
-            j.jsxExpressionContainer(body),
-            j.jsxExpressionContainer(j.memberExpression(j.identifier(portalIdent), j.identifier("portal"))),
-          ]),
-        ),
+      return j.ObjectExpression.check(body) && objectHasPortalProp(body);
+    }
+    return body.body.some((s: any) => {
+      if (!j.ReturnStatement.check(s) || !s.argument) return false;
+      return j.ObjectExpression.check(s.argument) && objectHasPortalProp(s.argument);
+    });
+  }
+
+  function objectHasPortalProp(obj: any): boolean {
+    return obj.properties.some((prop: any) => {
+      if (!j.Property.check(prop) && !j.ObjectProperty.check(prop) && !j.SpreadProperty.check(prop)) return false;
+      if (j.SpreadProperty.check(prop) || prop.type === "SpreadElement") return false;
+      const key = prop.key;
+      return (j.Identifier.check(key) && key.name === "portal") || (j.Literal.check(key) && key.value === "portal");
+    });
+  }
+
+  function portalJsxExpr(portalIdent: string, asMember: boolean) {
+    const expr = asMember
+      ? j.memberExpression(j.identifier(portalIdent), j.identifier("portal"))
+      : j.identifier(portalIdent);
+    return j.jsxExpressionContainer(expr);
+  }
+
+  function insertPortalIntoJsxReturn(lastReturn: any, portalIdent: string, asMember: boolean): boolean {
+    const arg = lastReturn.argument;
+    if (!arg) return false;
+    const portalExpr = portalJsxExpr(portalIdent, asMember);
+
+    if (j.JSXFragment.check(arg)) {
+      arg.children.push(portalExpr);
+      return true;
+    }
+    if (j.JSXElement.check(arg)) {
+      lastReturn.argument = j.jsxFragment(j.jsxOpeningFragment(), j.jsxClosingFragment(), [
+        j.jsxElement(arg.openingElement, arg.closingElement, arg.children),
+        portalExpr,
       ]);
-      dirty = true;
-      return;
+      return true;
+    }
+    return false;
+  }
+
+  function addPortalToObjectReturn(lastReturn: any, portalIdent: string): boolean {
+    const arg = lastReturn.argument;
+    if (!arg || !j.ObjectExpression.check(arg)) return false;
+    if (objectHasPortalProp(arg)) return false;
+    arg.properties.push(j.property("init", j.identifier("portal"), j.identifier(portalIdent)));
+    return true;
+  }
+
+  /** Returns true if portal was placed (JSX or object). False = straggler, skip mutating destructure. */
+  function placePortalOutlet(fnPath: any, portalIdent: string, asMember: boolean): boolean {
+    const body = fnPath.value.body;
+
+    // Arrow with expression body
+    if (!j.BlockStatement.check(body)) {
+      if (j.JSXElement.check(body) || j.JSXFragment.check(body)) {
+        const portalExpr = portalJsxExpr(portalIdent, asMember);
+        if (j.JSXFragment.check(body)) {
+          body.children.push(portalExpr);
+        } else {
+          fnPath.value.body = j.jsxFragment(j.jsxOpeningFragment(), j.jsxClosingFragment(), [
+            j.jsxElement(body.openingElement, body.closingElement, body.children),
+            portalExpr,
+          ]);
+        }
+        return true;
+      }
+      if (j.ObjectExpression.check(body)) {
+        if (!objectHasPortalProp(body)) {
+          body.properties.push(j.property("init", j.identifier("portal"), j.identifier(portalIdent)));
+        }
+        return true;
+      }
+      // Non-JSX expression body — leave alone
+      return false;
     }
 
     const returns = body.body.filter((s: any) => j.ReturnStatement.check(s));
-    if (returns.length === 0) {
-      body.body.push(
-        j.returnStatement(
-          j.jsxExpressionContainer(j.memberExpression(j.identifier(portalIdent), j.identifier("portal"))),
-        ),
-      );
-      dirty = true;
-      return;
-    }
+    if (returns.length === 0) return false;
 
-    // Insert portal into the last return if it's JSX; otherwise append a fragment wrapper.
     const lastReturn = returns[returns.length - 1];
-    const arg = lastReturn.argument;
-    if (!arg) return;
+    if (!lastReturn.argument) return false;
 
-    const portalExpr = j.jsxExpressionContainer(j.memberExpression(j.identifier(portalIdent), j.identifier("portal")));
-
-    if (j.JSXElement.check(arg) || j.JSXFragment.check(arg)) {
-      if (j.JSXFragment.check(arg)) {
-        arg.children.push(portalExpr);
-      } else {
-        lastReturn.argument = j.jsxFragment(j.jsxOpeningFragment(), j.jsxClosingFragment(), [
-          j.jsxElement(arg.openingElement, arg.closingElement, arg.children),
-          portalExpr,
-        ]);
-      }
-      dirty = true;
-      return;
-    }
-
-    // Return of non-JSX — wrap in fragment
-    lastReturn.argument = j.jsxFragment(j.jsxOpeningFragment(), j.jsxClosingFragment(), [
-      j.jsxExpressionContainer(arg),
-      portalExpr,
-    ]);
-    dirty = true;
+    if (insertPortalIntoJsxReturn(lastReturn, portalIdent, asMember)) return true;
+    if (addPortalToObjectReturn(lastReturn, portalIdent)) return true;
+    return false;
   }
 
   function processFunction(fnPath: any) {
-    // Find useModal() declarators in this function scope only (not nested functions).
     const declarators = j(fnPath)
       .find(j.VariableDeclarator)
       .filter((p: any) => {
-        // Skip nested function scopes
         let parent = p.parent;
         while (parent) {
-          if (
-            parent.node === fnPath.node ||
-            parent.value === fnPath.value
-          ) {
-            break;
-          }
+          if (parent.node === fnPath.node || parent.value === fnPath.value) break;
           if (
             j.FunctionDeclaration.check(parent.value) ||
             j.FunctionExpression.check(parent.value) ||
@@ -134,20 +169,17 @@ export default function transformer(file: any, api: any) {
       // const modal = useModal()
       if (j.Identifier.check(id)) {
         const name = id.name;
-        if (!hasPortalJsx(fnPath, name)) {
-          insertPortalBeforeReturn(fnPath, name);
-        }
+        if (hasPortalJsx(fnPath, name) || hasPortalInReturnedObject(fnPath)) return;
+        if (placePortalOutlet(fnPath, name, true)) dirty = true;
         return;
       }
 
       // const { openModal, closeModal } = useModal()
       if (j.ObjectPattern.check(id)) {
-        const props = id.properties;
         let portalLocal: string | null = null;
         let hasPortalProp = false;
-        let hostName = "modal";
 
-        for (const prop of props) {
+        for (const prop of id.properties) {
           if (!j.Property.check(prop) && !j.ObjectProperty.check(prop)) continue;
           const key = prop.key;
           const value = prop.value;
@@ -157,42 +189,18 @@ export default function transformer(file: any, api: any) {
           }
         }
 
-        if (!hasPortalProp) {
-          // Prefer renaming to `const modal = useModal()` when destructure is simple enough,
-          // otherwise add `portal` to the pattern.
-          props.push(j.property("init", j.identifier("portal"), j.identifier("portal")));
-          portalLocal = "portal";
-          dirty = true;
-        }
+        if (hasPortalJsx(fnPath, portalLocal ?? "portal") || hasPortalInReturnedObject(fnPath)) return;
 
-        if (portalLocal && !hasPortalJsx(fnPath, portalLocal === "portal" ? "portal" : portalLocal)) {
-          // For destructured `portal`, JSX is `{portal}` not `{modal.portal}`
-          if (portalLocal === "portal" || hasPortalProp) {
-            // Insert `{portal}` — reuse insert logic with a fake member by wrapping
-            const body = fnPath.value.body;
-            if (j.BlockStatement.check(body)) {
-              const returns = body.body.filter((s: any) => j.ReturnStatement.check(s));
-              const lastReturn = returns[returns.length - 1];
-              if (lastReturn?.argument && (j.JSXElement.check(lastReturn.argument) || j.JSXFragment.check(lastReturn.argument))) {
-                const portalExpr = j.jsxExpressionContainer(j.identifier(portalLocal));
-                if (j.JSXFragment.check(lastReturn.argument)) {
-                  lastReturn.argument.children.push(portalExpr);
-                } else {
-                  const el = lastReturn.argument;
-                  lastReturn.argument = j.jsxFragment(j.jsxOpeningFragment(), j.jsxClosingFragment(), [
-                    j.jsxElement(el.openingElement, el.closingElement, el.children),
-                    portalExpr,
-                  ]);
-                }
-                dirty = true;
-              } else {
-                insertPortalBeforeReturn(fnPath, hostName);
-              }
-            }
-          } else {
-            insertPortalBeforeReturn(fnPath, portalLocal);
-          }
+        // Try placing outlet first; only mutate the destructure if we can place it.
+        const localName = portalLocal ?? "portal";
+        const asMember = false; // destructured portal renders as {portal}
+        const placed = placePortalOutlet(fnPath, localName, asMember);
+        if (!placed) return;
+
+        if (!hasPortalProp) {
+          id.properties.push(j.property("init", j.identifier("portal"), j.identifier("portal")));
         }
+        dirty = true;
       }
     });
   }
@@ -201,5 +209,6 @@ export default function transformer(file: any, api: any) {
   root.find(j.FunctionExpression).forEach(processFunction);
   root.find(j.ArrowFunctionExpression).forEach(processFunction);
 
-  return dirty ? root.toSource({ quote: "double" }) : file.source;
+  // Preserve existing quote style / formatting as much as recast allows
+  return dirty ? root.toSource() : file.source;
 }

--- a/docs/modals.md
+++ b/docs/modals.md
@@ -1,10 +1,14 @@
-# Beam modals (call-site portals)
+# Beam modals
 
-## Contract
+## Overview
 
-`useModal()` owns a **local** modal host. Imperative `openModal` / `closeModal` are unchanged, but modal content mounts under the **calling component’s React tree** (full caller context). DOM paint still goes through react-aria `OverlayContainer` under Beam’s `OverlayProvider` — not a raw `document.body` portal and not a new React root.
+`useModal()` provides an imperative API (`openModal`, `closeModal`, and related helpers) for opening a modal whose content mounts in the **calling component’s React tree**. That means modal content inherits the same React context as the caller.
 
-Every component that calls `useModal()` **must** render the returned `portal` in the same function:
+Visually, the modal paints through react-aria’s `OverlayContainer` under Beam’s `OverlayProvider` — not via a raw `document.body` portal or a separate React root.
+
+## Usage
+
+Every component that calls `useModal()` must render the returned `portal` in the same function:
 
 ```tsx
 function MyPage() {
@@ -19,23 +23,23 @@ function MyPage() {
 }
 ```
 
-- `portal` is empty when closed; when open it renders `<Modal />` from this call site.
-- Prefer a single return object (`modal.portal`) so lint can tie the hook to the outlet.
-- If `portal` is missing, `openModal` is a **no-op** and logs a **dev error**. There is no legacy BeamProvider sibling `<Modal />` fallback.
+- `portal` is empty when the modal is closed; when open, it renders `<Modal />` from this call site.
+- Prefer keeping the hook result as a single object (`modal.portal`) so lint can associate the hook with the outlet.
+- If `portal` is not rendered, `openModal` is a no-op and logs a development error.
 
-## What stayed the same
+## Behavior
 
-- One modal at a time (a new `openModal` replaces the previous).
-- `ModalHeader` / `ModalBody` / `ModalFooter` APIs.
-- SuperDrawer remains a BeamProvider-owned host (not call-site portals in v1). Drawer confirm dialogs use an internal host under `OverlayProvider`.
+- Only one modal is open at a time; a new `openModal` replaces the previous modal.
+- Use `ModalHeader`, `ModalBody`, and `ModalFooter` for consistent modal layout.
+- SuperDrawer is hosted by `BeamProvider` (not call-site portals). Confirm dialogs opened from the drawer use an internal host under `OverlayProvider`.
 
-## Migration
+## Adding outlets at existing call sites
 
-Run the codemod to add `{modal.portal}` at existing call sites:
+To insert `{modal.portal}` (or equivalent) at call sites that already use `useModal()`:
 
 ```bash
 # from the consumer repo (e.g. internal-frontend), with beam as a sibling:
 npx jscodeshift -t ../beam/codemods/add-use-modal-portal.ts src --extensions=tsx,ts,jsx,js --parser=tsx
 ```
 
-Then fix any remaining sites flagged by the `@homebound` ESLint `useModal` portal-outlet rule (once published).
+The `@homebound/require-use-modal-portal` ESLint rule flags call sites that omit the outlet.

--- a/docs/modals.md
+++ b/docs/modals.md
@@ -1,0 +1,41 @@
+# Beam modals (call-site portals)
+
+## Contract
+
+`useModal()` owns a **local** modal host. Imperative `openModal` / `closeModal` are unchanged, but modal content mounts under the **calling component’s React tree** (full caller context). DOM paint still goes through react-aria `OverlayContainer` under Beam’s `OverlayProvider` — not a raw `document.body` portal and not a new React root.
+
+Every component that calls `useModal()` **must** render the returned `portal` in the same function:
+
+```tsx
+function MyPage() {
+  const modal = useModal();
+
+  return (
+    <>
+      <Button label="Edit" onClick={() => modal.openModal({ content: <EditForm /> })} />
+      {modal.portal}
+    </>
+  );
+}
+```
+
+- `portal` is empty when closed; when open it renders `<Modal />` from this call site.
+- Prefer a single return object (`modal.portal`) so lint can tie the hook to the outlet.
+- If `portal` is missing, `openModal` is a **no-op** and logs a **dev error**. There is no legacy BeamProvider sibling `<Modal />` fallback.
+
+## What stayed the same
+
+- One modal at a time (a new `openModal` replaces the previous).
+- `ModalHeader` / `ModalBody` / `ModalFooter` APIs.
+- SuperDrawer remains a BeamProvider-owned host (not call-site portals in v1). Drawer confirm dialogs use an internal host under `OverlayProvider`.
+
+## Migration
+
+Run the codemod to add `{modal.portal}` at existing call sites:
+
+```bash
+# from the consumer repo (e.g. internal-frontend), with beam as a sibling:
+npx jscodeshift -t ../beam/codemods/add-use-modal-portal.ts src --extensions=tsx,ts,jsx,js --parser=tsx
+```
+
+Then fix any remaining sites flagged by the `@homebound` ESLint `useModal` portal-outlet rule (once published).

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "dist",
     "!dist/**/*.{stories,test}.*",
     "!dist/setupTests.*",
-    "docs/layout-shells.md"
+    "docs/layout-shells.md",
+    "docs/modals.md",
+    "codemods"
   ],
   "engines": {
     "node": "~22.14.0"
@@ -30,7 +32,8 @@
     },
     "./Css.json": "./dist/Css.json",
     "./index.css": "./dist/index.css",
-    "./docs/layout-shells.md": "./docs/layout-shells.md"
+    "./docs/layout-shells.md": "./docs/layout-shells.md",
+    "./docs/modals.md": "./docs/modals.md"
   },
   "scripts": {
     "start": "yarn storybook",

--- a/src/components/BeamContext.test.tsx
+++ b/src/components/BeamContext.test.tsx
@@ -1,0 +1,25 @@
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+/**
+ * Guards the main-style SuperDrawer host: sibling under ToastProvider, outside OverlayProvider.
+ * Call-site modals + InternalModalHost stay under OverlayProvider.
+ */
+describe("BeamProvider overlay tree", () => {
+  it("keeps SuperDrawer outside OverlayProvider (main-style host)", () => {
+    const src = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "BeamContext.tsx"), "utf8");
+    const overlayClose = src.indexOf("</OverlayProvider>");
+    const internalHost = src.indexOf("<InternalModalHost");
+    const superDrawer = src.indexOf("<SuperDrawer");
+
+    expect(overlayClose).toBeGreaterThan(-1);
+    expect(internalHost).toBeGreaterThan(-1);
+    expect(superDrawer).toBeGreaterThan(-1);
+
+    // InternalModalHost must stay under OverlayProvider for OverlayContainer paint
+    expect(internalHost).toBeLessThan(overlayClose);
+    // SuperDrawer must remain a ToastProvider sibling outside OverlayProvider (as on main)
+    expect(superDrawer).toBeGreaterThan(overlayClose);
+  });
+});

--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -83,7 +83,6 @@ export function BeamProvider({ children, documentTitleConfig, ...presentationPro
           <SnackbarProvider>
             {/* OverlayProvider is required for Modals generated via React-Aria */}
             <ToastProvider>
-              {/* OverlayProvider is required for Modals generated via React-Aria */}
               <OverlayProvider>
                 {children}
                 {/* Beam-internal modal host for SuperDrawer ConfirmCloseModal only — not app useModal. */}

--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -2,26 +2,30 @@ import { createContext, MutableRefObject, PropsWithChildren, useContext, useMemo
 import { OverlayProvider } from "react-aria";
 import { AutoSaveStatusProvider } from "src/components/AutoSaveStatus/index";
 import { DocumentTitleConfig, DocumentTitleProvider } from "src/components/DocumentTitle";
-import { Modal, ModalProps } from "src/components/Modal/Modal";
+import { InternalModalHost } from "src/components/Modal/InternalModalHost";
+import { createModalCoordinator, ModalCoordinator } from "src/components/Modal/ModalCoordinator";
+import { ModalProps } from "src/components/Modal/Modal";
 import { PresentationContextProps, PresentationProvider } from "src/components/PresentationContext";
 import { SnackbarProvider } from "src/components/Snackbar/SnackbarContext";
 import { SuperDrawer } from "src/components/SuperDrawer/SuperDrawer";
 import { ContentStack } from "src/components/SuperDrawer/useSuperDrawer";
-import { CanCloseCheck, CheckFn } from "src/types";
+import { CanCloseCheck } from "src/types";
 import { EmptyRef } from "src/utils/index";
 import { RightPaneProvider } from "./Layout";
 import { ToastProvider } from "./Toast/ToastContext";
 
+/** Beam-internal API for SuperDrawer confirm modals (not for app useModal call sites). */
+export type InternalModalApi = {
+  openModal: (props: ModalProps) => void;
+  forceClose: () => void;
+};
+
 /** The internal state of our Beam context; see useModal and useSuperDrawer for the public APIs. */
 export type BeamContextState = {
-  modalState: MutableRefObject<ModalProps | undefined>;
-  modalCanCloseChecks: MutableRefObject<CheckFn[]>;
-  /** The div for ModalHeader to portal into. */
-  modalHeaderDiv: HTMLDivElement;
-  /** The div for ModalBody to portal into; note this can't be a ref b/c Modal hasn't set the ref at the time ModalBody renders. */
-  modalBodyDiv: HTMLDivElement;
-  /** The div for ModalFooter to portal into. */
-  modalFooterDiv: HTMLDivElement;
+  /** Coordinates one-modal-at-a-time and force-close for SuperDrawer. */
+  modalCoordinator: ModalCoordinator;
+  /** Set by InternalModalHost; used by useSuperDrawer for ConfirmCloseModal. */
+  internalModalApi: MutableRefObject<InternalModalApi | undefined>;
   /** SuperDrawer contentStack, i.e. the main/non-detail content + 0-N detail contents. */
   drawerContentStack: MutableRefObject<readonly ContentStack[]>;
   /** Checks when closing SuperDrawer, for the main/non-detail drawer content. */
@@ -34,11 +38,8 @@ export type BeamContextState = {
 
 /** This is only exported internally, for useModal and useSuperDrawer, it's not a public API. */
 export const BeamContext = createContext<BeamContextState>({
-  modalState: new EmptyRef(),
-  modalCanCloseChecks: new EmptyRef(),
-  modalHeaderDiv: undefined!,
-  modalBodyDiv: undefined!,
-  modalFooterDiv: undefined!,
+  modalCoordinator: createModalCoordinator(),
+  internalModalApi: new EmptyRef(),
   drawerContentStack: new EmptyRef(),
   drawerCanCloseChecks: new EmptyRef(),
   drawerCanCloseDetailsChecks: new EmptyRef(),
@@ -55,16 +56,8 @@ export function BeamProvider({ children, documentTitleConfig, ...presentationPro
   // dependencies as well, i.e. things like GridTable rowStyles will memoize on openInDrawer.
   // So we use refs + a tick.
   const [, tick] = useReducer((prev) => prev + 1, 0);
-  const modalRef = useRef<ModalProps | undefined>();
-  const modalHeaderDiv = useMemo(() => document.createElement("div"), []);
-  const modalBodyDiv = useMemo(() => {
-    const el = document.createElement("div");
-    // Ensure this wrapping div takes up the full height of its container in the case of a virtualized table within.
-    el.style.height = "100%";
-    return el;
-  }, []);
-  const modalCanCloseChecksRef = useRef<CheckFn[]>([]);
-  const modalFooterDiv = useMemo(() => document.createElement("div"), []);
+  const modalCoordinator = useMemo(() => createModalCoordinator(), []);
+  const internalModalApi = useRef<InternalModalApi | undefined>();
   const drawerContentStackRef = useRef<ContentStack[]>([]);
   const drawerCanCloseChecks = useRef<CanCloseCheck[]>([]);
   const drawerCanCloseDetailsChecks = useRef<CanCloseCheck[][]>([]);
@@ -74,19 +67,14 @@ export function BeamProvider({ children, documentTitleConfig, ...presentationPro
   // have the setters call `tick` to re-render this Provider
   const context = useMemo<BeamContextState>(() => {
     return {
-      // These two keys need to trigger re-renders on change
-      modalState: new PretendRefThatTicks(modalRef, tick),
+      modalCoordinator,
+      internalModalApi,
       drawerContentStack: new PretendRefThatTicks(drawerContentStackRef, tick),
-      // The rest we don't need to re-render when these are mutated, so just expose as-is
-      modalCanCloseChecks: modalCanCloseChecksRef,
-      modalHeaderDiv,
-      modalBodyDiv,
-      modalFooterDiv,
       drawerCanCloseChecks,
       drawerCanCloseDetailsChecks,
       sdHeaderDiv,
     };
-  }, [modalBodyDiv, modalFooterDiv, modalHeaderDiv, sdHeaderDiv]);
+  }, [modalCoordinator, sdHeaderDiv]);
 
   const beamTree = (
     <PresentationProvider {...presentationProps}>
@@ -97,9 +85,11 @@ export function BeamProvider({ children, documentTitleConfig, ...presentationPro
             <ToastProvider>
               <OverlayProvider>
                 {children}
-                {modalRef.current && <Modal {...modalRef.current} />}
+                {/* Beam-internal modal host for SuperDrawer ConfirmCloseModal only — not app useModal. */}
+                <InternalModalHost />
+                {/* Still BeamProvider-owned (not call-site); under OverlayProvider so createPortal keeps overlay context. */}
+                <SuperDrawer />
               </OverlayProvider>
-              <SuperDrawer />
             </ToastProvider>
           </SnackbarProvider>
         </AutoSaveStatusProvider>

--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -83,13 +83,14 @@ export function BeamProvider({ children, documentTitleConfig, ...presentationPro
           <SnackbarProvider>
             {/* OverlayProvider is required for Modals generated via React-Aria */}
             <ToastProvider>
+              {/* OverlayProvider is required for Modals generated via React-Aria */}
               <OverlayProvider>
                 {children}
                 {/* Beam-internal modal host for SuperDrawer ConfirmCloseModal only — not app useModal. */}
                 <InternalModalHost />
-                {/* Still BeamProvider-owned (not call-site); under OverlayProvider so createPortal keeps overlay context. */}
-                <SuperDrawer />
               </OverlayProvider>
+              {/* Main-style host: sibling under ToastProvider, outside OverlayProvider (not call-site). */}
+              <SuperDrawer />
             </ToastProvider>
           </SnackbarProvider>
         </AutoSaveStatusProvider>

--- a/src/components/Filters/Filters.tsx
+++ b/src/components/Filters/Filters.tsx
@@ -33,7 +33,7 @@ function Filters<F extends Record<string, unknown>, G extends Value = string>(pr
   const { filter, onChange, filterDefs, groupBy, vertical = false, numberOfInlineFilters = groupBy ? 3 : 4 } = props;
   const testId = useTestIds(props, filterTestIdPrefix);
 
-  const { openModal } = useModal();
+  const modal = useModal();
   const [pageFilters, modalFilters] = useMemo(() => {
     // Take the FilterDefs that have a `key => ...` factory and eval it
     const impls = safeEntries(filterDefs).map(([key, fn]) => [key, fn(key as string)]);
@@ -88,7 +88,7 @@ function Filters<F extends Record<string, unknown>, G extends Value = string>(pr
           endAdornment={<CountBadge count={numModalFilters} hideIfZero />}
           variant="secondary"
           onClick={() =>
-            openModal({
+            modal.openModal({
               // Spreading `props` to pass along `data-testid`
               content: <FilterModal {...props} filter={filter} onApply={onChange} filters={modalFilters} />,
             })
@@ -101,6 +101,7 @@ function Filters<F extends Record<string, unknown>, G extends Value = string>(pr
           <Button label="Clear" variant="tertiary" onClick={() => onChange({} as F)} {...testId.clearBtn} />
         </div>
       )}
+      {modal.portal}
     </div>
   );
 }

--- a/src/components/Modal/InternalModalHost.tsx
+++ b/src/components/Modal/InternalModalHost.tsx
@@ -1,0 +1,24 @@
+import { useLayoutEffect } from "react";
+import { useBeamContext } from "src/components/BeamContext";
+import { useModalHost } from "./useModal";
+
+/**
+ * Always-mounted portal host for Beam-internal modals (e.g. SuperDrawer ConfirmCloseModal).
+ * Lives under OverlayProvider so OverlayContainer paint stays correct. Not a fallback for app useModal().
+ */
+export function InternalModalHost() {
+  const { internalModalApi } = useBeamContext();
+  const host = useModalHost({ requirePortal: false });
+
+  useLayoutEffect(() => {
+    internalModalApi.current = {
+      openModal: host.openModal,
+      forceClose: host.closeModalSkippingChecks,
+    };
+    return () => {
+      internalModalApi.current = undefined;
+    };
+  }, [host.closeModalSkippingChecks, host.openModal, internalModalApi]);
+
+  return host.portal;
+}

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -43,7 +43,7 @@ export const WithFieldInHeader = () => <ModalExample withTextArea />;
 export const WithTextFieldInHeader = () => <ModalExample withTextField />;
 export const WithDrawHeaderBorder = () => <ModalExample drawHeaderBorder={true} />;
 export const VirtualizedTableInBody = () => {
-  const { openModal } = useModal();
+  const { openModal, portal } = useModal();
   const open = () =>
     openModal({
       content: <VirtualizedTable />,
@@ -51,11 +51,16 @@ export const VirtualizedTableInBody = () => {
     });
   // Immediately open the modal for Chromatic snapshots
   useEffect(open, [openModal]);
-  return <Button label="Open" onClick={open} />;
+  return (
+    <>
+      <Button label="Open" onClick={open} />
+      {portal}
+    </>
+  );
 };
 
 export const ButtonsInFooter = () => {
-  const { openModal, setSize } = useModal();
+  const { openModal, setSize, portal } = useModal();
   const open = () =>
     openModal({
       content: (
@@ -73,7 +78,12 @@ export const ButtonsInFooter = () => {
   // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(open, [openModal]);
-  return <Button label="Open" onClick={open} />;
+  return (
+    <>
+      <Button label="Open" onClick={open} />
+      {portal}
+    </>
+  );
 };
 
 export const OpenModalTest = () => {
@@ -130,7 +140,7 @@ function ModalExample(props: ModalExampleProps) {
     drawHeaderBorder = false,
     allowClosing = true,
   } = props;
-  const { openModal } = useModal();
+  const { openModal, portal } = useModal();
   const open = () =>
     openModal({
       size,
@@ -143,11 +153,16 @@ function ModalExample(props: ModalExampleProps) {
   // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(open, [openModal]);
-  return <Button label="Open" onClick={open} />;
+  return (
+    <>
+      <Button label="Open" onClick={open} />
+      {portal}
+    </>
+  );
 }
 
 function ModalFilterTableExample({ size, forceScrolling }: Pick<ModalProps, "size" | "forceScrolling">) {
-  const { openModal } = useModal();
+  const { openModal, portal } = useModal();
   const modalProps = {
     size,
     forceScrolling,
@@ -160,7 +175,12 @@ function ModalFilterTableExample({ size, forceScrolling }: Pick<ModalProps, "siz
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(open, [openModal]);
 
-  return <Button label="Open" onClick={open} />;
+  return (
+    <>
+      <Button label="Open" onClick={open} />
+      {portal}
+    </>
+  );
 }
 
 /** Demonstrates that clicking a tooltip rendered inside a modal does not close the modal. */

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -82,14 +82,19 @@ describe("Modal", () => {
 });
 
 function TestModalApp(props: ModalProps & { canClose?: () => boolean }) {
-  const { openModal, addCanClose } = useModal();
+  const { openModal, addCanClose, portal } = useModal();
   // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => openModal(props), [openModal]);
   if (props.canClose) {
     addCanClose(props.canClose);
   }
-  return <h1>Page title</h1>;
+  return (
+    <>
+      <h1>Page title</h1>
+      {portal}
+    </>
+  );
 }
 
 function TestModalComponent({ withTooltip = false }: { withTooltip?: boolean }) {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,16 +1,16 @@
 import { useResizeObserver } from "@react-aria/utils";
-import { MutableRefObject, PropsWithChildren, ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { MutableRefObject, PropsWithChildren, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { FocusScope, OverlayContainer, useDialog, useModal, useOverlay, usePreventScroll } from "react-aria";
 import { createPortal } from "react-dom";
 import { AutoSaveStatusProvider } from "src/components";
-import { useBeamContext } from "src/components/BeamContext";
 import { IconButton } from "src/components/IconButton";
-import { useModal as ourUseModal } from "src/components/Modal/useModal";
 import { Css, Only, Xss } from "src/Css";
 import { useBreakpoint } from "src/hooks";
+import { CheckFn } from "src/types";
 import { useTestIds } from "src/utils";
 import { zIndices } from "src/utils/zIndices";
 import { ModalProvider } from "./ModalContext";
+import { ModalInstanceProvider, useModalInstance } from "./ModalInstanceContext";
 
 export type ModalSize = "sm" | "md" | "lg" | "xl" | "xxl";
 
@@ -42,6 +42,13 @@ export type ModalProps = {
   allowClosing?: boolean;
 };
 
+/** Props injected by useModal's portal host — not part of the public openModal API. */
+export type ModalHostProps = {
+  hostCloseModal: VoidFunction;
+  hostAddCanClose: (canClose: CheckFn) => void;
+  hostSetSize: (size: ModalProps["size"]) => void;
+};
+
 export type ModalApi = {
   setSize: (size: ModalProps["size"]) => void;
 };
@@ -50,18 +57,28 @@ export type ModalApi = {
  * Internal component for displaying a Modal; see `useModal` for the public API.
  *
  * Provides underlay, modal container, and header. Will disable scrolling of page under the modal.
+ * Must be rendered via `useModal().portal` so it mounts under the caller's React tree; paint uses
+ * OverlayContainer under Beam's OverlayProvider.
  */
-export function Modal(props: ModalProps) {
-  const { size = "md", content, forceScrolling, api, drawHeaderBorder = false, allowClosing = true } = props;
+export function Modal(props: ModalProps & ModalHostProps) {
+  const {
+    size = "md",
+    content,
+    forceScrolling,
+    api,
+    drawHeaderBorder = false,
+    allowClosing = true,
+    hostCloseModal,
+    hostAddCanClose,
+    hostSetSize,
+  } = props;
   const isFixedHeight = typeof size !== "string";
   const ref = useRef(null);
-  const { modalBodyDiv, modalFooterDiv, modalHeaderDiv } = useBeamContext();
-  const { closeModal } = ourUseModal();
   const { overlayProps, underlayProps } = useOverlay(
     {
       ...props,
       isOpen: true,
-      onClose: closeModal,
+      onClose: hostCloseModal,
       isDismissable: true,
       shouldCloseOnInteractOutside: (el) => {
         // Do not close the Modal if the user is interacting with the Tribute mentions dropdown (via RichTextField),
@@ -89,6 +106,28 @@ export function Modal(props: ModalProps) {
   usePreventScroll();
   const { sm } = useBreakpoint();
 
+  // Per-modal-instance portal targets (not BeamProvider globals).
+  const modalHeaderDiv = useMemo(() => document.createElement("div"), []);
+  const modalBodyDiv = useMemo(() => {
+    const el = document.createElement("div");
+    // Ensure this wrapping div takes up the full height of its container in the case of a virtualized table within.
+    el.style.height = "100%";
+    return el;
+  }, []);
+  const modalFooterDiv = useMemo(() => document.createElement("div"), []);
+
+  const instanceValue = useMemo(
+    () => ({
+      closeModal: hostCloseModal,
+      addCanClose: hostAddCanClose,
+      setSize: hostSetSize,
+      modalHeaderDiv,
+      modalBodyDiv,
+      modalFooterDiv,
+    }),
+    [hostCloseModal, hostAddCanClose, hostSetSize, modalHeaderDiv, modalBodyDiv, modalFooterDiv],
+  );
+
   if (api) {
     api.current = { setSize: (size = "md") => setSize(getSize(size)) };
   }
@@ -110,75 +149,74 @@ export function Modal(props: ModalProps) {
     ),
   });
 
-  // Even though we use raw-divs for the createPortal calls, we do actually need to
-  // use refs + useEffect to stitch those raw divs back into the React component tree.
-  useEffect(
-    () => {
-      modalHeaderRef.current!.appendChild(modalHeaderDiv);
-      modalBodyRef.current!.appendChild(modalBodyDiv);
-      modalFooterRef.current!.appendChild(modalFooterDiv);
-    },
-    // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [modalBodyRef, modalFooterRef, modalHeaderRef],
-  );
+  // Stitch the portal target divs into the React-owned modal chrome.
+  useEffect(() => {
+    modalHeaderRef.current!.appendChild(modalHeaderDiv);
+    modalBodyRef.current!.appendChild(modalBodyDiv);
+    modalFooterRef.current!.appendChild(modalFooterDiv);
+  }, [modalBodyDiv, modalFooterDiv, modalHeaderDiv]);
 
   return (
-    <ModalProvider>
-      <OverlayContainer>
-        <AutoSaveStatusProvider>
-          <div css={Css.underlay.z(zIndices.modalUnderlay).$} {...underlayProps} {...testId.underlay}>
-            <FocusScope contain restoreFocus autoFocus>
-              <div
-                css={
-                  Css.br24.bgWhite.bshModal.oh
-                    .maxh("90vh")
-                    .df.fdc.wPx(width)
-                    .mhPx(defaultMinHeight)
-                    .if(isFixedHeight)
-                    .hPx(height)
-                    .if(sm)
-                    .add("height", "100dvh")
-                    .add("width", "100dvw")
-                    .maxh("none").br0.$
-                }
-                ref={ref}
-                {...overlayProps}
-                {...dialogProps}
-                {...modalProps}
-                {...testId}
-              >
-                {/*
-                  Setup three children (header, content, footer), and flex grow the content.
+    <ModalInstanceProvider value={instanceValue}>
+      <ModalProvider>
+        <OverlayContainer>
+          <AutoSaveStatusProvider>
+            <div css={Css.underlay.z(zIndices.modalUnderlay).$} {...underlayProps} {...testId.underlay}>
+              <FocusScope contain restoreFocus autoFocus>
+                <div
+                  css={
+                    Css.br24.bgWhite.bshModal.oh
+                      .maxh("90vh")
+                      .df.fdc.wPx(width)
+                      .mhPx(defaultMinHeight)
+                      .if(isFixedHeight)
+                      .hPx(height)
+                      .if(sm)
+                      .add("height", "100dvh")
+                      .add("width", "100dvw")
+                      .maxh("none").br0.$
+                  }
+                  ref={ref}
+                  {...overlayProps}
+                  {...dialogProps}
+                  {...modalProps}
+                  {...testId}
+                >
+                  {/*
+                    Setup three children (header, content, footer), and flex grow the content.
 
-                  Use `fdrr` so that the close icon won't sit between "modal header search field"
-                  and the modal body results in the DOM focus order, i.e. in our global search modal.
-                */}
-                <header css={Css.df.fdrr.p3.fs0.if(drawHeaderBorder).bb.bcGray200.$}>
-                  <span css={Css.fs0.pl1.$}>
-                    {allowClosing && <IconButton icon="x" onClick={closeModal} {...testId.titleClose} />}
-                  </span>
-                  <h1 css={Css.fg1.xl2.gray900.$} ref={modalHeaderRef} {...titleProps} {...testId.title} />
-                </header>
-                <main ref={modalBodyRef} css={Css.fg1.oya.if(hasScroll).bb.bcGray200.if(!!forceScrolling).oys.$}>
-                  {/* We'll include content here, but we expect ModalBody and ModalFooter to use their respective portals. */}
-                  {content}
-                </main>
-                <footer css={Css.fs0.$}>
-                  <div ref={modalFooterRef} />
-                </footer>
-              </div>
-            </FocusScope>
-          </div>
-        </AutoSaveStatusProvider>
-      </OverlayContainer>
-    </ModalProvider>
+                    Use `fdrr` so that the close icon won't sit between "modal header search field"
+                    and the modal body results in the DOM focus order, i.e. in our global search modal.
+                  */}
+                  <header css={Css.df.fdrr.p3.fs0.if(drawHeaderBorder).bb.bcGray200.$}>
+                    <span css={Css.fs0.pl1.$}>
+                      {allowClosing && <IconButton icon="x" onClick={hostCloseModal} {...testId.titleClose} />}
+                    </span>
+                    <h1 css={Css.fg1.xl2.gray900.$} ref={modalHeaderRef} {...titleProps} {...testId.title} />
+                  </header>
+                  <main ref={modalBodyRef} css={Css.fg1.oya.if(hasScroll).bb.bcGray200.if(!!forceScrolling).oys.$}>
+                    {/* We'll include content here, but we expect ModalBody and ModalFooter to use their respective portals. */}
+                    {content}
+                  </main>
+                  <footer css={Css.fs0.$}>
+                    <div ref={modalFooterRef} />
+                  </footer>
+                </div>
+              </FocusScope>
+            </div>
+          </AutoSaveStatusProvider>
+        </OverlayContainer>
+      </ModalProvider>
+    </ModalInstanceProvider>
   );
 }
 
 export function ModalHeader({ children }: { children: ReactNode }): JSX.Element {
-  const { modalHeaderDiv } = useBeamContext();
-  return createPortal(<>{children}</>, modalHeaderDiv);
+  const instance = useModalInstance();
+  if (!instance) {
+    throw new Error("ModalHeader must be rendered inside a Modal (via useModal().portal)");
+  }
+  return createPortal(<>{children}</>, instance.modalHeaderDiv);
 }
 
 /** Provides consistent styling and the scrolling behavior for a modal's primary content. */
@@ -186,14 +224,17 @@ export function ModalBody({
   children,
   virtualized = false,
 }: PropsWithChildren<{ virtualized?: boolean }>): JSX.Element {
-  const { modalBodyDiv } = useBeamContext();
+  const instance = useModalInstance();
+  if (!instance) {
+    throw new Error("ModalBody must be rendered inside a Modal (via useModal().portal)");
+  }
   const testId = useTestIds({}, testIdPrefix);
   return createPortal(
     // If `virtualized`, then we are expecting the `children` will handle their own scrollbar, so have the overflow hidden and adjust padding
     <div css={Css.h100.if(virtualized).oh.pl3.else.px3.$} {...testId.content}>
       {children}
     </div>,
-    modalBodyDiv,
+    instance.modalBodyDiv,
   );
 }
 
@@ -207,13 +248,16 @@ export function ModalFooter<X extends Only<ModalFooterXss, X>>({
   children: ReactNode;
   xss?: X;
 }): JSX.Element {
-  const { modalFooterDiv } = useBeamContext();
+  const instance = useModalInstance();
+  if (!instance) {
+    throw new Error("ModalFooter must be rendered inside a Modal (via useModal().portal)");
+  }
   const testId = useTestIds({}, testIdPrefix);
   return createPortal(
     <div css={{ ...Css.p3.df.aic.jcfe.gap1.$, ...xss }} {...testId.footer}>
       {children}
     </div>,
-    modalFooterDiv,
+    instance.modalFooterDiv,
   );
 }
 

--- a/src/components/Modal/ModalCoordinator.ts
+++ b/src/components/Modal/ModalCoordinator.ts
@@ -1,0 +1,42 @@
+/**
+ * Coordinates Beam modals so only one is active at a time and SuperDrawer can force-close.
+ * Content still mounts under each call-site `useModal().portal`; this does not own the React tree.
+ */
+export type ModalCoordinatorRegistration = {
+  id: string;
+  /** Closes without running canClose checks (used when replacing or SuperDrawer clears). */
+  forceClose: () => void;
+};
+
+export type ModalCoordinator = {
+  /** Registers a newly opened modal; force-closes any previous active modal. */
+  claim: (registration: ModalCoordinatorRegistration) => void;
+  /** Clears the active registration if it still matches `id`. */
+  release: (id: string) => void;
+  /** Force-closes the active modal, if any. */
+  forceCloseActive: () => void;
+};
+
+export function createModalCoordinator(): ModalCoordinator {
+  let active: ModalCoordinatorRegistration | undefined;
+
+  return {
+    claim(registration) {
+      if (active && active.id !== registration.id) {
+        active.forceClose();
+      }
+      active = registration;
+    },
+    release(id) {
+      if (active?.id === id) {
+        active = undefined;
+      }
+    },
+    forceCloseActive() {
+      if (!active) return;
+      const current = active;
+      active = undefined;
+      current.forceClose();
+    },
+  };
+}

--- a/src/components/Modal/ModalDrawerStacking.test.tsx
+++ b/src/components/Modal/ModalDrawerStacking.test.tsx
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { useModal } from "src/components/Modal/useModal";
+import { useSuperDrawer } from "src/components/SuperDrawer";
+import { render } from "src/utils/rtl";
+import { zIndices } from "src/utils/zIndices";
+
+describe("Modal + SuperDrawer stacking", () => {
+  it("stacks modal above an open drawer", async () => {
+    function TestApp() {
+      const { openInDrawer } = useSuperDrawer();
+      const { openModal, portal } = useModal();
+      useEffect(() => {
+        openInDrawer({ content: <div data-testid="drawerBody">Drawer</div> });
+        openModal({ content: <div data-testid="modalBody">Modal</div> });
+      }, [openInDrawer, openModal]);
+      return <div data-testid="app">{portal}</div>;
+    }
+
+    const r = await render(<TestApp />);
+    expect(r.drawerBody).toBeTruthy();
+    expect(r.modalBody).toBeTruthy();
+
+    const underlay = r.getByTestId("modal_underlay");
+    expect(underlay).toHaveStyle({ zIndex: String(zIndices.modalUnderlay) });
+
+    // Modal underlay sits above the drawer scrim in the shared z-index scale
+    expect(zIndices.modalUnderlay).toBeGreaterThan(zIndices.superDrawerScrim);
+  });
+});

--- a/src/components/Modal/ModalInstanceContext.tsx
+++ b/src/components/Modal/ModalInstanceContext.tsx
@@ -1,0 +1,33 @@
+import { createContext, ReactNode, useContext, useMemo } from "react";
+import { CheckFn } from "src/types";
+import { ModalProps } from "./Modal";
+
+/** Per-open-Modal state: portal slots + close/size APIs shared with ModalHeader/Body/Footer and nested useModal(). */
+export type ModalInstanceContextState = {
+  closeModal: VoidFunction;
+  addCanClose: (canClose: CheckFn) => void;
+  setSize: (size: ModalProps["size"]) => void;
+  /** The div for ModalHeader to portal into. */
+  modalHeaderDiv: HTMLDivElement;
+  /** The div for ModalBody to portal into. */
+  modalBodyDiv: HTMLDivElement;
+  /** The div for ModalFooter to portal into. */
+  modalFooterDiv: HTMLDivElement;
+};
+
+export const ModalInstanceContext = createContext<ModalInstanceContextState | undefined>(undefined);
+
+export function useModalInstance(): ModalInstanceContextState | undefined {
+  return useContext(ModalInstanceContext);
+}
+
+interface ModalInstanceProviderProps {
+  value: ModalInstanceContextState;
+  children: ReactNode;
+}
+
+export function ModalInstanceProvider({ value, children }: ModalInstanceProviderProps) {
+  // Keep provider value identity stable when the same fields are passed
+  const memo = useMemo(() => value, [value]);
+  return <ModalInstanceContext.Provider value={memo}>{children}</ModalInstanceContext.Provider>;
+}

--- a/src/components/Modal/OpenModal.tsx
+++ b/src/components/Modal/OpenModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { Modal, ModalProps } from "src/components/Modal/Modal";
 import { useModal } from "src/components/Modal/useModal";
+import { noop } from "src/utils";
 
 export interface OpenModalProps {
   /** The custom modal content to show. */
@@ -31,7 +32,7 @@ export interface OpenModalProps {
  * shows up in the DOM as expected.
  */
 export function OpenModal(props: OpenModalProps): JSX.Element {
-  const { openModal } = useModal();
+  const { openModal, portal } = useModal();
   const { size, children, keepOpen } = props;
   useEffect(() => {
     if (!keepOpen) {
@@ -39,8 +40,20 @@ export function OpenModal(props: OpenModalProps): JSX.Element {
     }
   }, [keepOpen, openModal, size, children]);
   if (keepOpen) {
-    return <Modal size={size} content={children} />;
-  } else {
-    return <div>dummy content</div>;
+    return (
+      <Modal
+        size={size}
+        content={children}
+        hostCloseModal={noop}
+        hostAddCanClose={noop}
+        hostSetSize={noop}
+      />
+    );
   }
+  return (
+    <>
+      <div>dummy content</div>
+      {portal}
+    </>
+  );
 }

--- a/src/components/Modal/useModal.test.tsx
+++ b/src/components/Modal/useModal.test.tsx
@@ -1,6 +1,6 @@
 import { act } from "@testing-library/react";
-import { useEffect } from "react";
-import { BeamContextState, useBeamContext } from "src/components/BeamContext";
+import { createContext, useContext, useEffect } from "react";
+import { useBeamContext } from "src/components/BeamContext";
 import { ModalProps } from "src/components/Modal/Modal";
 import { useModal, UseModalHook } from "src/components/Modal/useModal";
 import { click, render } from "src/utils/rtl";
@@ -14,7 +14,7 @@ describe("useModal", () => {
 
     function TestApp() {
       context = useModal();
-      return <div />;
+      return <div>{context.portal}</div>;
     }
 
     // When rendering a component without a modal defined
@@ -36,11 +36,11 @@ describe("useModal", () => {
 
   it("can provide a custom canClose method", async () => {
     function TestApp(props: ModalProps) {
-      const { openModal } = useModal();
+      const { openModal, portal } = useModal();
       // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects
       // eslint-disable-next-line react-hooks/exhaustive-deps
       useEffect(() => openModal(props), []);
-      return <div>App</div>;
+      return <div>App{portal}</div>;
     }
 
     // Given a modal that sets a custom `canClose` method
@@ -63,14 +63,12 @@ describe("useModal", () => {
   });
 
   it("can close modal when checks pass", async () => {
-    let beamContext: BeamContextState;
     function TestApp(props: ModalProps) {
-      beamContext = useBeamContext();
-      const { openModal } = useModal();
+      const { openModal, portal } = useModal();
       // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects
       // eslint-disable-next-line react-hooks/exhaustive-deps
       useEffect(() => openModal(props), []);
-      return <div>App</div>;
+      return <div>App{portal}</div>;
     }
 
     // Given a modal that sets a custom `canClose` method
@@ -92,17 +90,19 @@ describe("useModal", () => {
     // And the modal should have closed since the canClose check is true.
     expect(onClose).toBeCalledTimes(1);
     expect(r.queryByTestId("modal")).toBeFalsy();
-
-    // And the BeamContext has been cleared
-    expect(beamContext!.modalCanCloseChecks.current).toEqual([]);
   });
 
   it("can identify when component is In Modal", async () => {
     // Given a test app that opens a modal with content that checks if it is in a modal
     function TestApp(props: ModalProps) {
-      const { openModal, inModal } = useModal();
+      const { openModal, inModal, portal } = useModal();
       useEffect(() => openModal(props), [openModal, props]);
-      return <div data-testid="testApp">Behind Modal: InModal? {String(inModal)}</div>;
+      return (
+        <div data-testid="testApp">
+          Behind Modal: InModal? {String(inModal)}
+          {portal}
+        </div>
+      );
     }
 
     // And a modal content that checks if it is in a modal also
@@ -118,5 +118,117 @@ describe("useModal", () => {
     expect(r.testApp).toHaveTextContent("Behind Modal: InModal? false");
     // And the modal content should be in a modal
     expect(r.modalContent).toHaveTextContent("Modal Content: InModal? true");
+  });
+
+  it("no-ops openModal with a dev error when portal is not rendered", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    let context: UseModalHook;
+
+    function TestApp() {
+      context = useModal();
+      // Intentionally omit portal
+      return <div data-testid="app">App</div>;
+    }
+
+    const r = await render(<TestApp />);
+    act(() => context!.openModal({ content: <div>Should not show</div> }));
+
+    expect(r.queryByTestId("modal")).toBeFalsy();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("modal.portal"));
+    error.mockRestore();
+  });
+
+  it("mounts modal content under the caller so it sees caller-only providers", async () => {
+    const CallerContext = createContext("missing");
+
+    function TestApp() {
+      const { openModal, portal } = useModal();
+      useEffect(() => {
+        openModal({ content: <ModalReadsCallerContext /> });
+      }, [openModal]);
+      return (
+        <CallerContext.Provider value="from-caller">
+          <div data-testid="app">App{portal}</div>
+        </CallerContext.Provider>
+      );
+    }
+
+    function ModalReadsCallerContext() {
+      const value = useContext(CallerContext);
+      return <div data-testid="modalContextValue">{value}</div>;
+    }
+
+    const r = await render(<TestApp />);
+    expect(r.modalContextValue).toHaveTextContent("from-caller");
+  });
+
+  it("replaces the first modal when a second opens", async () => {
+    let first: UseModalHook;
+    let second: UseModalHook;
+
+    function TestApp() {
+      first = useModal();
+      second = useModal();
+      return (
+        <div>
+          {first.portal}
+          {second.portal}
+        </div>
+      );
+    }
+
+    const r = await render(<TestApp />);
+    act(() => first!.openModal({ content: <div data-testid="firstModal">First</div> }));
+    expect(r.firstModal).toBeTruthy();
+
+    act(() => second!.openModal({ content: <div data-testid="secondModal">Second</div> }));
+    expect(r.queryByTestId("firstModal")).toBeFalsy();
+    expect(r.secondModal).toBeTruthy();
+  });
+
+  it("closes cleanly when the caller unmounts while open", async () => {
+    const onClose = vi.fn();
+
+    function Host({ open }: { open: boolean }) {
+      if (!open) return <div data-testid="closed">closed</div>;
+      return <Caller onClose={onClose} />;
+    }
+
+    function Caller({ onClose }: { onClose: () => void }) {
+      const { openModal, portal } = useModal();
+      useEffect(() => {
+        openModal({ content: <div data-testid="modalBody">Body</div>, onClose });
+      }, [openModal, onClose]);
+      return <div data-testid="caller">{portal}</div>;
+    }
+
+    const r = await render(<Host open />);
+    expect(r.modalBody).toBeTruthy();
+
+    r.rerender(<Host open={false} />);
+    expect(r.queryByTestId("modal")).toBeFalsy();
+    expect(r.queryByTestId("modalBody")).toBeFalsy();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not mount a sibling Modal from BeamProvider modalState", async () => {
+    // BeamContext no longer exposes modalState; opening via useModal only paints through the call-site portal.
+    function TestApp() {
+      const { openModal, portal } = useModal();
+      const beam = useBeamContext();
+      useEffect(() => {
+        openModal({ content: <div data-testid="viaPortal">via portal</div> });
+      }, [openModal]);
+      return (
+        <div data-testid="app">
+          {"modalState" in beam ? "has-modalState" : "no-modalState"}
+          {portal}
+        </div>
+      );
+    }
+
+    const r = await render(<TestApp />);
+    expect(r.app).toHaveTextContent("no-modalState");
+    expect(r.viaPortal).toBeTruthy();
   });
 });

--- a/src/components/Modal/useModal.tsx
+++ b/src/components/Modal/useModal.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useMemo, useRef } from "react";
+import { ReactElement, useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useBeamContext } from "src/components/BeamContext";
 import { CheckFn } from "src/types";
 import { maybeCall } from "src/utils";
-import { ModalApi, ModalProps } from "./Modal";
+import { Modal, ModalApi, ModalProps } from "./Modal";
 import { useModalContext } from "./ModalContext";
+import { useModalInstance } from "./ModalInstanceContext";
 
 export interface UseModalHook {
   openModal: (props: ModalProps) => void;
@@ -11,51 +12,208 @@ export interface UseModalHook {
   addCanClose: (canClose: CheckFn) => void;
   setSize: (size: ModalProps["size"]) => void;
   inModal: boolean;
+  /**
+   * Must be rendered in the same component that called `useModal()`.
+   * Renders nothing visible when closed; when open, mounts `<Modal />` under this call site
+   * (React context) and paints via OverlayContainer under Beam's OverlayProvider.
+   */
+  portal: ReactElement | null;
 }
 
-export function useModal(): UseModalHook {
-  const { modalState, modalCanCloseChecks } = useBeamContext();
+type UseModalHostOptions = {
+  /**
+   * When true (default for public useModal), openModal no-ops with a dev error if `portal` is not mounted.
+   * InternalModalHost sets this false because it always renders its own portal.
+   */
+  requirePortal?: boolean;
+};
+
+/**
+ * Shared host logic for call-site modals and the Beam-internal SuperDrawer confirm host.
+ */
+export type UseModalHostResult = UseModalHook & {
+  /** Closes without canClose checks — used by coordinator replace + InternalModalHost.forceClose. */
+  closeModalSkippingChecks: VoidFunction;
+};
+
+export function useModalHost(options: UseModalHostOptions = {}): UseModalHostResult {
+  const { requirePortal = true } = options;
+  const { modalCoordinator } = useBeamContext();
   const { inModal } = useModalContext();
+  const instanceId = useId();
+
+  const [modalProps, setModalProps] = useState<ModalProps | undefined>();
+  const modalCanCloseChecks = useRef<CheckFn[]>([]);
   const lastCanClose = useRef<CheckFn | undefined>();
   const api = useRef<ModalApi>();
+  const portalMountedRef = useRef(false);
+  const modalPropsRef = useRef(modalProps);
+  modalPropsRef.current = modalProps;
+
+  const closeModal = useCallback(() => {
+    for (const canCloseModal of modalCanCloseChecks.current) {
+      if (!canCloseModal()) {
+        return;
+      }
+    }
+    maybeCall(modalPropsRef.current?.onClose);
+    setModalProps(undefined);
+    modalCanCloseChecks.current = [];
+    lastCanClose.current = undefined;
+    modalCoordinator.release(instanceId);
+  }, [instanceId, modalCoordinator]);
+
+  /** Closes without canClose checks — used by coordinator replace + InternalModalHost.forceClose. */
+  const closeModalSkippingChecks = useCallback(() => {
+    maybeCall(modalPropsRef.current?.onClose);
+    setModalProps(undefined);
+    modalCanCloseChecks.current = [];
+    lastCanClose.current = undefined;
+    modalCoordinator.release(instanceId);
+  }, [instanceId, modalCoordinator]);
+
+  // Keep forceClose identity stable for the coordinator registration
+  const forceClose = closeModalSkippingChecks;
+
+  const openModal = useCallback(
+    (props: ModalProps) => {
+      if (requirePortal && !portalMountedRef.current) {
+        if (process.env.NODE_ENV !== "production") {
+          console.error(
+            "[Beam] useModal().openModal() was called but `modal.portal` is not rendered in this component. " +
+              "Render `{modal.portal}` in the same component that calls useModal().",
+          );
+        }
+        return;
+      }
+      modalCoordinator.claim({ id: instanceId, forceClose });
+      setModalProps({ ...props, api });
+    },
+    [forceClose, instanceId, modalCoordinator, requirePortal],
+  );
+
+  const addCanClose = useCallback((canClose: CheckFn) => {
+    modalCanCloseChecks.current = [
+      ...modalCanCloseChecks.current.filter((c) => c !== lastCanClose.current),
+      canClose,
+    ];
+    lastCanClose.current = canClose;
+  }, []);
+
+  const setSize = useCallback((size: ModalProps["size"]) => {
+    if (modalPropsRef.current?.api?.current) {
+      modalPropsRef.current.api.current.setSize(size);
+    }
+  }, []);
+
   useEffect(() => {
     return () => {
-      modalCanCloseChecks.current = modalCanCloseChecks.current.filter((c) => c !== lastCanClose.current);
+      // Caller unmounted while open — unregister cleanly.
+      if (modalPropsRef.current) {
+        maybeCall(modalPropsRef.current.onClose);
+        modalCoordinator.release(instanceId);
+      }
     };
-  }, [modalCanCloseChecks]);
+  }, [instanceId, modalCoordinator]);
+
+  const onPortalMount = useCallback(() => {
+    portalMountedRef.current = true;
+  }, []);
+  const onPortalUnmount = useCallback(() => {
+    portalMountedRef.current = false;
+  }, []);
+
+  const portal = (
+    <ModalPortalOutlet
+      key={instanceId}
+      modalProps={modalProps}
+      closeModal={closeModal}
+      addCanClose={addCanClose}
+      setSize={setSize}
+      onMount={onPortalMount}
+      onUnmount={onPortalUnmount}
+    />
+  );
+
   return useMemo(
     () => ({
-      openModal(props) {
-        // TODO Check already open?
-        // TODO Check can leave?
-        modalState.current = { ...props, api };
-      },
-      closeModal() {
-        // TODO: Should remove checks
-        for (const canCloseModal of modalCanCloseChecks.current) {
-          if (!canCloseModal()) {
-            return;
-          }
-        }
-        maybeCall(modalState.current?.onClose);
-        modalState.current = undefined;
-      },
-      // TODO: Rename as a breaking change
-      addCanClose(canClose) {
-        modalCanCloseChecks.current = [
-          // Only allow one canClose per component at a time; this lets the caller avoid useMemo'ing their lambda
-          ...modalCanCloseChecks.current.filter((c) => c !== lastCanClose.current),
-          canClose,
-        ];
-        lastCanClose.current = canClose;
-      },
-      setSize(size: ModalProps["size"]) {
-        if (modalState.current && modalState.current.api?.current) {
-          modalState.current.api.current.setSize(size);
-        }
-      },
+      openModal,
+      closeModal,
+      closeModalSkippingChecks,
+      addCanClose,
+      setSize,
       inModal,
+      portal,
     }),
-    [inModal, modalState, modalCanCloseChecks],
+    // portal identity changes when modalProps changes — intentional re-render of outlet
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [openModal, closeModal, closeModalSkippingChecks, addCanClose, setSize, inModal, modalProps],
   );
+}
+
+function ModalPortalOutlet(props: {
+  modalProps: ModalProps | undefined;
+  closeModal: VoidFunction;
+  addCanClose: (canClose: CheckFn) => void;
+  setSize: (size: ModalProps["size"]) => void;
+  onMount: () => void;
+  onUnmount: () => void;
+}) {
+  const { modalProps, closeModal, addCanClose, setSize, onMount, onUnmount } = props;
+
+  useLayoutEffect(() => {
+    onMount();
+    return onUnmount;
+  }, [onMount, onUnmount]);
+
+  if (!modalProps) {
+    return null;
+  }
+
+  return (
+    <Modal
+      {...modalProps}
+      hostCloseModal={closeModal}
+      hostAddCanClose={addCanClose}
+      hostSetSize={setSize}
+    />
+  );
+}
+
+/**
+ * Public modal API. Each call creates a local host; render `{modal.portal}` in the same component.
+ * When called under an open Modal, returns that instance's close/addCanClose/setSize (portal is null).
+ */
+export function useModal(): UseModalHook {
+  const parentInstance = useModalInstance();
+  const { inModal } = useModalContext();
+
+  // Always call useModalHost to satisfy the rules of hooks; ignore it when nested under a Modal.
+  const host = useModalHost({ requirePortal: true });
+
+  if (parentInstance) {
+    return {
+      openModal: () => {
+        if (process.env.NODE_ENV !== "production") {
+          console.error(
+            "[Beam] openModal() from inside a Modal is not supported via the nested useModal() binding. " +
+              "Call useModal() in a parent component and render `{modal.portal}` there.",
+          );
+        }
+      },
+      closeModal: parentInstance.closeModal,
+      addCanClose: parentInstance.addCanClose,
+      setSize: parentInstance.setSize,
+      inModal: true,
+      portal: null,
+    };
+  }
+
+  if (inModal) {
+    const { closeModalSkippingChecks: _, ...publicHost } = host;
+    return { ...publicHost, inModal: true };
+  }
+
+  const { closeModalSkippingChecks: _, ...publicHost } = host;
+  return publicHost;
 }

--- a/src/components/SuperDrawer/ConfirmCloseModal.tsx
+++ b/src/components/SuperDrawer/ConfirmCloseModal.tsx
@@ -10,13 +10,11 @@ interface ConfirmCloseModalProps {
 /** Modal content to appear when a close checks fails */
 export function ConfirmCloseModal(props: ConfirmCloseModalProps) {
   const { onClose, discardText = "Discard Changes", continueText = "Continue Editing" } = props;
-  const { modalState } = useBeamContext();
+  const { internalModalApi } = useBeamContext();
 
-  // TODO: Change to closeModal from useModal when canCloseChecks are reset
+  // Force-close without canClose checks — same as the old modalState.current = undefined path.
   function closeModal() {
-    // Not using closeModal from useModal since the canClose checks are not reset
-    // after a close and could/will cause other close attempts to fail.
-    modalState.current = undefined;
+    internalModalApi.current?.forceClose();
   }
 
   return (

--- a/src/components/SuperDrawer/SuperDrawer.stories.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.stories.tsx
@@ -158,7 +158,7 @@ export function CanCloseDrawerDetailsChecks() {
 
 export function OpenWithModal() {
   const { openInDrawer } = useSuperDrawer();
-  const { openModal } = useModal();
+  const { openModal, portal } = useModal();
   function open() {
     openInDrawer({ content: <TestDrawerContent book={Books[0]} title="Drawer Title" /> });
     openModal({ content: <TestModalContent /> });
@@ -168,6 +168,7 @@ export function OpenWithModal() {
     <>
       <h1 css={Css.xl2.mb1.$}>SuperDrawer Open at Modal</h1>
       <Button label="Show SuperDrawer" onClick={open} />
+      {portal}
     </>
   );
 }
@@ -365,7 +366,7 @@ interface TestDrawerContentProps {
 function TestDrawerContent(props: TestDrawerContentProps) {
   const { book, hasActions = true, title, leftContent, rightContent, hideControls } = props;
   const { openDrawerDetail, closeDrawer } = useSuperDrawer();
-  const { openModal } = useModal();
+  const { openModal, portal } = useModal();
 
   function handlePurchase() {
     openModal({ content: <TestSimpleModalContent book={book} onPrimaryClick={closeDrawer} /> });
@@ -404,6 +405,7 @@ function TestDrawerContent(props: TestDrawerContentProps) {
           />
         </div>
       </SuperDrawerContent>
+      {portal}
     </>
   );
 }

--- a/src/components/SuperDrawer/useSuperDrawer.tsx
+++ b/src/components/SuperDrawer/useSuperDrawer.tsx
@@ -1,7 +1,6 @@
 import { ReactNode, useMemo } from "react";
 import { useBeamContext } from "src/components/BeamContext";
 import { CanCloseCheck } from "src/types";
-import { useModal } from "../Modal";
 import { ConfirmCloseModal } from "./ConfirmCloseModal";
 import { SuperDrawerWidth } from "./utils";
 
@@ -54,16 +53,27 @@ export interface UseSuperDrawerHook {
 export function useSuperDrawer(): UseSuperDrawerHook {
   const {
     drawerContentStack: contentStack,
-    modalState,
+    internalModalApi,
+    modalCoordinator,
     drawerCanCloseChecks: canCloseChecks,
     drawerCanCloseDetailsChecks: canCloseDetailsChecks,
   } = useBeamContext();
-  const { openModal } = useModal();
+
+  function openConfirmModal(content: ReactNode) {
+    const api = internalModalApi.current;
+    if (!api) {
+      if (process.env.NODE_ENV !== "production") {
+        console.error("[Beam] InternalModalHost is not mounted; cannot open SuperDrawer confirm modal.");
+      }
+      return;
+    }
+    api.openModal({ content });
+  }
 
   function canCloseDrawerDetails(i: number, doChange: VoidFunction) {
     for (const canCloseDrawerDetail of canCloseDetailsChecks.current[i] ?? []) {
       if (!canClose(canCloseDrawerDetail)) {
-        openModal({ content: <ConfirmCloseModal onClose={doChange} {...canCloseDrawerDetail} /> });
+        openConfirmModal(<ConfirmCloseModal onClose={doChange} {...canCloseDrawerDetail} />);
         return false;
       }
     }
@@ -94,9 +104,7 @@ export function useSuperDrawer(): UseSuperDrawerHook {
     // Attempt to close the drawer
     for (const canCloseDrawer of canCloseChecks.current) {
       if (!canClose(canCloseDrawer)) {
-        openModal({
-          content: <ConfirmCloseModal onClose={doChange} {...canCloseDrawer} />,
-        });
+        openConfirmModal(<ConfirmCloseModal onClose={doChange} {...canCloseDrawer} />);
         return;
       }
     }
@@ -136,8 +144,8 @@ export function useSuperDrawer(): UseSuperDrawerHook {
             // Pop contentStack and the current canCloseDrawerDetailsCheck
             contentStack.current = contentStack.current.slice(0, -1);
             canCloseDetailsChecks.current = canCloseDetailsChecks.current.slice(0, -1);
-            // Reset Modal state
-            modalState.current = undefined;
+            // Close any confirm modal opened over the drawer detail
+            modalCoordinator.forceCloseActive();
           }
 
           onClose();
@@ -146,7 +154,7 @@ export function useSuperDrawer(): UseSuperDrawerHook {
     },
     // TODO: validate this eslint-disable. It was automatically ignored as part of https://app.shortcut.com/homebound-team/story/40033/enable-react-hooks-exhaustive-deps-for-react-projects
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [canCloseChecks, canCloseDetailsChecks, contentStack, modalState, openModal],
+    [canCloseChecks, canCloseDetailsChecks, contentStack, modalCoordinator],
   );
 
   // useMemo the actions separately from the dynamic isDrawerOpen value

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -1,5 +1,5 @@
 import { Children, cloneElement, ReactNode } from "react";
-import { useModal } from "src/components";
+import { useModalContext } from "src/components/Modal/ModalContext";
 import { PresentationFieldProps, PresentationProvider } from "src/components/PresentationContext";
 import { Css } from "src/Css";
 
@@ -28,7 +28,7 @@ export type FormLinesProps = {
  * (see the `FieldGroup` component), where they will be laid out side-by-side.
  */
 export function FormLines(props: FormLinesProps) {
-  const { inModal } = useModal();
+  const { inModal } = useModalContext();
   const {
     children,
     width = inModal ? "full" : "lg",


### PR DESCRIPTION
## Summary
- Changes `useModal` so each hook instance owns local modal state and returns a `portal` outlet that must be rendered by the caller.
- Modal content mounts under the caller’s React tree (full caller context) while paint stays on Beam’s `OverlayContainer` / `OverlayProvider` root.
- Missing `portal`: `openModal` no-ops with a dev error (no legacy BeamProvider sibling Modal fallback).
- Moves Header/Body/Footer portal slots to per-modal instance; SuperDrawer stays outside `OverlayProvider` (main-style host); drawer confirms use `InternalModalHost`.
- Adds `docs/modals.md` and codemod `codemods/add-use-modal-portal.ts`.

## Test plan
- [ ] `yarn test src/components/Modal/useModal.test.tsx src/components/Modal/Modal.test.tsx src/components/Modal/ModalDrawerStacking.test.tsx src/components/BeamContext.test.tsx src/components/SuperDrawer/useSuperDrawer.test.tsx`
- [ ] Confirm modal content can read a provider mounted only around the caller
- [ ] Confirm drawer + modal stacking still works
- [ ] Confirm SuperDrawer remains outside `OverlayProvider`

## Notes
Breaking for call sites that omit `{modal.portal}`. Pair with eslint rule + IFE codemod PRs. Do not merge until consumers are ready / codemodded.