### PR TITLE
feat: SideNav is hoisted into global nav menu on mobile

### DIFF
--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -62,6 +62,8 @@ import {
 </EnvironmentBannerLayout>;
 ```
 
+On the `sm` breakpoint (≤599px), `NavbarLayout` + `SideNavLayout` share **one hamburger**. `SideNavLayout` does not render its rail or collapse toggle; it registers its `items` (and optional `top` / `footer`) as the mobile menu's nested pane. The drawer renders both levels with the same `AppNavItems` chrome and page-content inset. Opening the menu shows that mobile sub-nav first (`level: "sub"`), with **Main Menu** to switch to `Navbar.items` (`level: "global"`). Close, scrim, or route change dismisses the drawer; the next open lands on the sub-nav again. Pages without a registered mobile sub-nav keep the main-only drawer. On `mdAndUp` the SideNav rail is unchanged; a hamburger that appears from navbar overflow stays main-only.
+
 Step-based workflow pages skip `NavbarLayout`/`SideNavLayout` entirely — `WorkflowLayout` is a standalone,
 full-page experience. Its `steps` prop is the single source of truth: it drives the header's tab strip,
 picks which step's `content` renders as the body, and gates the Continue/Complete CTA on the active

--- a/src/components/Navbar/NavbarMobileMenu.test.tsx
+++ b/src/components/Navbar/NavbarMobileMenu.test.tsx
@@ -8,6 +8,7 @@ import {
   MobileSubNavProvider,
   useRegisterMobileSubNav,
 } from "src/layouts/NavbarLayout/MobileSubNavContext";
+import { setViewport } from "src/tests/viewport";
 import { click, render, withRouter } from "src/utils/rtl";
 import { zIndices } from "src/utils/zIndices";
 
@@ -171,6 +172,7 @@ function createMobileSubNav(): MobileSubNavContent {
 }
 
 function withRegisteredMobileSubNav(mobileSubNav: MobileSubNavContent, children: ReactNode) {
+  setViewport("sm");
   return (
     <MobileSubNavProvider>
       <RegisterMobileSubNav content={mobileSubNav} />
@@ -180,6 +182,6 @@ function withRegisteredMobileSubNav(mobileSubNav: MobileSubNavContent, children:
 }
 
 function RegisterMobileSubNav({ content }: { content: MobileSubNavContent }) {
-  useRegisterMobileSubNav(content, true);
+  useRegisterMobileSubNav(content);
   return null;
 }

--- a/src/components/Navbar/NavbarMobileMenu.test.tsx
+++ b/src/components/Navbar/NavbarMobileMenu.test.tsx
@@ -1,7 +1,13 @@
+import { ReactNode } from "react";
 import type { AppNavItem } from "src/components/AppNav/appNavTypes";
 import { environmentBannerSizePx } from "src/components/EnvironmentBanner/EnvironmentBanner";
 import { NavbarMobileMenu } from "src/components/Navbar/NavbarMobileMenu";
 import { EnvironmentBannerLayoutHeightProvider } from "src/layouts/EnvironmentBannerLayout/EnvironmentBannerLayoutHeightContext";
+import {
+  type MobileSubNavContent,
+  MobileSubNavProvider,
+  useRegisterMobileSubNav,
+} from "src/layouts/NavbarLayout/MobileSubNavContext";
 import { click, render, withRouter } from "src/utils/rtl";
 import { zIndices } from "src/utils/zIndices";
 
@@ -86,6 +92,57 @@ describe("NavbarMobileMenu", () => {
       zIndex: String(zIndices.navbarMobileMenuScrim),
     });
   });
+
+  it("opens on the sub-nav pane when sub-nav content is registered", async () => {
+    // Given a registered sub-nav
+    // When the drawer opens
+    const r = await render(
+      withRegisteredMobileSubNav(createMobileSubNav(), <NavbarMobileMenu items={createItems()} />),
+      withRouter(),
+    );
+    click(r.navbar_mobileMenu);
+
+    // Then the sub-nav items and Main Menu render, not the global items
+    expect(r.navbar_link_schedule).toHaveTextContent("Schedule");
+    expect(r.navbar_mobileMenuMainMenu).toBeInTheDocument();
+    expect(r.query.navbar_link_projects).toBeNull();
+  });
+
+  it("switches to the global pane when Main Menu is clicked", async () => {
+    // Given an open drawer on the sub-nav pane
+    const r = await render(
+      withRegisteredMobileSubNav(createMobileSubNav(), <NavbarMobileMenu items={createItems()} />),
+      withRouter(),
+    );
+    click(r.navbar_mobileMenu);
+
+    // When Main Menu is clicked
+    click(r.navbar_mobileMenuMainMenu);
+
+    // Then the global items replace the sub-nav and Main Menu is gone
+    expect(r.navbar_link_projects).toBeInTheDocument();
+    expect(r.query.navbar_link_schedule).toBeNull();
+    expect(r.query.navbar_mobileMenuMainMenu).toBeNull();
+  });
+
+  it("returns to the sub-nav pane after close and reopen", async () => {
+    // Given the user went up to the global pane
+    const r = await render(
+      withRegisteredMobileSubNav(createMobileSubNav(), <NavbarMobileMenu items={createItems()} />),
+      withRouter(),
+    );
+    click(r.navbar_mobileMenu);
+    click(r.navbar_mobileMenuMainMenu);
+    expect(r.navbar_link_projects).toBeInTheDocument();
+
+    // When the drawer is closed and opened again
+    click(r.navbar_mobileMenuClose);
+    click(r.navbar_mobileMenu);
+
+    // Then the sub-nav pane is shown again
+    expect(r.navbar_link_schedule).toHaveTextContent("Schedule");
+    expect(r.navbar_mobileMenuMainMenu).toBeInTheDocument();
+  });
 });
 
 function createItems(): AppNavItem[] {
@@ -107,4 +164,22 @@ function createItemsWithLinkGroup(): AppNavItem[] {
       ],
     },
   ];
+}
+
+function createMobileSubNav(): MobileSubNavContent {
+  return { items: [{ label: "Schedule", onClick: "/schedule" }] };
+}
+
+function withRegisteredMobileSubNav(mobileSubNav: MobileSubNavContent, children: ReactNode) {
+  return (
+    <MobileSubNavProvider>
+      <RegisterMobileSubNav content={mobileSubNav} />
+      {children}
+    </MobileSubNavProvider>
+  );
+}
+
+function RegisterMobileSubNav({ content }: { content: MobileSubNavContent }) {
+  useRegisterMobileSubNav(content, true);
+  return null;
 }

--- a/src/components/Navbar/NavbarMobileMenu.tsx
+++ b/src/components/Navbar/NavbarMobileMenu.tsx
@@ -5,12 +5,16 @@ import { createPortal } from "react-dom";
 import { useLocation } from "react-router-dom";
 import { AppNavItems } from "src/components/AppNav/AppNavItems";
 import type { AppNavItem } from "src/components/AppNav/appNavTypes";
+import { Button } from "src/components/Button";
 import { IconButton } from "src/components/IconButton";
 import { Css, Tokens } from "src/Css";
 import { useEnvironmentBannerLayoutHeight } from "src/layouts/EnvironmentBannerLayout/EnvironmentBannerLayoutHeightContext";
 import { pageContentPaddingX } from "src/layouts/layoutSpacing";
+import { type MobileSubNavContent, useMobileSubNav } from "src/layouts/NavbarLayout/MobileSubNavContext";
 import { useTestIds } from "src/utils";
 import { zIndices } from "src/utils/zIndices";
+
+type MobileNavLevel = "sub" | "global";
 
 type NavbarMobileMenuProps = {
   items: AppNavItem[];
@@ -22,17 +26,19 @@ export function NavbarMobileMenu(props: NavbarMobileMenuProps) {
   // its own `navbar` prefix (which wins), so ids are the same either way.
   const tid = useTestIds(props, "navbar");
   const [isOpen, setIsOpen] = useState(false);
+  const [level, setLevel] = useState<MobileNavLevel>("sub");
   const { pathname, search } = useLocation();
+  const mobileSubNav = useMobileSubNav();
 
   usePreventScroll({ isDisabled: !isOpen });
+
+  const close = () => setIsOpen(false);
 
   // Close when navigation changes the route — covers programmatic `navigate()` and any item whose
   // handler pushes a new location. Same-route taps are handled by the drawer's anchor-click capture.
   useEffect(() => {
-    setIsOpen(false);
+    close();
   }, [pathname, search]);
-
-  const close = () => setIsOpen(false);
 
   return (
     <>
@@ -40,12 +46,31 @@ export function NavbarMobileMenu(props: NavbarMobileMenuProps) {
         icon={isOpen ? "menuClose" : "menu"}
         color={Tokens.OnSurfaceMuted}
         label={isOpen ? "Close navigation" : "Open navigation"}
-        onClick={() => setIsOpen((open) => !open)}
+        onClick={() => {
+          if (isOpen) {
+            close();
+            return;
+          }
+          // Reset on open so a close from the global pane doesn't swap panes mid-exit.
+          setLevel("sub");
+          setIsOpen(true);
+        }}
         {...tid.mobileMenu}
       />
       {createPortal(
         /* AnimatePresence keeps the drawer mounted through its slide/fade-out before unmounting.*/
-        <AnimatePresence>{isOpen && <NavbarMobileDrawer items={items} onClose={close} tid={tid} />}</AnimatePresence>,
+        <AnimatePresence>
+          {isOpen && (
+            <NavbarMobileDrawer
+              items={items}
+              mobileSubNav={mobileSubNav}
+              level={level}
+              onLevelChange={setLevel}
+              onClose={close}
+              tid={tid}
+            />
+          )}
+        </AnimatePresence>,
         document.body,
       )}
     </>
@@ -54,16 +79,23 @@ export function NavbarMobileMenu(props: NavbarMobileMenuProps) {
 
 function NavbarMobileDrawer({
   items,
+  mobileSubNav,
+  level,
+  onLevelChange,
   onClose,
   tid,
 }: {
   items: AppNavItem[];
+  mobileSubNav: MobileSubNavContent | null;
+  level: MobileNavLevel;
+  onLevelChange: (level: MobileNavLevel) => void;
   onClose: VoidFunction;
   tid: ReturnType<typeof useTestIds>;
 }) {
   // Portal renders on `document.body`; read banner height from context (CSS vars are not inherited there).
   const bannerHeightPx = useEnvironmentBannerLayoutHeight();
   const overlayTopStyle = { top: bannerHeightPx };
+  const showSubLevel = mobileSubNav != null && level === "sub";
 
   return (
     <>
@@ -95,10 +127,22 @@ function NavbarMobileDrawer({
         >
           <div
             css={{
-              ...Css.df.aic.jcfe.pyPx(12).fs0.bb.bc(Tokens.SurfaceSeparator).$,
+              ...Css.df.aic.jcsb.pyPx(12).fs0.bb.bc(Tokens.SurfaceSeparator).$,
               ...pageContentPaddingX,
             }}
           >
+            <div css={Css.mw0.$}>
+              {showSubLevel && (
+                <Button
+                  label="Main Menu"
+                  icon="chevronLeft"
+                  variant="quaternary"
+                  size="sm"
+                  onClick={() => onLevelChange("global")}
+                  {...tid.mobileMenuMainMenu}
+                />
+              )}
+            </div>
             <IconButton
               icon="x"
               color={Tokens.OnSurfaceMuted}
@@ -107,22 +151,38 @@ function NavbarMobileDrawer({
               {...tid.mobileMenuClose}
             />
           </div>
-          <nav
-            css={{
-              ...Css.fg1.oya.pb3.pt2.df.fdc.gapPx(4).$,
-              ...pageContentPaddingX,
-            }}
-            // String-route items render as `<a>` (react-router Link) and external URLs as `<a href>`;
-            // closing on any anchor click covers same-route taps that don't change the location.
-            onClickCapture={(e) => {
-              if ((e.target as Element).closest("a")) {
-                onClose();
-              }
-            }}
-            {...tid.mobileMenuPanel}
-          >
-            <AppNavItems items={items} panelCollapsed={false} {...tid} />
-          </nav>
+          <div css={Css.fg1.mh0.oh.relative.$}>
+            {/* `initial={false}`: first open uses the drawer slide only; later level changes slide the panes. */}
+            <AnimatePresence initial={false}>
+              <motion.nav
+                key={showSubLevel ? "sub" : "global"}
+                css={{
+                  ...Css.absolute.top0.bottom0.left0.right0.oya.df.fdc.gapPx(4).pt2.pb3.$,
+                  ...pageContentPaddingX,
+                }}
+                initial={{ x: "-100%" }}
+                animate={{ x: 0 }}
+                exit={{ x: "100%" }}
+                transition={{ ease: "linear", duration: 0.2 }}
+                // String-route items render as `<a>` (react-router Link) and external URLs as `<a href>`;
+                // closing on any anchor click covers same-route taps that don't change the location.
+                onClickCapture={(e) => {
+                  if ((e.target as Element).closest("a")) {
+                    onClose();
+                  }
+                }}
+                {...tid.mobileMenuPanel}
+              >
+                {showSubLevel && mobileSubNav?.top}
+                <AppNavItems
+                  items={showSubLevel && mobileSubNav ? mobileSubNav.items : items}
+                  panelCollapsed={false}
+                  {...tid}
+                />
+                {showSubLevel && mobileSubNav?.footer}
+              </motion.nav>
+            </AnimatePresence>
+          </div>
         </motion.aside>
       </FocusScope>
     </>

--- a/src/layouts/NavbarLayout/MobileSubNavContext.tsx
+++ b/src/layouts/NavbarLayout/MobileSubNavContext.tsx
@@ -1,0 +1,48 @@
+import { createContext, ReactNode, useContext, useLayoutEffect, useMemo, useState } from "react";
+import type { SideNavProps } from "src/components/SideNav/SideNav";
+
+/** Nested pane of the mobile nav menu. Drawer-owned fields from {@link SideNavProps}. */
+export type MobileSubNavContent = Pick<SideNavProps, "top" | "items" | "footer">;
+
+type MobileSubNavContextValue = {
+  mobileSubNav: MobileSubNavContent | null;
+  setMobileSubNav: (content: MobileSubNavContent | null) => void;
+};
+
+const MobileSubNavContext = createContext<MobileSubNavContextValue | undefined>(undefined);
+
+/** Holds the mobile menu's nested nav. See `docs/layouts.md`. */
+export function MobileSubNavProvider(props: { children: ReactNode }) {
+  const [mobileSubNav, setMobileSubNav] = useState<MobileSubNavContent | null>(null);
+  const value = useMemo(() => ({ mobileSubNav, setMobileSubNav }), [mobileSubNav]);
+  return <MobileSubNavContext.Provider value={value}>{props.children}</MobileSubNavContext.Provider>;
+}
+
+/** Registered mobile sub-nav; `null` when the drawer has only the main pane. */
+export function useMobileSubNav(): MobileSubNavContent | null {
+  return useContext(MobileSubNavContext)?.mobileSubNav ?? null;
+}
+
+/**
+ * Publish `content` as the mobile menu's nested pane while `enabled`.
+ * Returns whether a {@link MobileSubNavProvider} exists (i.e. under `NavbarLayout`).
+ */
+export function useRegisterMobileSubNav(content: MobileSubNavContent, enabled: boolean): boolean {
+  const ctx = useContext(MobileSubNavContext);
+  const setMobileSubNav = ctx?.setMobileSubNav;
+  // Depend on fields, not the `content` object — callers pass `sideNav={{ items }}` inline.
+  const { top, items, footer } = content;
+
+  useLayoutEffect(() => {
+    if (!setMobileSubNav || !enabled) return;
+    setMobileSubNav({ top, items, footer });
+  }, [setMobileSubNav, enabled, top, items, footer]);
+
+  // Clear only when disabled or unmounted, not when `items`/`top`/`footer` identity changes.
+  useLayoutEffect(() => {
+    if (!setMobileSubNav || !enabled) return;
+    return () => setMobileSubNav(null);
+  }, [setMobileSubNav, enabled]);
+
+  return ctx !== undefined;
+}

--- a/src/layouts/NavbarLayout/MobileSubNavContext.tsx
+++ b/src/layouts/NavbarLayout/MobileSubNavContext.tsx
@@ -1,5 +1,6 @@
 import { createContext, ReactNode, useContext, useLayoutEffect, useMemo, useState } from "react";
 import type { SideNavProps } from "src/components/SideNav/SideNav";
+import { useBreakpoint } from "src/hooks";
 
 /** Nested pane of the mobile nav menu. Drawer-owned fields from {@link SideNavProps}. */
 export type MobileSubNavContent = Pick<SideNavProps, "top" | "items" | "footer">;
@@ -24,12 +25,13 @@ export function useMobileSubNav(): MobileSubNavContent | null {
 }
 
 /**
- * Publish `content` as the mobile menu's nested pane while `enabled`.
- * Returns whether a {@link MobileSubNavProvider} exists (i.e. under `NavbarLayout`).
+ * Publish `content` into the navbar mobile menu on `sm`. True under `NavbarLayout` on mobile (hide the rail);
+ * false for standalone `SideNavLayout` (no provider) or `mdAndUp` (rail stays).
  */
-export function useRegisterMobileSubNav(content: MobileSubNavContent, enabled: boolean): boolean {
+export function useRegisterMobileSubNav(content: MobileSubNavContent): boolean {
   const ctx = useContext(MobileSubNavContext);
   const setMobileSubNav = ctx?.setMobileSubNav;
+  const enabled = !useBreakpoint().mdAndUp;
   // Depend on fields, not the `content` object — callers pass `sideNav={{ items }}` inline.
   const { top, items, footer } = content;
 
@@ -44,5 +46,5 @@ export function useRegisterMobileSubNav(content: MobileSubNavContent, enabled: b
     return () => setMobileSubNav(null);
   }, [setMobileSubNav, enabled]);
 
-  return ctx !== undefined;
+  return ctx !== undefined && enabled;
 }

--- a/src/layouts/NavbarLayout/NavbarLayout.stories.tsx
+++ b/src/layouts/NavbarLayout/NavbarLayout.stories.tsx
@@ -6,8 +6,9 @@ import { EnvironmentBannerLayout } from "src/layouts";
 import { NavbarLayout } from "src/layouts/NavbarLayout";
 import { PageHeaderLayout } from "src/layouts/PageHeaderLayout";
 import { SideNavLayout } from "src/layouts/SideNavLayout/SideNavLayout";
-import { viewportModes, withBeamDecorator, withRouter } from "src/utils/sb";
+import { newStory, viewportModes, withBeamDecorator, withRouter } from "src/utils/sb";
 import { createNavbar, GridTableLayoutExample } from "src/utils/sbComponents";
+import { userEvent, within } from "storybook/test";
 
 export default {
   component: NavbarLayout,
@@ -41,6 +42,17 @@ export const Composed = () => (
     </SideNavLayout>
   </NavbarLayout>
 );
+
+/** Mobile: hamburger opens on the mobile sub-nav with Main Menu + close. */
+export const ComposedWithOpenSubNav = newStory(Composed, {
+  parameters: { chromatic: { modes: viewportModes("mobile1") } },
+  play: async ({ canvasElement }) => {
+    const mobileMenu = within(canvasElement).queryByTestId("navbar_mobileMenu");
+    if (mobileMenu) {
+      await userEvent.click(mobileMenu);
+    }
+  },
+});
 
 /**
  * Same as {@link Composed} wrapped in {@link EnvironmentBannerLayout} with a displayed dev environment banner.

--- a/src/layouts/NavbarLayout/NavbarLayout.tsx
+++ b/src/layouts/NavbarLayout/NavbarLayout.tsx
@@ -12,6 +12,7 @@ import {
 } from "../layoutVars";
 import { useAutoHideOnScroll } from "../useAutoHideOnScroll";
 import { useMeasuredHeight } from "../useMeasuredHeight";
+import { MobileSubNavProvider } from "./MobileSubNavContext";
 import { NavbarLayoutHeightProvider } from "./NavbarLayoutHeightContext";
 
 export type NavbarLayoutProps = {
@@ -62,17 +63,19 @@ export function NavbarLayout(props: NavbarLayoutProps) {
   return (
     <DocumentScrollLayoutProvider>
       <NavbarLayoutHeightProvider value={navbarOffsetPx}>
-        <div css={Css.df.fdc.wfc.mw100.$} style={cssVars} {...tid}>
-          {/* Spacer reserves height when inner flips to fixed. */}
-          <div ref={spacerRef} css={Css.fs0.w100.$} style={{ height: navHeight }}>
-            <div ref={navMetricsRef} css={innerCss} style={innerStyle} {...tid.navbar}>
-              {navbarEl}
+        <MobileSubNavProvider>
+          <div css={Css.df.fdc.wfc.mw100.$} style={cssVars} {...tid}>
+            {/* Spacer reserves height when inner flips to fixed. */}
+            <div ref={spacerRef} css={Css.fs0.w100.$} style={{ height: navHeight }}>
+              <div ref={navMetricsRef} css={innerCss} style={innerStyle} {...tid.navbar}>
+                {navbarEl}
+              </div>
+            </div>
+            <div css={Css.df.fdc.mh0.mw100.w100.$} {...tid.body}>
+              {children}
             </div>
           </div>
-          <div css={Css.df.fdc.mh0.mw100.w100.$} {...tid.body}>
-            {children}
-          </div>
-        </div>
+        </MobileSubNavProvider>
       </NavbarLayoutHeightProvider>
     </DocumentScrollLayoutProvider>
   );

--- a/src/layouts/SideNavLayout/SideNavLayout.test.tsx
+++ b/src/layouts/SideNavLayout/SideNavLayout.test.tsx
@@ -1,16 +1,12 @@
 import type { AppNavItem } from "src/components/AppNav/appNavTypes";
+import { NavbarLayout } from "src/layouts/NavbarLayout";
 import { SideNavLayout } from "src/layouts/SideNavLayout/SideNavLayout";
 import {
   SIDE_NAV_LAYOUT_STATE_STORAGE_KEY,
   SideNavLayoutProvider,
 } from "src/layouts/SideNavLayout/SideNavLayoutContext";
 import { setViewport } from "src/tests/viewport";
-import { click, render } from "src/utils/rtl";
-
-const items: AppNavItem[] = [
-  { label: "Dashboard", icon: "columns", onClick: () => {}, active: true },
-  { label: "Projects", icon: "search", onClick: () => {} },
-];
+import { click, render, withRouter } from "src/utils/rtl";
 
 describe("SideNavLayout", () => {
   it("renders the rail, side nav slot, and page content at desktop", async () => {
@@ -149,4 +145,31 @@ describe("SideNavLayout", () => {
     // Then nothing is written to localStorage
     expect(window.localStorage.getItem(SIDE_NAV_LAYOUT_STATE_STORAGE_KEY)).toBeNull();
   });
+
+  it("hides the rail on mobile when composed under NavbarLayout", async () => {
+    // Given a mobile viewport and NavbarLayout → SideNavLayout
+    setViewport("sm");
+
+    // When rendered
+    const r = await render(
+      <NavbarLayout navbar={{ brand: "Brand", items: [{ label: "Home", onClick: "/" }] }}>
+        <SideNavLayout sideNav={{ items }} />
+      </NavbarLayout>,
+      withRouter(),
+    );
+
+    // Then the rail and toggle are absent
+    expect(r.query.sideNavLayout_sideNav).toBeNull();
+    expect(r.query.sideNavLayout_toggle).toBeNull();
+
+    // And the items show in the navbar mobile menu
+    click(r.navbar_mobileMenu);
+    expect(r.navbar_mobileMenuMainMenu).toBeInTheDocument();
+    expect(r.navbar_link_dashboard).toHaveTextContent("Dashboard");
+  });
 });
+
+const items: AppNavItem[] = [
+  { label: "Dashboard", icon: "columns", onClick: () => {}, active: true },
+  { label: "Projects", icon: "search", onClick: () => {} },
+];

--- a/src/layouts/SideNavLayout/SideNavLayout.tsx
+++ b/src/layouts/SideNavLayout/SideNavLayout.tsx
@@ -11,6 +11,7 @@ import {
   beamNavbarLayoutHeightVar,
   beamSideNavLayoutWidthVar,
 } from "src/layouts/layoutVars";
+import { useRegisterMobileSubNav } from "src/layouts/NavbarLayout/MobileSubNavContext";
 import { useTestIds } from "src/utils";
 import { zIndices } from "src/utils/zIndices";
 import { DocumentScrollLayoutProvider } from "../DocumentScrollLayoutContext";
@@ -46,9 +47,12 @@ function SideNavLayoutContent(props: SideNavLayoutProps) {
   const bp = useBreakpoint();
   const tid = useTestIds(props, "sideNavLayout");
   const railCollapsedWidthPx = 56;
+  // Under NavbarLayout on `sm`, the rail is hidden and items show as the mobile menu's nested pane.
+  const hasMobileSubNavProvider = useRegisterMobileSubNav(sideNav, !bp.mdAndUp);
+  const showMobileSubNav = hasMobileSubNavProvider && !bp.mdAndUp;
 
   const collapsed = navState === "collapse";
-  const showRail = navState !== "hidden";
+  const showRail = navState !== "hidden" && !showMobileSubNav;
 
   // Rail width reserved in content space (mobile overlay only reserves the collapsed strip).
   const railOffsetPx = !showRail ? 0 : !bp.mdAndUp || collapsed ? railCollapsedWidthPx : railWidthPx;

--- a/src/layouts/SideNavLayout/SideNavLayout.tsx
+++ b/src/layouts/SideNavLayout/SideNavLayout.tsx
@@ -48,8 +48,7 @@ function SideNavLayoutContent(props: SideNavLayoutProps) {
   const tid = useTestIds(props, "sideNavLayout");
   const railCollapsedWidthPx = 56;
   // Under NavbarLayout on `sm`, the rail is hidden and items show as the mobile menu's nested pane.
-  const hasMobileSubNavProvider = useRegisterMobileSubNav(sideNav, !bp.mdAndUp);
-  const showMobileSubNav = hasMobileSubNavProvider && !bp.mdAndUp;
+  const showMobileSubNav = useRegisterMobileSubNav(sideNav);
 
   const collapsed = navState === "collapse";
   const showRail = navState !== "hidden" && !showMobileSubNav;


### PR DESCRIPTION
Using a context, we pass the SideNav props needed for rendering the Side Nav in the mobile menu. Mobile Menu now is smart enough to start at the side nav, supporting going "back" to the Main Menu. Once a user does this, the only way back to the SideNav/Sub menu is by closing the menu and re-opening it. This is a corner cut for now until we can revisit for IA work down the road