### PR TITLE
docs: Figma Console MCP designer brown-bag materials

### DIFF
--- a/docs/figma-console-mcp/README.md
+++ b/docs/figma-console-mcp/README.md
@@ -1,0 +1,38 @@
+# Figma Console MCP — Designer brown bag
+
+Materials for a ~45–60 minute lunch-and-learn on installing, using, and getting value from [Figma Console MCP](https://github.com/southleft/figma-console-mcp) with Beam.
+
+| Artifact | Purpose |
+| --- | --- |
+| [`slides.html`](./slides.html) | Presenter deck — open in a browser, use ←/→ or space |
+| [`how-to.md`](./how-to.md) | Step-by-step install + smoke tests (handout) |
+| [`use-cases.md`](./use-cases.md) | Beam-flavored prompts and workflows |
+
+**Official product docs:** [docs.figma-console-mcp.southleft.com](https://docs.figma-console-mcp.southleft.com/)
+
+## Suggested agenda (50 min)
+
+| Time | Segment | Deck slides |
+| --- | --- | --- |
+| 0–5 | Why this matters for Beam | 1–4 |
+| 5–15 | Install walkthrough (live) | 5–10 |
+| 15–35 | Use cases + demos | 11–18 |
+| 35–45 | Hands-on exercise | 19 |
+| 45–50 | Tips, gotchas, Q&A | 20–22 |
+
+## Facilitator prep
+
+1. Confirm **Node.js 18+**, **Figma Desktop**, and **Cursor** on the demo machine.
+2. Have a Figma PAT ready (or create one live — scopes in [`how-to.md`](./how-to.md)).
+3. Open the [Beam Design System Refresh](https://www.figma.com/file/aWUE4pPeUTgrYZ4vaTYZQU/) file and run the **Desktop Bridge** plugin before the meeting.
+4. Clone or open this repo in Cursor so design–code parity demos can see `tokens/` and `src/`.
+5. Pre-run `Check Figma status` once so first-time `npx` download isn’t mid-demo.
+
+## Audience outcomes
+
+After the session, designers should be able to:
+
+- Install Figma Console MCP in Cursor and connect the Desktop Bridge
+- Choose read-only vs full write setup
+- Run Beam-relevant workflows: token export, component specs, variant scaffolding, a11y checks, design–code parity
+- Write prompts that name files, components, and constraints clearly

--- a/docs/figma-console-mcp/how-to.md
+++ b/docs/figma-console-mcp/how-to.md
@@ -1,0 +1,167 @@
+# How to install & use Figma Console MCP (for Beam designers)
+
+This is the handout companion to the brown bag. Prefer the **NPX + Cursor** path below — it unlocks full write tools and pairs well with the Beam repo open in the same workspace.
+
+> **Not the same as Figma’s official MCP.** Official Figma MCP (`/add-plugin figma` in Cursor) is excellent for design-to-code and Code Connect. **Figma Console MCP** (Southleft) is a separate open-source server focused on design-system extraction, token sync, variable management, component creation, a11y scanning, and design–code parity. Many teams run both.
+
+---
+
+## What you need
+
+| Prerequisite | Why |
+| --- | --- |
+| [Node.js 18+](https://nodejs.org) | Runs the MCP server via `npx` |
+| [Figma Desktop](https://www.figma.com/downloads/) | Desktop Bridge plugin (web-only Figma is not enough for write tools) |
+| [Cursor](https://cursor.com) (or another MCP client) | Chat UI that calls the tools |
+| Figma personal access token (`figd_…`) | Auth for file / variable APIs |
+
+Check Node: `node --version` in Terminal.
+
+---
+
+## Path A — Full power (recommended)
+
+~10 minutes. **106 tools**, including create/edit, variables, token sync, FigJam, Slides.
+
+### 1. Create a Figma personal access token
+
+1. Follow Figma Help: [Manage personal access tokens](https://help.figma.com/hc/en-us/articles/8085703771159-Manage-personal-access-tokens).
+2. Description: `Figma Console MCP`.
+3. Suggested scopes: **File content** (Read), **File versions** (Read), **Variables** (Read), **Comments** (Read and write).
+4. Copy the token once — it won’t be shown again.
+
+Treat the token like a password. Don’t paste it into Slack, Storybook, or git.
+
+### 2. Add the server in Cursor
+
+1. Open **Cursor Settings → Tools & MCP**.
+2. **Add Custom MCP** (or edit `~/.cursor/mcp.json` on macOS / `%USERPROFILE%\.cursor\mcp.json` on Windows).
+3. Use:
+
+```json
+{
+  "mcpServers": {
+    "figma-console": {
+      "command": "npx",
+      "args": ["-y", "figma-console-mcp@latest"],
+      "env": {
+        "FIGMA_ACCESS_TOKEN": "figd_YOUR_TOKEN_HERE",
+        "ENABLE_MCP_APPS": "true"
+      }
+    }
+  }
+}
+```
+
+4. Replace `figd_YOUR_TOKEN_HERE` with your real token.
+5. Save. Restart Cursor if the server doesn’t show as connected.
+
+### 3. Install & run the Desktop Bridge plugin
+
+The MCP server auto-creates the plugin at a stable path the first time it starts.
+
+1. Open **Figma Desktop** and a Beam file (e.g. Beam Design System Refresh).
+2. **Plugins → Development → Import plugin from manifest…**
+3. Choose: `~/.figma-console-mcp/plugin/manifest.json`  
+   - macOS: `/Users/YourName/.figma-console-mcp/plugin/manifest.json`  
+   - Windows: `C:\Users\YourName\.figma-console-mcp\plugin\manifest.json`
+4. Run **Figma Desktop Bridge** in that file.
+5. Leave the plugin running while you work with the AI client.
+
+The plugin scans ports **9223–9232** and connects to the local MCP server over WebSocket.
+
+**Plugin updates:** After some MCP releases, re-import the same manifest so Figma picks up a new `code.js`. Check release notes when tools suddenly fail after an upgrade.
+
+### 4. Smoke tests
+
+In Cursor Agent chat, try:
+
+```
+Check Figma status
+```
+
+Expect: connected, WebSocket / Desktop Bridge active, file context visible.
+
+```
+Create a simple frame named "MCP smoke test" with a teal background
+```
+
+Expect: a new frame appears in the open Figma file (write path works).
+
+```
+Get design variables from the current Figma file
+```
+
+Expect: collections / variables listed (read path works).
+
+---
+
+## Path B — Read-only (quick taste)
+
+~2 minutes. **9 tools**. Good for a first peek; **cannot** create or edit designs.
+
+Cursor `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "figma-console": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://figma-console-mcp.southleft.com/sse"]
+    }
+  }
+}
+```
+
+Upgrade to Path A when you want write + token sync.
+
+---
+
+## Path C — Cloud Mode (web AI clients)
+
+For Claude.ai / similar **without** Node on your machine: use `https://figma-console-mcp.southleft.com/mcp` with your PAT, run Desktop Bridge, then ask the AI to **pair** with a short code from the plugin. Details: [upstream quick start](https://github.com/southleft/figma-console-mcp#️-cloud-mode-web-ai-clients).
+
+For Beam work we still recommend Path A inside Cursor with this repo open.
+
+---
+
+## Daily workflow checklist
+
+1. Open the target Figma file in **Desktop**.
+2. Run **Desktop Bridge**.
+3. Open Cursor on the Beam (or product) repo when you care about code parity.
+4. Ask for status before a long task.
+5. Prefer **dry-run** when importing tokens back into Figma.
+6. Name the file URL, component, and “don’t invent new tokens / props” constraints in the prompt.
+
+---
+
+## Troubleshooting
+
+| Symptom | Try |
+| --- | --- |
+| MCP red / not connected | Restart Cursor; confirm JSON is valid; `node --version` ≥ 18 |
+| Status says no bridge | Open Figma Desktop, run Desktop Bridge in the **same** file |
+| Writes don’t appear | Confirm Path A (not read-only SSE); plugin still running |
+| Token / variable tools empty | PAT scopes; file permissions; correct file focused |
+| Plugin behaves oddly after upgrade | Re-import `~/.figma-console-mcp/plugin/manifest.json` |
+| First call is slow | Normal — `npx` may download `@latest` once |
+
+Diagnostic prompts:
+
+```
+Diagnose my Figma Console MCP setup
+```
+
+```
+Reconnect to the Desktop Bridge plugin
+```
+
+---
+
+## Security & team norms
+
+- Prefer personal PATs with least privilege; rotate if leaked.
+- Don’t commit `mcp.json` with real tokens into Beam.
+- Treat AI-created components as **drafts** until a designer reviews against Beam conventions (few props, semantic tokens, existing variants).
+- Token export into this repo must still pass `yarn validate:tokens` and follow [`tokens/README.md`](../../tokens/README.md).

--- a/docs/figma-console-mcp/slides.html
+++ b/docs/figma-console-mcp/slides.html
@@ -1,0 +1,751 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Figma Console MCP · Beam designer brown bag</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=Syne:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        --bg: #101418;
+        --bg-elevated: #1a222c;
+        --ink: #f2f4f6;
+        --muted: #93a0ad;
+        --line: rgba(242, 244, 246, 0.12);
+        --accent: #3d9b8f;
+        --accent-soft: rgba(61, 155, 143, 0.16);
+        --warm: #e8a54b;
+        --danger: #e07a6a;
+        --code-bg: #0b0f13;
+        --slide-pad: clamp(2rem, 5vw, 4.5rem);
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: var(--bg);
+        color: var(--ink);
+        font-family: "IBM Plex Sans", system-ui, sans-serif;
+        overflow: hidden;
+      }
+
+      body {
+        background:
+          radial-gradient(ellipse 80% 55% at 100% -10%, rgba(61, 155, 143, 0.22), transparent 55%),
+          radial-gradient(ellipse 60% 40% at -10% 110%, rgba(232, 165, 75, 0.12), transparent 50%),
+          var(--bg);
+      }
+
+      .deck {
+        height: 100%;
+        width: 100%;
+        position: relative;
+      }
+
+      .slide {
+        position: absolute;
+        inset: 0;
+        display: none;
+        padding: var(--slide-pad);
+        flex-direction: column;
+        justify-content: center;
+        gap: 1.25rem;
+        animation: fadeIn 280ms ease;
+      }
+
+      .slide.active {
+        display: flex;
+      }
+
+      @keyframes fadeIn {
+        from {
+          opacity: 0;
+          transform: translateY(8px);
+        }
+        to {
+          opacity: 1;
+          transform: none;
+        }
+      }
+
+      .eyebrow {
+        font-size: 0.85rem;
+        font-weight: 600;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
+        color: var(--accent);
+        margin: 0;
+      }
+
+      h1,
+      h2 {
+        font-family: "Syne", sans-serif;
+        font-weight: 750;
+        line-height: 1.05;
+        letter-spacing: -0.03em;
+        margin: 0;
+      }
+
+      h1 {
+        font-size: clamp(2.6rem, 6vw, 4.4rem);
+        max-width: 14ch;
+      }
+
+      h2 {
+        font-size: clamp(2rem, 4.5vw, 3.2rem);
+        max-width: 22ch;
+      }
+
+      .lede {
+        font-size: clamp(1.1rem, 2vw, 1.35rem);
+        color: var(--muted);
+        max-width: 46ch;
+        line-height: 1.45;
+        margin: 0;
+      }
+
+      ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: grid;
+        gap: 0.75rem;
+        max-width: 52rem;
+      }
+
+      li {
+        position: relative;
+        padding-left: 1.35rem;
+        font-size: clamp(1.05rem, 1.8vw, 1.25rem);
+        line-height: 1.4;
+        color: var(--ink);
+      }
+
+      li::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.55em;
+        width: 0.55rem;
+        height: 0.55rem;
+        border-radius: 2px;
+        background: var(--accent);
+      }
+
+      li strong {
+        font-weight: 600;
+      }
+
+      .grid-2 {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 1.25rem;
+        width: min(100%, 56rem);
+      }
+
+      .card {
+        background: var(--bg-elevated);
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 1.25rem 1.35rem;
+      }
+
+      .card h3 {
+        font-family: "Syne", sans-serif;
+        font-size: 1.15rem;
+        margin: 0 0 0.5rem;
+      }
+
+      .card p,
+      .card li {
+        font-size: 0.98rem;
+        color: var(--muted);
+        margin: 0;
+      }
+
+      .card ul {
+        gap: 0.45rem;
+        margin-top: 0.65rem;
+      }
+
+      .card li::before {
+        width: 0.4rem;
+        height: 0.4rem;
+        top: 0.5em;
+      }
+
+      .prompt {
+        font-family: ui-monospace, "SF Mono", Menlo, monospace;
+        font-size: clamp(0.85rem, 1.4vw, 1rem);
+        background: var(--code-bg);
+        border: 1px solid var(--line);
+        border-left: 3px solid var(--accent);
+        border-radius: 10px;
+        padding: 1rem 1.15rem;
+        color: #d7e0e8;
+        max-width: 52rem;
+        white-space: pre-wrap;
+        line-height: 1.45;
+      }
+
+      .meta-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+        margin-top: 0.25rem;
+      }
+
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 0.35rem 0.75rem;
+        border-radius: 999px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        font-size: 0.85rem;
+        font-weight: 500;
+        border: 1px solid rgba(61, 155, 143, 0.35);
+      }
+
+      .pill.warm {
+        background: rgba(232, 165, 75, 0.14);
+        color: var(--warm);
+        border-color: rgba(232, 165, 75, 0.35);
+      }
+
+      .steps {
+        counter-reset: step;
+        display: grid;
+        gap: 0.85rem;
+        max-width: 48rem;
+      }
+
+      .steps li {
+        padding-left: 3rem;
+      }
+
+      .steps li::before {
+        counter-increment: step;
+        content: counter(step);
+        width: 1.75rem;
+        height: 1.75rem;
+        border-radius: 50%;
+        top: 0.1em;
+        display: grid;
+        place-items: center;
+        font-size: 0.8rem;
+        font-weight: 600;
+        color: var(--bg);
+        background: var(--accent);
+      }
+
+      .compare {
+        width: min(100%, 56rem);
+        border-collapse: collapse;
+        font-size: 0.95rem;
+      }
+
+      .compare th,
+      .compare td {
+        text-align: left;
+        padding: 0.7rem 0.85rem;
+        border-bottom: 1px solid var(--line);
+      }
+
+      .compare th {
+        color: var(--muted);
+        font-weight: 500;
+        font-size: 0.8rem;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+      }
+
+      .compare td:first-child {
+        font-weight: 600;
+      }
+
+      .chrome {
+        position: fixed;
+        left: var(--slide-pad);
+        right: var(--slide-pad);
+        bottom: 1.25rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 1rem;
+        color: var(--muted);
+        font-size: 0.8rem;
+        pointer-events: none;
+        z-index: 2;
+      }
+
+      .progress {
+        flex: 1;
+        max-width: 12rem;
+        height: 3px;
+        background: var(--line);
+        border-radius: 99px;
+        overflow: hidden;
+      }
+
+      .progress > span {
+        display: block;
+        height: 100%;
+        background: var(--accent);
+        width: 0%;
+        transition: width 200ms ease;
+      }
+
+      .hint {
+        opacity: 0.7;
+      }
+
+      .title-slide h1 {
+        max-width: 16ch;
+      }
+
+      .big-number {
+        font-family: "Syne", sans-serif;
+        font-size: clamp(3.5rem, 8vw, 5.5rem);
+        color: var(--accent);
+        line-height: 1;
+        margin: 0;
+      }
+
+      .split-title {
+        display: grid;
+        grid-template-columns: 1.1fr 1fr;
+        gap: 2rem;
+        align-items: center;
+        width: min(100%, 60rem);
+      }
+
+      @media (max-width: 800px) {
+        .grid-2,
+        .split-title {
+          grid-template-columns: 1fr;
+        }
+
+        h1 {
+          max-width: none;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="deck" id="deck">
+      <!-- 1 -->
+      <section class="slide title-slide active" data-notes="Welcome. Housekeeping: this is hands-on friendly — Node + Figma Desktop + Cursor.">
+        <p class="eyebrow">Beam · Designer brown bag</p>
+        <h1>Figma Console MCP</h1>
+        <p class="lede">
+          Install it, talk to your design system in plain language, and keep Figma ↔ Beam code honest.
+        </p>
+        <div class="meta-row">
+          <span class="pill">~50 minutes</span>
+          <span class="pill warm">Slides + how-to in docs/</span>
+        </div>
+      </section>
+
+      <!-- 2 -->
+      <section class="slide">
+        <p class="eyebrow">Agenda</p>
+        <h2>What we’ll cover</h2>
+        <ul>
+          <li><strong>Why</strong> designers should care (beyond “AI demos”)</li>
+          <li><strong>Install</strong> Cursor + Desktop Bridge (live)</li>
+          <li><strong>Beam use cases</strong> — tokens, components, parity, a11y</li>
+          <li><strong>Hands-on</strong> + tips / Q&amp;A</li>
+        </ul>
+      </section>
+
+      <!-- 3 -->
+      <section class="slide">
+        <p class="eyebrow">The problem</p>
+        <h2>Design systems leak at the seams</h2>
+        <ul>
+          <li>Figma variables drift from <code>tokens/tokens.json</code></li>
+          <li>Variants exist in one place but not the other</li>
+          <li>Mocks reinvent Navbar / SideNav / PageHeader shells</li>
+          <li>Handoff becomes archaeology instead of a checklist</li>
+        </ul>
+      </section>
+
+      <!-- 4 -->
+      <section class="slide">
+        <p class="eyebrow">What MCP is</p>
+        <h2>A USB-C port for AI tools</h2>
+        <p class="lede">
+          Model Context Protocol lets Cursor (or Claude, etc.) call structured tools — not just guess from screenshots.
+        </p>
+        <ul>
+          <li><strong>You</strong> stay in natural language</li>
+          <li><strong>The server</strong> reads/writes Figma with real APIs</li>
+          <li><strong>Beam repo</strong> in Cursor = code context for free</li>
+        </ul>
+      </section>
+
+      <!-- 5 -->
+      <section class="slide">
+        <p class="eyebrow">Important distinction</p>
+        <h2>Two different “Figma MCPs”</h2>
+        <div class="grid-2">
+          <div class="card">
+            <h3>Official Figma MCP</h3>
+            <p>Figma’s own server / Cursor plugin</p>
+            <ul>
+              <li>Design → code, Code Connect</li>
+              <li>Selection-aware Dev Mode flows</li>
+              <li>Great for implementation</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Figma Console MCP</h3>
+            <p>Open source (Southleft) — today’s focus</p>
+            <ul>
+              <li>Tokens, variables, DS kit dump</li>
+              <li>Create / arrange components</li>
+              <li>A11y + design–code parity</li>
+            </ul>
+          </div>
+        </div>
+        <p class="lede" style="margin-top: 0.5rem">You can run both. Today we deepen Console MCP.</p>
+      </section>
+
+      <!-- 6 -->
+      <section class="slide">
+        <p class="eyebrow">Capabilities</p>
+        <div class="split-title">
+          <div>
+            <p class="big-number">100+</p>
+            <h2>tools for a living design system</h2>
+          </div>
+          <ul>
+            <li>Extract variables, styles, components</li>
+            <li>Export / import tokens (DTCG, CSS, …)</li>
+            <li>Create frames, variants, component sets</li>
+            <li>Screenshots + accessibility checks</li>
+            <li>Parity reports against your codebase</li>
+            <li>FigJam boards &amp; Slides helpers</li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- 7 -->
+      <section class="slide">
+        <p class="eyebrow">Setup paths</p>
+        <h2>Pick based on ambition</h2>
+        <table class="compare">
+          <thead>
+            <tr>
+              <th>Path</th>
+              <th>Time</th>
+              <th>Write?</th>
+              <th>Best for</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>NPX + Cursor</td>
+              <td>~10 min</td>
+              <td>Yes (full)</td>
+              <td>Beam day-to-day — recommended</td>
+            </tr>
+            <tr>
+              <td>Remote SSE</td>
+              <td>~2 min</td>
+              <td>No</td>
+              <td>Taste test only</td>
+            </tr>
+            <tr>
+              <td>Cloud Mode</td>
+              <td>~5 min</td>
+              <td>Yes</td>
+              <td>Web AI clients (Claude.ai)</td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+
+      <!-- 8 -->
+      <section class="slide">
+        <p class="eyebrow">Install · Part 1</p>
+        <h2>Prerequisites</h2>
+        <ol class="steps">
+          <li>Node.js 18+ (<code>node --version</code>)</li>
+          <li>Figma <strong>Desktop</strong> (not only the browser)</li>
+          <li>Cursor installed</li>
+          <li>Figma personal access token (<code>figd_…</code>)</li>
+        </ol>
+      </section>
+
+      <!-- 9 -->
+      <section class="slide">
+        <p class="eyebrow">Install · Part 2</p>
+        <h2>Wire Cursor → MCP</h2>
+        <p class="lede">Settings → Tools &amp; MCP → Add Custom MCP, or edit <code>~/.cursor/mcp.json</code></p>
+        <pre class="prompt">{
+  "mcpServers": {
+    "figma-console": {
+      "command": "npx",
+      "args": ["-y", "figma-console-mcp@latest"],
+      "env": {
+        "FIGMA_ACCESS_TOKEN": "figd_…",
+        "ENABLE_MCP_APPS": "true"
+      }
+    }
+  }</pre>
+      </section>
+
+      <!-- 10 -->
+      <section class="slide">
+        <p class="eyebrow">Install · Part 3</p>
+        <h2>Desktop Bridge plugin</h2>
+        <ol class="steps">
+          <li>Open Beam DS file in Figma Desktop</li>
+          <li>Plugins → Development → Import plugin from manifest…</li>
+          <li>Select <code>~/.figma-console-mcp/plugin/manifest.json</code></li>
+          <li>Run <strong>Figma Desktop Bridge</strong> and leave it open</li>
+        </ol>
+        <p class="lede">This WebSocket bridge is what unlocks create / edit / variables.</p>
+      </section>
+
+      <!-- 11 -->
+      <section class="slide">
+        <p class="eyebrow">Smoke tests</p>
+        <h2>Three prompts that prove it works</h2>
+        <pre class="prompt">Check Figma status</pre>
+        <pre class="prompt">Create a simple frame named "MCP smoke test" with a teal background</pre>
+        <pre class="prompt">Get design variables from the current Figma file</pre>
+      </section>
+
+      <!-- 12 -->
+      <section class="slide">
+        <p class="eyebrow">Mental model</p>
+        <h2>Read · Write · Sync · Compare</h2>
+        <div class="grid-2">
+          <div class="card">
+            <h3>Read</h3>
+            <p>Kit dump, component specs, screenshots, version history</p>
+          </div>
+          <div class="card">
+            <h3>Write</h3>
+            <p>Draft frames, variants, variable modes — on a scratch page first</p>
+          </div>
+          <div class="card">
+            <h3>Sync</h3>
+            <p>Export Figma → DTCG / import code → Figma (dry-run!)</p>
+          </div>
+          <div class="card">
+            <h3>Compare</h3>
+            <p>Parity + a11y against Beam <code>src/</code> and tokens</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- 13 -->
+      <section class="slide">
+        <p class="eyebrow">Use case · Tokens</p>
+        <h2>Figma variables vs tokens.json</h2>
+        <pre class="prompt">Export variables from the Beam Figma file as DTCG JSON.
+Compare to tokens/tokens.json under beam.color.semantic.
+Report missing / extra / renamed — do not write files yet.</pre>
+        <p class="lede">Beam still validates with <code>yarn validate:tokens</code>. MCP is the bridge; JSON remains the codegen source of truth.</p>
+      </section>
+
+      <!-- 14 -->
+      <section class="slide">
+        <p class="eyebrow">Use case · Components</p>
+        <h2>Spec a component for handoff</h2>
+        <pre class="prompt">Get the Button component from Beam Figma with a visual reference.
+Compare to src/components/Button.tsx — what exists, what’s Figma-only,
+and what would need a new prop (flag new props as discouraged).</pre>
+      </section>
+
+      <!-- 15 -->
+      <section class="slide">
+        <p class="eyebrow">Use case · Parity</p>
+        <h2>Design–code scorecard</h2>
+        <pre class="prompt">Run design-code parity for SideNav: Figma vs src/components/SideNav/.
+Scored report + concrete fix items for design and code.
+Prefer semantic tokens over hard-coded hex.</pre>
+        <p class="lede">Best when this repo is open in Cursor alongside the Figma bridge.</p>
+      </section>
+
+      <!-- 16 -->
+      <section class="slide">
+        <p class="eyebrow">Use case · Creation</p>
+        <h2>Scaffold variants — draft only</h2>
+        <pre class="prompt">On a scratch page, draft component set "FilterChip"
+(selected × size). Use existing Beam variables — no new hex.
+Name it "[MCP] FilterChip — review". Do not publish to the library.</pre>
+      </section>
+
+      <!-- 17 -->
+      <section class="slide">
+        <p class="eyebrow">Use case · Quality</p>
+        <h2>A11y + layout shells</h2>
+        <ul>
+          <li><strong>A11y:</strong> contrast, targets, truncation on a selected frame</li>
+          <li><strong>Layouts:</strong> map mocks to EnvironmentBanner → Navbar → SideNav → PageHeader</li>
+          <li>Stops one-off chrome that fights Beam’s layout contracts</li>
+        </ul>
+      </section>
+
+      <!-- 18 -->
+      <section class="slide">
+        <p class="eyebrow">Use case · Collaboration</p>
+        <h2>FigJam workshops &amp; changelogs</h2>
+        <ul>
+          <li>Token-naming boards with columns for Figma name / <code>--b-*</code> / ships?</li>
+          <li>Version-history summaries after a DS refresh</li>
+          <li>Generated markdown docs merging Figma + Storybook sources</li>
+        </ul>
+      </section>
+
+      <!-- 19 -->
+      <section class="slide">
+        <p class="eyebrow">Prompt craft</p>
+        <h2>Constraints beat vibes</h2>
+        <div class="grid-2">
+          <div class="card">
+            <h3>Do</h3>
+            <ul>
+              <li>File URL + component name</li>
+              <li>“Existing tokens only”</li>
+              <li>“Draft / don’t publish”</li>
+              <li>“Report first, then apply”</li>
+              <li>Beam few-props philosophy</li>
+            </ul>
+          </div>
+          <div class="card">
+            <h3>Don’t</h3>
+            <ul>
+              <li>“Make it modern”</li>
+              <li>Silent library publishes</li>
+              <li>Blind token imports</li>
+              <li>Five new style props</li>
+              <li>Paste PATs into chat logs</li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- 20 -->
+      <section class="slide">
+        <p class="eyebrow">Hands-on · 10 min</p>
+        <h2>Your turn</h2>
+        <ol class="steps">
+          <li>Get a green <code>Check Figma status</code></li>
+          <li>Pick a component you own (or Button)</li>
+          <li>Run a spec or parity prompt</li>
+          <li>Share one surprise: design-only, code-only, or token drift</li>
+        </ol>
+      </section>
+
+      <!-- 21 -->
+      <section class="slide">
+        <p class="eyebrow">Gotchas</p>
+        <h2>When it misbehaves</h2>
+        <ul>
+          <li>Bridge not running → writes silently fail or status looks empty</li>
+          <li>Read-only SSE path → can’t create (upgrade to NPX)</li>
+          <li>After MCP upgrades → re-import plugin manifest if tools break</li>
+          <li>First call slow → <code>npx</code> downloading <code>@latest</code></li>
+          <li>AI drafts still need a human Beam review</li>
+        </ul>
+      </section>
+
+      <!-- 22 -->
+      <section class="slide">
+        <p class="eyebrow">Resources</p>
+        <h2>Take it with you</h2>
+        <ul>
+          <li><code>docs/figma-console-mcp/how-to.md</code> — install handout</li>
+          <li><code>docs/figma-console-mcp/use-cases.md</code> — Beam prompt cookbook</li>
+          <li><code>docs/figma-console-mcp/slides.html</code> — this deck</li>
+          <li>Upstream: docs.figma-console-mcp.southleft.com</li>
+          <li>Beam tokens: <code>tokens/README.md</code> · layouts: <code>docs/layouts.md</code></li>
+        </ul>
+        <p class="lede">Questions? What should we automate first for Beam?</p>
+      </section>
+    </div>
+
+    <div class="chrome">
+      <span id="counter">1 / 22</span>
+      <div class="progress"><span id="bar"></span></div>
+      <span class="hint">← → or space · F fullscreen</span>
+    </div>
+
+    <script>
+      const slides = [...document.querySelectorAll(".slide")];
+      const counter = document.getElementById("counter");
+      const bar = document.getElementById("bar");
+      let i = 0;
+
+      function show(next) {
+        i = Math.max(0, Math.min(slides.length - 1, next));
+        slides.forEach((s, idx) => s.classList.toggle("active", idx === i));
+        counter.textContent = `${i + 1} / ${slides.length}`;
+        bar.style.width = `${((i + 1) / slides.length) * 100}%`;
+        history.replaceState(null, "", `#${i + 1}`);
+      }
+
+      function fromHash() {
+        const n = parseInt(location.hash.slice(1), 10);
+        if (!Number.isNaN(n)) show(n - 1);
+      }
+
+      document.addEventListener("keydown", (e) => {
+        if (["ArrowRight", "PageDown", " ", "Enter"].includes(e.key)) {
+          e.preventDefault();
+          show(i + 1);
+        } else if (["ArrowLeft", "PageUp", "Backspace"].includes(e.key)) {
+          e.preventDefault();
+          show(i - 1);
+        } else if (e.key === "Home") {
+          show(0);
+        } else if (e.key === "End") {
+          show(slides.length - 1);
+        } else if (e.key === "f" || e.key === "F") {
+          if (!document.fullscreenElement) document.documentElement.requestFullscreen?.();
+          else document.exitFullscreen?.();
+        }
+      });
+
+      let touchX = null;
+      document.addEventListener(
+        "touchstart",
+        (e) => {
+          touchX = e.changedTouches[0].screenX;
+        },
+        { passive: true },
+      );
+      document.addEventListener(
+        "touchend",
+        (e) => {
+          if (touchX == null) return;
+          const dx = e.changedTouches[0].screenX - touchX;
+          if (Math.abs(dx) > 40) show(i + (dx < 0 ? 1 : -1));
+          touchX = null;
+        },
+        { passive: true },
+      );
+
+      window.addEventListener("hashchange", fromHash);
+      fromHash();
+      show(i);
+    </script>
+  </body>
+</html>

--- a/docs/figma-console-mcp/use-cases.md
+++ b/docs/figma-console-mcp/use-cases.md
@@ -1,0 +1,208 @@
+# Beam use cases & prompt cookbook
+
+Copy-paste prompts for the brown bag demos. Swap in the live Beam Figma URL if needed:
+
+`https://www.figma.com/file/aWUE4pPeUTgrYZ4vaTYZQU/` (Beam Design System Refresh)
+
+Open this repo in Cursor when a prompt mentions `tokens/` or `src/`.
+
+---
+
+## 1. Design-system kit dump (orientation)
+
+**When:** Onboarding, auditing a library page, or briefing an agent before a bigger task.
+
+```
+Using Figma Console MCP, get the design system kit for the Beam Design System Refresh file.
+Summarize: variable collections/modes, top-level component sets, and text/color styles.
+Call out anything that looks like semantic color vs primitive ramps.
+```
+
+**Why it matters for Beam:** Grounds the AI in *our* library before it invents Material-like APIs. Beam prefers consistency and few props over flexible kits.
+
+---
+
+## 2. Token export vs `tokens/tokens.json`
+
+**When:** Design updated Figma variables; engineering needs DTCG aligned with Beam authoring rules.
+
+```
+Export variables from the open Beam Figma file as DTCG JSON.
+Compare the semantic color roles to tokens/tokens.json under beam.color.semantic.
+List: (1) tokens in Figma missing from JSON, (2) JSON tokens missing from Figma,
+(3) name mismatches. Do not write files yet — report only.
+```
+
+Follow-up after human review:
+
+```
+Propose a minimal tokens.json patch that adds only the agreed semantic roles,
+using PascalCase leaf keys, primitive references where possible, and
+$extensions["com.homebound.beam"].cssVar following tokens/README.md.
+Dry-run first.
+```
+
+**Guardrails:** Beam’s source of truth for codegen is `tokens/tokens.json`, then `yarn generate:design-tokens` + `yarn validate:tokens`. MCP export is a bridge, not a free pass to skip validation or invent `--b-*` names.
+
+---
+
+## 3. Contrast / theme modes
+
+**When:** Exploring high-contrast or future theme axes (see `docs/design-tokens/`).
+
+```
+Inspect variable modes in the Beam file related to contrast or theme.
+Map them to how Beam applies [data-theme] via ContrastScope and theme-scopes.css.
+Suggest which Figma modes should stay design-only vs which should sync to code.
+```
+
+---
+
+## 4. Component spec for implementation
+
+**When:** Handing a Figma component to eng, or checking Storybook coverage.
+
+```
+Get the Button component from the Beam Figma file with a visual reference.
+List variants, properties, spacing, and bound variables.
+Compare against src/components/Button.tsx and Button.stories.tsx:
+what already exists, what’s only in Figma, and what would require a new prop
+(flag new props as discouraged per Beam’s “few props” philosophy).
+```
+
+Swap `Button` for `SideNav`, `PageHeader`, `Banner`, `Chip`, `Modal`, etc.
+
+---
+
+## 5. Design–code parity scorecard
+
+**When:** Before a release train or after a visual refresh.
+
+```
+Run a design-code parity check for SideNav: Figma component vs
+src/components/SideNav/. Produce a scored report with concrete fix items
+for design and for code. Prefer semantic tokens over hard-coded hex.
+```
+
+---
+
+## 6. Scaffold a variant matrix (designer-led)
+
+**When:** Exploring a new component set without clicking every combination by hand.
+
+```
+In a scratch page of the Beam file, create a draft component set for
+"FilterChip" with variants: selected true/false × size sm/md.
+Use existing Beam color variables for fill/text — do not invent new hex values.
+Use auto-layout. Leave it as a draft named "[MCP] FilterChip — review".
+Do not publish to the team library.
+```
+
+**Review checklist:** Matches Beam density? Uses semantic roles? New API knobs justifiable, or should this be an existing `Chip` / filter pattern?
+
+---
+
+## 7. Arrange messy variants into a proper set
+
+**When:** You generated or duplicated variants and need the purple component-set treatment.
+
+```
+Select my FilterChip draft variants and arrange them into a proper
+component set with row/column labels for selected × size.
+```
+
+---
+
+## 8. Accessibility pass before handoff
+
+**When:** Visual QA on a new pattern or marketing-adjacent frame in the DS file.
+
+```
+Run accessibility design checks on the selected frame (or Page Header examples).
+Prioritize contrast, touch target size, and text truncation risks.
+Relate findings to Beam tokens (e.g. OnSurface vs OnSurfaceMuted) where possible.
+```
+
+---
+
+## 9. Layout shell audit
+
+**When:** Product mocks reinvent navbar / side nav / page header structure.
+
+```
+Look at the selected product mock. Compare its page chrome to Beam layouts:
+EnvironmentBannerLayout → NavbarLayout → SideNavLayout → PageHeaderLayout
+(see docs/layouts.md). List where the mock should reuse Beam layout components
+instead of custom frames, and suggest Figma structure that mirrors that nesting.
+```
+
+---
+
+## 10. Version history / changelog for a library page
+
+**When:** Writing release notes after a DS refresh.
+
+```
+List recent versions of the Beam Design System file and summarize visual/API
+changes relevant to Button and form fields. Draft a short designer-facing changelog.
+```
+
+---
+
+## 11. FigJam workshop board
+
+**When:** Crit, prioritization, or token naming workshop.
+
+```
+Create a FigJam board for a Beam token naming workshop with columns:
+Proposed name | Figma variable | CSS --b-* | Ships in code? | Notes.
+Add three example stickies using FieldBorderDefault as a filled-in sample.
+```
+
+---
+
+## 12. Documentation generation
+
+**When:** Filling gaps between Figma descriptions and Storybook.
+
+```
+Generate markdown documentation for Banner by merging Figma component data
+with src/components/Banner.tsx. Include when to use / when not to use,
+variants, and token dependencies. Keep the tone consistent with Beam docs.
+```
+
+---
+
+## Prompt patterns that work
+
+| Do | Don’t |
+| --- | --- |
+| Paste the Figma file URL or say “current open file” | Assume the agent knows which file is focused |
+| Name the Beam component and repo path | Say “make a Material button” |
+| “Use existing variables; don’t invent hex” | “Make it look modern” with no constraints |
+| “Draft only / don’t publish to library” | Silent writes to shared library pages |
+| “Report first, then apply” for token sync | Blind import into `tokens.json` |
+| “Few props — prefer global change or existing variant” | Ask for five new stylistic props by default |
+
+### Starter template
+
+```
+Context: Beam design system (Homebound). Figma: [URL]. Repo open in Cursor.
+Task: [one outcome].
+Constraints: reuse existing components/tokens; no new hex; no library publish;
+follow tokens/README.md and Beam’s few-props philosophy.
+Output: [summary | Figma draft | suggested tokens.json diff | parity report].
+```
+
+---
+
+## Hands-on exercise (10 minutes)
+
+Pairs or solo:
+
+1. Confirm `Check Figma status` is green with Desktop Bridge.
+2. Pick **one** component you own (or Button if unsure).
+3. Run use case **4** or **5** and save the agent’s report.
+4. Share with the group: one surprise (design-only, code-only, or token drift).
+
+Stretch: run use case **2** on a single semantic color and discuss whether Figma or `tokens.json` should win.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a designer lunch-and-learn kit for **Figma Console MCP** (Southleft) tailored to Beam:

- **`docs/figma-console-mcp/slides.html`** — 22-slide presenter deck (open in a browser; ←/→ / space)
- **`how-to.md`** — step-by-step Cursor + Desktop Bridge install, smoke tests, troubleshooting
- **`use-cases.md`** — Beam-specific prompt cookbook (tokens vs `tokens.json`, Button/SideNav parity, variant scaffolding, a11y, layouts, FigJam)
- **`README.md`** — agenda, facilitator prep, outcomes

Clarifies Console MCP vs official Figma MCP, and ties prompts to Beam conventions (few props, `tokens/README.md`, layout shells).

## Preview

[Title slide](https://cursor.com/agents/bc-019f7310-82ef-7eae-a65d-a399e57de55e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffigma-mcp-slide-01.png)
[Official vs Console MCP](https://cursor.com/agents/bc-019f7310-82ef-7eae-a65d-a399e57de55e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffigma-mcp-slide-05.png)
[Token use-case slide](https://cursor.com/agents/bc-019f7310-82ef-7eae-a65d-a399e57de55e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffigma-mcp-slide-13.png)

## How to present

1. Open `docs/figma-console-mcp/slides.html` in Chrome
2. Hand out / share `how-to.md` + `use-cases.md`
3. Live-demo Desktop Bridge + the three smoke-test prompts

## Note

Figma Slides couldn’t be generated in this environment (Figma MCP unavailable), so the deck ships as self-contained HTML instead.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7310-82ef-7eae-a65d-a399e57de55e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7310-82ef-7eae-a65d-a399e57de55e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

