### PR TITLE
feat: Workflow Header

### DIFF
--- a/src/components/Headers/BaseHeader.test.tsx
+++ b/src/components/Headers/BaseHeader.test.tsx
@@ -1,27 +1,29 @@
 import { BeamProvider } from "src/components/BeamContext";
 import { Button } from "src/components/Button";
-import { PageHeader } from "src/components/PageHeader";
-import { Tab } from "src/components/Tabs";
+import { BaseHeader } from "src/components/Headers/BaseHeader";
 import { noop } from "src/utils";
-import { render, withRouter } from "src/utils/rtl";
+import { render } from "src/utils/rtl";
 
-describe("PageHeader", () => {
+describe("BaseHeader", () => {
   beforeEach(() => {
     document.title = "";
   });
 
   it("renders", async () => {
-    const r = await render(<PageHeader title="Test Title" />);
-    expect(r.pageHeader).toBeInTheDocument();
-    expect(r.pageHeader_title.textContent).toEqual("Test Title");
+    // Given a BaseHeader with a title
+    // When rendered
+    const r = await render(<BaseHeader title="Test Title" />);
+    // Then the header and its title are shown
+    expect(r.header).toBeInTheDocument();
+    expect(r.header_title.textContent).toEqual("Test Title");
   });
 
   it("sets document.title when BeamProvider documentTitleConfig is configured", async () => {
-    // Given BeamProvider with documentTitleConfig and a PageHeader
+    // Given BeamProvider with documentTitleConfig and a BaseHeader
     // When rendered
     await render(
       <BeamProvider documentTitleConfig={{ env: "local", suffix: "Blueprint | Homebound" }}>
-        <PageHeader title="Projects" />
+        <BaseHeader title="Projects" />
       </BeamProvider>,
       { omitBeamContext: true },
     );
@@ -31,27 +33,32 @@ describe("PageHeader", () => {
   });
 
   it("includes documentTitleSuffix in document.title only", async () => {
-    // Given a PageHeader with documentTitleSuffix inside BeamProvider
+    // Given a BaseHeader with documentTitleSuffix inside BeamProvider
     const r = await render(
       <BeamProvider documentTitleConfig={{ env: "qa", suffix: "Blueprint | Homebound" }}>
-        <PageHeader title="Schedule" documentTitleSuffix="123 Sesame St" />
+        <BaseHeader title="Schedule" documentTitleSuffix="123 Sesame St" />
       </BeamProvider>,
       { omitBeamContext: true },
     );
 
     // Then the suffix appears in document.title but not the visible heading
     expect(document.title).toBe("[QA] Schedule | 123 Sesame St | Blueprint | Homebound");
-    expect(r.pageHeader_title.textContent).toBe("Schedule");
+    expect(r.header_title.textContent).toBe("Schedule");
   });
 
   it("renders with right slot", async () => {
-    const r = await render(<PageHeader title="Test Title" rightSlot={<Button label="Test Button" onClick={noop} />} />);
+    // Given a BaseHeader with rightSlot content
+    // When rendered
+    const r = await render(<BaseHeader title="Test Title" rightSlot={<Button label="Test Button" onClick={noop} />} />);
+    // Then the right slot content is shown
     expect(r.testButton).toBeInTheDocument();
   });
 
   it("renders breadcrumbs when provided", async () => {
+    // Given a BaseHeader with breadcrumbs
+    // When rendered
     const r = await render(
-      <PageHeader
+      <BaseHeader
         title="Test Title"
         breadcrumbs={{
           breadcrumbs: [
@@ -62,29 +69,16 @@ describe("PageHeader", () => {
       />,
       {},
     );
+    // Then the breadcrumbs are shown
     expect(r.breadcrumb_link_0.textContent).toEqual("Home");
     expect(r.breadcrumb_link_1.textContent).toEqual("Projects");
   });
 
-  it("renders with tabs", async () => {
-    const tabs: Tab[] = [
-      { name: "Tab A", value: "tabA" },
-      { name: "Tab B", value: "tabB" },
-      { name: "Tab C", value: "tabC" },
-    ];
-    const r = await render(
-      <PageHeader
-        title="Test Title"
-        tabs={{
-          tabs,
-          selected: "tabA",
-          onChange: noop,
-        }}
-      />,
-      withRouter(),
-    );
-    expect(r.tabs_tabA).toBeInTheDocument();
-    expect(r.tabs_tabB).toBeInTheDocument();
-    expect(r.tabs_tabC).toBeInTheDocument();
+  it("renders bottom slot content", async () => {
+    // Given a BaseHeader with bottomSlot content
+    // When rendered
+    const r = await render(<BaseHeader title="Test Title" bottomSlot={<div data-testid="customBottomSlot" />} />);
+    // Then the bottom slot content is shown
+    expect(r.customBottomSlot).toBeInTheDocument();
   });
 });

--- a/src/components/Headers/BaseHeader.tsx
+++ b/src/components/Headers/BaseHeader.tsx
@@ -19,10 +19,10 @@ export function BaseHeader(props: BaseHeaderProps) {
   useDocumentTitle(title, documentTitleSuffix);
 
   return (
-    <header {...tid} css={Css.df.fdc.pt3.px3.bb.gap2.bc(Tokens.SurfaceSeparator).bgColor(Tokens.Surface).$}>
+    <header {...tid} css={Css.df.fdc.pt3.bb.gap2.bc(Tokens.SurfaceSeparator).bgColor(Tokens.Surface).$}>
       <div
         css={{
-          ...Css.df.jcsb.w100.gap1.$,
+          ...Css.df.jcsb.w100.gap1.px3.$,
           ...Css.if(!bottomSlot).mb2.$,
         }}
       >

--- a/src/components/Headers/BaseHeader.tsx
+++ b/src/components/Headers/BaseHeader.tsx
@@ -1,24 +1,21 @@
 import { ReactNode } from "react";
 import { Breadcrumbs, BreadcrumbsProps } from "src/components/Breadcrumbs";
-import { RouteTabsProps, Tabs, TabsContentXss, TabsProps } from "src/components/Tabs";
-import { Css, Only, Tokens } from "src/Css";
+import { Css, Tokens } from "src/Css";
 import { useDocumentTitle } from "src/hooks/useDocumentTitle";
 import { useTestIds } from "src/utils";
 
-export type PageHeaderProps<V extends string, X> = {
+export type BaseHeaderProps = {
   title: string;
   /** Extra segment(s) for `document.title` only; not shown in the visible page heading. */
   documentTitleSuffix?: string;
   rightSlot?: ReactNode;
-  tabs?:
-    | Omit<TabsProps<V, X>, "contentXss" | "omitFullBleedPadding" | "includeBottomBorder">
-    | Omit<RouteTabsProps<V, X>, "contentXss" | "omitFullBleedPadding" | "includeBottomBorder">;
   breadcrumbs?: BreadcrumbsProps;
+  bottomSlot?: ReactNode;
 };
 
-export function PageHeader<V extends string, X extends Only<TabsContentXss, X>>(props: PageHeaderProps<V, X>) {
-  const { title, documentTitleSuffix, rightSlot, tabs, breadcrumbs, ...otherProps } = props;
-  const tid = useTestIds(otherProps, "pageHeader");
+export function BaseHeader(props: BaseHeaderProps) {
+  const { title, documentTitleSuffix, rightSlot, breadcrumbs, bottomSlot, ...otherProps } = props;
+  const tid = useTestIds(otherProps, "header");
   useDocumentTitle(title, documentTitleSuffix);
 
   return (
@@ -26,7 +23,7 @@ export function PageHeader<V extends string, X extends Only<TabsContentXss, X>>(
       <div
         css={{
           ...Css.df.jcsb.w100.gap1.$,
-          ...Css.if(!tabs).mb2.$,
+          ...Css.if(!bottomSlot).mb2.$,
         }}
       >
         <div css={Css.mw0.$}>
@@ -37,7 +34,7 @@ export function PageHeader<V extends string, X extends Only<TabsContentXss, X>>(
         </div>
         <div css={Css.fs0.$}>{rightSlot}</div>
       </div>
-      {tabs && <Tabs {...tabs} />}
+      {bottomSlot}
     </header>
   );
 }

--- a/src/components/Headers/PageHeader.stories.tsx
+++ b/src/components/Headers/PageHeader.stories.tsx
@@ -2,7 +2,7 @@ import { Meta } from "@storybook/react-vite";
 import { useState } from "react";
 import { Breadcrumb } from "src/components/Breadcrumbs";
 import { Button } from "src/components/Button";
-import { PageHeader } from "src/components/PageHeader";
+import { PageHeader } from "src/components/Headers/PageHeader";
 import { TabContent } from "src/components/Tabs";
 import { testTabs } from "src/components/testData";
 import { withBeamDecorator, withRouter } from "src/utils/sb";

--- a/src/components/Headers/PageHeader.test.tsx
+++ b/src/components/Headers/PageHeader.test.tsx
@@ -1,0 +1,31 @@
+import { PageHeader } from "src/components/Headers/PageHeader";
+import { Tab } from "src/components/Tabs";
+import { noop } from "src/utils";
+import { render, withRouter } from "src/utils/rtl";
+
+describe("PageHeader", () => {
+  it("renders with tabs", async () => {
+    // Given a PageHeader with tabs
+    const tabs: Tab[] = [
+      { name: "Tab A", value: "tabA" },
+      { name: "Tab B", value: "tabB" },
+      { name: "Tab C", value: "tabC" },
+    ];
+    // When rendered
+    const r = await render(
+      <PageHeader
+        title="Test Title"
+        tabs={{
+          tabs,
+          selected: "tabA",
+          onChange: noop,
+        }}
+      />,
+      withRouter(),
+    );
+    // Then each tab is shown, nested under the header's tabs test id
+    expect(r.header_tabs_tabA).toBeInTheDocument();
+    expect(r.header_tabs_tabB).toBeInTheDocument();
+    expect(r.header_tabs_tabC).toBeInTheDocument();
+  });
+});

--- a/src/components/Headers/PageHeader.tsx
+++ b/src/components/Headers/PageHeader.tsx
@@ -1,0 +1,16 @@
+import { BaseHeader, BaseHeaderProps } from "src/components/Headers/BaseHeader";
+import { RouteTabsProps, Tabs, TabsContentXss, TabsProps } from "src/components/Tabs";
+import { Only } from "src/Css";
+import { useTestIds } from "src/utils";
+
+export type PageHeaderProps<V extends string, X> = Omit<BaseHeaderProps, "bottomSlot"> & {
+  tabs?:
+    | Omit<TabsProps<V, X>, "contentXss" | "omitFullBleedPadding" | "includeBottomBorder">
+    | Omit<RouteTabsProps<V, X>, "contentXss" | "omitFullBleedPadding" | "includeBottomBorder">;
+};
+
+export function PageHeader<V extends string, X extends Only<TabsContentXss, X>>(props: PageHeaderProps<V, X>) {
+  const { tabs, ...otherProps } = props;
+  const tid = useTestIds(otherProps, "header");
+  return <BaseHeader {...otherProps} bottomSlot={tabs && <Tabs {...tabs} {...tid.tabs} />} />;
+}

--- a/src/components/Headers/PageHeader.tsx
+++ b/src/components/Headers/PageHeader.tsx
@@ -1,6 +1,6 @@
 import { BaseHeader, BaseHeaderProps } from "src/components/Headers/BaseHeader";
 import { RouteTabsProps, Tabs, TabsContentXss, TabsProps } from "src/components/Tabs";
-import { Only } from "src/Css";
+import { Css, Only } from "src/Css";
 import { useTestIds } from "src/utils";
 
 export type PageHeaderProps<V extends string, X> = Omit<BaseHeaderProps, "bottomSlot"> & {
@@ -12,5 +12,16 @@ export type PageHeaderProps<V extends string, X> = Omit<BaseHeaderProps, "bottom
 export function PageHeader<V extends string, X extends Only<TabsContentXss, X>>(props: PageHeaderProps<V, X>) {
   const { tabs, ...otherProps } = props;
   const tid = useTestIds(otherProps, "header");
-  return <BaseHeader {...otherProps} bottomSlot={tabs && <Tabs {...tabs} {...tid.tabs} />} />;
+  return (
+    <BaseHeader
+      {...otherProps}
+      bottomSlot={
+        tabs && (
+          <div css={Css.px3.$}>
+            <Tabs {...tabs} {...tid.tabs} />
+          </div>
+        )
+      }
+    />
+  );
 }

--- a/src/components/Headers/WorkflowHeader.stories.tsx
+++ b/src/components/Headers/WorkflowHeader.stories.tsx
@@ -1,0 +1,70 @@
+import { Meta } from "@storybook/react-vite";
+import { useState } from "react";
+import { Breadcrumb } from "src/components/Breadcrumbs";
+import { WorkflowHeader } from "src/components/Headers/WorkflowHeader";
+import { StepperTabsStep } from "src/components/StepperTabs";
+import { withBeamDecorator, withRouter } from "src/utils/sb";
+import { action } from "storybook/actions";
+
+export default {
+  component: WorkflowHeader,
+  parameters: {
+    layout: "fullscreen",
+  },
+  decorators: [withRouter(), withBeamDecorator],
+} as Meta;
+
+const steps: StepperTabsStep[] = [
+  { label: "Trade Partners", value: "trade", completed: true },
+  { label: "Draft Email", value: "draft", completed: false },
+  { label: "Send Email", value: "send", completed: false },
+];
+
+function useSteps() {
+  const [currentStep, setCurrentStep] = useState(steps[0].value);
+  return { steps, currentStep, onChange: setCurrentStep };
+}
+
+export function Default() {
+  const stepperTabs = useSteps();
+  return <WorkflowHeader title="Test Title" stepperTabs={stepperTabs} />;
+}
+
+export function WithRightSlotButtons() {
+  const stepperTabs = useSteps();
+  return (
+    <WorkflowHeader
+      title="Test Title"
+      rightSlot={[
+        { label: "Save Draft", variant: "secondary", onClick: action("save clicked") },
+        { label: "Continue", variant: "primary", onClick: action("continue clicked") },
+      ]}
+      stepperTabs={stepperTabs}
+    />
+  );
+}
+
+export function WithBreadcrumbs() {
+  const stepperTabs = useSteps();
+  const breadcrumbs: Breadcrumb[] = [
+    { label: "Test 1", href: "" },
+    { label: "Test 2", href: "" },
+  ];
+  return <WorkflowHeader title="Test Title" breadcrumbs={{ breadcrumbs }} stepperTabs={stepperTabs} />;
+}
+
+export function WithBreadcrumbsAndButtons() {
+  const stepperTabs = useSteps();
+  const breadcrumbs: Breadcrumb[] = [
+    { label: "Test 1", href: "" },
+    { label: "Test 2", href: "" },
+  ];
+  return (
+    <WorkflowHeader
+      title="Test Title"
+      breadcrumbs={{ breadcrumbs }}
+      rightSlot={[{ label: "Continue", variant: "primary", onClick: action("continue clicked") }]}
+      stepperTabs={stepperTabs}
+    />
+  );
+}

--- a/src/components/Headers/WorkflowHeader.test.tsx
+++ b/src/components/Headers/WorkflowHeader.test.tsx
@@ -1,0 +1,49 @@
+import { WorkflowHeader } from "src/components/Headers/WorkflowHeader";
+import { StepperTabsStep } from "src/components/StepperTabs";
+import { click, render } from "src/utils/rtl";
+import { vi } from "vitest";
+
+describe("WorkflowHeader", () => {
+  it("renders each button in rightSlot and fires its onClick", async () => {
+    // Given a WorkflowHeader with a button in rightSlot
+    const onClick = vi.fn();
+    const r = await render(
+      <WorkflowHeader
+        title="Test Title"
+        rightSlot={[{ label: "Save", onClick }]}
+        stepperTabs={{ steps: makeSteps(), currentStep: "trade", onChange: vi.fn() }}
+      />,
+    );
+
+    // When the button is clicked
+    click(r.save);
+
+    // Then its onClick handler fires
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders StepperTabs in the bottom slot and forwards step changes", async () => {
+    // Given a WorkflowHeader with stepperTabs
+    const onChange = vi.fn();
+    const r = await render(
+      <WorkflowHeader title="Test Title" stepperTabs={{ steps: makeSteps(), currentStep: "trade", onChange }} />,
+    );
+
+    // Then the steps are shown, nested under the header's stepperTabs test id
+    expect(r.header_stepperTabs_tab_trade).toBeInTheDocument();
+    expect(r.header_stepperTabs_tab_send).toBeInTheDocument();
+
+    // When a step is clicked
+    click(r.header_stepperTabs_tab_send);
+
+    // Then onChange is invoked with that step's value
+    expect(onChange).toHaveBeenCalledWith("send");
+  });
+});
+
+function makeSteps(): StepperTabsStep[] {
+  return [
+    { label: "Trade Partners", value: "trade", completed: false },
+    { label: "Send Email", value: "send", completed: false },
+  ];
+}

--- a/src/components/Headers/WorkflowHeader.tsx
+++ b/src/components/Headers/WorkflowHeader.tsx
@@ -1,0 +1,30 @@
+import { Button, ButtonProps } from "src/components/Button";
+import { BaseHeader, BaseHeaderProps } from "src/components/Headers/BaseHeader";
+import { StepperTabs, StepperTabsProps } from "src/components/StepperTabs";
+import { Css } from "src/Css";
+import { useTestIds } from "src/utils";
+
+export type WorkflowHeaderProps = Omit<BaseHeaderProps, "rightSlot" | "bottomSlot"> & {
+  rightSlot?: ButtonProps[];
+  stepperTabs: StepperTabsProps;
+};
+
+export function WorkflowHeader(props: WorkflowHeaderProps) {
+  const { rightSlot, stepperTabs, ...otherProps } = props;
+  const tid = useTestIds(otherProps, "header");
+  return (
+    <BaseHeader
+      {...otherProps}
+      rightSlot={
+        rightSlot && (
+          <div css={Css.df.aic.gap1.$}>
+            {rightSlot.map((buttonProps, i) => (
+              <Button key={typeof buttonProps.label === "string" ? buttonProps.label : i} {...buttonProps} />
+            ))}
+          </div>
+        )
+      }
+      bottomSlot={<StepperTabs {...stepperTabs} {...tid.stepperTabs} />}
+    />
+  );
+}

--- a/src/components/Headers/index.ts
+++ b/src/components/Headers/index.ts
@@ -1,4 +1,0 @@
-export { PageHeader } from "./PageHeader";
-export type { PageHeaderProps } from "./PageHeader";
-export { WorkflowHeader } from "./WorkflowHeader";
-export type { WorkflowHeaderProps } from "./WorkflowHeader";

--- a/src/components/Headers/index.ts
+++ b/src/components/Headers/index.ts
@@ -1,0 +1,4 @@
+export { PageHeader } from "./PageHeader";
+export type { PageHeaderProps } from "./PageHeader";
+export { WorkflowHeader } from "./WorkflowHeader";
+export type { WorkflowHeaderProps } from "./WorkflowHeader";

--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -2,7 +2,7 @@ import { Meta } from "@storybook/react-vite";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "src/components/Button";
 import { checkboxFilter, multiFilter } from "src/components/Filters";
-import { PageHeader } from "src/components/PageHeader";
+import { PageHeader } from "src/components/Headers/PageHeader";
 import { GridDataRow, SimpleHeaderAndData } from "src/components/Table";
 import {
   cardBadgeSlot,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,6 +32,7 @@ export type { EnvironmentFaviconUrls } from "./EnvironmentBanner/setEnvironmentF
 export * from "./Filters";
 export * from "./Grid";
 export { HB_QUIPS_FLAVOR, HB_QUIPS_MISSION, HbLoadingSpinner, HbSpinnerProvider } from "./HbLoadingSpinner";
+export * from "./Headers";
 export * from "./HelperText";
 export * from "./HomeboundLogo";
 export * from "./Icon";
@@ -46,7 +47,6 @@ export * from "./Modal/useModal";
 export * from "./Navbar";
 export { NavLink, getNavLinkStyles } from "./NavLinks";
 export type { NavLinkProps, NavLinkVariant } from "./NavLinks";
-export * from "./PageHeader";
 export * from "./Pagination";
 export { PresentationProvider } from "./PresentationContext";
 export type { InputStylePalette, PresentationFieldProps } from "./PresentationContext";

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,7 +32,6 @@ export type { EnvironmentFaviconUrls } from "./EnvironmentBanner/setEnvironmentF
 export * from "./Filters";
 export * from "./Grid";
 export { HB_QUIPS_FLAVOR, HB_QUIPS_MISSION, HbLoadingSpinner, HbSpinnerProvider } from "./HbLoadingSpinner";
-export * from "./Headers";
 export * from "./HelperText";
 export * from "./HomeboundLogo";
 export * from "./Icon";

--- a/src/hooks/useDocumentTitle.test.tsx
+++ b/src/hooks/useDocumentTitle.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { DocumentTitleProvider } from "src/components/DocumentTitle/DocumentTitleContext";
-import { PageHeader } from "src/components/PageHeader";
+import { PageHeader } from "src/components/Headers/PageHeader";
 import { useDocumentTitle } from "src/hooks/useDocumentTitle";
 import { render } from "src/utils/rtl";
 
@@ -118,7 +118,7 @@ describe("useDocumentTitle", () => {
 
     // Then the suffix appears in document.title but not the visible heading
     expect(document.title).toBe("[QA] Schedule | 123 Sesame St | Blueprint | Homebound");
-    expect(r.pageHeader_title.textContent).toBe("Schedule");
+    expect(r.header_title.textContent).toBe("Schedule");
   });
 
   it("leaves document.title unchanged when PageHeader renders without a provider", async () => {

--- a/src/layouts/PageHeaderLayout/PageHeaderLayout.tsx
+++ b/src/layouts/PageHeaderLayout/PageHeaderLayout.tsx
@@ -1,5 +1,5 @@
 import { CSSProperties, ReactNode, useCallback, useMemo, useRef } from "react";
-import { PageHeader, PageHeaderProps } from "src/components/PageHeader";
+import { PageHeader, PageHeaderProps } from "src/components/Headers/PageHeader";
 import { TabsContentXss } from "src/components/Tabs";
 import { Css, Only } from "src/Css";
 import { useTestIds } from "src/utils";


### PR DESCRIPTION
### Workflow Header

Adds in the Workflow Header. This adjusts how headers work internally by providing a `BaseHeader` component to allow for different behaviors between headers while still following the base styles. If we only have these two headers, it might be a tad overkill but the abstraction is incredibly simple so I don't think it'll be too big of an issue down the road.

_note_: Workflow headers will have their CTAs appear on the bottom of the page in a sticky footer-like fashion in mobile. The plan is to have the future `WorkflowLayout` handle that piece so it can appropriately keep track of what it needs to keep track of w/ regards to heights and such.