### PR TITLE
feat: Consolidate headers into single component

### DIFF
--- a/src/components/Headers/ContentHeader.stories.tsx
+++ b/src/components/Headers/ContentHeader.stories.tsx
@@ -42,3 +42,38 @@ export function DescriptionAndActions() {
     />
   );
 }
+
+export function WithAutoSave() {
+  return (
+    <ContentHeader
+      title="Trade Partners"
+      description="Assign and manage trade partners for this project."
+      withAutoSave
+      actions={[{ label: "Add", onClick: () => {} }]}
+    />
+  );
+}
+
+/** `level={3}` is the `FormSection` heading — `h3` / `lg`. Default `level={2}` is `h2` / `xl`. */
+export function Level3() {
+  return (
+    <ContentHeader
+      title="General Contractor"
+      description="The primary contractor responsible for this project."
+      level={3}
+      actions={[{ label: "Add", onClick: () => {} }]}
+    />
+  );
+}
+
+/** `level={4}` is the `FormSectionChild` heading — `h4` / `mdSb`. */
+export function Level4() {
+  return (
+    <ContentHeader
+      title="Electrical"
+      description="Electrical contracts are needed for the construction to continue."
+      level={4}
+      actions={[{ label: "Add", onClick: () => {} }]}
+    />
+  );
+}

--- a/src/components/Headers/ContentHeader.test.tsx
+++ b/src/components/Headers/ContentHeader.test.tsx
@@ -50,4 +50,53 @@ describe("ContentHeader", () => {
     // Then it renders nothing at all, not even an empty wrapper
     expect(r.query.contentHeader).not.toBeInTheDocument();
   });
