### PR TITLE
fix: [PINT-86] Show list Card tag below the text

### DIFF
--- a/src/components/Card.stories.tsx
+++ b/src/components/Card.stories.tsx
@@ -93,7 +93,7 @@ export const FullWidthListCards = newStory(
       <div>
         <h2>fullWidth (follows its column, narrow or wide)</h2>
         <div css={Css.wPx(800).dg.gtc("1fr 1fr").gap2.$}>
-          <CardComponent {...baseArgs} type="list" bordered fullWidth />
+          <CardComponent {...baseArgs} type="list" bordered fullWidth tag={{ text: "Active", type: "success" }} />
           <CardComponent {...baseArgs} type="list" bordered fullWidth />
         </div>
       </div>

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -86,10 +86,10 @@ export function Card(props: CardProps) {
           />
         </div>
       )}
-      {/* Tag */}
-      {tag && (
+      {/* Tag - list cards flow it below the text, otherwise it overlays the image */}
+      {tag && !isList && (
         <div css={Css.absolute.left1.topPx(4).$}>
-          <Tag type={tag?.type} text={tag?.text} {...tid.tag} />
+          <Tag type={tag.type} text={tag.text} {...tid.tag} />
         </div>
       )}
       {/* Titles and detailContent */}
@@ -103,6 +103,7 @@ export function Card(props: CardProps) {
           </div>
         </div>
         <div {...tid.details}>{detailContent}</div>
+        {tag && isList && <Tag type={tag.type} text={tag.text} {...tid.tag} />}
       </div>
     </div>
   );


### PR DESCRIPTION
### [PINT-86](https://linear.app/homebound-team/issue/PINT-86)

Fixes tag placement on `Card` when `type="list"`
**Changes**

#### Before
<img width="369" height="156" alt="Screenshot 2026-08-25 at 10 06 52 AM" src="https://github.com/user-attachments/assets/6ba1a62c-0659-4498-808f-35d1543408e5" />



#### After
<img width="363" height="141" alt="Screenshot 2026-08-25 at 10 10 34 AM" src="https://github.com/user-attachments/assets/8081d969-bf22-4017-9d0e-d2877115b49f" />
