### PR TITLE
feat: Update default text color and storybook background

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,7 +1,7 @@
 import { Preview } from "@storybook/react-vite";
 import { configure } from "mobx";
 import { INITIAL_VIEWPORTS, MINIMAL_VIEWPORTS } from "storybook/viewport";
-import { CssReset } from "../src";
+import { CssReset, Tokens } from "../src";
 import beamTheme from "./beamTheme";
 
 // formState doesn't use actions
@@ -20,8 +20,8 @@ const preview: Preview = {
       options: {
         light: { name: "light", value: "#F8F8F8" },
 
-        // Adding this to help view with off-white hover states
-        white: { name: "white", value: "#FFF" },
+        // Default Surface; also useful for off-white hover states
+        white: { name: "white", value: `var(${Tokens.Surface})` },
 
         dark: { name: "dark", value: "rgba(53,53,53,1)" },
       },
@@ -56,7 +56,7 @@ const preview: Preview = {
 
   initialGlobals: {
     backgrounds: {
-      value: "light",
+      value: "white",
     },
   },
 };

--- a/src/components/Accordion.stories.tsx
+++ b/src/components/Accordion.stories.tsx
@@ -5,11 +5,6 @@ import { Accordion } from "./Accordion";
 
 export default {
   component: Accordion,
-  globals: {
-    backgrounds: {
-      value: "white",
-    },
-  },
 } as Meta;
 
 export function AccordionVariations() {

--- a/src/components/AccordionList.stories.tsx
+++ b/src/components/AccordionList.stories.tsx
@@ -6,11 +6,6 @@ import { AccordionList } from "./AccordionList";
 
 export default {
   component: AccordionList,
-  globals: {
-    backgrounds: {
-      value: "white",
-    },
-  },
 } as Meta;
 
 export function AccordionListWithMultipleSelections() {

--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -8,11 +8,6 @@ import { action } from "storybook/actions";
 export default {
   component: Button,
   decorators: [withRouter()],
-  globals: {
-    backgrounds: {
-      value: "white",
-    },
-  },
 } as Meta;
 
 const sizes: ButtonSize[] = ["sm", "md", "lg"];

--- a/src/components/IconButton.stories.tsx
+++ b/src/components/IconButton.stories.tsx
@@ -27,12 +27,6 @@ export default {
       url: "https://www.figma.com/file/aWUE4pPeUTgrYZ4vaTYZQU/%E2%9C%A8Beam-Design-System?node-id=31586%3A99884",
     },
   },
-
-  globals: {
-    backgrounds: {
-      value: "white",
-    },
-  },
 } as Meta<IconButtonProps & { storyContrast?: boolean }>;
 
 type IconButtonStoryArgs = IconButtonProps & { storyContrast?: boolean };

--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -14,7 +14,7 @@ import { collapseColumn, column, numericColumn, selectColumn } from "src/compone
 import { simpleHeader } from "src/components/Table/utils/simpleHelpers";
 import { Css } from "src/Css";
 import { noop } from "src/utils";
-import { newStory, withBeamDecorator, withRouter, zeroTo } from "src/utils/sb";
+import { withBeamDecorator, withRouter, zeroTo } from "src/utils/sb";
 import { TestProjectLayout } from "src/utils/sbComponents";
 import { GridTableLayout as GridTableLayoutComponent, useGridTableLayoutState } from "./GridTableLayout";
 
@@ -197,64 +197,58 @@ export function WithoutHeader() {
   );
 }
 
-export const DefaultEmptyState = newStory(
-  () => {
-    const columns = useMemo(() => getColumns(false), []);
+export function DefaultEmptyState() {
+  const columns = useMemo(() => getColumns(false), []);
 
-    return (
-      <TestProjectLayout pageTitle="Product Offerings">
-        <GridTableLayoutComponent
-          pageTitle="Product Offerings"
-          primaryAction={{ label: "Create New", onClick: noop }}
-          tableProps={{
-            columns,
-            rows: [simpleHeader],
-            sorting: { on: "client", initial: [columns[1].id!, "ASC"] },
-          }}
-        />
-      </TestProjectLayout>
-    );
-  },
-  { globals: { backgrounds: { value: "white" } } },
-);
+  return (
+    <TestProjectLayout pageTitle="Product Offerings">
+      <GridTableLayoutComponent
+        pageTitle="Product Offerings"
+        primaryAction={{ label: "Create New", onClick: noop }}
+        tableProps={{
+          columns,
+          rows: [simpleHeader],
+          sorting: { on: "client", initial: [columns[1].id!, "ASC"] },
+        }}
+      />
+    </TestProjectLayout>
+  );
+}
 
