### PR TITLE
feat: Show single filter inline rather than under filter toggle

### DIFF
--- a/src/components/Layout/GridTableLayout/FilterPanel.tsx
+++ b/src/components/Layout/GridTableLayout/FilterPanel.tsx
@@ -11,18 +11,14 @@ import {
 } from "src/components/Filters";
 import { ToggleChip } from "src/components/ToggleChip";
 import { Css } from "src/Css";
-import { SelectField } from "src/inputs/SelectField";
 import { Value } from "src/inputs/Value";
 import { useDocumentScrollLayout } from "src/layouts/DocumentScrollLayoutContext";
 import { isDefined, maybeCall, safeEntries, useTestIds } from "src/utils";
+import { GroupByField, GroupByFieldProps } from "./GroupByField";
 
 type FilterPanelProps<F extends Record<string, unknown>, G extends Value = string> = {
   isOpen: boolean;
-  groupBy?: {
-    value: G;
-    setValue: (g: G) => void;
-    options: Array<{ id: G; name: string }>;
-  };
+  groupBy?: GroupByFieldProps<G>;
   filterImpls: FilterImpls<F>;
   filter?: F;
   setFilter?: (filter: F) => void;
@@ -56,18 +52,7 @@ function FilterPanelOpen<F extends Record<string, unknown>, G extends Value = st
         ...Css.if(inDocumentScrollLayout).px3.$,
       }}
     >
-      {groupBy && (
-        <SelectField
-          label="Group by"
-          labelStyle="inline"
-          sizeToContent
-          options={groupBy.options}
-          getOptionValue={(o) => o.id}
-          getOptionLabel={(o) => o.name}
-          value={groupBy.value}
-          onSelect={(g) => g && groupBy.setValue(g)}
-        />
-      )}
+      {groupBy && <GroupByField {...groupBy} />}
       {filterControls}
       {activeFilterCount > 0 && (
         <Button label="Clear" variant="tertiary" onClick={() => maybeCall(onClear)} {...tid.clearBtn} />
@@ -99,7 +84,7 @@ function FilterPanelClosed<F extends Record<string, unknown>, G extends Value = 
   );
 }
 
