### PR TITLE
fix: Keep structure in TreeSelectField filtering.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,27 @@ After editing a test file, run `yarn lint:fix:files` on that path (see **Linting
 - In tests, use each component’s default prefix (e.g. `r.sideNav_trigger`) — do not pass `data-testid` on the component under test.
 - For **absence** checks, use `r.query.someTestId` (e.g. `expect(r.query.sideNav_section_label).toBeNull()`), not `r.queryByTestId("sideNav_section_label")`.
 
+### Never query by accessible name
+
+**Do not use `getByRole(role, { name })`** (or `getAllByRole` / `findByRole` / `queryByRole` with a `name`). It is the single most expensive thing a Beam test can do, and it has repeatedly caused CI timeouts.
+
+Passing `name` makes Testing Library compute each candidate’s **accessible name** via `dom-accessibility-api`, which calls `getComputedStyle` on every candidate *and its subtree*. jsdom has no cascade cache, so each of those calls re-matches **every CSS rule in the document** — and Truss injects ~2.5k atomic utility rules (`.br4 { … }`), for ~2.7k rules total. Measured on a 14-option `TreeSelectField` listbox:
+
+| Query | Cost |
+| --- | --- |
+| `getByRole("option", { name: "Grandparent 0" })` | **270ms** |
+| `getAllByRole("option")` (no `name`) | 10ms |
+| `getByText("Grandparent 0")` | ~0ms |
+| the `click` itself | 10ms |
+
+That is ~96% of the interaction spent in jsdom’s CSS matcher, and it scales with both option count and stylesheet size. Three such lookups per test made `TreeFilter.test.tsx` take 1.1s locally and **16.4s in CI** (CI runs ~13x slower), blowing the 15s `testTimeout` on `main` and on unrelated branches until the queries were replaced.
+
+Use instead:
+
+- **Beam listbox options** — [`select(r.field, "Label")`](src/utils/rtlUtils.tsx) or `select(r.field, ["A", "B"])`, which opens the listbox and matches each option’s `data-label` / `data-key`. Related helpers: `getOptions(r.field)`, `getSelected(r.field)`.
+- **Everything else** — `data-testid` via `useTestIds` (see above), or `getByText` when the text is unique.
+- If you genuinely need role semantics, query the role **without** `name` (`getAllByRole("option")` is cheap) and narrow by `textContent` / `dataset` yourself.
+
 ### `useTestIds` for components
 
 Use [`useTestIds`](src/utils/useTestIds.tsx) for any element tests need to target — do **not** set `data-testid={...}` by hand in components or tests.

--- a/src/components/Filters/TreeFilter.test.tsx
+++ b/src/components/Filters/TreeFilter.test.tsx
@@ -4,9 +4,11 @@ import { treeFilter, TreeFilterProps } from "src/components/Filters/TreeFilter";
 import { FilterDefs } from "src/components/Filters/types";
 import { NestedOption } from "src/inputs";
 import { HasIdAndName } from "src/types";
-import { click, render } from "src/utils/rtl";
+import { render, select } from "src/utils/rtl";
 import { zeroTo } from "src/utils/sb";
 
+// Pick options with `select` (which matches on `data-label`), never `getByRole("option", { name })`:
+// the by-name lookup cost ~270ms a call here and timed this file out in CI. See AGENTS.md.
 describe("TreeFilter", () => {
   it("can select root values (default)", async () => {
     // Given the tree filter filtering by root option values (default)
@@ -15,10 +17,7 @@ describe("TreeFilter", () => {
     expect(r.filter_tree).toHaveValue("All");
     expect(r.value).toHaveTextContent("{}");
     // When selecting some options
-    click(r.filter_tree);
-    click(r.getByRole("option", { name: "Grandparent 0" }));
-    click(r.getByRole("option", { name: "Child 1-0-0" }));
-    click(r.getByRole("option", { name: "Parent 1-1" }));
+    select(r.filter_tree, ["Grandparent 0", "Child 1-0-0", "Parent 1-1"]);
     // Then the filter's value is empty now that we're making selections
     expect(r.filter_tree).toHaveValue("");
     // Then the filter is set to only return the "root" values that are selected.
@@ -29,10 +28,7 @@ describe("TreeFilter", () => {
     // Given the tree filter filtering by leaf option values
     const r = await render(<TestFilter filterBy="leaf" />);
     // When selecting some options
-    click(r.filter_tree);
-    click(r.getByRole("option", { name: "Grandparent 0" }));
-    click(r.getByRole("option", { name: "Child 1-0-0" }));
-    click(r.getByRole("option", { name: "Parent 1-1" }));
+    select(r.filter_tree, ["Grandparent 0", "Child 1-0-0", "Parent 1-1"]);
     // Then the filter is set to only return the "root" values that are selected.
     expect(r.value).toHaveTextContent(
       '{"tree":["child:0-0-0","child:0-0-1","child:0-1-0","child:0-1-1","child:1-0-0","child:1-1-0","child:1-1-1"]}',
@@ -43,10 +39,7 @@ describe("TreeFilter", () => {
     // Given the tree filter filtering by all option values
     const r = await render(<TestFilter filterBy="all" />);
     // When selecting some options
-    click(r.filter_tree);
-    click(r.getByRole("option", { name: "Grandparent 0" }));
-    click(r.getByRole("option", { name: "Child 1-0-0" }));
-    click(r.getByRole("option", { name: "Parent 1-1" }));
+    select(r.filter_tree, ["Grandparent 0", "Child 1-0-0", "Parent 1-1"]);
     // Then the filter is set to only return the "root" values that are selected.
     expect(r.value).toHaveTextContent(
       '{"tree":["gp:0","parent:0-0","child:0-0-0","child:0-0-1","parent:0-1","child:0-1-0","child:0-1-1","child:1-0-0","parent:1-1","child:1-1-0","child:1-1-1"]}',
@@ -74,8 +67,7 @@ describe("TreeFilter", () => {
     const r = await render(<TestFilter defaultValue={["child:0-0-1"]} />);
     expect(r.value).toHaveTextContent('{"tree":["child:0-0-1"]}');
     // When clearing the selection
-    click(r.filter_tree);
-    click(r.getByRole("option", { name: "Child 0-0-1" }));
+    select(r.filter_tree, "Child 0-0-1");
     // Then the value is undefined
     expect(r.value).toHaveTextContent("{}");
   });

--- a/src/inputs/TreeSelectField/TreeOption.tsx
+++ b/src/inputs/TreeSelectField/TreeOption.tsx
@@ -13,13 +13,12 @@ import { useTestIds } from "src/utils";
 type TreeOptionProps<O> = {
   item: Node<LeveledOption<O>>;
   state: ListState<O>;
-  allowCollapsing?: boolean;
   /** When the option is disabled, the reason shown as a tooltip on hover. */
   disabledReason?: string;
 };
 /** Represents a single option within a ListBox - used by SelectField, MultiSelectField, and TreeSelectField */
 export function TreeOption<O>(props: TreeOptionProps<O>) {
-  const { item, state, allowCollapsing = true, disabledReason } = props;
+  const { item, state, disabledReason } = props;
   const leveledOption = item.value;
   if (!leveledOption) return null;
 
@@ -46,7 +45,7 @@ export function TreeOption<O>(props: TreeOptionProps<O>) {
     ref,
   );
   const isGroup = groupKeys.includes(item.key);
-  const canCollapse = allowCollapsing && !!option.children?.length;
+  const canCollapse = !!option.children?.length;
 
   function toggleCollapsed() {
     if (!canCollapse) return;
@@ -86,24 +85,22 @@ export function TreeOption<O>(props: TreeOptionProps<O>) {
           ...(isDisabled && !isGroup ? listItemStyles.disabled : {}),
         }}
       >
-        {allowCollapsing && (
-          <span css={Css.wPx(18).fs0.df.aic.$}>
-            {canCollapse && (
-              <button
-                onClick={(e) => {
-                  e.preventDefault();
-                  e.stopPropagation();
-                  toggleCollapsed();
-                  return false;
-                }}
-                css={Css.br4.hPx(16).wPx(16).bgTransparent.onHover.bgGray300.$}
-                {...tid[`collapseToggle_${item.key}`]}
-              >
-                <Icon icon={collapsedKeys.includes(item.key) ? "triangleRight" : "triangleDown"} inc={2} />
-              </button>
-            )}
-          </span>
-        )}
+        <span css={Css.wPx(18).fs0.df.aic.$}>
+          {canCollapse && (
+            <button
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                toggleCollapsed();
+                return false;
+              }}
+              css={Css.br4.hPx(16).wPx(16).bgTransparent.onHover.bgGray300.$}
+              {...tid[`collapseToggle_${item.key}`]}
+            >
+              <Icon icon={collapsedKeys.includes(item.key) ? "triangleRight" : "triangleDown"} inc={2} />
+            </button>
+          )}
+        </span>
         <span css={Css.df.aic.gap1.h100.fg1.py1.pr2.$} ref={ref} {...optionProps} data-label={item.textValue}>
           {!isGroup && (
             <StyledCheckbox

--- a/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
@@ -8,7 +8,7 @@ import { NestedOption } from "src/inputs/TreeSelectField/utils";
 import { HasIdAndName } from "src/types";
 import { newStory, zeroTo } from "src/utils/sb";
 import { action } from "storybook/actions";
-import { within } from "storybook/test";
+import { userEvent, within } from "storybook/test";
 
 export default {
   component: TreeSelectField,
@@ -206,6 +206,25 @@ export const OpenMenuWithSelections = newStory(
     play: async ({ canvasElement }) => {
       const canvas = within(canvasElement);
       canvas.getByTestId("toggleListBox").click();
+    },
+  },
+);
+
+/** Filtering keeps the tree intact, i.e. "nba" leaves NBA/WNBA nested under (and collapsible from) Basketball. */
+export const FilteredMenu = newStory(
+  () => (
+    <TestTreeSelectField
+      values={[]}
+      options={getLeagueOptions()}
+      label="Favorite League"
+      placeholder="Select a league"
+    />
+  ),
+  {
+    play: async ({ canvasElement }) => {
+      const canvas = within(canvasElement);
+      canvas.getByTestId("toggleListBox").click();
+      await userEvent.type(canvas.getByTestId("favoriteLeague"), "nba");
     },
   },
 );

--- a/src/inputs/TreeSelectField/TreeSelectField.test.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.test.tsx
@@ -595,6 +595,33 @@ describe("TreeSelectField", () => {
     expect(getOptionLabels(r)).toEqual(collapsed);
   });
 
+  it("keeps the filter when selecting options", async () => {
+    // Given a TreeSelectField with nested options
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={getNestedOptions()}
+        label="Favorite League"
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    click(r.favoriteLeague);
+    fireEvent.input(r.favoriteLeague, { target: { value: "nba" } });
+    // When selecting one of the matched options
+    click(r.treeOption_nba_checkbox);
+    // Then it is selected, and the filter + filtered options are left as-is
+    expect(r.treeOption_nba_checkbox).toHaveAttribute("data-checked", "true");
+    expect(r.favoriteLeague).toHaveValue("nba");
+    expect(getOptionLabels(r)).toEqual(["Basketball", "NBA", "WNBA"]);
+    // And when unselecting it, i.e. clearing the last selection, the filter is still kept
+    click(r.treeOption_nba_checkbox);
+    expect(r.treeOption_nba_checkbox).toHaveAttribute("data-checked", "false");
+    expect(r.favoriteLeague).toHaveValue("nba");
+    expect(getOptionLabels(r)).toEqual(["Basketball", "NBA", "WNBA"]);
+  });
+
   it("shows the correct input text when selecting options", async () => {
     // Given a TreeSelectField with nested options
     const r = await render(

--- a/src/inputs/TreeSelectField/TreeSelectField.test.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.test.tsx
@@ -528,13 +528,71 @@ describe("TreeSelectField", () => {
     // When opening the options
     click(r.favoriteLeague);
     // Then the child options are visible
-    expect(r.getByRole("option", { name: "MLB" })).toBeVisible();
+    expect(getOptionLabels(r)).toEqual([
+      "Baseball",
+      "MLB",
+      "Minor League Baseball",
+      "Basketball",
+      "NBA",
+      "WNBA",
+      "Football",
+      "NFL",
+      "XFL",
+    ]);
     // When we collapse the parent option
     click(r.treeOption_collapseToggle_basketball);
     // And typing in the filter input
     fireEvent.input(r.favoriteLeague, { target: { value: "nba" } });
     // Then the options that match the filter are visible, even though their parent was collapsed
     expect(getOptionLabels(r)).toEqual(["Basketball", "NBA", "WNBA"]);
+  });
+
+  it("can collapse parents within the filtered options", async () => {
+    // Given a TreeSelectField with nested options
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={getNestedOptions()}
+        label="Favorite League"
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    click(r.favoriteLeague);
+    // When filtering down to a matched child
+    fireEvent.input(r.favoriteLeague, { target: { value: "nba" } });
+    expect(getOptionLabels(r)).toEqual(["Basketball", "NBA", "WNBA"]);
+    // Then its parent can still be collapsed
+    click(r.treeOption_collapseToggle_basketball);
+    expect(getOptionLabels(r)).toEqual(["Basketball"]);
+    // And expanded again
+    click(r.treeOption_collapseToggle_basketball);
+    expect(getOptionLabels(r)).toEqual(["Basketball", "NBA", "WNBA"]);
+  });
+
+  it("restores the collapsed options when the filter is cleared", async () => {
+    // Given a TreeSelectField with a collapsed parent
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={getNestedOptions()}
+        label="Favorite League"
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    click(r.favoriteLeague);
+    click(r.treeOption_collapseToggle_baseball);
+    const collapsed = ["Baseball", "Basketball", "NBA", "WNBA", "Football", "NFL", "XFL"];
+    expect(getOptionLabels(r)).toEqual(collapsed);
+    // When filtering and then clearing the filter
+    fireEvent.input(r.favoriteLeague, { target: { value: "mlb" } });
+    expect(getOptionLabels(r)).toEqual(["Baseball", "MLB"]);
+    fireEvent.input(r.favoriteLeague, { target: { value: "" } });
+    // Then the parent we'd collapsed is collapsed again
+    expect(getOptionLabels(r)).toEqual(collapsed);
   });
 
   it("shows the correct input text when selecting options", async () => {

--- a/src/inputs/TreeSelectField/TreeSelectField.test.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.test.tsx
@@ -1,3 +1,4 @@
+import { RenderResult } from "@homebound/rtl-utils";
 import { fireEvent, within } from "@testing-library/react";
 import { useState } from "react";
 import { TreeSelectField } from "src/inputs";
@@ -467,10 +468,49 @@ describe("TreeSelectField", () => {
     // And typing in the filter input
     fireEvent.input(r.favoriteLeague, { target: { value: "nba" } });
     expect(r.favoriteLeague).toHaveValue("nba");
-    // Then only the NBA option is visible
-    expect(r.queryAllByRole("option")).toHaveLength(2);
-    expect(r.getByRole("option", { name: "NBA" })).toBeVisible();
-    expect(r.getByRole("option", { name: "WNBA" })).toBeVisible();
+    // Then only the matched options, and their parent, are visible
+    expect(getOptionLabels(r)).toEqual(["Basketball", "NBA", "WNBA"]);
+  });
+
+  it("keeps the tree structure when filtering", async () => {
+    // Given a TreeSelectField with three levels of options
+    const r = await render(
+      <TreeSelectField
+        onSelect={noop}
+        options={[
+          {
+            id: "sports",
+            name: "Sports",
+            children: [
+              {
+                id: "basketball",
+                name: "Basketball",
+                children: [
+                  { id: "nba", name: "NBA" },
+                  { id: "wnba", name: "WNBA" },
+                ],
+              },
+              { id: "football", name: "Football", children: [{ id: "nfl", name: "NFL" }] },
+            ],
+          },
+        ]}
+        label="Favorite League"
+        values={[]}
+        getOptionValue={(o) => o.id}
+        getOptionLabel={(o) => o.name}
+      />,
+    );
+    click(r.favoriteLeague);
+    // When filtering on a grandchild option
+    fireEvent.input(r.favoriteLeague, { target: { value: "wnba" } });
+    // Then all of its parents are shown, still nested
+    expect(getOptionLabels(r)).toEqual(["Sports", "Basketball", "WNBA"]);
+    expect(getOptionLevels(r)).toEqual([0, 1, 2]);
+    // And when filtering on a mid-level parent option
+    fireEvent.input(r.favoriteLeague, { target: { value: "basketball" } });
+    // Then its parent and all of its children are shown
+    expect(getOptionLabels(r)).toEqual(["Sports", "Basketball", "NBA", "WNBA"]);
+    expect(getOptionLevels(r)).toEqual([0, 1, 2, 2]);
   });
 
   it("can filter options even if parent if collapsed", async () => {
@@ -493,10 +533,8 @@ describe("TreeSelectField", () => {
     click(r.treeOption_collapseToggle_basketball);
     // And typing in the filter input
     fireEvent.input(r.favoriteLeague, { target: { value: "nba" } });
-    // Then only the options that match the filter are visible
-    expect(r.queryAllByRole("option")).toHaveLength(2);
-    expect(r.getByRole("option", { name: "NBA" })).toBeVisible();
-    expect(r.getByRole("option", { name: "WNBA" })).toBeVisible();
+    // Then the options that match the filter are visible, even though their parent was collapsed
+    expect(getOptionLabels(r)).toEqual(["Basketball", "NBA", "WNBA"]);
   });
 
   it("shows the correct input text when selecting options", async () => {
@@ -904,6 +942,20 @@ describe("TreeSelectField", () => {
     expect(getSelected(r.favoriteLeague)).toEqual(undefined);
   });
 });
+
+/** Returns the labels of the currently-shown options, in menu order, i.e. `["Basketball", "NBA"]`. */
+function getOptionLabels(r: RenderResult): string[] {
+  return r.queryAllByRole("option").map((o) => o.textContent ?? "");
+}
+
+/** Returns the nesting level of each currently-shown option, based on its indentation, i.e. `[0, 1]`. */
+function getOptionLevels(r: RenderResult): number[] {
+  return r.queryAllByRole("option").map((o) => {
+    // The level is applied as `plPx(16 + level * 8)` on the option's `li`, i.e. `--paddingLeft: 24px`
+    const paddingLeft = Number.parseInt(o.closest("li")!.style.getPropertyValue("--paddingLeft"), 10);
+    return (paddingLeft - 16) / 8;
+  });
+}
 
 function getNestedOptions(): NestedOption<HasIdAndName>[] {
   return [

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -186,7 +186,7 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
   const initialOptions = Array.isArray(options) ? options : options.current;
   const { contains } = useFilter({ sensitivity: "base" });
 
-  const { collapsedKeys } = useTreeSelectFieldProvider();
+  const { collapsedKeys, setCollapsedKeys } = useTreeSelectFieldProvider();
   const groupKeys = useMemo(() => _groupOptions?.map((option) => valueToKey(option)) ?? [], [_groupOptions]);
   const groupKeySet = useMemo<Set<AriaKey>>(() => new Set(groupKeys), [groupKeys]);
 
@@ -274,7 +274,6 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
       allOptions: initialOptions,
       selectedOptionsLabels: selectedChipState.labels,
       optionsLoading: false,
-      allowCollapsing: true,
     };
   }, [
     initialOptions,
@@ -313,6 +312,24 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getOptionValue, initTreeFieldState, values]);
 
+  // Searching expands the tree, so that matches nested inside a collapsed parent are visible, and
+  // we restore the user's own collapsed-ness when the search ends. Within the search results the
+  // user can still collapse/expand as usual, i.e. the menu behaves the same filtered or not.
+  const preSearchCollapsedKeys = useRef<AriaKey[] | undefined>(undefined);
+  useEffect(() => {
+    if (fieldState.searchValue) {
+      // Only snapshot on the 1st render of a search, so mid-search collapsing isn't treated as the user's state
+      if (preSearchCollapsedKeys.current === undefined) {
+        preSearchCollapsedKeys.current = collapsedKeys;
+        if (collapsedKeys.length > 0) setCollapsedKeys([]);
+      }
+    } else if (preSearchCollapsedKeys.current !== undefined) {
+      const keys = preSearchCollapsedKeys.current;
+      preSearchCollapsedKeys.current = undefined;
+      setCollapsedKeys(keys);
+    }
+  }, [fieldState.searchValue, collapsedKeys, setCollapsedKeys]);
+
   const filteredOptions = useMemo(
     () =>
       getFilteredOptions(
@@ -333,7 +350,6 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
         ...prevState,
         inputValue,
         searchValue: inputValue.length === 0 ? undefined : inputValue,
-        allowCollapsing: inputValue.length === 0,
       };
     });
   }, []);
@@ -371,7 +387,6 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
         ...prevState,
         inputValue: "",
         searchValue: undefined,
-        allowCollapsing: true,
       }));
     }
   }
@@ -425,7 +440,6 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
             ...prevState,
             inputValue: nothingSelectedText,
             searchValue: undefined,
-            allowCollapsing: true,
             selectedKeys: [],
             selectedOptions: [],
             selectedChipOptions: [],
@@ -571,7 +585,6 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
               ? nothingSelectedText
               : "",
         searchValue: undefined,
-        allowCollapsing: true,
       }));
     }
   }
@@ -667,7 +680,6 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
             getOptionValue={(o) => valueToKey(getOptionValue(o))}
             horizontalLayout={labelStyle === "left"}
             loading={fieldState.optionsLoading}
-            allowCollapsing={fieldState.allowCollapsing}
             disabledOptionsWithReasons={disabledOptionsWithReasons}
             isTree
           />
@@ -716,39 +728,32 @@ function getFilteredOptions<O, V extends Value>(
   getOptionLabel: (o: O) => string,
   getOptionValue: (o: O) => V,
 ): LeveledOption<O>[] {
-  return searchValue
-    ? allOptions.flatMap((option) => matchedOptions(option, 0, false, searchValue, contains, getOptionLabel))
-    : allOptions.flatMap((option) => levelOptions(option, 0, collapsedKeys, getOptionValue));
-}
+  if (!searchValue) return allOptions.flatMap((option) => levelOptions(option, 0, collapsedKeys, getOptionValue));
+  // Copy to a const so the nested `matchedOptions` sees it as a defined string
+  const search = searchValue;
+  return allOptions.flatMap((option) => matchedOptions(option, 0, false));
 
-/**
- * Filters `o`'s subtree against `searchValue`, but keeps the tree structure/levels intact.
- *
- * This mirrors GridTable's `RowState.isMatched` heuristic, i.e. an option is shown if it directly
- * matches, if an ancestor directly matched (a matched parent shows all of its children), or if a
- * descendant directly matched (a matched child shows its parents).
- *
- * I.e. searching "nba" shows `Basketball > [NBA, WNBA]` instead of a flat `[NBA, WNBA]`.
- *
- * Note that, unlike GridTable, collapsed-ness is ignored while searching, so that matches hidden
- * within a collapsed parent are still shown.
- */
-function matchedOptions<O>(
-  o: NestedOption<O>,
-  level: number,
-  hasMatchedParent: boolean,
-  searchValue: string,
-  contains: (string: string, substring: string) => boolean,
-  getOptionLabel: (o: O) => string,
-): LeveledOption<O>[] {
-  const isDirectlyMatched = contains(getOptionLabel(o), searchValue);
-  const children =
-    o.children?.flatMap((oc) =>
-      matchedOptions(oc, level + 1, hasMatchedParent || isDirectlyMatched, searchValue, contains, getOptionLabel),
-    ) ?? [];
-  // I.e. a non-empty `children` here means a descendant directly matched, b/c if `isDirectlyMatched`
-  // or `hasMatchedParent` was true, every child would have been kept regardless of its own match.
-  return isDirectlyMatched || hasMatchedParent || children.length > 0 ? [[o, level], ...children] : [];
+  /**
+   * Filters `o`'s subtree against `searchValue`, keeping the tree structure/levels intact, so that
+   * the menu looks & behaves the same filtered or not--we've just dropped the unmatched branches.
+   *
+   * Whether an option matches mirrors GridTable's `RowState.isMatched` heuristic, i.e. show it if it
+   * directly matches, if an ancestor directly matched (a matched parent shows all of its children),
+   * or if a descendant directly matched (a matched child shows its parents).
+   *
+   * I.e. searching "nba" shows `Basketball > [NBA, WNBA]` instead of a flat `[NBA, WNBA]`.
+   */
+  function matchedOptions(o: NestedOption<O>, level: number, hasMatchedParent: boolean): LeveledOption<O>[] {
+    const isDirectlyMatched = contains(getOptionLabel(o), search);
+    // Recurse even when collapsed, b/c a matched descendant is what keeps `o` itself in the results
+    const children = o.children?.flatMap((oc) => matchedOptions(oc, level + 1, hasMatchedParent || isDirectlyMatched));
+    // I.e. non-empty `children` here means a descendant directly matched, b/c if `isDirectlyMatched`
+    // or `hasMatchedParent` was true, every child would have been kept regardless of its own match.
+    if (!isDirectlyMatched && !hasMatchedParent && !children?.length) return [];
+    // Collapsing works within the search results just like it does in the unfiltered tree
+    const isCollapsed = collapsedKeys.includes(valueToKey(getOptionValue(o)));
+    return isCollapsed ? [[o, level]] : [[o, level], ...(children ?? [])];
+  }
 }
 
 function isOptionFullySelected<O, V extends Value>(

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -677,22 +677,18 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
   );
 }
 
+/** Flattens `o` + its not-collapsed descendants into leveled options, i.e. `[[o, 0], [child, 1]]`. */
 function levelOptions<O, V extends Value>(
   o: NestedOption<O>,
   level: number,
-  filtering: boolean,
   collapsedKeys: AriaKey[],
   getOptionValue: (o: O) => V,
 ): LeveledOption<O>[] {
-  // If a user is filtering, then do not provide level to the options as the various paddings may look quite odd.
-  const actualLevel = filtering ? 0 : level;
   return [
-    [o, actualLevel],
-    // Flat map the children if the parent is not collapsed or if we are filtering (for the search results)
-    ...(o.children?.length && (!collapsedKeys.includes(valueToKey(getOptionValue(o))) || filtering)
-      ? o.children.flatMap((oc: NestedOption<O>) =>
-          levelOptions(oc, actualLevel + 1, filtering, collapsedKeys, getOptionValue),
-        )
+    [o, level],
+    // Flat map the children if the parent is not collapsed
+    ...(o.children?.length && !collapsedKeys.includes(valueToKey(getOptionValue(o)))
+      ? o.children.flatMap((oc: NestedOption<O>) => levelOptions(oc, level + 1, collapsedKeys, getOptionValue))
       : []),
   ];
 }
@@ -711,6 +707,7 @@ function getTopLevelSelections<O, V extends Value>(
   return [];
 }
 
+/** The options to show in the menu, i.e. either the not-collapsed tree, or the search results. */
 function getFilteredOptions<O, V extends Value>(
   allOptions: NestedOption<O>[],
   searchValue: string | undefined,
@@ -719,11 +716,39 @@ function getFilteredOptions<O, V extends Value>(
   getOptionLabel: (o: O) => string,
   getOptionValue: (o: O) => V,
 ): LeveledOption<O>[] {
-  return allOptions.flatMap((option) =>
-    levelOptions(option, 0, !!searchValue, collapsedKeys, getOptionValue).filter(([nestedOption]) =>
-      searchValue ? contains(getOptionLabel(nestedOption), searchValue) : true,
-    ),
-  );
+  return searchValue
+    ? allOptions.flatMap((option) => matchedOptions(option, 0, false, searchValue, contains, getOptionLabel))
+    : allOptions.flatMap((option) => levelOptions(option, 0, collapsedKeys, getOptionValue));
+}
+
+/**
+ * Filters `o`'s subtree against `searchValue`, but keeps the tree structure/levels intact.
+ *
+ * This mirrors GridTable's `RowState.isMatched` heuristic, i.e. an option is shown if it directly
+ * matches, if an ancestor directly matched (a matched parent shows all of its children), or if a
+ * descendant directly matched (a matched child shows its parents).
+ *
+ * I.e. searching "nba" shows `Basketball > [NBA, WNBA]` instead of a flat `[NBA, WNBA]`.
+ *
+ * Note that, unlike GridTable, collapsed-ness is ignored while searching, so that matches hidden
+ * within a collapsed parent are still shown.
+ */
+function matchedOptions<O>(
+  o: NestedOption<O>,
+  level: number,
+  hasMatchedParent: boolean,
+  searchValue: string,
+  contains: (string: string, substring: string) => boolean,
+  getOptionLabel: (o: O) => string,
+): LeveledOption<O>[] {
+  const isDirectlyMatched = contains(getOptionLabel(o), searchValue);
+  const children =
+    o.children?.flatMap((oc) =>
+      matchedOptions(oc, level + 1, hasMatchedParent || isDirectlyMatched, searchValue, contains, getOptionLabel),
+    ) ?? [];
+  // I.e. a non-empty `children` here means a descendant directly matched, b/c if `isDirectlyMatched`
+  // or `hasMatchedParent` was true, every child would have been kept regardless of its own match.
+  return isDirectlyMatched || hasMatchedParent || children.length > 0 ? [[o, level], ...children] : [];
 }
 
 function isOptionFullySelected<O, V extends Value>(

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -438,8 +438,8 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
         if (newKeys.size === 0) {
           setFieldState((prevState) => ({
             ...prevState,
-            inputValue: nothingSelectedText,
-            searchValue: undefined,
+            // Unselecting the last option shouldn't drop the search either
+            inputValue: prevState.searchValue ?? nothingSelectedText,
             selectedKeys: [],
             selectedOptions: [],
             selectedChipOptions: [],
@@ -551,9 +551,9 @@ function TreeSelectFieldBase<O, V extends Value>(props: TreeSelectFieldProps<O, 
 
         setFieldState((prevState) => ({
           ...prevState,
-          // Since we reset the list of options upon selection changes, then set the `inputValue` to empty string to reflect that.
-          inputValue: "",
-          searchValue: undefined,
+          // Keep any search in place, so picking several options out of the same filtered list doesn't
+          // make the user retype it; when they're not searching the input stays empty as before.
+          inputValue: prevState.searchValue ?? "",
           selectedKeys: [...selectedKeys],
           selectedOptions,
           selectedChipOptions: selectedChipState.options,

--- a/src/inputs/TreeSelectField/utils.ts
+++ b/src/inputs/TreeSelectField/utils.ts
@@ -19,7 +19,6 @@ export type TreeFieldState<O> = {
   selectedOptionsLabels: string[];
   allOptions: NestedOption<O>[];
   optionsLoading: boolean;
-  allowCollapsing: boolean;
 };
 
 export type TreeSelectResponse<O, V extends Value> = {

--- a/src/inputs/internal/ListBox.tsx
+++ b/src/inputs/internal/ListBox.tsx
@@ -21,7 +21,6 @@ type ListBoxProps<O, V extends AriaKey> = {
   loading?: boolean | (() => JSX.Element);
   disabledOptionsWithReasons?: Record<string, string | undefined>;
   isTree?: boolean;
-  allowCollapsing?: boolean;
 };
 
 /** A ListBox is an internal component used by SelectField and MultiSelectField to display the list of options */
@@ -37,7 +36,6 @@ export function ListBox<O, V extends AriaKey>(props: ListBoxProps<O, V>) {
     loading,
     disabledOptionsWithReasons = {},
     isTree,
-    allowCollapsing,
   } = props;
   const { listBoxProps } = useListBox({ disallowEmptySelection: true, ...props }, state, listBoxRef);
   const positionMaxHeight = positionProps.style?.maxHeight;
@@ -152,7 +150,6 @@ export function ListBox<O, V extends AriaKey>(props: ListBoxProps<O, V>) {
             loading={loading}
             disabledOptionsWithReasons={disabledOptionsWithReasons}
             isTree={isTree}
-            allowCollapsing={allowCollapsing}
           />
         )}
       </ul>

--- a/src/inputs/internal/VirtualizedOptions.tsx
+++ b/src/inputs/internal/VirtualizedOptions.tsx
@@ -18,21 +18,11 @@ type VirtualizedOptionsProps<O> = {
   loading?: boolean | (() => JSX.Element);
   disabledOptionsWithReasons: Record<string, string | undefined>;
   isTree?: boolean;
-  allowCollapsing?: boolean;
 };
 
 // Displays ListBox options in a virtualized container for performance reasons
 export function VirtualizedOptions<O>(props: VirtualizedOptionsProps<O>) {
-  const {
-    state,
-    items,
-    onListHeightChange,
-    scrollOnFocus,
-    loading,
-    disabledOptionsWithReasons,
-    isTree,
-    allowCollapsing,
-  } = props;
+  const { state, items, onListHeightChange, scrollOnFocus, loading, disabledOptionsWithReasons, isTree } = props;
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const focusedKey = state.selectionManager.focusedKey;
   const focusedItem = focusedKey != null ? state.collection.getItem(focusedKey) : null;
@@ -91,7 +81,6 @@ export function VirtualizedOptions<O>(props: VirtualizedOptionsProps<O>) {
                 item={item}
                 state={state}
                 // scrollToIndex={scrollOnFocus ? undefined : virtuosoRef.current?.scrollToIndex}
-                allowCollapsing={allowCollapsing}
                 disabledReason={disabledOptionsWithReasons[item.key]}
               />
             );


### PR DESCRIPTION
Before any type we filtered a `TreeSelectField` it become flat:

<img width="2340" height="878" alt="image" src="https://github.com/user-attachments/assets/54050abc-45f1-4f40-88a7-61e846875dbd" />

Now we keep the structure:

<img width="1452" height="560" alt="image" src="https://github.com/user-attachments/assets/21acf9db-4726-4f55-b62a-f8e7e377c581" />

ANd use the same logic as GridTable, i.e. roughly:

* If the search matches the parent, show the parent + all children
* If the search matches a child, show the child + its parent
* etc

I also included:

* Keep the ability to expand/collapse mid-search
* Don't reset the search on click

ALl of this comes from working with non-trivially large `TreeSelectField`s on this page, where currently it's not great:

https://blueprint.homebound.com/libraries/design-packages/rp:2076/rpav:51313/required-options