### PR TITLE
feat: ds-306 - banner in superdrawer ai btn variant

### DIFF
--- a/src/Css.json
+++ b/src/Css.json
@@ -903,6 +903,7 @@
     "zUnset": {"kind":"static","defs":{"zIndex":"unset"}},
     "z": {"kind":"variable","props":["zIndex"],"incremented":false},
     "aiWash": {"kind":"static","defs":{"backgroundImage":"linear-gradient(90deg, rgba(124, 58, 237, 0.07) 0%, rgba(147, 197, 253, 0.07) 36%, rgba(124, 58, 237, 0.07) 73%)"}},
+    "aiGradientBg": {"kind":"static","defs":{"backgroundImage":"linear-gradient(90deg, rgba(109, 40, 217, 1), rgba(29, 78, 216, 1))"}},
     "aiGradientText": {"kind":"static","defs":{"color":"rgba(109, 40, 217, 1)","backgroundImage":"linear-gradient(90deg, rgba(109, 40, 217, 1), rgba(29, 78, 216, 1))","backgroundClip":"text","WebkitBackgroundClip":"text","WebkitTextFillColor":"transparent"}},
     "sansSerif": {"kind":"static","defs":{"fontFamily":"'Inter', sans-serif"}},
     "fontFamily": {"kind":"variable","props":["fontFamily"],"incremented":false},

--- a/src/Css.ts
+++ b/src/Css.ts
@@ -3956,6 +3956,10 @@ class CssBuilder<T extends Properties, S extends StyleKind = "buildtime"> {
       "linear-gradient(90deg, rgba(124, 58, 237, 0.07) 0%, rgba(147, 197, 253, 0.07) 36%, rgba(124, 58, 237, 0.07) 73%)",
     );
   }
