### PR TITLE
feat: Support 'CompanionRow' in GridTable

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/react-vite";
 import { observable } from "mobx";
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   actionColumn,
   Button,
@@ -19,6 +19,7 @@ import {
   GridDataRow,
   GridRowLookup,
   GridTable,
+  GridTableLayout,
   Icon,
   IconButton,
   insertAtIndex,
@@ -30,6 +31,7 @@ import {
   simpleHeader,
   SimpleHeaderAndData,
   useGridTableApi,
+  useGridTableLayoutState,
 } from "src/components/index";
 import {
   cardBadgeSlot,
@@ -39,14 +41,17 @@ import {
   cardStatusSlot,
   cardTitleSlot,
 } from "src/components/Table/cardSlots";
-import { Css, Palette } from "src/Css";
+import type { GridRowCompanion } from "src/components/Table/components/CompanionRow";
+import { PinToggle } from "src/components/Table/components/PinToggle";
+import { Css, Palette, Tokens } from "src/Css";
 import { jan1, jan2, jan29 } from "src/forms/formStateDomain";
 import { useComputed } from "src/hooks";
 import { DateField, SelectField } from "src/inputs";
 import { NumberField } from "src/inputs/NumberField";
 import { type PlainDate } from "src/types";
 import { noop } from "src/utils";
-import { newStory, withRouter, zeroTo } from "src/utils/sb";
+import { newStory, withBeamDecorator, withRouter, zeroTo } from "src/utils/sb";
+import { TestProjectLayout } from "src/utils/sbComponents";
 import { action } from "storybook/actions";
 
 export default {
@@ -578,7 +583,7 @@ export function StickyHeader() {
   );
 }
 
-/** Demonstrates interactive, user-driven row pinning via the `pinColumn` toggle (div render). */
+/** Interactive row pinning via `pinColumn`, including companions that hoist with their parent when pinned. */
 export function InteractiveRowPinning() {
   const nameColumn: GridColumn<Row> = { header: "Name", data: ({ name }) => name };
   const valueColumn: GridColumn<Row> = { header: "Value", data: ({ value }) => value };
@@ -597,6 +602,14 @@ export function InteractiveRowPinning() {
             // Pre-pin a couple rows so the sticky pinned section (and its separator) shows in the snapshot;
             // any row can be pinned/unpinned via the pin column.
             ...(i === 3 || i === 8 ? { initPinned: true } : {}),
+            // Row 8: pre-pinned trailing companion (also has a PinToggle in companion content).
+            ...(i === 8
+              ? { companion: createPinningCompanion(`${i}`, "Pre-pinned — companion hoists with parent.") }
+              : {}),
+            // Row 15: leading companion with a PinToggle — pin/unpin from the companion row.
+            ...(i === 15
+              ? { companion: createPinningCompanion(`${i}`, "Pin from companion content.", "leading") }
+              : {}),
           })),
         ]}
       />
@@ -621,6 +634,12 @@ export function InteractiveRowPinningVirtual() {
             id: `${i}`,
             data: { name: `row ${i}`, value: i },
             ...(i === 3 || i === 8 ? { initPinned: true } : {}),
+            ...(i === 8
+              ? { companion: createPinningCompanion(`${i}`, "Pre-pinned — companion hoists with parent.") }
+              : {}),
+            ...(i === 15
+              ? { companion: createPinningCompanion(`${i}`, "Pin from companion content.", "leading") }
+              : {}),
           })),
         ]}
       />
@@ -694,6 +713,128 @@ export function InteractiveGroupRowPinning() {
     </div>
   );
 }
