### PR TITLE
fix: fixed icon menu link styling

### DIFF
--- a/src/components/ButtonMenu.test.tsx
+++ b/src/components/ButtonMenu.test.tsx
@@ -207,6 +207,22 @@ describe("ButtonMenu", () => {
     openSpy.mockRestore();
   });
 
+  it("keeps an icon and label on one row when the item is an in-app link", async () => {
+    // Given a menu item that is both an icon item and a relative URL
+    const r = await render(
+      <ButtonMenu
+        trigger={{ label: "Trigger" }}
+        items={[{ label: "Install Tasks", onClick: "/install-tasks", icon: "linkExternal" }]}
+      />,
+      withRouter(),
+    );
+    // When opening the menu
+    click(r.trigger);
+    // Then the in-app link is a flex row so the block-level SVG does not wrap the label
+    expect(r.trigger_installTasks.querySelector("a")).toHaveStyle({ display: "flex" });
+    expect(r.trigger_installTasks).toHaveTextContent("Install Tasks");
+  });
+
   it("closes the menu when clicking the trigger again", async () => {
     // Given a ButtonMenu
     const r = await render(

--- a/src/components/ButtonMenu.test.tsx
+++ b/src/components/ButtonMenu.test.tsx
@@ -207,22 +207,6 @@ describe("ButtonMenu", () => {
     openSpy.mockRestore();
   });
 
-  it("keeps an icon and label on one row when the item is an in-app link", async () => {
-    // Given a menu item that is both an icon item and a relative URL
-    const r = await render(
-      <ButtonMenu
-        trigger={{ label: "Trigger" }}
-        items={[{ label: "Install Tasks", onClick: "/install-tasks", icon: "linkExternal" }]}
-      />,
-      withRouter(),
-    );
-    // When opening the menu
-    click(r.trigger);
-    // Then the in-app link is a flex row so the block-level SVG does not wrap the label
-    expect(r.trigger_installTasks.querySelector("a")).toHaveStyle({ display: "flex" });
-    expect(r.trigger_installTasks).toHaveTextContent("Install Tasks");
-  });
-
   it("closes the menu when clicking the trigger again", async () => {
     // Given a ButtonMenu
     const r = await render(

--- a/src/components/internal/Menu.stories.tsx
+++ b/src/components/internal/Menu.stories.tsx
@@ -43,6 +43,7 @@ export function IconMenuItems() {
         { label: "Edit", icon: "pencil", onClick: noop },
         { label: "Like", icon: "thumbsUp", onClick: noop },
         { label: "Favorite", icon: "star", onClick: noop },
+        { label: "Install Tasks", icon: "linkExternal", onClick: "/install-tasks" },
         { label: "Delete", icon: "trash", onClick: noop, destructive: true },
       ]}
     />

--- a/src/components/internal/MenuItem.tsx
+++ b/src/components/internal/MenuItem.tsx
@@ -170,7 +170,7 @@ function maybeWrapInLink(
       </span>
     </a>
   ) : (
-    <Link className="navLink" to={onClick}>
+    <Link className="navLink" css={Css.df.aic.w100.$} to={onClick}>
       {content}
     </Link>
   );

--- a/src/components/internal/MenuItem.tsx
+++ b/src/components/internal/MenuItem.tsx
@@ -170,7 +170,7 @@ function maybeWrapInLink(
       </span>
     </a>
   ) : (
-    <Link className="navLink" css={Css.df.aic.w100.$} to={onClick}>
+    <Link className="navLink" css={Css.df.aic.$} to={onClick}>
       {content}
     </Link>
   );


### PR DESCRIPTION
## Description

- Menu items that are both an icon item and an in-app `Link` were wrapping the label under the icon. `Icon` renders a block-level SVG, and the relative-URL `Link` had no flex layout, unlike the external `<a>` wrapper.
- Apply `display: flex` / `align-items: center` / `width: 100%` to in-app `Link` menu items so the icon and label stay on one row.
- Cover the icon + relative URL case in `ButtonMenu` tests and the `IconMenuItems` story.

## Screenshots

### Old
<img width="170" height="308" alt="Screenshot 2026-08-20 at 8 32 20 AM" src="https://github.com/user-attachments/assets/a7f1925b-eb01-4e64-bf30-341ee4ce976c" />

### New
<img width="182" height="308" alt="Screenshot 2026-08-20 at 8 32 43 AM" src="https://github.com/user-attachments/assets/c8d92d1c-779a-468a-b5fd-5186d5b46869" />