+
+  it("prepends AutoSaveIndicator in the actions area when withAutoSave is true", async () => {
+    // Given a ContentHeader with withAutoSave and actions
+    const r = await render(
+      <ContentHeader title="Trade Partners" withAutoSave actions={[{ label: "Add", onClick: () => {} }]} />,
+    );
+    // Then AutoSaveIndicator renders before the actions
+    expect(r.autoSave).toBeInTheDocument();
+    expect(r.autoSave.compareDocumentPosition(r.add)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  it("renders AutoSaveIndicator in the actions area when withAutoSave is true and actions are omitted", async () => {
+    // Given a ContentHeader with withAutoSave and no actions
+    const r = await render(<ContentHeader title="Trade Partners" withAutoSave />);
+    // Then the actions slot still renders with AutoSaveIndicator
+    expect(r.contentHeader_actions).toBeInTheDocument();
+    expect(r.autoSave).toBeInTheDocument();
+  });
+
+  it("renders an h2 at the xl size by default", async () => {
+    // Given a ContentHeader with a title
+    const r = await render(<ContentHeader title="Trade Partners" />);
+    // Then the title is an h2 at the xl size
+    expect(r.contentHeader_title.tagName).toBe("H2");
+    expect(r.contentHeader_title).toHaveStyle({ fontSize: "20px" });
+  });
+
+  it("renders an h3 at the lg size when level is 3", async () => {
+    // Given a ContentHeader at level 3
+    const r = await render(<ContentHeader title="Trade Partners" level={3} />);
+    // Then the title is an h3 at the lg size
+    expect(r.contentHeader_title.tagName).toBe("H3");
+    expect(r.contentHeader_title).toHaveStyle({ fontSize: "18px" });
+  });
+
+  it("renders an h4 at the mdSb size when level is 4", async () => {
+    // Given a ContentHeader at level 4
+    const r = await render(<ContentHeader title="Electrical" level={4} />);
+    // Then the title is an h4 at the mdSb size
+    expect(r.contentHeader_title.tagName).toBe("H4");
+    expect(r.contentHeader_title).toHaveStyle({ fontSize: "16px" });
+  });
+
+  it("renders startAdornment before the title", async () => {
+    // Given a ContentHeader with a start adornment
+    const r = await render(<ContentHeader title="Electrical" startAdornment={<span>Drag</span>} />);
+    // Then the adornment renders before the title
+    expect(r.getByText("Drag").compareDocumentPosition(r.contentHeader_title)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
 });

--- a/src/components/Headers/ContentHeader.tsx
+++ b/src/components/Headers/ContentHeader.tsx
@@ -1,14 +1,23 @@
 import { ReactNode } from "react";
+import { AutoSaveIndicator } from "src/components/AutoSaveIndicator";
 import { HeaderAction, HeaderActions } from "src/components/Headers/HeaderActions";
 import { Css, Only, Padding, Tokens, Xss } from "src/Css";
 import { useTestIds } from "src/utils";
 
 type ContentHeaderXss = Xss<Padding>;
 
+export type ContentHeaderLevel = 2 | 3 | 4;
+
 export type ContentHeaderProps<X = ContentHeaderXss> = {
   title?: string;
   description?: ReactNode;
   actions?: HeaderAction[];
+  /** When true, prepends `AutoSaveIndicator` in the actions area. */
+  withAutoSave?: boolean;
+  /** Heading tag and size. `2` = `h2`/`xl` (default); `3` = `h3`/`lg`; `4` = `h4`/`mdSb`. Never `h1`. */
+  level?: ContentHeaderLevel;
+  /** Rendered before the title, e.g. a drag handle on `FormSectionChild`. */
+  startAdornment?: ReactNode;
   /** Style overrides for padding. */
   xss?: X;
 };
@@ -30,10 +39,11 @@ export type ContentHeaderProps<X = ContentHeaderXss> = {
  * from padded ancestors (e.g. {@link CenteredLayout}).
  */
 export function ContentHeader<X extends Only<ContentHeaderXss, X>>(props: ContentHeaderProps<X>) {
-  const { title, description, actions, xss } = props;
+  const { title, description, actions, withAutoSave, level = 2, startAdornment, xss } = props;
   const tid = useTestIds(props, "contentHeader");
+  const { tag: Heading, css: headingCss } = headingByLevel[level];
 
-  if (!title && !description && !actions) {
+  if (!title && !description && !actions && !withAutoSave) {
     return null;
   }
 
@@ -44,18 +54,38 @@ export function ContentHeader<X extends Only<ContentHeaderXss, X>>(props: Conten
   );
 
   return (
-    <div css={{ ...Css.df.fdc.gapPx(12).layoutContainer.mw0.bgColor(Tokens.Surface).$, ...xss }} {...tid}>
+    <div
+      css={{
+        ...Css.df.fdc.gapPx(12).layoutContainer.mw0.bgColor(Tokens.Surface).$,
+        ...xss,
+      }}
+      {...tid}
+    >
       <div css={Css.df.aic.jcsb.mw0.$}>
         {title ? (
-          <h2 css={Css.xl.$} {...tid.title}>
-            {title}
-          </h2>
+          <div css={Css.df.aic.gap1.mw0.$}>
+            {startAdornment}
+            <Heading css={headingCss} {...tid.title}>
+              {title}
+            </Heading>
+          </div>
         ) : (
           descriptionEl
         )}
-        {actions && <HeaderActions actions={actions} {...tid.actions} />}
+        {(withAutoSave || actions) && (
+          <div css={Css.df.gap1.fs0.$} {...tid.actions}>
+            {withAutoSave && <AutoSaveIndicator />}
+            {actions && <HeaderActions actions={actions} />}
+          </div>
+        )}
       </div>
       {title && descriptionEl}
     </div>
   );
 }
+
+const headingByLevel = {
+  2: { tag: "h2", css: Css.xl.$ },
+  3: { tag: "h3", css: Css.lg.$ },
+  4: { tag: "h4", css: Css.mdSb.$ },
+} as const;

--- a/src/forms/FormSection/FormSection.test.tsx
+++ b/src/forms/FormSection/FormSection.test.tsx
@@ -57,7 +57,8 @@ describe("FormSection", () => {
     // Given a top-level FormSection
     // When rendered
     const r = await render(<FormSection title="Trade Partners" />);
-    // Then it renders at the section (lg) heading size
+    // Then it renders as an h3 at the section (lg) heading size
+    expect(r.formSection_title.tagName).toBe("H3");
     expect(r.formSection_title).toHaveStyle({ fontSize: "18px" });
   });
 
@@ -77,10 +78,11 @@ describe("FormSection", () => {
     expect(r.formSection_title).toHaveTextContent("Trade Partners");
     expect(r.electricalFields).toBeInTheDocument();
     expect(r.plumbingFields).toBeInTheDocument();
-    // And each child section's title renders at the child heading size
-    [r.formSection_childSection_title_0, r.formSection_childSection_title_1].forEach((title) =>
-      expect(title).toHaveStyle({ fontSize: "16px" }),
-    );
+    // And each child section's title renders as an h4 at the child heading size
+    [r.formSection_childSection_header_title_0, r.formSection_childSection_header_title_1].forEach((title) => {
+      expect(title.tagName).toBe("H4");
+      expect(title).toHaveStyle({ fontSize: "16px" });
+    });
   });
 
   it("does not render a DnDGrid or drag handles when childSections have no orderField", async () => {
@@ -184,8 +186,8 @@ describe("FormSection", () => {
       />,
     );
     // Then they render in orderField order (Electrical first), not array order
-    expect(r.formSection_childSection_title_0).toHaveTextContent("Electrical");
-    expect(r.formSection_childSection_title_1).toHaveTextContent("Plumbing");
+    expect(r.formSection_childSection_header_title_0).toHaveTextContent("Electrical");
+    expect(r.formSection_childSection_header_title_1).toHaveTextContent("Plumbing");
   });
 
   it("permutes existing (non-zero-based) order values rather than resetting them to 0-based indices", async () => {

--- a/src/forms/FormSection/FormSection.tsx
+++ b/src/forms/FormSection/FormSection.tsx
@@ -1,23 +1,18 @@
 import { ReactNode } from "react";
-import { Button, ButtonProps } from "src/components/Button";
 import { DnDGrid } from "src/components/DnDGrid/DnDGrid";
-import { IconButton, IconButtonProps } from "src/components/IconButton";
-import { Css, Tokens } from "src/Css";
+import { ContentHeader } from "src/components/Headers/ContentHeader";
+import { HeaderAction } from "src/components/Headers/HeaderActions";
+import { Css } from "src/Css";
 import { useTestIds } from "src/utils";
 import { FormSectionChild, type PlainFormSectionChild, type ReorderableFormSectionChild } from "./FormSectionChild";
 
-/**
- * An action in a `FormSection`/`FormSectionLayout` title row — a `Button`, or an icon-only `IconButton` via `kind: "icon"`.
- * Uses `kind` rather than `type` since `ButtonProps` already has its own `type` (button/submit/reset).
- */
-export type FormSectionAction =
-  | ({ kind?: "default" } & ButtonProps)
-  | ({ kind: "icon" } & Omit<IconButtonProps, "variant">);
+/** @see {@link HeaderAction} */
+export type FormSectionAction = HeaderAction;
 
 export type FormSectionProps = {
   title: string;
   description?: ReactNode;
-  actions?: FormSectionAction[];
+  actions?: HeaderAction[];
   fields?: ReactNode;
   childSections?: PlainFormSectionChild[] | ReorderableFormSectionChild[];
 };
@@ -27,32 +22,8 @@ export function FormSection(props: FormSectionProps) {
   const tid = useTestIds(props, "formSection");
 
   return (
-    <div css={Css.df.fdc.gap2.$} {...tid}>
-      <div css={Css.df.fdc.gapPx(12).$}>
-        <div css={Css.df.jcsb.$}>
-          <div css={Css.df.aic.gap1.$}>
-            <h2 css={Css.lg.$} {...tid.title}>
-              {title}
-            </h2>
-          </div>
-          {actions && (
-            <div css={Css.df.gap1.fs0.$} {...tid.actions}>
-              {actions.map((action) =>
-                action.kind === "icon" ? (
-                  <IconButton key={action.icon} {...action} variant="outline" />
-                ) : (
-                  <Button key={`${action.label}`} {...action} />
-                ),
-              )}
-            </div>
-          )}
-        </div>
-        {description && (
-          <div css={Css.sm.color(Tokens.OnSurface).$} {...tid.description}>
-            {description}
-          </div>
-        )}
-      </div>
+    <div css={Css.df.fdc.gap2.$}>
+      <ContentHeader {...tid} title={title} description={description} actions={actions} level={3} />
       {fields}
       {childSections &&
         (isReorderable(childSections) ? (

--- a/src/forms/FormSection/FormSectionChild.tsx
+++ b/src/forms/FormSection/FormSectionChild.tsx
@@ -1,9 +1,8 @@
 import type { FieldState } from "@homebound/form-state";
 import { useRef } from "react";
-import { Button } from "src/components/Button";
 import { DnDGridItemHandle } from "src/components/DnDGrid/DnDGridItemHandle";
 import { useDnDGridItem } from "src/components/DnDGrid/useDnDGridItem";
-import { IconButton } from "src/components/IconButton";
+import { ContentHeader } from "src/components/Headers/ContentHeader";
 import { Css, Tokens } from "src/Css";
 import { useTestIds } from "src/utils";
 import type { FormSectionProps } from "./FormSection";
@@ -36,32 +35,16 @@ export function FormSectionChild(props: PlainFormSectionChild | ReorderableFormS
       css={Css.df.fdc.gap2.bgColor(Tokens.SurfaceRaised).pb3.bb.bc(Tokens.SurfaceSeparator).ifLastOfType.bn.$}
       {...tid}
     >
-      <div css={Css.df.fdc.gapPx(12).$}>
-        <div css={Css.df.jcsb.gap2.$}>
-          <div css={Css.df.aic.gap1.$}>
-            {isDraggable && <DnDGridItemHandle dragHandleProps={dragHandleProps} icon="drag" compact />}
-            <h3 css={Css.mdSb.$} {...tid.title}>
-              {title}
-            </h3>
-          </div>
-          {actions && (
-            <div css={Css.df.gap1.fs0.$} {...tid.actions}>
-              {actions.map((action) =>
-                action.kind === "icon" ? (
-                  <IconButton key={action.icon} {...action} variant="outline" />
-                ) : (
-                  <Button key={`${action.label}`} {...action} />
-                ),
-              )}
-            </div>
-          )}
-        </div>
-        {description && (
-          <div css={Css.sm.color(Tokens.OnSurface).$} {...tid.description}>
-            {description}
-          </div>
-        )}
-      </div>
+      <ContentHeader
+        {...tid.header}
+        title={title}
+        description={description}
+        actions={actions}
+        level={4}
+        startAdornment={
+          isDraggable ? <DnDGridItemHandle dragHandleProps={dragHandleProps} icon="drag" compact /> : undefined
+        }
+      />
       {fields}
     </div>
   );

--- a/src/layouts/FormSectionLayout/FormSectionLayout.test.tsx
+++ b/src/layouts/FormSectionLayout/FormSectionLayout.test.tsx
@@ -17,6 +17,7 @@ describe("FormSectionLayout", () => {
     );
     // Then the form-level title/description render
     expect(r.formSectionLayout_title).toHaveTextContent("Trade Partners");
+    expect(r.formSectionLayout_title.tagName).toBe("H2");
     expect(r.formSectionLayout_description).toHaveTextContent("Set up trade partner assignments for this project");
     // And each section is delegated to FormSection, rendering its own content
     expect(r.gcFields).toBeInTheDocument();

--- a/src/layouts/FormSectionLayout/FormSectionLayout.tsx
+++ b/src/layouts/FormSectionLayout/FormSectionLayout.tsx
@@ -1,9 +1,8 @@
 import { ReactNode } from "react";
-import { AutoSaveIndicator } from "src/components/AutoSaveIndicator";
-import { Button } from "src/components/Button";
-import { IconButton } from "src/components/IconButton";
-import { Css, Tokens } from "src/Css";
-import { FormSection, FormSectionAction, FormSectionProps } from "src/forms/FormSection";
+import { ContentHeader } from "src/components/Headers/ContentHeader";
+import { HeaderAction } from "src/components/Headers/HeaderActions";
+import { Css } from "src/Css";
+import { FormSection, FormSectionProps } from "src/forms/FormSection";
 import { CenteredLayout } from "src/layouts/CenteredLayout";
 import { useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
@@ -15,7 +14,7 @@ export type FormSectionLayoutProps = {
   /** Rendered before form sections. Useful in forms that only need the main form title, or for form fields that shape the context of a form beforehand.  */
   initialFields?: ReactNode;
   /** Rendered top-right of the title row, e.g. an "Add items" Button. */
-  actions?: FormSectionAction[];
+  actions?: HeaderAction[];
   /** When true, prepends `AutoSaveIndicator` in the actions area. */
   withAutoSave?: boolean;
   sections?: FormSectionProps[];
@@ -28,32 +27,16 @@ export function FormSectionLayout(props: FormSectionLayoutProps) {
 
   return (
     <CenteredLayout size="sm">
-      <div css={Css.df.fdc.gap8.pt4.$} {...tid}>
+      <div css={Css.df.fdc.gap8.pt4.$}>
         <div css={Css.df.fdc.gap3.$}>
-          <div css={Css.df.fdc.jcsb.gapPx(12).$}>
-            <div css={Css.df.jcsb.aic.$}>
-              <h1 css={Css.xl.$} {...tid.title}>
-                {title}
-              </h1>
-              {(withAutoSave || actions) && (
-                <div css={Css.df.gap1.fs0.$} {...tid.actions}>
-                  {withAutoSave && <AutoSaveIndicator />}
-                  {actions?.map((action) =>
-                    action.kind === "icon" ? (
-                      <IconButton key={action.icon} {...action} variant="outline" />
-                    ) : (
-                      <Button key={`${action.label}`} {...action} />
-                    ),
-                  )}
-                </div>
-              )}
-            </div>
-            {description && (
-              <div css={Css.sm.color(Tokens.OnSurface).$} {...tid.description}>
-                {description}
-              </div>
-            )}
-          </div>
+          <ContentHeader
+            {...tid}
+            title={title}
+            description={description}
+            actions={actions}
+            withAutoSave={withAutoSave}
+            level={2}
+          />
           {initialFields}
         </div>
         {sections && (


### PR DESCRIPTION
FormSectionLayout, FormSection, and FormSectionChild did their own header styles. ContentHeader followed the same makeup, but was used for outside of forms. Due to their increasing similarities, we are consolidating all of them.