+
+/** AI-suggestion style companions: full-width content with a data row and no mid separator. */
+export const CompanionRows = newStory(() => {
+  type OptionData = {
+    code: string;
+    name: string;
+    type: string;
+    location: string;
+    suggestion?: "add" | "remove";
+  };
+  type OptionRow = SimpleHeaderAndData<OptionData>;
+
+  const columns: GridColumn<OptionRow>[] = [
+    { header: "Option Code", data: ({ code, suggestion }) => styleOptionCell(code, suggestion) },
+    { header: "Option Name", data: ({ name, suggestion }) => styleOptionCell(name, suggestion) },
+    { header: "Type", data: ({ type, suggestion }) => styleOptionCell(type, suggestion) },
+    { header: "Location", data: ({ location, suggestion }) => styleOptionCell(location, suggestion) },
+  ];
+
+  const rows: GridDataRow<OptionRow>[] = [
+    simpleHeader,
+    {
+      kind: "data",
+      id: "1",
+      data: {
+        code: "—",
+        name: "Add Stained Wood Ceiling",
+        type: "—",
+        location: "Kitchen 109",
+        suggestion: "add",
+      },
+      companion: {
+        position: "leading",
+        content: () => (
+          <CompanionBanner
+            tone="error"
+            message="Add Stained Wood Ceiling was not found in the option library. Review 2 Possible matches."
+            actions={<Button label="Review Matches" variant="text" onClick={noop} />}
+          />
+        ),
+      },
+    },
+    {
+      kind: "data",
+      id: "2",
+      data: {
+        code: "TRMCLG0004",
+        name: "Slab Backsplash Upgrade",
+        type: "ADD-ON",
+        location: "Kitchen 109",
+        suggestion: "remove",
+      },
+      companion: () => (
+        <CompanionBanner
+          tone="warning"
+          message="Referenced by 1 takeoff line."
+          actions={
+            <>
+              <Button label="Keep" variant="text" onClick={noop} />
+              <Button label="Remove" variant="text" onClick={noop} />
+            </>
+          }
+        />
+      ),
+    },
+    {
+      kind: "data",
+      id: "3",
+      data: {
+        code: "CAB001",
+        name: "Upper Cabinet Extension",
+        type: "ADD-ON",
+        location: "Kitchen 109",
+        suggestion: "remove",
+      },
+      companion: () => (
+        <CompanionBanner
+          tone="warning"
+          message="Used as a requirement for 2 other options."
+          actions={
+            <>
+              <Button label="Keep" variant="text" onClick={noop} />
+              <Button label="Remove" variant="text" onClick={noop} />
+            </>
+          }
+        />
+      ),
+    },
+    {
+      kind: "data",
+      id: "4",
+      data: { code: "FLR100", name: "Standard Vinyl Plank", type: "BASE", location: "Kitchen 109" },
+    },
+  ];
+
+  return <GridTable columns={columns} rows={rows} />;
+}, {});
+
+/**
+ * Wide table in the document-scroll layout stack so horizontal overflow is a window scrollbar.
+ * Sticky left/right columns and companion chrome (message / actions) should stay in the viewport.
+ */
+export const CompanionRowsWideDocumentScroll = newStory(
+  () => {
+    const layoutState = useGridTableLayoutState({ search: "client" });
+    const columns = useMemo(() => createCompanionWideColumns(), []);
+    const rows = useMemo(() => createCompanionWideRows(), []);
+    return (
+      <TestProjectLayout pageTitle="Option library">
+        <GridTableLayout layoutState={layoutState} tableProps={{ as: "virtual", columns, rows }} />
+      </TestProjectLayout>
+    );
+  },
+  {
+    decorators: [withBeamDecorator],
+    parameters: { chromatic: { delay: 400 } },
+    play: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      window.scrollTo({ left: 420, top: 160 });
+    },
+  },
+);
 
 export const StyleDefault = newStory(() => {
   const nameColumn: GridColumn<Row> = { header: "Name", data: ({ name }) => name };
@@ -2981,4 +3122,264 @@ export function CardViewInfiniteScroll() {
       </div>
     </div>
   );
+}
+
+type CompanionOptionData = {
+  code: string;
+  name: string;
+  type: string;
+  location: string;
+  finish: string;
+  vendor: string;
+  leadTime: string;
+  notes: string;
+  cost: string;
+  suggestion?: "add" | "remove";
+};
+type CompanionOptionRow = SimpleHeaderAndData<CompanionOptionData>;
+
+function styleOptionCell(value: string, suggestion: "add" | "remove" | undefined) {
+  if (suggestion === "add") {
+    return { content: value, css: Css.purple700.fsyi.$ };
+  }
+  if (suggestion === "remove") {
+    return { content: value, css: Css.color(Tokens.OnSurfaceMuted).tdlt.$ };
+  }
+  return value;
+}
+
+/** Companion content with an inline {@link PinToggle} for the InteractiveRowPinning stories. */
+function createPinningCompanion(rowId: string, message: string, position?: "leading" | "trailing"): GridRowCompanion {
+  const content = () => (
+    <div css={Css.df.aic.jcsb.gap2.px1.w100.$}>
+      <span css={Css.xs.$}>{message}</span>
+      <PinToggle rowId={rowId} />
+    </div>
+  );
+  return position ? { position, content } : content;
+}
+
+function CompanionBanner(props: { tone: "error" | "warning"; message: string; actions: ReactNode }) {
+  const { tone, message, actions } = props;
+  const isError = tone === "error";
+  return (
+    <div
+      css={{
+        ...Css.df.aic.jcsb.gap2.w100.px1.py1.br4.xs.ba.$,
+        ...(isError ? Css.bgRed50.bc(Palette.Red400).$ : Css.bgOrange50.bc(Palette.Orange400).$),
+      }}
+    >
+      <div css={Css.df.aic.gap1.$}>
+        <Icon icon={isError ? "xCircle" : "error"} color={isError ? Palette.Red600 : Palette.Orange600} inc={2} />
+        <span>{message}</span>
+      </div>
+      <div css={Css.df.aic.gap1.fs0.$}>{actions}</div>
+    </div>
+  );
+}
+
+function createCompanionWideColumns(): GridColumn<CompanionOptionRow>[] {
+  return [
+    selectColumn<CompanionOptionRow>({ sticky: "left" }),
+    column<CompanionOptionRow>({
+      id: "code",
+      name: "Option Code",
+      header: "Option Code",
+      data: ({ code, suggestion }) => styleOptionCell(code, suggestion),
+      w: "140px",
+      sticky: "left",
+    }),
+    column<CompanionOptionRow>({
+      id: "name",
+      name: "Option Name",
+      header: "Option Name",
+      data: ({ name, suggestion }) => styleOptionCell(name, suggestion),
+      w: "280px",
+    }),
+    column<CompanionOptionRow>({
+      id: "type",
+      name: "Type",
+      header: "Type",
+      data: ({ type, suggestion }) => styleOptionCell(type, suggestion),
+      w: "160px",
+    }),
+    column<CompanionOptionRow>({
+      id: "location",
+      name: "Location",
+      header: "Location",
+      data: ({ location, suggestion }) => styleOptionCell(location, suggestion),
+      w: "220px",
+    }),
+    column<CompanionOptionRow>({
+      id: "finish",
+      name: "Finish",
+      header: "Finish",
+      data: ({ finish }) => finish,
+      w: "200px",
+    }),
+    column<CompanionOptionRow>({
+      id: "vendor",
+      name: "Vendor",
+      header: "Vendor",
+      data: ({ vendor }) => vendor,
+      w: "220px",
+    }),
+    column<CompanionOptionRow>({
+      id: "leadTime",
+      name: "Lead Time",
+      header: "Lead Time",
+      data: ({ leadTime }) => leadTime,
+      w: "160px",
+    }),
+    column<CompanionOptionRow>({ id: "notes", name: "Notes", header: "Notes", data: ({ notes }) => notes, w: "280px" }),
+    column<CompanionOptionRow>({ id: "cost", name: "Cost", header: "Cost", data: ({ cost }) => cost, w: "140px" }),
+    column<CompanionOptionRow>({
+      id: "actions",
+      name: "Actions",
+      header: "Actions",
+      data: () => "Actions",
+      w: "140px",
+      sticky: "right",
+      clientSideSort: false,
+    }),
+  ];
+}
+
+function createCompanionWideRows(): GridDataRow<CompanionOptionRow>[] {
+  const extra = zeroTo(12).map((i) => {
+    const row: GridDataRow<CompanionOptionRow> = {
+      kind: "data",
+      id: String(i + 5),
+      data: {
+        code: `OPT${String(i + 100).padStart(4, "0")}`,
+        name: `Additional Option ${i + 1}`,
+        type: i % 2 === 0 ? "ADD-ON" : "BASE",
+        location: `Kitchen ${109 + (i % 3)}`,
+        finish: i % 2 === 0 ? "Stained Oak" : "Matte White",
+        vendor: i % 2 === 0 ? "West Elm Millwork" : "Homebound Supply",
+        leadTime: `${4 + (i % 5)} weeks`,
+        notes: "Shown to force horizontal overflow in document scroll.",
+        cost: `$${(1200 + i * 85).toLocaleString()}`,
+      },
+      ...(i % 4 === 0
+        ? {
+            companion: () => (
+              <CompanionBanner
+                tone="warning"
+                message={`Referenced by ${i + 1} takeoff line${i === 0 ? "" : "s"}.`}
+                actions={
+                  <>
+                    <Button label="Keep" variant="text" onClick={noop} />
+                    <Button label="Remove" variant="text" onClick={noop} />
+                  </>
+                }
+              />
+            ),
+          }
+        : {}),
+    };
+    return row;
+  });
+
+  return [
+    simpleHeader,
+    {
+      kind: "data",
+      id: "1",
+      data: {
+        code: "—",
+        name: "Add Stained Wood Ceiling",
+        type: "—",
+        location: "Kitchen 109",
+        finish: "Stained Oak",
+        vendor: "—",
+        leadTime: "—",
+        notes: "Not in the option library.",
+        cost: "—",
+        suggestion: "add",
+      },
+      companion: {
+        position: "leading",
+        content: () => (
+          <CompanionBanner
+            tone="error"
+            message="Add Stained Wood Ceiling was not found in the option library. Review 2 Possible matches."
+            actions={<Button label="Review Matches" variant="text" onClick={noop} />}
+          />
+        ),
+      },
+    },
+    {
+      kind: "data",
+      id: "2",
+      data: {
+        code: "TRMCLG0004",
+        name: "Slab Backsplash Upgrade",
+        type: "ADD-ON",
+        location: "Kitchen 109",
+        finish: "Calacatta Gold",
+        vendor: "Stone Yard",
+        leadTime: "6 weeks",
+        notes: "Referenced by takeoff lines in this room.",
+        cost: "$4,200",
+        suggestion: "remove",
+      },
+      companion: () => (
+        <CompanionBanner
+          tone="warning"
+          message="Referenced by 1 takeoff line."
+          actions={
+            <>
+              <Button label="Keep" variant="text" onClick={noop} />
+              <Button label="Remove" variant="text" onClick={noop} />
+            </>
+          }
+        />
+      ),
+    },
+    {
+      kind: "data",
+      id: "3",
+      data: {
+        code: "CAB001",
+        name: "Upper Cabinet Extension",
+        type: "ADD-ON",
+        location: "Kitchen 109",
+        finish: "Matte White",
+        vendor: "Cabinetworks",
+        leadTime: "8 weeks",
+        notes: "Used as a requirement for other options.",
+        cost: "$1,850",
+        suggestion: "remove",
+      },
+      companion: () => (
+        <CompanionBanner
+          tone="warning"
+          message="Used as a requirement for 2 other options."
+          actions={
+            <>
+              <Button label="Keep" variant="text" onClick={noop} />
+              <Button label="Remove" variant="text" onClick={noop} />
+            </>
+          }
+        />
+      ),
+    },
+    {
+      kind: "data",
+      id: "4",
+      data: {
+        code: "FLR100",
+        name: "Standard Vinyl Plank",
+        type: "BASE",
+        location: "Kitchen 109",
+        finish: "Oak",
+        vendor: "Homebound Supply",
+        leadTime: "2 weeks",
+        notes: "No companion on this row.",
+        cost: "$980",
+      },
+    },
+    ...extra,
+  ];
 }

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1135,6 +1135,272 @@ describe("GridTable", () => {
     });
   });
 
