### PR TITLE
feat: added image support on the radio group field component

### DIFF
--- a/src/inputs/RadioGroupField.stories.tsx
+++ b/src/inputs/RadioGroupField.stories.tsx
@@ -315,6 +315,27 @@ export function HelperText() {
   );
 }
 
+/** Photo picker use case: radio beside a plain image, no card border, no visible label. */
+export function ImageOptions() {
+  const [state, setState] = useState<string | undefined>("c");
+  return (
+    <div css={Css.wPx(500).$}>
+      <RadioGroupField
+        label="Featured image"
+        labelStyle="hidden"
+        layout="horizontal"
+        value={state}
+        onChange={setState}
+        options={[
+          { value: "a", label: "Sherwin Williams Paint - Pure White", image: "fridge.jpeg" },
+          { value: "b", label: "Sherwin Williams Paint - Off White", image: "fridge2.jpeg" },
+          { value: "c", label: "Benjamin Moore - Rockport Gray", image: "disposal.png" },
+        ]}
+      />
+    </div>
+  );
+}
+
 export function HorizontalLayout() {
   const [state, setState] = useState<string | undefined>("option-1");
   return (

--- a/src/inputs/RadioGroupField.test.tsx
+++ b/src/inputs/RadioGroupField.test.tsx
@@ -1,5 +1,6 @@
 import { RadioGroupField } from "src/inputs";
 import { click, render } from "src/utils/rtl";
+import { vi } from "vitest";
 
 describe("RadioGroupField", () => {
   it("has data-testids for its options", async () => {
@@ -99,5 +100,31 @@ describe("RadioGroupField", () => {
     // The flex container that wraps the option labels uses row direction.
     const optionsContainer = r.container.querySelector(`[data-testid="favoriteCheese_a"]`)!.closest("div")!;
     expect(optionsContainer).toHaveStyle({ "flex-direction": "row" });
+  });
+
+  it("renders an image instead of the label/description text when image is provided", async () => {
+    const onChange = vi.fn();
+    const r = await render(
+      <RadioGroupField
+        label="Featured image"
+        labelStyle="hidden"
+        layout="horizontal"
+        value="a"
+        onChange={onChange}
+        options={[
+          { value: "a", label: "Pure White", image: "pure-white.png" },
+          { value: "b", label: "Off White", image: "off-white.png" },
+        ]}
+      />,
+    );
+    // Then each option renders its image
+    const inputA = r.container.querySelector(`[data-testid="featuredImage_a"]`)!;
+    const image = inputA.closest("label")!.querySelector("img")!;
+    expect(image).toHaveAttribute("src", "pure-white.png");
+    // And the label is still available to assistive tech
+    expect(r.getByText("Pure White")).toBeInTheDocument();
+    // And selection still works
+    click(r.featuredImage_b);
+    expect(onChange).toHaveBeenCalledWith("b");
   });
 });

--- a/src/inputs/RadioGroupField.tsx
+++ b/src/inputs/RadioGroupField.tsx
@@ -1,5 +1,5 @@
 import { Fragment, ReactNode, useMemo, useRef } from "react";
-import { useFocusRing, useHover, useRadio, useRadioGroup } from "react-aria";
+import { useFocusRing, useHover, useRadio, useRadioGroup, VisuallyHidden } from "react-aria";
 import { RadioGroupState, useRadioGroupState } from "react-stately";
 import { maybeTooltip, resolveTooltip } from "src/components";
 import { HelperText } from "src/components/HelperText";
@@ -24,6 +24,11 @@ export type RadioFieldOption<K extends string> = {
   value: K;
   /** Disable only specific option, with an optional reason */
   disabled?: boolean | ReactNode;
+  /**
+   * Optional image shown beside the radio instead of the label/description text, i.e. for a
+   * photo picker. `label` is still required and used for assistive tech, but is visually hidden.
+   */
+  image?: string;
 };
 
 export type RadioGroupFieldLayout = "vertical" | "horizontal";
@@ -134,7 +139,7 @@ function Radio<K extends string>(props: {
 }) {
   const {
     parentId,
-    option: { description, label, value },
+    option: { description, label, value, image },
     state,
     isOptionDisabled,
     ...others
@@ -156,7 +161,13 @@ function Radio<K extends string>(props: {
   const { hoverProps, isHovered } = useHover({ isDisabled: disabled });
 
   return (
-    <label css={Css.df.cursorPointer.if(disabled).add("cursor", "initial").$} {...hoverProps}>
+    <label
+      css={{
+        ...Css.df.cursorPointer.if(disabled).add("cursor", "initial").$,
+        ...(image && Css.aic.gap1.$),
+      }}
+      {...hoverProps}
+    >
       <input
         type="radio"
         ref={ref}
@@ -166,8 +177,9 @@ function Radio<K extends string>(props: {
           ...getRadioStateStyles({ isDisabled: disabled, isSelected }),
           ...(isHovered && !disabled ? radioHover : {}),
           ...(isFocusVisible ? radioFocus : {}),
-          // Nudge down so the center of the circle lines up with the label text
-          ...Css.mtPx(2).mr1.$,
+          // Without an image, nudge down so the center of the circle lines up with the label text.
+          // With an image, the label is hidden and `gap1` on the label above handles spacing instead.
+          ...(image ? Css.fs0.$ : Css.mtPx(2).mr1.$),
         }}
         disabled={disabled}
         aria-labelledby={labelId}
@@ -176,20 +188,32 @@ function Radio<K extends string>(props: {
         // Put others here b/c it could have data-testid in it or onX events.
         {...others}
       />
-      <div>
-        <div
-          id={labelId}
-          css={Css.sm.gray800.if(disabled).gray400.$}
-          {...(description ? { "aria-describedby": descriptionId } : {})}
-        >
-          {label}
-        </div>
-        {description && (
-          <div id={descriptionId} css={Css.sm.gray700.if(disabled).gray400.$}>
-            {typeof description === "function" ? description() : description}
+      {image ? (
+        <>
+          {/* Kept for accessibility; the image stands in for the visible label. */}
+          <VisuallyHidden>
+            <span id={labelId}>{label}</span>
+          </VisuallyHidden>
+          <div css={Css.sqPx(120).ba.bw1.bcGray200.br8.bgWhite.df.aic.jcc.oh.p1.fs0.$}>
+            <img src={image} alt="" css={Css.w100.h100.objectContain.$} />
           </div>
-        )}
-      </div>
+        </>
+      ) : (
+        <div>
+          <div
+            id={labelId}
+            css={Css.sm.gray800.if(disabled).gray400.$}
+            {...(description ? { "aria-describedby": descriptionId } : {})}
+          >
+            {label}
+          </div>
+          {description && (
+            <div id={descriptionId} css={Css.sm.gray700.if(disabled).gray400.$}>
+              {typeof description === "function" ? description() : description}
+            </div>
+          )}
+        </div>
+      )}
     </label>
   );
 }


### PR DESCRIPTION
### RadioGroupField image options

Adds an optional `image` prop on radio options so `RadioGroupField` can act as a photo picker: the radio sits beside a framed image, with the label kept for accessibility but visually hidden.

```tsx
<RadioGroupField
  label="Featured image"
  labelStyle="hidden"
  layout="horizontal"
  value={value}
  onChange={setValue}
  options={[
    { value: "a", label: "Pure White", image: "/swatches/pure-white.png" },
    { value: "b", label: "Off White", image: "/swatches/off-white.png" },
  ]}
/>
```

- When `image` is set, the option renders a 120×120 bordered image instead of visible label/description text
- `label` remains required and is exposed via `VisuallyHidden` for screen readers
- Includes an `ImageOptions` Storybook story and a unit test covering render + selection

<img width="527" height="159" alt="Screenshot 2026-07-31 at 2 43 40 PM" src="https://github.com/user-attachments/assets/4fc99358-26c9-48b3-9a1e-83bab84d531b" />
<img width="505" height="488" alt="Screenshot 2026-07-31 at 2 46 13 PM" src="https://github.com/user-attachments/assets/64c2c568-01ef-4120-b808-95b622010a1d" />
