### PR TITLE
feat: Remove built in Header component from GridTableLayout

### DIFF
--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -1,6 +1,8 @@
 import { Meta } from "@storybook/react-vite";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { Button } from "src/components/Button";
 import { checkboxFilter, multiFilter } from "src/components/Filters";
+import { PageHeader } from "src/components/PageHeader";
 import { GridDataRow, SimpleHeaderAndData } from "src/components/Table";
 import {
   cardBadgeSlot,
@@ -43,25 +45,29 @@ export function GridTableLayout() {
   });
 
   return (
-    <TestProjectLayout pageTitle="Grid Table Layout">
+    <TestProjectLayout>
+      <PageHeader
+        title="Grid Table Layout Example"
+        breadcrumbs={{
+          breadcrumbs: [
+            { href: "/", label: "Home" },
+            { href: "/", label: "Sub Page" },
+          ],
+        }}
+        rightSlot={
+          <div css={Css.df.fwr.jcfe.gap1.aic.$}>
+            <Button label="Tertiary Action" variant="tertiary" tooltip="I am tertiary" onClick={noop} />
+            <Button label="Secondary Action" variant="secondary" onClick={noop} />
+            <Button label="Primary Action" onClick={noop} />
+          </div>
+        }
+      />
       <GridTableLayoutComponent
-        pageTitle="Grid Table Layout Example"
-        breadCrumb={[
-          { href: "/", label: "Home" },
-          { href: "/", label: "Sub Page" },
-        ]}
         layoutState={layoutState}
         tableProps={{
           columns,
           rows: [simpleHeader, ...makeNestedRows(3)],
           sorting: { on: "client", initial: [columns[1].id!, "ASC"] },
-        }}
-        primaryAction={{ label: "Primary Action", onClick: noop }}
-        secondaryAction={{ label: "Secondary Action", onClick: noop }}
-        tertiaryAction={{
-          label: "Tertiary Action",
-          tooltip: "I am tertiary",
-          onClick: noop,
         }}
         actionMenu={{
           tooltip: "I am the actionMenu",
@@ -90,19 +96,23 @@ export function ManyFilters() {
 
   return (
     <TestProjectLayout>
+      <PageHeader
+        title="Grid Table Layout with Many Filters"
+        breadcrumbs={{
+          breadcrumbs: [
+            { href: "/", label: "Home" },
+            { href: "/", label: "Sub Page" },
+          ],
+        }}
+        rightSlot={<Button label="Primary Action" onClick={noop} />}
+      />
       <GridTableLayoutComponent
-        pageTitle="Grid Table Layout with Many Filters"
-        breadCrumb={[
-          { href: "/", label: "Home" },
-          { href: "/", label: "Sub Page" },
-        ]}
         layoutState={layoutState}
         tableProps={{
           columns,
           rows: [simpleHeader, ...makeNestedRows(3)],
           sorting: { on: "client", initial: [columns[3].id!, "ASC"] },
         }}
-        primaryAction={{ label: "Primary Action", onClick: noop }}
       />
     </TestProjectLayout>
   );
@@ -122,19 +132,23 @@ export function WithCheckboxFilter() {
 
   return (
     <TestProjectLayout>
+      <PageHeader
+        title="Grid Table Layout with Checkbox Filter"
+        breadcrumbs={{
+          breadcrumbs: [
+            { href: "/", label: "Home" },
+            { href: "/", label: "Sub Page" },
+          ],
+        }}
+        rightSlot={<Button label="Primary Action" onClick={noop} />}
+      />
       <GridTableLayoutComponent
-        pageTitle="Grid Table Layout with Checkbox Filter"
-        breadCrumb={[
-          { href: "/", label: "Home" },
-          { href: "/", label: "Sub Page" },
-        ]}
         layoutState={layoutState}
         tableProps={{
           columns,
           rows: [simpleHeader, ...makeNestedRows(3)],
           sorting: { on: "client", initial: [columns[3].id!, "ASC"] },
         }}
-        primaryAction={{ label: "Primary Action", onClick: noop }}
       />
     </TestProjectLayout>
   );
@@ -158,13 +172,18 @@ export function QueryTableLayout() {
 
   return (
     <TestProjectLayout>
+      <PageHeader
+        title="Query Table Layout Example"
+        breadcrumbs={{
+          breadcrumbs: [
+            { href: "/", label: "Home" },
+            { href: "/", label: "Sub Page A" },
+            { href: "/", label: "Sub Page B" },
+          ],
+        }}
+        rightSlot={<Button label="Primary Action" onClick={noop} />}
+      />
       <GridTableLayoutComponent
-        pageTitle="Query Table Layout Example"
-        breadCrumb={[
-          { href: "/", label: "Home" },
-          { href: "/", label: "Sub Page A" },
-          { href: "/", label: "Sub Page B" },
-        ]}
         layoutState={layoutState}
         tableProps={{
           columns,
@@ -175,7 +194,6 @@ export function QueryTableLayout() {
           ],
           sorting: { on: "client", initial: [columns[1].id!, "ASC"] },
         }}
-        primaryAction={{ label: "Primary Action", onClick: noop }}
       />
     </TestProjectLayout>
   );
@@ -201,10 +219,9 @@ export function DefaultEmptyState() {
   const columns = useMemo(() => getColumns(false), []);
 
   return (
-    <TestProjectLayout pageTitle="Product Offerings">
+    <TestProjectLayout>
+      <PageHeader title="Product Offerings" rightSlot={<Button label="Create New" onClick={noop} />} />
       <GridTableLayoutComponent
-        pageTitle="Product Offerings"
-        primaryAction={{ label: "Create New", onClick: noop }}
         tableProps={{
           columns,
           rows: [simpleHeader],
@@ -234,12 +251,11 @@ export function EmptyState() {
   }, []);
 
   return (
-    <TestProjectLayout pageTitle="Product Offerings">
+    <TestProjectLayout>
+      <PageHeader title="Product Offerings" rightSlot={<Button label="Create New" onClick={noop} />} />
       <GridTableLayoutComponent
-        pageTitle="Product Offerings"
         layoutState={layoutState}
         emptyFallback="No product offerings found"
-        primaryAction={{ label: "Create New", onClick: noop }}
         tableProps={{
           columns,
           rows: [simpleHeader, ...makeNestedRows(3)],
@@ -281,12 +297,23 @@ export function GridTableLayoutWithColor() {
 
   return (
     <TestProjectLayout>
+      <PageHeader
+        title="Grid Table Layout with Color for clearer column manipulation"
+        breadcrumbs={{
+          breadcrumbs: [
+            { href: "/", label: "Home" },
+            { href: "/", label: "Sub Page" },
+          ],
+        }}
+        rightSlot={
+          <div css={Css.df.fwr.jcfe.gap1.aic.$}>
+            <Button label="Tertiary Action" variant="tertiary" onClick={noop} />
+            <Button label="Secondary Action" variant="secondary" onClick={noop} />
+            <Button label="Primary Action" onClick={noop} />
+          </div>
+        }
+      />
       <GridTableLayoutComponent
-        pageTitle="Grid Table Layout with Color for clearer column manipulation"
-        breadCrumb={[
-          { href: "/", label: "Home" },
-          { href: "/", label: "Sub Page" },
-        ]}
         layoutState={layoutState}
         tableProps={{
           columns,
@@ -294,9 +321,6 @@ export function GridTableLayoutWithColor() {
           sorting: { on: "client", initial: [columns[1].id!, "ASC"] },
           visibleColumnsStorageKey: storageKey,
         }}
-        primaryAction={{ label: "Primary Action", onClick: noop }}
-        secondaryAction={{ label: "Secondary Action", onClick: noop }}
-        tertiaryAction={{ label: "Tertiary Action", onClick: noop }}
       />
     </TestProjectLayout>
   );
@@ -733,8 +757,8 @@ export function WithInfiniteScroll() {
 
   return (
     <TestProjectLayout>
+      <PageHeader title="Grid Table Layout with Infinite Scroll" />
       <GridTableLayoutComponent
-        pageTitle="Grid Table Layout with Infinite Scroll"
         tableProps={{
           as: "virtual",
           rows,
@@ -775,8 +799,8 @@ export function WithQueryTableInfiniteScroll() {
 
   return (
     <TestProjectLayout>
+      <PageHeader title="Query Table with Infinite Scroll" />
       <GridTableLayoutComponent
-        pageTitle="Query Table with Infinite Scroll"
         tableProps={{
           as: "virtual",
           query,

--- a/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
@@ -43,35 +43,17 @@ describe("GridTableLayout", () => {
           },
           search: "client",
         }}
-        pageTitle="Grid Table Layout Example"
-        breadCrumb={[
-          { href: "/", label: "Home" },
-          { href: "/", label: "Sub Page" },
-        ]}
         tableProps={{
           columns: getColumns(),
           rows: [simpleHeader, ...getRows()],
         }}
-        primaryAction={{ label: "Primary Action", onClick: noop }}
-        secondaryAction={{ label: "Secondary Action", onClick: noop }}
-        tertiaryAction={{ label: "Tertiary Action", onClick: noop }}
       />,
       withRouter(),
     );
 
-    // We expect the Header to be rendered
-    expect(r.pageTitle).toHaveTextContent("Grid Table Layout Example");
-    expect(r.primaryAction).toBeInTheDocument();
-    expect(r.secondaryAction).toBeInTheDocument();
-    expect(r.tertiaryAction).toBeInTheDocument();
-    expect(r.pageHeaderBreadcrumbs_navLink_0).toHaveTextContent("Home");
-    expect(r.pageHeaderBreadcrumbs_navLink_1).toHaveTextContent("Sub Page");
-
-    // And the table actions to be rendered
+    // Then the table actions are rendered
     expect(r.search).toHaveValue("");
     expect(r.gridTableLayoutActions_filterButton).toBeInTheDocument();
-
-    // And the table content to be rendered
     expect(tableSnapshot(r)).toMatchInlineSnapshot(`
       "
       | Name  | Value | Action  |
@@ -98,11 +80,6 @@ describe("GridTableLayout", () => {
           },
           // And no search config
         }}
-        pageTitle="Query Table Layout Example"
-        breadCrumb={[
-          { href: "/", label: "Home" },
-          { href: "/", label: "Sub Page" },
-        ]}
         tableProps={{
           columns: getColumns(),
           query: {
@@ -117,7 +94,6 @@ describe("GridTableLayout", () => {
             ...(data?.map((row: Data & { id: string }) => ({ kind: "data", id: row.id, data: row })) ?? []),
           ],
         }}
-        primaryAction={{ label: "Primary Action", onClick: noop }}
       />,
       withRouter(),
     );
@@ -144,7 +120,6 @@ describe("GridTableLayout", () => {
       const r = await render(
         <TestWrapper
           layoutStateProps={{}}
-          pageTitle="Test"
           hideEditColumns={true}
           tableProps={{
             columns: getColumns(),
@@ -165,7 +140,6 @@ describe("GridTableLayout", () => {
       const r = await render(
         <TestWrapper
           layoutStateProps={{}}
-          pageTitle="Test"
           tableProps={{
             columns: columnsWithoutId,
             rows: [simpleHeader, ...getRows()],
@@ -186,7 +160,6 @@ describe("GridTableLayout", () => {
       const r = await render(
         <TestWrapper
           layoutStateProps={{}}
-          pageTitle="Test"
           tableProps={{
             columns: columnsWithoutName,
             rows: [simpleHeader, ...getRows()],
@@ -208,7 +181,6 @@ describe("GridTableLayout", () => {
       const r = await render(
         <TestWrapper
           layoutStateProps={{}}
-          pageTitle="Test"
           hideEditColumns={true}
           tableProps={{
             columns: columnsWithoutId,
@@ -218,7 +190,7 @@ describe("GridTableLayout", () => {
         withRouter(),
       );
 
-      expect(r.pageTitle).toBeInTheDocument();
+      expect(r.gridTable).toBeInTheDocument();
     });
   });
 
@@ -227,7 +199,6 @@ describe("GridTableLayout", () => {
       const r = await render(
         <TestWrapper
           layoutStateProps={{}}
-          pageTitle="Test"
           tableProps={{
             columns: getColumns(),
             rows: [simpleHeader, ...getRows()],
@@ -244,7 +215,6 @@ describe("GridTableLayout", () => {
       const r = await render(
         <TestWrapper
           layoutStateProps={{}}
-          pageTitle="Test"
           tableProps={{
             columns: getColumns(),
             rows: [simpleHeader, ...getRows()],
@@ -262,7 +232,6 @@ describe("GridTableLayout", () => {
       const r = await render(
         <TestWrapper
           layoutStateProps={{}}
-          pageTitle="Test"
           tableProps={{
             columns: getColumns(),
             rows: [simpleHeader, ...getRows()],
@@ -289,7 +258,6 @@ describe("GridTableLayout", () => {
       const r = await render(
         <TestWrapper
           layoutStateProps={{}}
-          pageTitle="Test"
           tableProps={{
             columns: getColumns(),
             rows: [simpleHeader, ...getRows()],
@@ -311,7 +279,6 @@ describe("GridTableLayout", () => {
       const r = await render(
         <TestWrapper
           layoutStateProps={{}}
-          pageTitle="Test"
           tableProps={{
             columns: getColumns(),
             rows: [simpleHeader, ...getRows()],
@@ -332,7 +299,6 @@ describe("GridTableLayout", () => {
       await render(
         <TestWrapper
           layoutStateProps={{}}
-          pageTitle="Test"
           tableProps={{
             columns: getColumns(),
             rows: [simpleHeader, ...getRows()],
@@ -350,7 +316,6 @@ describe("GridTableLayout", () => {
       const r = await render(
         <TestWrapper
           layoutStateProps={{}}
-          pageTitle="Test"
           defaultView="list"
           tableProps={{
             columns: getColumns(),
@@ -415,6 +380,29 @@ describe("GridTableLayout", () => {
       // Then the card shows the title and status
       expect(r.tableCard_title).toHaveTextContent("The Conroy");
       expect(r.tableCard_status).toHaveTextContent("Active");
+    });
+  });
+
+  describe("actionMenu", () => {
+    it("renders the action menu in table actions", async () => {
+      // Given a GridTableLayout with only an actionMenu configured
+      const r = await render(
+        <TestWrapper
+          layoutStateProps={{}}
+          hideEditColumns
+          actionMenu={{
+            items: [{ label: "First Action", onClick: noop }],
+          }}
+          tableProps={{
+            columns: getColumns(),
+            rows: [simpleHeader, ...getRows()],
+          }}
+        />,
+        withRouter(),
+      );
+
+      // Then the action menu trigger is rendered in table actions
+      expect(r.verticalDots).toBeInTheDocument();
     });
   });
 

--- a/src/components/Layout/GridTableLayout/GridTableLayout.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.tsx
@@ -1,8 +1,7 @@
 import { useResizeObserver } from "@react-aria/utils";
-import React, { ReactNode, RefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import React, { RefObject, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { ScrollableContent } from "src/components";
 import { Button } from "src/components/Button";
-import { ButtonMenu, ButtonMenuProps } from "src/components/ButtonMenu";
 import { getActiveFilterCount } from "src/components/Filters/utils";
 import { TableView } from "src/components/Table/components/ViewToggleButton";
 import { GridTable } from "src/components/Table/GridTable";
@@ -21,15 +20,10 @@ import {
 } from "src/layouts/layoutVars";
 import { noop, useTestIds } from "src/utils";
 import { zIndices } from "src/utils/zIndices";
-import { FullBleed } from "../FullBleed";
-import { ActionButtonProps, BaseQueryTableProps, GridTablePropsWithRows, isGridTableProps } from "../layoutTypes";
-import { HeaderBreadcrumb, PageHeaderBreadcrumbs } from "../PageHeaderBreadcrumbs";
-import { GridTableLayoutActions, SearchBoxApi } from "./GridTableLayoutActions";
+import { BaseQueryTableProps, GridTablePropsWithRows, isGridTableProps } from "../layoutTypes";
+import { ActionButtonMenuProps, GridTableLayoutActions, SearchBoxApi } from "./GridTableLayoutActions";
 import { QueryTable, QueryTableProps } from "./QueryTable";
 import { usePersistedTableView } from "./usePersistedTableView";
-
-// Omit to force all action button menus to look the same
-type ActionButtonMenuProps = Omit<ButtonMenuProps, "trigger">;
 
 // GridTableLayout-specific query props extend the shared base with display extras.
 type QueryTablePropsWithQuery<R extends Kinded, X extends Only<GridTableXss, X>, QData> = BaseQueryTableProps<
@@ -47,17 +41,12 @@ export type GridTableLayoutProps<
   X extends Only<GridTableXss, X>,
   QData,
 > = {
-  pageTitle?: ReactNode;
   tableProps: GridTablePropsWithRows<R, X> | QueryTablePropsWithQuery<R, X, QData>;
-  breadCrumb?: HeaderBreadcrumb | HeaderBreadcrumb[];
   layoutState?: ReturnType<typeof useGridTableLayoutState<F>>;
   /** Title for the empty state when the table has no data rows. */
   emptyFallback?: string;
   /** Renders a ButtonMenu with "verticalDots" icon as trigger */
   actionMenu?: ActionButtonMenuProps;
-  primaryAction?: ActionButtonProps;
-  secondaryAction?: ActionButtonProps;
-  tertiaryAction?: ActionButtonProps;
   hideEditColumns?: boolean;
   totalCount?: number;
   /** When true, shows a view toggle button and renders the table with `as="card"` when in card view. */
@@ -98,13 +87,8 @@ function GridTableLayoutComponent<
   QData,
 >(props: GridTableLayoutProps<F, R, X, QData>) {
   const {
-    pageTitle,
-    breadCrumb,
     tableProps,
     layoutState,
-    primaryAction,
-    secondaryAction,
-    tertiaryAction,
     actionMenu,
     hideEditColumns = false,
     withCardView,
@@ -128,7 +112,13 @@ function GridTableLayoutComponent<
   );
   const [view, setView] = usePersistedTableView(defaultView, !!withCardView);
   const clientSearch = layoutState?.search === "client" ? layoutState.searchString : undefined;
-  const showTableActions = !!(layoutState?.filterDefs || layoutState?.search || hasHideableColumns || withCardView);
+  const showTableActions = !!(
+    layoutState?.filterDefs ||
+    layoutState?.search ||
+    hasHideableColumns ||
+    withCardView ||
+    actionMenu
+  );
   const isVirtualized = tableProps.as === "virtual" || (!!withCardView && view === "card");
   const inDocumentScrollLayout = useDocumentScrollLayout();
   const tableActionsRef = useRef<HTMLDivElement>(null);
@@ -178,6 +168,7 @@ function GridTableLayoutComponent<
       setView={setView}
       clearFilters={clearFilters}
       searchApi={searchApiRef}
+      actionMenu={actionMenu}
     />
   );
 
@@ -243,22 +234,10 @@ function GridTableLayoutComponent<
   );
 
   return (
-    <>
-      {pageTitle && (
-        <Header
-          pageTitle={pageTitle}
-          breadCrumb={breadCrumb}
-          primaryAction={primaryAction}
-          secondaryAction={secondaryAction}
-          tertiaryAction={tertiaryAction}
-          actionMenu={actionMenu}
-        />
-      )}
-      {/* Wrapper sets --beam-table-actions-height so GridTable's sticky header can read it. */}
-      <div ref={tableWrapperRef} css={Css.display("contents").$} {...tid.tableWrapper}>
-        {tableScrollContent}
-      </div>
-    </>
+    /* Wrapper sets --beam-table-actions-height so GridTable's sticky header can read it. */
+    <div ref={tableWrapperRef} css={Css.display("contents").$} {...tid.tableWrapper}>
+      {tableScrollContent}
+    </div>
   );
 }
 
@@ -351,15 +330,6 @@ function composeEmptyState<F extends Record<string, unknown>, R extends Kinded, 
   };
 }
 
-type HeaderProps = {
-  pageTitle: ReactNode;
-  breadCrumb?: HeaderBreadcrumb | HeaderBreadcrumb[];
-  primaryAction?: ActionButtonProps;
-  secondaryAction?: ActionButtonProps;
-  tertiaryAction?: ActionButtonProps;
-  actionMenu?: ActionButtonMenuProps;
-};
-
 /** Sets `--beam-table-actions-height` on the table wrapper so the sticky header can read it without re-rendering children. */
 function useSetTableActionsHeight(
   tableWrapperRef: RefObject<HTMLElement | null>,
@@ -392,31 +362,6 @@ function useSetTableActionsHeight(
       tableWrapper?.style.removeProperty(beamTableActionsHeightVar);
     };
   }, [tableWrapperRef, syncHeightVar]);
-}
-
-function Header(props: HeaderProps) {
-  const { pageTitle, breadCrumb, primaryAction, secondaryAction, tertiaryAction, actionMenu } = props;
-  const tids = useTestIds(props);
-
-  return (
-    <FullBleed>
-      <header css={{ ...Css.p3.mhPx(50).bgWhite.df.jcsb.aic.$ }} {...tids.header}>
-        <div>
-          {breadCrumb && <PageHeaderBreadcrumbs breadcrumb={breadCrumb} />}
-          <h1 css={Css.xl2.mt1.$} {...tids.pageTitle}>
-            {pageTitle}
-          </h1>
-        </div>
-        {/* Flex wrap reverse and justify flex end allows the buttons to wrap naturally/responsively on smaller screens */}
-        <div css={Css.df.fwr.jcfe.gap1.aic.$}>
-          {tertiaryAction && <Button {...tertiaryAction} variant="tertiary" />}
-          {secondaryAction && <Button {...secondaryAction} variant="secondary" />}
-          {primaryAction && <Button {...primaryAction} />}
-          {actionMenu && <ButtonMenu {...actionMenu} trigger={{ icon: "verticalDots" }} />}
-        </div>
-      </header>
-    </FullBleed>
-  );
 }
 
 /** Merges layout defaults with a GridStyleDef, or passes a full GridStyle through unchanged. */

--- a/src/components/Layout/GridTableLayout/GridTableLayoutActions.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayoutActions.stories.tsx
@@ -59,6 +59,22 @@ export function WithCardView() {
   return <GridTableLayoutActions withCardView view={view} setView={setView} />;
 }
 
+export function WithActionMenu() {
+  return (
+    <GridTableLayoutActions
+      actionMenu={{
+        tooltip: "More actions",
+        defaultOpen: true,
+        items: [
+          { label: "Export", onClick: () => {} },
+          { label: "Import", onClick: () => {} },
+          { label: "Archive", onClick: () => {} },
+        ],
+      }}
+    />
+  );
+}
+
 export function AllFeatures() {
   const [filter, setFilter] = useState<TestFilter>({ status: ["active"] });
   const [view, setView] = useState<TableView>("list");
@@ -74,6 +90,14 @@ export function AllFeatures() {
       withCardView
       view={view}
       setView={setView}
+      actionMenu={{
+        tooltip: "More actions",
+        items: [
+          { label: "Export", onClick: () => {} },
+          { label: "Import", onClick: () => {} },
+          { label: "Archive", onClick: () => {} },
+        ],
+      }}
     />
   );
 }

--- a/src/components/Layout/GridTableLayout/GridTableLayoutActions.test.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayoutActions.test.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { FilterDefs } from "src/components/Filters";
 import { checkboxFilter } from "src/components/Filters";
+import { noop } from "src/utils";
 import { click, render, withRouter } from "src/utils/rtl";
 import { typeAndWait } from "src/utils/rtlUtils";
 import { vi } from "vitest";
@@ -94,5 +95,24 @@ describe("GridTableLayoutActions", () => {
       // Then clearFilters is called
       expect(clearFilters).toHaveBeenCalled();
     });
+  });
+});
+
+describe("actionMenu", () => {
+  it("renders the action menu when actionMenu is provided", async () => {
+    // Given actionMenu is provided
+    const r = await render(
+      <GridTableLayoutActions actionMenu={{ items: [{ label: "Action", onClick: noop }] }} />,
+      withRouter(),
+    );
+    // Then the vertical-dots menu trigger is shown
+    expect(r.verticalDots).toBeInTheDocument();
+  });
+
+  it("does not render the action menu when actionMenu is not provided", async () => {
+    // Given no actionMenu
+    const r = await render(<GridTableLayoutActions />, withRouter());
+    // Then the vertical-dots menu trigger is not shown
+    expect(r.query.verticalDots).not.toBeInTheDocument();
   });
 });

--- a/src/components/Layout/GridTableLayout/GridTableLayoutActions.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayoutActions.tsx
@@ -1,5 +1,6 @@
 import { memo, MutableRefObject, useMemo, useState } from "react";
 import { Button } from "src/components/Button";
+import { ButtonMenu, ButtonMenuProps } from "src/components/ButtonMenu";
 import { CountBadge } from "src/components/CountBadge";
 import { FilterDefs, FilterImpls } from "src/components/Filters";
 import { getActiveFilterCount } from "src/components/Filters/utils";
@@ -27,6 +28,9 @@ export type SearchBoxApi = {
   clear: VoidFunction;
 };
 
+// Omit to force all action button menus to look the same
+export type ActionButtonMenuProps = Omit<ButtonMenuProps, "trigger">;
+
 type GridTableLayoutActionsProps<
   F extends Record<string, unknown>,
   G extends Value = string,
@@ -49,6 +53,7 @@ type GridTableLayoutActionsProps<
   setView?: (v: TableView) => void;
   clearFilters?: () => void;
   searchApi?: MutableRefObject<SearchBoxApi | undefined>;
+  actionMenu?: ActionButtonMenuProps;
 };
 
 function GridTableLayoutActionsComponent<
@@ -70,6 +75,7 @@ function GridTableLayoutActionsComponent<
     setView,
     clearFilters,
     searchApi,
+    actionMenu,
   } = props;
   const testId = useTestIds(props, "gridTableLayoutActions");
 
@@ -170,12 +176,13 @@ function GridTableLayoutActionsComponent<
             />
           )}
         </div>
-        {(hasHideableColumns || withCardView) && (
-          <div css={Css.df.gapPx(12).$}>
+        {(hasHideableColumns || withCardView || actionMenu) && (
+          <div css={Css.df.aic.gapPx(12).$}>
             {hasHideableColumns && view === "list" && columns && api && (
               <EditColumnsButton columns={columns} api={api} tooltip="Display columns" />
             )}
             {withCardView && view !== undefined && setView && <ViewToggleButton view={view} onChange={setView} />}
+            {actionMenu && <ButtonMenu {...actionMenu} trigger={{ icon: "verticalDots" }} />}
           </div>
         )}
       </div>

--- a/src/utils/sbComponents.tsx
+++ b/src/utils/sbComponents.tsx
@@ -66,11 +66,15 @@ export function TableExample({
 }
 
 export function TestProjectLayout({ pageTitle, children }: { pageTitle?: string; children: ReactNode }) {
+  const content = pageTitle ? (
+    <PageHeaderLayout pageHeader={{ title: pageTitle }}>{children}</PageHeaderLayout>
+  ) : (
+    children
+  );
+
   return (
     <NavbarLayout navbar={createNavbar()}>
-      <SideNavLayout sideNav={{ items: sideNavItems() }}>
-        <PageHeaderLayout pageHeader={{ title: pageTitle ?? "" }}>{children}</PageHeaderLayout>
-      </SideNavLayout>
+      <SideNavLayout sideNav={{ items: sideNavItems() }}>{content}</SideNavLayout>
     </NavbarLayout>
   );
 }


### PR DESCRIPTION
Moves the actionMenu to the GridTableLayoutActions area, where I believe it was originally intended to be. Updates stories and tests as needed