+  describe("companion rows", () => {
+    const insetSeparator = `inset 0 -1px 0 ${maybeCssVar(Tokens.SurfaceSeparator)}`;
+
+    it("renders a trailing companion under its owning row at full column width", async () => {
+      // Given a data row with trailing companion content and a following data row
+      const r = await render(
+        <GridTable<Row>
+          columns={[nameColumn, valueColumn]}
+          rows={[
+            simpleHeader,
+            {
+              kind: "data",
+              id: "1",
+              data: { name: "foo", value: 1 },
+              companion: () => <div data-testid="companionMessage">Review matches</div>,
+            },
+            { kind: "data", id: "2", data: { name: "bar", value: 2 } },
+          ]}
+        />,
+      );
+
+      // Then the companion sits directly under the owning row, before the next data row
+      expect(cell(r, 1, 0)).toHaveTextContent("foo");
+      expect(r.companion_1).toBeInTheDocument();
+      expect(r.companionMessage).toHaveTextContent("Review matches");
+      expect(cell(r, 3, 0)).toHaveTextContent("bar");
+      // And the companion cell spans all columns
+      expect(cell(r, 2, 0).style.getPropertyValue("--width")).toContain("+");
+    });
+
+    it("transfers the row separator from parent to a trailing companion", async () => {
+      // Given a trailing companion between two data rows
+      const r = await render(
+        <GridTable<Row>
+          columns={[nameColumn, valueColumn]}
+          rows={[
+            simpleHeader,
+            {
+              kind: "data",
+              id: "1",
+              data: { name: "foo", value: 1 },
+              companion: () => <span>Companion</span>,
+            },
+            { kind: "data", id: "2", data: { name: "bar", value: 2 } },
+          ]}
+        />,
+      );
+
+      // Then the parent row has no bottom separator
+      expect(cell(r, 1, 0)).toHaveStyle({ boxShadow: "none" });
+      expect(cell(r, 1, 1)).toHaveStyle({ boxShadow: "none" });
+      // And the companion row carries the separator between row groups
+      expect(cell(r, 2, 0)).toHaveStyle({ boxShadow: insetSeparator });
+    });
+
+    it("applies last-row styling to the trailing companion when it is the final body row", async () => {
+      // Given a single data row whose trailing companion is the last body entry
+      const r = await render(
+        <GridTable<Row>
+          columns={[nameColumn, valueColumn]}
+          rows={[
+            simpleHeader,
+            {
+              kind: "data",
+              id: "1",
+              data: { name: "foo", value: 1 },
+              companion: () => <span>Last companion</span>,
+            },
+          ]}
+        />,
+      );
+
+      // Then the parent is not the last body row (no bottom separator)
+      expect(cell(r, 1, 0)).toHaveStyle({ boxShadow: "none" });
+      // And the companion receives last-row styling (no bottom separator)
+      expect(cell(r, 2, 0)).toHaveStyle({ boxShadow: "none" });
+    });
+
+    it("hoists a companion into the pinned section with its parent row", async () => {
+      // Given a body row with a companion, between two other data rows
+      const api = new GridTableApiImpl<Row>();
+      const r = await render(
+        <GridTable<Row>
+          api={api}
+          columns={[nameColumn, valueColumn]}
+          rows={[
+            simpleHeader,
+            { kind: "data", id: "1", data: { name: "foo", value: 1 } },
+            {
+              kind: "data",
+              id: "2",
+              data: { name: "bar", value: 2 },
+              companion: () => <span data-testid="pinnedCompanion">Pinned note</span>,
+            },
+            { kind: "data", id: "3", data: { name: "zaz", value: 3 } },
+          ]}
+        />,
+      );
+
+      // When the owning row is pinned
+      act(() => api.pinRow("2"));
+
+      // Then the companion moves with its parent into the pinned section
+      expect(cell(r, 1, 0)).toHaveTextContent("bar");
+      expect(r.companion_2).toBeInTheDocument();
+      expect(r.pinnedCompanion).toHaveTextContent("Pinned note");
+      // And the remaining body rows stay in place
+      expect(cell(r, 3, 0)).toHaveTextContent("foo");
+      expect(cell(r, 4, 0)).toHaveTextContent("zaz");
+    });
+
+    it("renders a leading companion above its owning row", async () => {
+      // Given a data row with a leading companion and a following data row
+      const r = await render(
+        <GridTable<Row>
+          columns={[nameColumn, valueColumn]}
+          rows={[
+            simpleHeader,
+            {
+              kind: "data",
+              id: "1",
+              data: { name: "foo", value: 1 },
+              companion: {
+                position: "leading",
+                content: () => <div data-testid="leadingCompanion">Above</div>,
+              },
+            },
+            { kind: "data", id: "2", data: { name: "bar", value: 2 } },
+          ]}
+        />,
+      );
+
+      // Then the companion renders above the owning row
+      expect(r.companion_1).toBeInTheDocument();
+      expect(r.leadingCompanion).toHaveTextContent("Above");
+      expect(cell(r, 2, 0)).toHaveTextContent("foo");
+      expect(cell(r, 3, 0)).toHaveTextContent("bar");
+    });
+
+    it("keeps the row separator on the parent when the companion is leading", async () => {
+      // Given a leading companion followed by another data row
+      const r = await render(
+        <GridTable<Row>
+          columns={[nameColumn, valueColumn]}
+          rows={[
+            simpleHeader,
+            {
+              kind: "data",
+              id: "1",
+              data: { name: "foo", value: 1 },
+              companion: {
+                position: "leading",
+                content: () => <span>Above</span>,
+              },
+            },
+            { kind: "data", id: "2", data: { name: "bar", value: 2 } },
+          ]}
+        />,
+      );
+
+      // Then the leading companion has no bottom separator (flush against the parent)
+      expect(cell(r, 1, 0)).toHaveStyle({ boxShadow: "none" });
+      // And the parent row owns the separator before the next data row
+      expect(cell(r, 2, 0)).toHaveStyle({ boxShadow: insetSeparator });
+    });
+
+    it("defaults object-form companion config to trailing placement", async () => {
+      // Given an object-form companion without an explicit position
+      const r = await render(
+        <GridTable<Row>
+          columns={[nameColumn, valueColumn]}
+          rows={[
+            simpleHeader,
+            {
+              kind: "data",
+              id: "1",
+              data: { name: "foo", value: 1 },
+              companion: { content: () => <div data-testid="objectCompanion">Note</div> },
+            },
+            { kind: "data", id: "2", data: { name: "bar", value: 2 } },
+          ]}
+        />,
+      );
+
+      // Then the companion renders under the owning row (trailing)
+      expect(cell(r, 1, 0)).toHaveTextContent("foo");
+      expect(r.companion_1).toBeInTheDocument();
+      expect(r.objectCompanion).toHaveTextContent("Note");
+      expect(cell(r, 3, 0)).toHaveTextContent("bar");
+    });
+
+    it("sticks companion content to document-scroll chrome inset by layout gutters", async () => {
+      // Given a companion inside a document-scroll table with column gutters
+      const r = await render(
+        <DocumentScrollLayoutProvider>
+          <GridTable<Row>
+            columnGutter
+            columns={[nameColumn, valueColumn]}
+            rows={[
+              simpleHeader,
+              {
+                kind: "data",
+                id: "1",
+                data: { name: "foo", value: 1 },
+                companion: () => <span>Note</span>,
+              },
+            ]}
+          />
+        </DocumentScrollLayoutProvider>,
+      );
+
+      // Then the companion content is wrapped in a sticky chrome container aligned to the layout gutters
+      expect(r.companion_chrome).toBeInTheDocument();
+      expect(r.companion_chrome.style.getPropertyValue("--left")).toContain("12px");
+    });
+
+    it("groups parent and companion in one row group for shared hover in div mode", async () => {
+      // Given a trailing companion followed by another data row
+      const r = await render(
+        <GridTable<Row>
+          columns={[nameColumn, valueColumn]}
+          rows={[
+            simpleHeader,
+            {
+              kind: "data",
+              id: "1",
+              data: { name: "foo", value: 1 },
+              companion: () => <span>Companion</span>,
+            },
+            { kind: "data", id: "2", data: { name: "bar", value: 2 } },
+          ]}
+        />,
+      );
+
+      // Then parent and companion share a row group wrapper, separate from the next row
+      expect(r.companion_1.parentElement).toBe(row(r, 1).parentElement);
+      expect(row(r, 3).parentElement).not.toBe(r.companion_1.parentElement);
+      expect(r.companion_1.parentElement).toHaveClass("beam-row-hover");
+    });
+
+    it("groups parent and companion in one tbody per row group in table mode", async () => {
+      // Given a table-mode row with a companion, followed by another row
+      const r = await render(
+        <GridTable<Row>
+          as="table"
+          columns={[nameColumn, valueColumn]}
+          rows={[
+            simpleHeader,
+            {
+              kind: "data",
+              id: "1",
+              data: { name: "foo", value: 1 },
+              companion: () => <span>Companion</span>,
+            },
+            { kind: "data", id: "2", data: { name: "bar", value: 2 } },
+          ]}
+        />,
+      );
+
+      // Then parent and companion share one tbody, and the next row has its own
+      expect(r.companion_1.closest("tbody")).toBe(row(r, 1).closest("tbody"));
+      expect(row(r, 3).closest("tbody")).not.toBe(r.companion_1.closest("tbody"));
+      expect(row(r, 1).closest("table")!.querySelectorAll("tbody")).toHaveLength(2);
+    });
+  });
+
   describe("column sizes", () => {
     it("as=virtual defaults to fr widths", () => {
       expect(calcColumnSizes([{ id: "c1" }, { id: "c2" }], undefined, undefined, []).join(" ")).toEqual(
@@ -1255,6 +1521,30 @@ describe("GridTable", () => {
 
     expect(api.getVisibleColumnIds()[0]).toBe(layoutGutterLeftColumnId);
     expect(api.getVisibleColumnIds().at(-1)).toBe(layoutGutterRightColumnId);
+  });
+
+  it("pins layout gutters to match sticky left/right columns", () => {
+    // Given columns with sticky left and sticky right
+    const columns = withColumnGutters([
+      selectColumn<Row>({ sticky: "left" }),
+      nameColumn,
+      { ...valueColumn, sticky: "right" },
+    ]);
+
+    // Then the left gutter sticks with the left columns, and the right gutter with the right
+    expect(columns[0].id).toBe(layoutGutterLeftColumnId);
+    expect(columns[0].sticky).toBe("left");
+    expect(columns[columns.length - 1].id).toBe(layoutGutterRightColumnId);
+    expect(columns[columns.length - 1].sticky).toBe("right");
+  });
+
+  it("does not pin layout gutters when no columns are sticky", () => {
+    // Given columns with no sticky sides
+    const columns = withColumnGutters([selectColumn<Row>(), nameColumn, valueColumn]);
+
+    // Then neither gutter is sticky
+    expect(columns[0].sticky).toBeUndefined();
+    expect(columns[columns.length - 1].sticky).toBeUndefined();
   });
 
   it("does not inject layout gutter columns outside document-scroll layout", async () => {
@@ -2654,7 +2944,8 @@ describe("GridTable", () => {
       expect(baseElement.querySelector("table")).toBeTruthy();
       expect(baseElement.querySelector("thead")).toBeTruthy();
       expect(baseElement.querySelector("th")).toBeTruthy();
-      expect(baseElement.querySelector("tbody")).toBeTruthy();
+      // One tbody per body row (header stays in thead)
+      expect(baseElement.querySelectorAll("tbody")).toHaveLength(2);
       expect(baseElement.querySelector("tr")).toBeTruthy();
       expect(baseElement.querySelector("td")).toBeTruthy();
     });

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -36,6 +36,7 @@ import {
   HEADER,
   isCursorBelowMidpoint,
   KEPT_GROUP,
+  reservedRowKinds,
   TOTALS,
 } from "src/components/Table/utils/utils";
 import { Css, Only } from "src/Css";
@@ -45,8 +46,10 @@ import { useDocumentScrollLayout } from "src/layouts/DocumentScrollLayoutContext
 import { stickyTableHeaderOffset } from "src/layouts/layoutVars";
 import { isPromise } from "src/utils";
 import { zIndices } from "src/utils/zIndices";
+import { CompanionRow, resolveCompanion } from "./components/CompanionRow";
 import type { GridDataRow, GridRowKind } from "./components/Row";
 import { Row } from "./components/Row";
+import { RowGroup } from "./components/RowGroup";
 import { TableCard } from "./components/TableCard";
 import { GridTableEmptyState, GridTableEmptyStateProps } from "./GridTableEmptyState";
 import { DraggedOver, RowState } from "./utils/RowState";
@@ -508,12 +511,16 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
     const visibleRows = tableState.visibleRows.filter((rs) => !pinnedIds.has(rs.row.id));
     const hasExpandableHeader = visibleRows.some((rs) => rs.row.id === EXPANDABLE_HEADER);
 
+    const omitRowHover = "rowHover" in maybeStyle && maybeStyle.rowHover === false;
+    const isHeadKind = (kind: string) => [HEADER, EXPANDABLE_HEADER, TOTALS].includes(kind);
+
     // Builds a `<Row>` element; shared by the partition loop and the pinned section so they stay in sync.
     const makeRow = (
       rs: RowState<R>,
       isFirstHeadRow: boolean,
       isFirstBodyRow: boolean,
       isLastBodyRow: boolean,
+      hasTrailingCompanion: boolean,
     ): ReactElement => (
       <Row
         key={rs.key}
@@ -530,11 +537,12 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
           columnSizes,
           getCount,
           cellHighlight: "cellHighlight" in maybeStyle && maybeStyle.cellHighlight === true,
-          omitRowHover: "rowHover" in maybeStyle && maybeStyle.rowHover === false,
+          omitRowHover,
           hasExpandableHeader,
           isFirstHeadRow,
           isFirstBodyRow,
           isLastBodyRow,
+          hasTrailingCompanion,
           resizedWidths,
           setResizedWidth: handleColumnResize,
           disableColumnResizing,
@@ -543,40 +551,91 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
       />
     );
 
-    const bodyRowsCount = visibleRows.filter((rs) => ![HEADER, EXPANDABLE_HEADER, TOTALS].includes(rs.kind)).length;
-    const onlyKeptBodyRows =
-      bodyRowsCount > 0 &&
-      visibleRows.every(
-        (rs) =>
-          // For our purposes, "body rows" are any non-header / non-totals rows.
-          [HEADER, EXPANDABLE_HEADER, TOTALS].includes(rs.kind) || rs.isKept || rs.kind === KEPT_GROUP,
+    const makeCompanionRow = (
+      rs: RowState<R>,
+      resolved: NonNullable<ReturnType<typeof resolveCompanion>>,
+      isFirstBodyRow: boolean,
+      isLastBodyRow: boolean,
+    ): ReactElement => {
+      const levelStyle =
+        style.levels && (typeof style.levels === "function" ? style.levels(rs.level) : style.levels[rs.level]);
+      return (
+        <CompanionRow
+          key={`${rs.key}-companion`}
+          as={as}
+          style={style}
+          columnSizes={columnSizes}
+          rowId={rs.row.id}
+          colSpan={columns.length}
+          isFirstBodyRow={isFirstBodyRow}
+          isLastBodyRow={isLastBodyRow}
+          position={resolved.position}
+          companion={resolved.content}
+          levelIndent={levelStyle?.rowIndent}
+        />
       );
-    let bodyRowsSeen = 0;
+    };
+
+    /** One wrapper per logical body row so parent + companion virtualize, hover, and print together. */
+    const makeRowGroup = (
+      rs: RowState<R>,
+      isFirstBodyRow: boolean,
+      isLastBodyRow: boolean,
+      inHead: boolean,
+    ): ReactElement => {
+      const resolved = resolveCompanion(rs.row.companion);
+      const position = resolved?.position;
+      const row = makeRow(
+        rs,
+        false,
+        isFirstBodyRow && position !== "leading",
+        isLastBodyRow && position !== "trailing",
+        position === "trailing",
+      );
+      const companionEl = resolved
+        ? makeCompanionRow(
+            rs,
+            resolved,
+            isFirstBodyRow && position === "leading",
+            isLastBodyRow && position === "trailing",
+          )
+        : undefined;
+      const children =
+        position === "leading" && companionEl ? [companionEl, row] : companionEl ? [row, companionEl] : row;
+      const showRowHover = !reservedRowKinds.includes(rs.kind) && !omitRowHover && style.rowHoverColor !== "none";
+      return (
+        <RowGroup key={rs.key} as={as} inHead={inHead} showRowHover={showRowHover} style={style}>
+          {children}
+        </RowGroup>
+      );
+    };
+
+    const bodyRowStates = visibleRows.filter((rs) => !isHeadKind(rs.kind));
+    const onlyKeptBodyRows =
+      bodyRowStates.length > 0 && bodyRowStates.every((rs) => rs.isKept || rs.kind === KEPT_GROUP);
+    const lastBodyRs = !onlyKeptBodyRows ? bodyRowStates[bodyRowStates.length - 1] : undefined;
     let foundFirstBodyRow = false;
     let foundFirstHeadRow = false;
 
     // Get the flat list or rows from the header down...
     visibleRows.forEach((rs) => {
-      const isHeadRow = [HEADER, EXPANDABLE_HEADER, TOTALS].includes(rs.kind);
+      const isHeadRow = isHeadKind(rs.kind);
       const isFirstHeadRow = isHeadRow && !foundFirstHeadRow;
-      const isBodyRow = ![HEADER, EXPANDABLE_HEADER, TOTALS].includes(rs.kind);
+      const isBodyRow = !isHeadRow;
       const isFirstBodyRow = isBodyRow && !foundFirstBodyRow;
       if (isHeadRow) foundFirstHeadRow = true;
-      if (isBodyRow) bodyRowsSeen += 1;
       if (isBodyRow) foundFirstBodyRow = true;
-      const isLastBodyRow = isBodyRow && bodyRowsSeen === bodyRowsCount && !onlyKeptBodyRows;
 
-      const row = makeRow(rs, isFirstHeadRow, isFirstBodyRow, isLastBodyRow);
       if (rs.kind === "header") {
-        headerRows.push(row);
+        headerRows.push(makeRow(rs, isFirstHeadRow, false, false, false));
       } else if (rs.kind === "expandableHeader") {
-        expandableHeaderRows.push(row);
+        expandableHeaderRows.push(makeRow(rs, isFirstHeadRow, false, false, false));
       } else if (rs.kind === "totals") {
-        totalsRows.push(row);
+        totalsRows.push(makeRow(rs, isFirstHeadRow, false, false, false));
       } else if (rs.isKept || rs.kind === KEPT_GROUP) {
-        keptSelectedRows.push(row);
+        keptSelectedRows.push(makeRowGroup(rs, isFirstBodyRow, rs === lastBodyRs, false));
       } else {
-        visibleDataRows.push(row);
+        visibleDataRows.push(makeRowGroup(rs, isFirstBodyRow, rs === lastBodyRs, false));
       }
     });
 
@@ -585,15 +644,15 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
 
     // Build the runtime pinned section from `pinnedRowStates` (sourced from all states, so pins the
     // current filter would otherwise hide still show — mirroring how kept rows are sourced).
-    const pinnedRows = pinnedRowStates.map((rs) => makeRow(rs, false, false, false));
+    const pinnedRows = pinnedRowStates.map((rs) => makeRowGroup(rs, false, false, as === "table"));
 
     const tooManyClientSideRows = !!filterMaxRows && visibleDataRows.length > filterMaxRows;
     if (tooManyClientSideRows) {
-      visibleDataRows = visibleDataRows.slice(0, filterMaxRows + keptSelectedRows.length);
+      visibleDataRows = visibleDataRows.slice(0, filterMaxRows);
     }
 
     return [tableHeadRows, visibleDataRows, keptSelectedRows, pinnedRows, tooManyClientSideRows];
-  }, [as, api, style, rowStyles, maybeStyle, columnSizes, getCount, filterMaxRows]);
+  }, [as, api, style, rowStyles, maybeStyle, columnSizes, columns.length, getCount, filterMaxRows]);
 
   // Push back to the caller a way to ask us where a row is.
   // Refs are cheap to assign to, so we don't bother doing this in a useEffect
@@ -830,10 +889,10 @@ function renderTable<R extends Kinded>(
         {tableHeadRows}
         {pinnedRows}
       </thead>
-      <tbody>
-        {keptSelectedRows}
-        {/* Show an all-column-span info message if it's set. */}
-        {firstRowMessage && (
+      {keptSelectedRows}
+      {/* Own tbody so we never mix bare `<tr>`s with row groups. */}
+      {firstRowMessage && (
+        <tbody>
           <tr
             css={{
               ...tableRowPrintBreakCss,
@@ -854,9 +913,9 @@ function renderTable<R extends Kinded>(
               {firstRowMessage}
             </td>
           </tr>
-        )}
-        {visibleDataRows}
-      </tbody>
+        </tbody>
+      )}
+      {visibleDataRows}
     </table>
   );
 }

--- a/src/components/Table/components/CompanionRow.tsx
+++ b/src/components/Table/components/CompanionRow.tsx
@@ -1,0 +1,128 @@
+import { isValidElement, ReactNode } from "react";
+import { maybeApply } from "src/components/Table/GridTableApi";
+import type { GridStyle } from "src/components/Table/TableStyles";
+import type { MaybeFn, RenderAs } from "src/components/Table/types";
+import { Css } from "src/Css";
+import { useDocumentScrollLayout } from "src/layouts/DocumentScrollLayoutContext";
+import { pageContentGutterPx } from "src/layouts/layoutSpacing";
+import { beamRightPaneWidthVar, documentScrollChromeLeft, documentScrollChromeWidth } from "src/layouts/layoutVars";
+import { useTestIds } from "src/utils/useTestIds";
+
+type CompanionRowProps = {
+  as: RenderAs;
+  columnSizes: string[];
+  style: GridStyle;
+  /** Owning data row id — used for keys / test ids. */
+  rowId: string;
+  colSpan: number;
+  isFirstBodyRow: boolean;
+  isLastBodyRow: boolean;
+  /** Defaults to trailing; leading clears the separator so the owning row sits flush below. */
+  position?: CompanionPosition;
+  companion: CompanionContent;
+  levelIndent?: number;
+};
+
+/** Full-width row rendered beside a data row when `GridDataRow.companion` is set. */
+export function CompanionRow(props: CompanionRowProps) {
+  const {
+    as,
+    columnSizes,
+    style,
+    rowId,
+    colSpan,
+    isFirstBodyRow,
+    isLastBodyRow,
+    companion,
+    position = "trailing",
+    levelIndent,
+  } = props;
+  const RowTag = as === "table" ? "tr" : "div";
+  const CellTag = as === "table" ? "td" : "div";
+  // Same pattern as PinToggle: prefix + rowId → `companion_${rowId}` for `r.companion_1`.
+  const tid = useTestIds({}, "companion");
+  const content = maybeApply(companion);
+  const isLeading = position === "leading";
+  const inDocumentScrollLayout = useDocumentScrollLayout();
+  // Pin the card to the visible chrome, inset by the layout gutters so padding does not scroll away.
+  const chromeCss = inDocumentScrollLayout
+    ? Css.w100.sticky
+        .left(`calc(${documentScrollChromeLeft()} + ${pageContentGutterPx}px)`)
+        .maxw(
+          `calc(${documentScrollChromeWidth()} - var(${beamRightPaneWidthVar}, 0px) - ${pageContentGutterPx * 2}px)`,
+        ).$
+    : undefined;
+
+  return (
+    <RowTag
+      css={{
+        ...(as === "table" ? {} : Css.relative.df.fg1.fs1.$),
+        ...(isFirstBodyRow && style.firstBodyRowCss),
+        ...(levelIndent && Css.mlPx(levelIndent).$),
+        ...(isLastBodyRow && style.lastRowCss),
+      }}
+      data-gridrow
+      {...tid[rowId]}
+    >
+      <CellTag
+        css={{
+          ...style.cellCss,
+          ...style.betweenRowsCss,
+          // Leading companions sit flush above the owning row — clear the bottom separator.
+          ...(isLeading && Css.bsh0.$),
+          ...(isLastBodyRow && style.lastRowCellCss),
+          ...(isLastBodyRow && style.lastRowFirstCellCss),
+          ...(isLastBodyRow && style.lastRowLastCellCss),
+          // Companion content is arbitrary — allow wrapping and grow with content.
+          ...Css.h("auto")
+            .whiteSpace("normal")
+            .pyPx(8)
+            .w(`calc(${columnSizes.join(" + ")}${levelIndent ? ` - ${levelIndent}px` : ""})`).$,
+        }}
+        {...(as === "table" ? { colSpan } : {})}
+      >
+        {chromeCss ? (
+          <div css={chromeCss} {...tid.chrome}>
+            {content}
+          </div>
+        ) : (
+          content
+        )}
+      </CellTag>
+    </RowTag>
+  );
+}
+
+export type CompanionPosition = "leading" | "trailing";
+
+export type CompanionContent = MaybeFn<ReactNode>;
+
+/** Object form of `GridDataRow.companion` — omit `position` to default to `"trailing"`. */
+export type CompanionConfig = {
+  position?: CompanionPosition;
+  content: CompanionContent;
+};
+
+/** Full-width companion content for a data row; plain content defaults to trailing. */
+export type GridRowCompanion = CompanionContent | CompanionConfig;
+
+export function isCompanionConfig(companion: GridRowCompanion): companion is CompanionConfig {
+  return (
+    typeof companion === "object" &&
+    companion !== null &&
+    !isValidElement(companion) &&
+    !Array.isArray(companion) &&
+    "content" in companion
+  );
+}
+
+type ResolvedCompanion = { position: CompanionPosition; content: CompanionContent };
+
+/** Resolves companion placement and content; `undefined` when there is no companion. */
+export function resolveCompanion(companion: GridRowCompanion | null | undefined): ResolvedCompanion | undefined {
+  if (companion == null) return undefined;
+  if (isCompanionConfig(companion)) {
+    return { position: companion.position ?? "trailing", content: companion.content };
+  }
+  return { position: "trailing", content: companion };
+}

--- a/src/components/Table/components/Row.css.ts
+++ b/src/components/Table/components/Row.css.ts
@@ -5,10 +5,12 @@ import { Css, Tokens } from "src/Css";
  *
  * - `.beam-bhp` / `.beam-bhc`: when a row is hovered, child fields get a focus-colored border
  *   (unless the field itself is hovered). Used with TextFieldBase `borderOnHover`.
- * - `.beam-row-hover`: paints direct children with `--beam-row-hover-bg` on row hover,
- *   so cell backgrounds do not hide the row hover color.
+ * - `.beam-row-hover`: paints cells with `--beam-row-hover-bg` on hover. The class sits on the
+ *   row itself (`> *` = cells) or on a RowGroup wrapper (`> [data-gridrow] > *` = cells of the
+ *   parent and companion).
  */
 export const css = {
   ".beam-bhp:hover:not(:has(.beam-bhc:hover)) .beam-bhc": Css.ba.bc(Tokens.FieldBorderFocus).$,
   ".beam-row-hover:hover > *": Css.bgColor("var(--beam-row-hover-bg)").$,
+  ".beam-row-hover:hover > [data-gridrow] > *": Css.bgColor("var(--beam-row-hover-bg)").$,
 };

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -9,6 +9,7 @@ import {
   rowLinkRenderFn,
 } from "src/components/Table/components/cell";
 import { ColumnResizeHandle } from "src/components/Table/components/ColumnResizeHandle";
+import type { GridRowCompanion } from "src/components/Table/components/CompanionRow";
 import { KeptGroupRow } from "src/components/Table/components/KeptGroupRow";
 import { ResizedWidths } from "src/components/Table/hooks/useColumnResizing";
 import { GridStyle, RowStyles, tableRowPrintBreakCss } from "src/components/Table/TableStyles";
@@ -52,6 +53,8 @@ type RowProps<R extends Kinded> = {
   isFirstHeadRow: boolean;
   isFirstBodyRow: boolean;
   isLastBodyRow: boolean;
+  /** When true, a trailing companion sits under this row — suppress the bottom separator. */
+  hasTrailingCompanion?: boolean;
   /* column resizers */
   resizedWidths: ResizedWidths;
   setResizedWidth: (columnId: string, width: number, columnIndex: number) => void;
@@ -89,6 +92,7 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
     isFirstHeadRow,
     isFirstBodyRow,
     isLastBodyRow,
+    hasTrailingCompanion = false,
     resizedWidths,
     setResizedWidth,
     disableColumnResizing = true,
@@ -348,6 +352,9 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
             ...(isBodyRow && style.betweenRowsCss),
             ...(isFirstHeadCellRow && style.firstRowCellCss),
             ...(isLastBodyRow && style.lastRowCellCss),
+            // Trailing companion sits directly under this row — clear the bottom inset separator so
+            // the companion owns the group divider instead.
+            ...(hasTrailingCompanion && Css.bsh0.$),
             // Then override with first/last cell styling
             ...getFirstOrLastCellCss(style, columnIndex, columns, currentColspan),
             ...(columnIndex === 0 && isFirstHeadCellRow && style.firstRowFirstCellCss),
@@ -558,6 +565,11 @@ export type GridDataRow<R extends Kinded> = {
   draggable?: boolean;
   /** Image src for the row, to be used for card view */
   imgSrc?: string;
+  /**
+   * Full-width content rendered with this row (no separator between them).
+   * Plain content / render fn defaults to `"trailing"`; use `{ position, content }` for `"leading"`.
+   */
+  companion?: GridRowCompanion;
 } & IfAny<R, AnyObject, DiscriminateUnion<R, "kind", R["kind"]>>;
 
 // Used by TextFieldBase to set a border when the row is being hovered over

--- a/src/components/Table/components/RowGroup.tsx
+++ b/src/components/Table/components/RowGroup.tsx
@@ -1,0 +1,41 @@
+import { Fragment, ReactNode } from "react";
+import { BorderHoverParent, rowHoverBgVar, RowHoverClass } from "src/components/Table/components/Row";
+import { GridStyle, tableRowPrintBreakCss } from "src/components/Table/TableStyles";
+import type { RenderAs } from "src/components/Table/types";
+import { Css, maybeCssVar, Tokens } from "src/Css";
+
+type RowGroupProps = {
+  as: RenderAs;
+  /** Skip the tbody wrapper when rows render inside `<thead>` (e.g. pinned table rows). */
+  inHead?: boolean;
+  showRowHover?: boolean;
+  style: GridStyle;
+  children: ReactNode;
+};
+
+/** Groups a data row and optional companion as one table/list unit. */
+export function RowGroup(props: RowGroupProps) {
+  const { as, inHead = false, showRowHover = false, style, children } = props;
+
+  if (as === "table" && inHead) {
+    // Pinned rows in `as="table"` live in `<thead>` — emit a fragment, not `<tbody>`.
+    return <Fragment>{children}</Fragment>;
+  }
+
+  const Tag = as === "table" ? "tbody" : "div";
+  const rowHoverBg: string = maybeCssVar(
+    style.rowHoverColor !== undefined && style.rowHoverColor !== "none" ? style.rowHoverColor : Tokens.SurfaceHover,
+  );
+
+  return (
+    <Tag
+      css={{
+        ...(as === "table" ? tableRowPrintBreakCss : undefined),
+        ...(showRowHover && Css.style({ [rowHoverBgVar]: rowHoverBg }).$),
+      }}
+      className={showRowHover ? `${BorderHoverParent} ${RowHoverClass}` : BorderHoverParent}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/src/components/Table/index.ts
+++ b/src/components/Table/index.ts
@@ -24,6 +24,12 @@ export {
 } from "src/components/Table/components/cell";
 export type { GridCellContent, RenderCellFn } from "src/components/Table/components/cell";
 export * from "src/components/Table/components/CollapseToggle";
+export type {
+  CompanionConfig,
+  CompanionContent,
+  CompanionPosition,
+  GridRowCompanion,
+} from "src/components/Table/components/CompanionRow";
 export { EditColumnsButton } from "src/components/Table/components/EditColumnsButton";
 export * from "src/components/Table/components/PinToggle";
 export { Row } from "src/components/Table/components/Row";

--- a/src/components/Table/utils/columns.tsx
+++ b/src/components/Table/utils/columns.tsx
@@ -134,7 +134,7 @@ export function isContentColumn(column: Pick<GridColumn<Kinded>, "isAction" | "i
 }
 
 /** Empty fixed-width column inset for document-scroll table layouts. */
-function layoutGutterColumn<T extends Kinded>(side: "left" | "right"): GridColumn<T> {
+function layoutGutterColumn<T extends Kinded>(side: "left" | "right", sticky?: "left" | "right"): GridColumn<T> {
   const id = side === "left" ? layoutGutterLeftColumnId : layoutGutterRightColumnId;
   const base = {
     ...nonKindDefaults(),
@@ -146,13 +146,20 @@ function layoutGutterColumn<T extends Kinded>(side: "left" | "right"): GridColum
     canHide: false,
     expandableHeader: emptyCell,
     totals: emptyCell,
+    ...(sticky ? { sticky } : {}),
   };
   return newMethodMissingProxy(base, () => () => emptyCell) as GridColumn<T>;
 }
 
 /** Prepends and appends layout gutter columns for document-scroll table alignment. */
 export function withColumnGutters<T extends Kinded>(columns: GridColumn<T>[]): GridColumn<T>[] {
-  return [layoutGutterColumn("left"), ...columns, layoutGutterColumn("right")];
+  const stickyLeft = columns.some((c) => c.sticky === "left");
+  const stickyRight = columns.some((c) => c.sticky === "right");
+  return [
+    layoutGutterColumn("left", stickyLeft ? "left" : undefined),
+    ...columns,
+    layoutGutterColumn("right", stickyRight ? "right" : undefined),
+  ];
 }
 
 // Keep keys like `w` and `mw` from hitting the method missing proxy


### PR DESCRIPTION
A CompanionRow is a "companion"/related row to one of the "data" rows in the table. This can be used for different circumstances:
1. AI row actions - per new designs
2. Row details/actions like in the existing Product Option variants table