-function buildFilterControls<F extends Record<string, unknown>>(
+export function buildFilterControls<F extends Record<string, unknown>>(
   filterImpls: FilterImpls<F>,
   filter: F,
   setFilter: (f: F) => void,

--- a/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
@@ -1,5 +1,5 @@
 import { act } from "@testing-library/react";
-import { checkboxFilter } from "src/components/Filters";
+import { checkboxFilter, multiFilter } from "src/components/Filters";
 import { setRunningInJest } from "src/components/Table/GridTable";
 import { GridTableApiImpl } from "src/components/Table/GridTableApi";
 import { cardStyle } from "src/components/Table/TableStyles";
@@ -51,9 +51,10 @@ describe("GridTableLayout", () => {
       withRouter(),
     );
 
-    // Then the table actions are rendered
+    // Then the table actions are rendered (single filter is inline on desktop)
     expect(r.search).toHaveValue("");
-    expect(r.gridTableLayoutActions_filterButton).toBeInTheDocument();
+    expect(r.filter_needsRevision).toBeInTheDocument();
+    expect(r.query.gridTableLayoutActions_filterButton).toBeNull();
     expect(tableSnapshot(r)).toMatchInlineSnapshot(`
       "
       | Name  | Value | Action  |
@@ -100,8 +101,9 @@ describe("GridTableLayout", () => {
 
     // And the search to not be rended
     expect(r.query.search).not.toBeInTheDocument();
-    // But the filter button still is
-    expect(r.gridTableLayoutActions_filterButton).toBeInTheDocument();
+    // But the single filter is inline on desktop
+    expect(r.filter_needsRevision).toBeInTheDocument();
+    expect(r.query.gridTableLayoutActions_filterButton).toBeNull();
 
     // And the table content to be rendered
     expect(tableSnapshot(r)).toMatchInlineSnapshot(`
@@ -522,11 +524,11 @@ describe("GridTableLayout", () => {
 
   describe("filters", () => {
     it("removes the filter value when a chip is clicked", async () => {
-      // Given the panel is closed with an active filter
+      // Given multiple filters so controls nest behind the Filter toggle (chips show when closed)
       const storageKey = "chip-click-test";
       sessionStorage.setItem(storageKey, JSON.stringify({ needsRevision: true }));
 
-      type ChipFilter = { needsRevision?: boolean };
+      type ChipFilter = { needsRevision?: boolean; status?: string[] };
       let capturedFilter: ChipFilter = {};
 
       function FilterChipWrapper() {
@@ -534,6 +536,15 @@ describe("GridTableLayout", () => {
           persistedFilter: {
             filterDefs: {
               needsRevision: checkboxFilter({ label: "Needs Revision" }),
+              status: multiFilter({
+                options: [
+                  { label: "Active", value: "active" },
+                  { label: "Inactive", value: "inactive" },
+                ],
+                getOptionLabel: (o) => o.label,
+                getOptionValue: (o) => o.value,
+                label: "Status",
+              }),
             },
             storageKey: storageKey,
           },
@@ -555,7 +566,7 @@ describe("GridTableLayout", () => {
       click(r.filter_chip_needsRevision);
 
       // Then the chip is removed and the filter state is cleared
-      expect(r.query.filter_chip_needsRevision).not.toBeInTheDocument();
+      expect(r.query.filter_chip_needsRevision).toBeNull();
       expect(capturedFilter).toEqual({});
     });
   });

--- a/src/components/Layout/GridTableLayout/GridTableLayoutActions.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayoutActions.stories.tsx
@@ -48,6 +48,59 @@ export function WithFilters() {
   return <GridTableLayoutActions filterDefs={filterDefs} filter={filter} setFilter={setFilter} />;
 }
 
+export function WithSingleFilter() {
+  const [filter, setFilter] = useState<{ needsRevision?: boolean }>({});
+  return (
+    <GridTableLayoutActions
+      searchProps={{ onSearch: () => {} }}
+      filterDefs={{ needsRevision: checkboxFilter({ label: "Needs Revision" }) }}
+      filter={filter}
+      setFilter={setFilter}
+      hasHideableColumns
+      columns={columns}
+      api={api}
+      view="list"
+      setView={() => {}}
+    />
+  );
+}
+
+export function WithGroupByOnly() {
+  const [groupBy, setGroupBy] = useState("none");
+  return (
+    <GridTableLayoutActions
+      searchProps={{ onSearch: () => {} }}
+      groupBy={{
+        value: groupBy,
+        setValue: setGroupBy,
+        options: createGroupByOptions(),
+      }}
+      hasHideableColumns
+      columns={columns}
+      api={api}
+      view="list"
+      setView={() => {}}
+    />
+  );
+}
+
+export function WithGroupByAndFilters() {
+  const [filter, setFilter] = useState<TestFilter>({ status: ["active"] });
+  const [groupBy, setGroupBy] = useState("none");
+  return (
+    <GridTableLayoutActions
+      filterDefs={filterDefs}
+      filter={filter}
+      setFilter={setFilter}
+      groupBy={{
+        value: groupBy,
+        setValue: setGroupBy,
+        options: createGroupByOptions(),
+      }}
+    />
+  );
+}
+
 export function WithEditColumns() {
   return (
     <GridTableLayoutActions hasHideableColumns={true} columns={columns} api={api} view="list" setView={() => {}} />
@@ -100,4 +153,12 @@ export function AllFeatures() {
       }}
     />
   );
+}
+
+function createGroupByOptions() {
+  return [
+    { id: "none", name: "None" },
+    { id: "status", name: "Status" },
+    { id: "tag", name: "Tag" },
+  ];
 }

--- a/src/components/Layout/GridTableLayout/GridTableLayoutActions.test.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayoutActions.test.tsx
@@ -1,16 +1,12 @@
 import { useState } from "react";
 import type { FilterDefs } from "src/components/Filters";
-import { checkboxFilter } from "src/components/Filters";
+import { checkboxFilter, multiFilter } from "src/components/Filters";
+import { setViewport } from "src/tests/viewport";
 import { noop } from "src/utils";
 import { click, render, withRouter } from "src/utils/rtl";
 import { typeAndWait } from "src/utils/rtlUtils";
 import { vi } from "vitest";
 import { GridTableLayoutActions } from "./GridTableLayoutActions";
-
-type TestFilter = { needsRevision?: boolean };
-const filterDefs: FilterDefs<TestFilter> = {
-  needsRevision: checkboxFilter({ label: "Needs Revision" }),
-};
 
 describe("GridTableLayoutActions", () => {
   describe("search", () => {
@@ -40,28 +36,81 @@ describe("GridTableLayoutActions", () => {
   });
 
   describe("filters", () => {
-    it("shows the filter button when filterDefs is provided", async () => {
-      // Given filterDefs is provided
+    it("renders a single filter inline on desktop without a Filter button or panel chips", async () => {
+      // Given a single filter and no groupBy on desktop
       const r = await render(
-        <GridTableLayoutActions filterDefs={filterDefs} filter={{}} setFilter={vi.fn()} />,
+        <GridTableLayoutActions filterDefs={createSingleFilterDefs()} filter={{}} setFilter={vi.fn()} />,
         withRouter(),
       );
-      // Then the filter button is shown
-      expect(r.gridTableLayoutActions_filterButton).toBeInTheDocument();
+      // Then the filter control is inline and the toggle / chips are not shown
+      expect(r.filter_needsRevision).toBeInTheDocument();
+      expect(r.query.gridTableLayoutActions_filterButton).toBeNull();
+      expect(r.query.filter_chip_needsRevision).toBeNull();
+      expect(r.query.filter_clearBtn).toBeNull();
     });
 
-    it("does not show the filter button when filterDefs is not provided", async () => {
-      // Given no filterDefs
+    it("renders groupBy inline on desktop when there are no filters", async () => {
+      // Given groupBy only on desktop
+      const r = await render(
+        <GridTableLayoutActions
+          groupBy={{
+            value: "none",
+            setValue: vi.fn(),
+            options: [
+              { id: "none", name: "None" },
+              { id: "status", name: "Status" },
+            ],
+          }}
+        />,
+        withRouter(),
+      );
+      // Then groupBy is inline and the Filter toggle is not shown
+      expect(r.groupBy).toBeInTheDocument();
+      expect(r.query.gridTableLayoutActions_filterButton).toBeNull();
+    });
+
+    it("shows the Filter button when groupBy and filters are nested", async () => {
+      // Given groupBy plus filters on desktop
+      const r = await render(
+        <GridTableLayoutActions
+          filterDefs={createSingleFilterDefs()}
+          filter={{}}
+          setFilter={vi.fn()}
+          groupBy={{
+            value: "none",
+            setValue: vi.fn(),
+            options: [
+              { id: "none", name: "None" },
+              { id: "status", name: "Status" },
+            ],
+          }}
+        />,
+        withRouter(),
+      );
+      // Then the Filter toggle is shown and controls are not inline until opened
+      expect(r.gridTableLayoutActions_filterButton).toBeInTheDocument();
+      expect(r.query.filter_needsRevision).toBeNull();
+      expect(r.query.groupBy).toBeNull();
+
+      // When the Filter button is clicked
+      click(r.gridTableLayoutActions_filterButton);
+      // Then groupBy and the filter are nested in the open panel
+      expect(r.groupBy).toBeInTheDocument();
+      expect(r.filter_needsRevision).toBeInTheDocument();
+    });
+
+    it("does not show the filter button when filterDefs and groupBy are not provided", async () => {
+      // Given no filterDefs or groupBy
       const r = await render(<GridTableLayoutActions />, withRouter());
       // Then the filter button is not shown
-      expect(r.query.filter_filterButton).not.toBeInTheDocument();
+      expect(r.query.gridTableLayoutActions_filterButton).toBeNull();
     });
 
     it("opens the filter panel on filter button click and closes it on a second click", async () => {
-      // Given the panel is closed with an active filter
+      // Given multiple filters with an active filter on desktop
       function Wrapper() {
-        const [filter, setFilter] = useState<TestFilter>({ needsRevision: true });
-        return <GridTableLayoutActions filterDefs={filterDefs} filter={filter} setFilter={setFilter} />;
+        const [filter, setFilter] = useState<MultiFilter>({ needsRevision: true });
+        return <GridTableLayoutActions filterDefs={createMultiFilterDefs()} filter={filter} setFilter={setFilter} />;
       }
       const r = await render(<Wrapper />, withRouter());
       expect(r.filter_chip_needsRevision).toBeInTheDocument();
@@ -69,7 +118,8 @@ describe("GridTableLayoutActions", () => {
       // When the filter button is clicked
       click(r.gridTableLayoutActions_filterButton);
       // Then the panel opens and chips are hidden
-      expect(r.query.filter_chip_needsRevision).not.toBeInTheDocument();
+      expect(r.query.filter_chip_needsRevision).toBeNull();
+      expect(r.filter_needsRevision).toBeInTheDocument();
 
       // When the filter button is clicked again
       click(r.gridTableLayoutActions_filterButton);
@@ -78,11 +128,11 @@ describe("GridTableLayoutActions", () => {
     });
 
     it("calls clearFilters when Clear is clicked in an open panel", async () => {
-      // Given the panel is closed with an active filter
+      // Given multiple filters with an active filter on desktop
       const clearFilters = vi.fn();
       const r = await render(
         <GridTableLayoutActions
-          filterDefs={filterDefs}
+          filterDefs={createMultiFilterDefs()}
           filter={{ needsRevision: true }}
           setFilter={vi.fn()}
           clearFilters={clearFilters}
@@ -94,6 +144,29 @@ describe("GridTableLayoutActions", () => {
       click(r.filter_clearBtn);
       // Then clearFilters is called
       expect(clearFilters).toHaveBeenCalled();
+    });
+
+    it("toggles the filter panel from the icon button on mobile for a single filter", async () => {
+      // Given a single filter on mobile
+      setViewport("sm");
+      const r = await render(
+        <GridTableLayoutActions
+          filterDefs={createSingleFilterDefs()}
+          filter={{ needsRevision: true }}
+          setFilter={vi.fn()}
+        />,
+        withRouter(),
+      );
+      // Then the small-screen toggle is shown and the control is not inline in the toolbar
+      expect(r.gridTableLayoutActions_filterSmallButton).toBeInTheDocument();
+      expect(r.query.gridTableLayoutActions_filterButton).toBeNull();
+      expect(r.filter_chip_needsRevision).toBeInTheDocument();
+
+      // When the filter icon is clicked
+      click(r.gridTableLayoutActions_filterSmallButton);
+      // Then the panel opens with the filter control
+      expect(r.query.filter_chip_needsRevision).toBeNull();
+      expect(r.filter_needsRevision).toBeInTheDocument();
     });
   });
 });
@@ -116,3 +189,27 @@ describe("actionMenu", () => {
     expect(r.query.verticalDots).not.toBeInTheDocument();
   });
 });
+
+type SingleFilter = { needsRevision?: boolean };
+type MultiFilter = { needsRevision?: boolean; status?: string[] };
+
+function createSingleFilterDefs(): FilterDefs<SingleFilter> {
+  return {
+    needsRevision: checkboxFilter({ label: "Needs Revision" }),
+  };
+}
+
+function createMultiFilterDefs(): FilterDefs<MultiFilter> {
+  return {
+    needsRevision: checkboxFilter({ label: "Needs Revision" }),
+    status: multiFilter({
+      options: [
+        { label: "Active", value: "active" },
+        { label: "Inactive", value: "inactive" },
+      ],
+      getOptionLabel: (o) => o.label,
+      getOptionValue: (o) => o.value,
+      label: "Status",
+    }),
+  };
+}

--- a/src/components/Layout/GridTableLayout/GridTableLayoutActions.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayoutActions.tsx
@@ -95,10 +95,9 @@ function GridTableLayoutActionsComponent<
   const hasSearch = !!searchProps;
   const filterCount = Object.keys(filterDefs ?? {}).length;
   const hasGroupBy = !!groupBy;
-  const hasFilterControls = filterCount > 0 || hasGroupBy;
   const controlCount = filterCount + (hasGroupBy ? 1 : 0);
+  const hasFilterControls = controlCount > 0;
   // One control only — nothing to nest behind a toggle; show it inline in the toolbar on desktop.
-  // Fall back to the Filter button if a lone filter is missing filter/setFilter.
   const showInlineControl = !sm && controlCount === 1 && (hasGroupBy || !!(filter && setFilter));
   const activeFilterCount = useMemo(() => (filter ? getActiveFilterCount(filter) : 0), [filter]);
   const filterImpls = useMemo(() => (filterDefs ? buildFilterImpls(filterDefs) : ({} as FilterImpls<F>)), [filterDefs]);

--- a/src/components/Layout/GridTableLayout/GridTableLayoutActions.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayoutActions.tsx
@@ -2,7 +2,7 @@ import { memo, MutableRefObject, useMemo, useState } from "react";
 import { Button } from "src/components/Button";
 import { ButtonMenu, ButtonMenuProps } from "src/components/ButtonMenu";
 import { CountBadge } from "src/components/CountBadge";
-import { FilterDefs, FilterImpls } from "src/components/Filters";
+import { FilterDefs, FilterImpls, filterTestIdPrefix } from "src/components/Filters";
 import { getActiveFilterCount } from "src/components/Filters/utils";
 import { Icon } from "src/components/Icon";
 import { IconButton } from "src/components/IconButton";
@@ -18,7 +18,8 @@ import { useDocumentScrollLayout } from "src/layouts/DocumentScrollLayoutContext
 import { useTestIds } from "src/utils";
 import { useDebouncedCallback } from "use-debounce";
 import { StringParam, useQueryParams } from "use-query-params";
-import { buildFilterImpls, FilterPanel } from "./FilterPanel";
+import { buildFilterControls, buildFilterImpls, FilterPanel } from "./FilterPanel";
+import { GroupByField, GroupByFieldProps } from "./GroupByField";
 
 export type SearchBoxProps = {
   onSearch: (filter: string) => void;
@@ -39,11 +40,7 @@ type GridTableLayoutActionsProps<
   filterDefs?: FilterDefs<F>;
   filter?: F;
   setFilter?: (filter: F) => void;
-  groupBy?: {
-    value: G;
-    setValue: (groupBy: G) => void;
-    options: Array<{ id: G; name: string }>;
-  };
+  groupBy?: GroupByFieldProps<G>;
   searchProps?: SearchBoxProps;
   hasHideableColumns?: boolean;
   columns?: GridColumn<R>[];
@@ -78,6 +75,8 @@ function GridTableLayoutActionsComponent<
     actionMenu,
   } = props;
   const testId = useTestIds(props, "gridTableLayoutActions");
+  // Separate prefix so inline filter controls match FilterPanel's `filter_*` test ids.
+  const filterTid = useTestIds({}, filterTestIdPrefix);
 
   const { sm } = useBreakpoint();
   const inDocumentScrollLayout = useDocumentScrollLayout();
@@ -94,7 +93,13 @@ function GridTableLayoutActionsComponent<
   }, 300);
 
   const hasSearch = !!searchProps;
-  const hasFilters = !!filterDefs && Object.keys(filterDefs ?? {}).length > 0;
+  const filterCount = Object.keys(filterDefs ?? {}).length;
+  const hasGroupBy = !!groupBy;
+  const hasFilterControls = filterCount > 0 || hasGroupBy;
+  const controlCount = filterCount + (hasGroupBy ? 1 : 0);
+  // One control only — nothing to nest behind a toggle; show it inline in the toolbar on desktop.
+  // Fall back to the Filter button if a lone filter is missing filter/setFilter.
+  const showInlineControl = !sm && controlCount === 1 && (hasGroupBy || !!(filter && setFilter));
   const activeFilterCount = useMemo(() => (filter ? getActiveFilterCount(filter) : 0), [filter]);
   const filterImpls = useMemo(() => (filterDefs ? buildFilterImpls(filterDefs) : ({} as FilterImpls<F>)), [filterDefs]);
 
@@ -146,7 +151,7 @@ function GridTableLayoutActionsComponent<
           )}
 
           {/* Small screen: filter icon toggle */}
-          {sm && hasFilters && (
+          {sm && hasFilterControls && (
             <IconButton
               variant="outline"
               icon={activeFilterCount > 0 ? "filterBadged" : "filter"}
@@ -157,8 +162,16 @@ function GridTableLayoutActionsComponent<
             />
           )}
 
-          {/* Large screen: full Filter button with badge + chevron */}
-          {!sm && hasFilters && (
+          {/* Desktop: single control inline in place of the Filter toggle */}
+          {showInlineControl &&
+            (groupBy ? (
+              <GroupByField {...groupBy} />
+            ) : (
+              filter && setFilter && buildFilterControls(filterImpls, filter, setFilter, filterTid)
+            ))}
+
+          {/* Large screen: Filter button when controls are nested (or inline isn't possible) */}
+          {!sm && hasFilterControls && !showInlineControl && (
             <Button
               label="Filter"
               icon="filter"
@@ -190,8 +203,8 @@ function GridTableLayoutActionsComponent<
       {/* Search row — spans full width below TableActions (including under right-side buttons) */}
       {sm && showSearch && <div css={Css.px3.$}>{searchTextField}</div>}
 
-      {/* Combined filter panel — controls when open, chips when closed */}
-      {hasFilters && (
+      {/* Combined filter panel — omitted when the single control is already inline in the toolbar */}
+      {hasFilterControls && !showInlineControl && (
         <FilterPanel
           isOpen={showFilters}
           groupBy={groupBy}

--- a/src/components/Layout/GridTableLayout/GroupByField.tsx
+++ b/src/components/Layout/GridTableLayout/GroupByField.tsx
@@ -1,0 +1,24 @@
+import { SelectField } from "src/inputs/SelectField";
+import { Value } from "src/inputs/Value";
+
+export type GroupByFieldProps<G extends Value = string> = {
+  value: G;
+  setValue: (g: G) => void;
+  options: Array<{ id: G; name: string }>;
+};
+
+/** Group-by select shared by the filter panel and the desktop inline toolbar control. */
+export function GroupByField<G extends Value = string>({ value, setValue, options }: GroupByFieldProps<G>) {
+  return (
+    <SelectField
+      label="Group by"
+      labelStyle="inline"
+      sizeToContent
+      options={options}
+      getOptionValue={(o) => o.id}
+      getOptionLabel={(o) => o.name}
+      value={value}
+      onSelect={(g) => g && setValue(g)}
+    />
+  );
+}


### PR DESCRIPTION
In GridTableLayoutActions we were hiding all filters under a filters toggle. However, when there is only one action, it seemed unnecessary to hide on desktop views. This change allows for displaying the single fitler, or group by, control in place of the toggle button when in the desktop view. In mobile, the toggle button still exists and will display the single filter or group by option, which is the same behavior as it is today.