+  /** Sets `backgroundImage: "linear-gradient(90deg, rgba(109, 40, 217, 1), rgba(29, 78, 216, 1))"`. */
+  get aiGradientBg() {
+    return this.add("backgroundImage", "linear-gradient(90deg, rgba(109, 40, 217, 1), rgba(29, 78, 216, 1))");
+  }
   /** Sets `color: "rgba(109, 40, 217, 1)"; backgroundImage: "linear-gradient(90deg, rgba(109, 40, 217, 1), rgba(29, 78, 216, 1))"; backgroundClip: "text"; WebkitBackgroundClip: "text"; WebkitTextFillColor: "transparent"`. */
   get aiGradientText() {
     return this.add("color", "rgba(109, 40, 217, 1)").add(

--- a/src/components/AiPanel.stories.tsx
+++ b/src/components/AiPanel.stories.tsx
@@ -104,6 +104,18 @@ export const Upload = () => (
   </div>
 );
 
+/** The review banner — copy left, actions right. */
+export const Actions = () => (
+  <div css={Css.wPx(1440).$}>
+    <AiPanel
+      title="Review changes to your plan found in your latest document capture."
+      message="Review the changes highlighted below including 4 warnings."
+      secondaryAction={{ label: "Ignore All", onClick: () => {} }}
+      primaryAction={{ label: "Accept All", onClick: () => {} }}
+    />
+  </div>
+);
+
 /** `align` and `rounded` combined — all four are the same width, `rounded` only changes corners. */
 export const AlignAndRounded = () => (
   <div css={Css.df.fdc.gap4.wPx(720).$}>

--- a/src/components/AiPanel.test.tsx
+++ b/src/components/AiPanel.test.tsx
@@ -1,4 +1,5 @@
 import { AiPanel } from "src";
+import { noop } from "src/utils";
 import { render } from "src/utils/rtl";
 
 describe("AiPanel", () => {
@@ -106,5 +107,43 @@ describe("AiPanel", () => {
   it("uses the roomier card for the page variant", async () => {
     const r = await render(<AiPanel variant="page" title="t" />);
     expect(r.aiPanel_card).toHaveStyle({ borderRadius: "16px" });
+  });
+
+  it("has no actions row unless given actions", async () => {
+    const r = await render(<AiPanel title="t" message="m" />);
+    expect(r.query.aiPanel_actions).not.toBeInTheDocument();
+  });
+
+  it("puts actions beside the copy", async () => {
+    const r = await render(
+      <AiPanel
+        title="Review updates found in your import."
+        message="m"
+        secondaryAction={{ label: "Clear Import", onClick: noop }}
+      />,
+    );
+    // Then the card is a row, with the copy and the actions as its two children
+    expect(r.aiPanel_card.children).toHaveLength(2);
+    expect(r.aiPanel_card.lastElementChild).toBe(r.aiPanel_actions);
+    expect(r.aiPanel_actions).toHaveTextContent("Clear Import");
+  });
+
+  it("compacts the title when actions share its row", async () => {
+    const r = await render(<AiPanel title="t" secondaryAction={{ label: "a", onClick: noop }} />);
+    // Then the title drops to 16/24 from the 18/28 the stacked layout uses
+    expect(r.aiPanel_title).toHaveStyle({ fontSize: "16px", lineHeight: "24px" });
+  });
+
+  it("renders the secondary action left of the primary", async () => {
+    const r = await render(
+      <AiPanel
+        title="t"
+        secondaryAction={{ label: "Ignore All", onClick: noop }}
+        primaryAction={{ label: "Accept All", onClick: noop }}
+      />,
+    );
+    expect(r.aiPanel_actions.children).toHaveLength(2);
+    expect(r.aiPanel_actions.firstElementChild).toHaveTextContent("Ignore All");
+    expect(r.aiPanel_actions.lastElementChild).toHaveTextContent("Accept All");
   });
 });

--- a/src/components/AiPanel.tsx
+++ b/src/components/AiPanel.tsx
@@ -82,7 +82,7 @@ export function AiPanel(props: AiPanelProps) {
     >
       <div css={{ ...Css.df.fdc.aifs.w100.$, ...column }} {...tid.column}>
         <BlueprintAiLogo height={logoHeight} />
-        {/* actions need to render themselves on the right side of the the title & message */}
+        {/* actions need to render themselves on the right side of the title & message */}
         {hasActions ? (
           <div css={{ ...Css.df.aic.gap2.w100.bgColor(Tokens.Surface).bshBasic.$, ...card }} {...tid.card}>
             <div css={Css.df.fdc.gapPx(4).fg1.mw0.$}>{panelContent}</div>

--- a/src/components/AiPanel.tsx
+++ b/src/components/AiPanel.tsx
@@ -1,5 +1,7 @@
 import { AriaAttributes, AriaRole, ReactNode } from "react";
 import { AiLoader } from "src/components/AiLoader";
+import { Button } from "src/components/Button";
+import type { ActionButtonProps } from "src/components/Layout/layoutTypes";
 import { BlueprintAiLogo } from "src/components/Logos";
 import { Css, Properties, Tokens } from "src/Css";
 import { useTestIds } from "src/utils";
@@ -22,6 +24,8 @@ export type AiPanelProps = {
   align?: "left" | "center";
   rounded?: boolean;
   variant?: AiPanelVariant;
+  primaryAction?: ActionButtonProps;
+  secondaryAction?: ActionButtonProps;
 } & AriaAttributes & { role?: AriaRole };
 
 /**
@@ -39,10 +43,29 @@ export function AiPanel(props: AiPanelProps) {
     align = "left",
     rounded = false,
     variant = "banner",
+    primaryAction,
+    secondaryAction,
     ...others
   } = props;
   const tid = useTestIds(others, "aiPanel");
   const { column, card, logoHeight } = variantStyles[variant];
+  const hasActions = !!(primaryAction || secondaryAction);
+  const panelContent = (
+    <>
+      {loading && <AiLoader />}
+      {title && (
+        <span css={{ ...Css.if(hasActions).mdSb.else.lg.$, ...Css.aiGradientText.$ }} {...tid.title}>
+          {title}
+        </span>
+      )}
+      {message && (
+        <span css={{ ...Css.sm.color(Tokens.OnSurface).$, ...alignStyles[align].text }} {...tid.message}>
+          {message}
+        </span>
+      )}
+      {children}
+    </>
+  );
   return (
     // The wash is out here rather than on the column, so it fills the container even when `page` caps
     // the content inside it.
@@ -59,23 +82,23 @@ export function AiPanel(props: AiPanelProps) {
     >
       <div css={{ ...Css.df.fdc.aifs.w100.$, ...column }} {...tid.column}>
         <BlueprintAiLogo height={logoHeight} />
-        <div
-          css={{ ...Css.df.fdc.gap1.w100.bgColor(Tokens.Surface).bshBasic.$, ...card, ...alignStyles[align].card }}
-          {...tid.card}
-        >
-          {loading && <AiLoader />}
-          {title && (
-            <span css={Css.lg.aiGradientText.$} {...tid.title}>
-              {title}
-            </span>
-          )}
-          {message && (
-            <span css={{ ...Css.sm.color(Tokens.OnSurface).$, ...alignStyles[align].text }} {...tid.message}>
-              {message}
-            </span>
-          )}
-          {children}
-        </div>
+        {/* actions need to render themselves on the right side of the the title & message */}
+        {hasActions ? (
+          <div css={{ ...Css.df.aic.gap2.w100.bgColor(Tokens.Surface).bshBasic.$, ...card }} {...tid.card}>
+            <div css={Css.df.fdc.gapPx(4).fg1.mw0.$}>{panelContent}</div>
+            <div css={Css.df.gap2.fs0.$} {...tid.actions}>
+              {secondaryAction && <Button {...secondaryAction} variant="quaternary" />}
+              {primaryAction && <Button {...primaryAction} variant="ai" />}
+            </div>
+          </div>
+        ) : (
+          <div
+            css={{ ...Css.df.fdc.gap1.w100.bgColor(Tokens.Surface).bshBasic.$, ...card, ...alignStyles[align].card }}
+            {...tid.card}
+          >
+            {panelContent}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -12,6 +12,7 @@ export default {
 
 const sizes: ButtonSize[] = ["sm", "md", "lg"];
 const variants: ButtonVariant[] = [
+  "ai",
   "primary",
   "secondary",
   "tertiary",

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -2,7 +2,7 @@ import { AriaButtonProps } from "@react-types/button";
 import { ButtonHTMLAttributes, ReactNode, RefObject, useMemo, useState } from "react";
 import { useButton, useFocusRing, useHover } from "react-aria";
 import { Icon, IconProps, Loader, maybeTooltip, navLink, resolveTooltip } from "src/components";
-import { Css, Properties, Tokens } from "src/Css";
+import { Css, Palette, Properties, Tokens } from "src/Css";
 import { useGetRef } from "src/hooks/useGetRef";
 import { BeamButtonProps, BeamFocusableProps } from "src/interfaces";
 import { isAbsoluteUrl, isPromise, noop } from "src/utils";
@@ -142,6 +142,17 @@ const variantStyles: Record<
     focusStyles: Properties;
   }
 > = {
+  ai: {
+    baseStyles: Css.aiGradientBg.color(Tokens.OnPrimary).$,
+    hoverStyles: Css.add("backgroundImage", `linear-gradient(90deg, ${Palette.Purple800}, ${Palette.Blue800})`).$,
+    pressedStyles: Css.add("backgroundImage", `linear-gradient(90deg, ${Palette.Purple900}, ${Palette.Blue900})`).$,
+    disabledStyles: Css.add(
+      "backgroundImage",
+      `linear-gradient(90deg, ${Palette.Purple200}, ${Palette.Blue200})`,
+    ).color(Tokens.ButtonPrimaryDisabledFg).$,
+    focusStyles: Css.bshFocus.$,
+  },
+
   primary: {
     baseStyles: Css.bgColor(Tokens.Primary).color(Tokens.OnPrimary).$,
     hoverStyles: Css.bgColor(Tokens.PrimaryHover).$,
@@ -243,6 +254,7 @@ const iconStyles: Record<ButtonSize, IconProps["xss"]> = {
 
 export type ButtonSize = "sm" | "md" | "lg";
 export type ButtonVariant =
+  | "ai"
   | "primary"
   | "secondary"
   | "secondaryBlack"

--- a/src/components/SuperDrawer/SuperDrawer.stories.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.stories.tsx
@@ -13,13 +13,14 @@ import {
   SimpleHeaderAndData,
   Tag,
 } from "src/components";
+import { AiPanel } from "src/components/AiPanel";
 import { TestModalContent } from "src/components/Modal/TestModalContent";
 import { useModal } from "src/components/Modal/useModal";
 import { SuperDrawerHeader } from "src/components/SuperDrawer/components/SuperDrawerHeader";
 import { GridDataRow, GridRowLookup } from "src/components/Table";
-import { Css } from "src/Css";
+import { Css, Tokens } from "src/Css";
 import { noop } from "src/utils";
-import { withBeamDecorator, withDimensions } from "src/utils/sb";
+import { withBeamDecorator, withDimensions, zeroTo } from "src/utils/sb";
 import { SuperDrawerContent, useSuperDrawer } from "./index";
 import { SuperDrawer as SuperDrawerComponent } from "./SuperDrawer";
 import { SuperDrawerWidth } from "./utils";
@@ -359,6 +360,46 @@ interface TestDrawerContentProps {
   leftContent?: ReactNode;
   rightContent?: ReactNode;
   hideControls?: boolean;
+}
+
+/** An `AiPanel` in `SuperDrawerContent`'s `banner` slot, spanning the drawer while the content stays inset. */
+export function WithAiBanner() {
+  const { openInDrawer, isDrawerOpen } = useSuperDrawer();
+  function open() {
+    openInDrawer({ content: <AiBannerDrawerContent /> });
+  }
+  useEffect(open, [openInDrawer]);
+  return (
+    <div css={Css.hPx(1200).$}>
+      <h1 css={Css.xl2.mb1.$}>SuperDrawer with an AI banner</h1>
+      <Button label={isDrawerOpen ? "SuperDrawer is open" : "Show SuperDrawer"} onClick={open} />
+    </div>
+  );
+}
+
+function AiBannerDrawerContent() {
+  const { closeDrawer } = useSuperDrawer();
+  return (
+    <>
+      <SuperDrawerHeader title="Edit Material" />
+      <SuperDrawerContent
+        actions={[{ label: "Cancel", onClick: closeDrawer, variant: "tertiary" }]}
+        banner={
+          <AiPanel
+            title="Review updates found in your import."
+            message="Blueprint AI captured a change to the name of your product, added a description, and added 1 additional variant."
+            secondaryAction={{ label: "Clear Import", onClick: noop }}
+            primaryAction={{ label: "Accept Import", onClick: noop }}
+          />
+        }
+      >
+        <h2 css={Css.lg.mb2.$}>Material Overview</h2>
+        {zeroTo(6).map((i) => (
+          <div key={i} css={Css.hPx(56).br4.bgColor(Tokens.SurfaceSeparator).mb2.$} />
+        ))}
+      </SuperDrawerContent>
+    </>
+  );
 }
 
 /** Example component to render inside the SuperDrawer */

--- a/src/components/SuperDrawer/SuperDrawerContent.test.tsx
+++ b/src/components/SuperDrawer/SuperDrawerContent.test.tsx
@@ -1,0 +1,45 @@
+import { ReactNode, useEffect } from "react";
+import { SuperDrawerHeader } from "src/components/SuperDrawer/components/SuperDrawerHeader";
+import { render } from "src/utils/rtl";
+import { SuperDrawerContent, useSuperDrawer } from "./index";
+
+describe("SuperDrawerContent", () => {
+  it("renders a banner above the content", async () => {
+    // Given a drawer whose content declares a banner
+    const r = await render(<TestDrawerContent banner={<div data-testid="banner">Banner</div>} />);
+    // Then the banner renders ahead of the children, sharing their scroll container.
+    // The negative margins that bleed it past the padding aren't assertable here —
+    // they compile to `calc(var(--t-spacing) * -3)`, which jsdom won't resolve.
+    expect(r.banner).toBeTruthy();
+    expect(r.banner.parentElement!.nextElementSibling).toBe(r.drawerBody);
+  });
+
+  it("omits the banner wrapper when no banner is given", async () => {
+    // Given a drawer whose content has no banner
+    const r = await render(<TestDrawerContent />);
+    // Then nothing is emitted above the children
+    expect(r.query.banner).not.toBeInTheDocument();
+    expect(r.drawerBody.parentElement!.firstElementChild).toBe(r.drawerBody);
+  });
+});
+
+function TestDrawerContent(props: { banner?: ReactNode }) {
+  const context = useSuperDrawer();
+  useEffect(
+    () => {
+      context.openInDrawer({
+        content: (
+          <>
+            <SuperDrawerHeader title="Title" />
+            <SuperDrawerContent banner={props.banner}>
+              <h2 data-testid="drawerBody">SuperDrawer Content</h2>
+            </SuperDrawerContent>
+          </>
+        ),
+      });
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  );
+  return <h1>Page Content</h1>;
+}

--- a/src/components/SuperDrawer/SuperDrawerContent.tsx
+++ b/src/components/SuperDrawer/SuperDrawerContent.tsx
@@ -9,6 +9,11 @@ import { SuperDrawerWidth } from "./utils";
 type SuperDrawerContentProps = {
   children: ReactNode;
   /**
+   * Spans the drawer's full width above the content cancelling the padding while
+   * the children keep it.
+   */
+  banner?: ReactNode;
+  /**
    * Actions represents an array of button props with represents that different
    * actions that can be conducted in the SuperDrawer page.
    *
@@ -24,7 +29,7 @@ type SuperDrawerContentProps = {
  * NOTE: This does not include the header props since the caller will be the one
  * that knows how to handle the title, prev/next link and the onClose handler.
  */
-export const SuperDrawerContent = ({ children, actions }: SuperDrawerContentProps) => {
+export const SuperDrawerContent = ({ children, banner, actions }: SuperDrawerContentProps) => {
   const { closeDrawerDetail } = useSuperDrawer();
   const { drawerContentStack: contentStack } = useBeamContext();
 
@@ -38,6 +43,7 @@ export const SuperDrawerContent = ({ children, actions }: SuperDrawerContentProp
     if (kind === "open") {
       return (
         <motion.div key="content" css={Css.p3.fg1.oa.$}>
+          {banner && <div css={Css.mx(-3).mt(-3).mb3.$}>{banner}</div>}
           {children}
         </motion.div>
       );

--- a/src/components/SuperDrawer/SuperDrawerContent.tsx
+++ b/src/components/SuperDrawer/SuperDrawerContent.tsx
@@ -9,8 +9,7 @@ import { SuperDrawerWidth } from "./utils";
 type SuperDrawerContentProps = {
   children: ReactNode;
   /**
-   * Spans the drawer's full width above the content cancelling the padding while
-   * the children keep it.
+   * Rendered above the children, spanning the drawer's full width without receiving the padding set on the content
    */
   banner?: ReactNode;
   /**

--- a/truss-config.ts
+++ b/truss-config.ts
@@ -69,6 +69,7 @@ const sections: Sections = {
   ai: () => [
     // `backgroundImage` only, so the caller supplies the surface under it and it stays themeable.
     newMethod("aiWash", { backgroundImage: aiWash }),
+    newMethod("aiGradientBg", { backgroundImage: aiGradient }),
     newMethod("aiGradientText", {
       // Fallback where a background can't be clipped to text; `transparent` would hide it outright.
       color: palette.Purple700,


### PR DESCRIPTION
## [DS-306](https://linear.app/homebound-team/issue/DS-306/support-of-ai-banner-in-superdrawer)

### SuperDrawer

- `SuperDrawerContent` takes a `banner?: ReactNode` slot that renders above the children and cancels the content padding, so the panel spans the drawer's full width while the content stays inset

### AiPanel actions

- `primaryAction` / `secondaryAction` named slots typed as `ActionButtonProps`, matching our  `fooBarLayout` components. Caller supplies label/onClick and the component owns variants (`ai` for primary, `quaternary` for secondary)

### `ai` Button variant

- New variant on the same purple→blue gradient as designed