### PR TITLE
feat: Add Css.layoutContainer.$ custom truss property

### DIFF
--- a/src/Css.json
+++ b/src/Css.json
@@ -906,6 +906,7 @@
     "br24": {"kind":"static","defs":{"borderRadius":"24px"}},
     "brt4": {"kind":"static","defs":{"borderTopRightRadius":"4px","borderTopLeftRadius":"4px"}},
     "brb4": {"kind":"static","defs":{"borderBottomRightRadius":"4px","borderBottomLeftRadius":"4px"}},
+    "layoutContainer": {"kind":"static","defs":{"width":"calc(var(--beam-layout-viewport-width, 100vw) - var(--beam-side-nav-layout-width, 0px))","left":"var(--beam-side-nav-layout-width, 0px)","position":"sticky","paddingLeft":"24px","paddingRight":"24px"}},
     "transition": {"kind":"static","defs":{"transition":"background-color 200ms cubic-bezier(0.4, 0, 0.2, 1), border-color 200ms cubic-bezier(0.4, 0, 0.2, 1), box-shadow 200ms cubic-bezier(0.4, 0, 0.2, 1), left 200ms cubic-bezier(0.4, 0, 0.2, 1), right 200ms cubic-bezier(0.4, 0, 0.2, 1), margin 200ms cubic-bezier(0.4, 0, 0.2, 1), width 200ms cubic-bezier(0.4, 0, 0.2, 1), opacity 200ms cubic-bezier(0.4, 0, 0.2, 1)"}},
     "transitionWidth": {"kind":"static","defs":{"transition":"width 200ms cubic-bezier(0.4, 0, 0.2, 1)"}},
     "transitionOpacity": {"kind":"static","defs":{"transition":"opacity 200ms cubic-bezier(0.4, 0, 0.2, 1)"}},

--- a/src/Css.ts
+++ b/src/Css.ts
@@ -3942,6 +3942,16 @@ class CssBuilder<T extends Properties, S extends StyleKind = "buildtime"> {
     return this.add("fontFamily", value);
   }
 
+  // layoutContainer
+  /** Sets `width: "calc(var(--beam-layout-viewport-width, 100vw) - var(--beam-side-nav-layout-width, 0px))"; left: "var(--beam-side-nav-layout-width, 0px)"; position: "sticky"; paddingLeft: "24px"; paddingRight: "24px"`. */
+  get layoutContainer() {
+    return this.add("width", "calc(var(--beam-layout-viewport-width, 100vw) - var(--beam-side-nav-layout-width, 0px))")
+      .add("left", "var(--beam-side-nav-layout-width, 0px)").add("position", "sticky").add("paddingLeft", "24px").add(
+        "paddingRight",
+        "24px",
+      );
+  }
+
   // animation
   /** Sets `transition: "background-color 200ms cubic-bezier(0.4, 0, 0.2, 1), border-color 200ms cubic-bezier(0.4, 0, 0.2, 1), box-shadow 200ms cubic-bezier(0.4, 0, 0.2, 1), left 200ms cubic-bezier(0.4, 0, 0.2, 1), right 200ms cubic-bezier(0.4, 0, 0.2, 1), margin 200ms cubic-bezier(0.4, 0, 0.2, 1), width 200ms cubic-bezier(0.4, 0, 0.2, 1), opacity 200ms cubic-bezier(0.4, 0, 0.2, 1)"`. */
   get transition() {

--- a/src/layouts/EnvironmentBannerLayout/EnvironmentBannerLayout.stories.tsx
+++ b/src/layouts/EnvironmentBannerLayout/EnvironmentBannerLayout.stories.tsx
@@ -58,6 +58,14 @@ export function Composed() {
           }}
         >
           <PageHeaderLayout pageHeader={{ title: "Page header" }}>
+            <p css={Css.p3.$}>
+              This text will take up the entire width of its container and get scrolled away both horizontally and
+              vertically.
+            </p>
+            <p css={Css.layoutContainer.py3.$}>
+              This text uses <pre>Css.layoutContainer.$</pre> to fix itself in place horizontally, but will still scroll
+              away vertically.
+            </p>
             <GridTableLayoutExample storageKey="environment-banner-layout-composed" />
           </PageHeaderLayout>
         </SideNavLayout>

--- a/src/layouts/layoutSpacing.ts
+++ b/src/layouts/layoutSpacing.ts
@@ -1,4 +1,5 @@
 import { Css } from "src/Css";
+import { pageContentPaddingXValue } from "./layoutVars";
 
 /**
  * Empty table gutter column width. Default cell pad is 12px and gutters use `px0`, so
@@ -7,7 +8,7 @@ import { Css } from "src/Css";
 export const pageContentGutterPx = 12;
 
 /** Horizontal inset for page body / page header content. */
-export const pageContentPaddingX = Css.px3.$;
+export const pageContentPaddingX = Css.px(pageContentPaddingXValue).$;
 
 /**
  * Horizontal inset for global header chrome (navbar, env banner): `px1` below `md`, `px5` at

--- a/src/layouts/layoutVars.ts
+++ b/src/layouts/layoutVars.ts
@@ -59,3 +59,8 @@ export function stickyTableHeaderOffset(basePx = 0): string {
 export function getFloatingBottomOffset(basePx = 0): string {
   return `calc(${basePx}px + var(${beamWorkflowLayoutFooterHeightVar}, 0px))`;
 }
+
+/** Page content horizontal inset (px).
+ * Setting in layoutVars instead of layoutSpacing to avoid circular dependency with truss-config.ts
+ */
+export const pageContentPaddingXValue = "24px";

--- a/truss-config.ts
+++ b/truss-config.ts
@@ -1,4 +1,9 @@
 import { defineConfig, newMethod, newMethodsForProp, Sections } from "@homebound/truss";
+import {
+  documentScrollChromeLeft,
+  documentScrollChromeWidth,
+  pageContentPaddingXValue,
+} from "./src/layouts/layoutVars";
 import { motion } from "./truss-motion";
 import { palette } from "./truss-palette";
 import { Tokens } from "./truss-token-vars";
@@ -62,6 +67,15 @@ const sections: Sections = {
     newMethod("brt4", { borderTopRightRadius: "4px", borderTopLeftRadius: "4px" }),
     newMethod("brb4", { borderBottomRightRadius: "4px", borderBottomLeftRadius: "4px" }),
   ],
+  layoutContainer: () => [
+    newMethod("layoutContainer", {
+      width: documentScrollChromeWidth(),
+      left: documentScrollChromeLeft(),
+      position: "sticky",
+      paddingLeft: pageContentPaddingXValue,
+      paddingRight: pageContentPaddingXValue,
+    }),
+  ],
   animation: () => [
     newMethod("transition", { transition }),
     newMethod("transitionWidth", {
@@ -81,7 +95,7 @@ const sections: Sections = {
     }),
     newMethod("transitionAll", {
       transition: `all ${motion.duration.normal} ${motion.easing.standard}`,
-    })
+    }),
   ],
   boxShadow: () =>
     newMethodsForProp("boxShadow", {


### PR DESCRIPTION
layoutContainer adds the styles necessary to fix elements in place within the layouts when other content triggers a horiztonal scroll. For instance, if you place copy above a very long table, and you want that copy to always stay visible as the user scrolls left and right within the table, then this is for you! It does however, scroll away vertically. This is on purpose, as our stance going forward is fix as little content in the vertical scroll as possible