-export const EmptyState = newStory(
-  () => {
-    const filterDefs = useMemo(() => getFilterDefs(), []);
-    const columns = useMemo(() => getColumns(false), []);
+export function EmptyState() {
+  const filterDefs = useMemo(() => getFilterDefs(), []);
+  const columns = useMemo(() => getColumns(false), []);
 
-    const layoutState = useGridTableLayoutState({
-      persistedFilter: {
-        filterDefs,
-        storageKey: "grid-table-layout-empty-state",
-      },
-      search: "client",
-    });
+  const layoutState = useGridTableLayoutState({
+    persistedFilter: {
+      filterDefs,
+      storageKey: "grid-table-layout-empty-state",
+    },
+    search: "client",
+  });
 
-    useEffect(() => {
-      layoutState.setSearchString("no-match");
-      // This is a hack to ensure the empty state is shown initially while still allowing the user to use the search
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+  useEffect(() => {
+    layoutState.setSearchString("no-match");
+    // This is a hack to ensure the empty state is shown initially while still allowing the user to use the search
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-    return (
-      <TestProjectLayout pageTitle="Product Offerings">
-        <GridTableLayoutComponent
-          pageTitle="Product Offerings"
-          layoutState={layoutState}
-          emptyFallback="No product offerings found"
-          primaryAction={{ label: "Create New", onClick: noop }}
-          tableProps={{
-            columns,
-            rows: [simpleHeader, ...makeNestedRows(3)],
-            sorting: { on: "client", initial: [columns[1].id!, "ASC"] },
-          }}
-        />
-      </TestProjectLayout>
-    );
-  },
-  { globals: { backgrounds: { value: "white" } } },
-);
+  return (
+    <TestProjectLayout pageTitle="Product Offerings">
+      <GridTableLayoutComponent
+        pageTitle="Product Offerings"
+        layoutState={layoutState}
+        emptyFallback="No product offerings found"
+        primaryAction={{ label: "Create New", onClick: noop }}
+        tableProps={{
+          columns,
+          rows: [simpleHeader, ...makeNestedRows(3)],
+          sorting: { on: "client", initial: [columns[1].id!, "ASC"] },
+        }}
+      />
+    </TestProjectLayout>
+  );
+}
 
 export function GridTableLayoutWithColor() {
   const filterDefs = useMemo(() => getFilterDefs(), []);

--- a/src/components/NavLinks/NavLink.stories.tsx
+++ b/src/components/NavLinks/NavLink.stories.tsx
@@ -27,12 +27,6 @@ export default {
   },
 
   decorators: [withRouter()],
-
-  globals: {
-    backgrounds: {
-      value: "white",
-    },
-  },
 } as Meta;
 
 export function BaseStates() {

--- a/src/components/Pagination.stories.tsx
+++ b/src/components/Pagination.stories.tsx
@@ -12,12 +12,6 @@ export default {
       url: "https://www.figma.com/file/aWUE4pPeUTgrYZ4vaTYZQU/%E2%9C%A8Beam-Design-System?node-id=3214%3A10519",
     },
   },
-
-  globals: {
-    backgrounds: {
-      value: "white",
-    },
-  },
 } as Meta;
 
 export function WithPages() {

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -57,12 +57,6 @@ export default {
   },
 
   decorators: [withRouter()],
-
-  globals: {
-    backgrounds: {
-      value: "white",
-    },
-  },
 } as Meta;
 
 type Data = { name: string | undefined; value: number | undefined };

--- a/src/components/Tabs.stories.tsx
+++ b/src/components/Tabs.stories.tsx
@@ -21,12 +21,6 @@ export default {
   },
 
   decorators: [withRouter("/ce:2", "/:ceId/*"), withBeamDecorator],
-
-  globals: {
-    backgrounds: {
-      value: "white",
-    },
-  },
 } as Meta;
 
 export function TabBaseStates() {

--- a/src/components/internal/ContextualModal.stories.tsx
+++ b/src/components/internal/ContextualModal.stories.tsx
@@ -13,12 +13,6 @@ export default {
       url: "https://www.figma.com/file/aWUE4pPeUTgrYZ4vaTYZQU/%E2%9C%A8Beam-Design-System?node-id=32720%3A99727",
     },
   },
-
-  globals: {
-    backgrounds: {
-      value: "white",
-    },
-  },
 } as Meta;
 
 export function BasicContextualModal() {

--- a/src/css/CssReset.css
+++ b/src/css/CssReset.css
@@ -387,6 +387,7 @@ Add the correct display in Chrome and Safari.
   body {
     font-family: inherit;
     line-height: inherit;
+    color: var(--b-on-surface);
   }
 
   /**

--- a/src/inputs/MultiLineSelectField.stories.tsx
+++ b/src/inputs/MultiLineSelectField.stories.tsx
@@ -6,11 +6,6 @@ import { FormLines } from "..";
 
 export default {
   component: MultiLineSelectField,
-  globals: {
-    backgrounds: {
-      value: "white",
-    },
-  },
 } as Meta;
 
 type TestOption = {

--- a/src/inputs/ToggleButton.stories.tsx
+++ b/src/inputs/ToggleButton.stories.tsx
@@ -14,12 +14,6 @@ export default {
       url: "https://www.figma.com/file/aWUE4pPeUTgrYZ4vaTYZQU/%E2%9C%A8Beam-Design-System?node-id=31580%3A99845",
     },
   },
-
-  globals: {
-    backgrounds: {
-      value: "white",
-    },
-  },
 } as Meta<ToggleButtonProps>;
 
 export const ToggleButton = () => {

--- a/src/inputs/hooks/useGrowingTextField.stories.tsx
+++ b/src/inputs/hooks/useGrowingTextField.stories.tsx
@@ -11,12 +11,6 @@ export default {
   },
 
   decorators: [withRouter()],
-
-  globals: {
-    backgrounds: {
-      value: "white",
-    },
-  },
 } as Meta;
 
 export function InVirtualizedTable() {


### PR DESCRIPTION
Defaults the body text color to our Gray900 in CSS Reset - this was a miss from the beginning.

Our primary consuming app (internal-frontend) is moving toward a white background by default, so updating our storybook default background to match