### PR TITLE
fix: make RightSidebar fill the remaining viewport height

### DIFF
--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -49,7 +49,12 @@ export function RightSidebar({ content, headerHeightPx }: RightSidebarProps) {
             animate={{ x: 0, opacity: 1 }}
             transition={{ delay: 0.2, ease: [0.51, 0.92, 0.24, 1], duration: 0.3 }}
             exit={{ transition: { ease: "linear", duration: 0.2 }, x: "100%" }}
-            css={Css.w100.mw(RIGHT_SIDEBAR_MIN_WIDTH).z0.maxh(`calc(100vh - ${headerHeightPx}px)`).oya.pl4.pr3.$}
+            css={
+              Css.w100
+                .mw(RIGHT_SIDEBAR_MIN_WIDTH)
+                .z0.mh(`calc(100vh - ${headerHeightPx}px)`)
+                .maxh(`calc(100vh - ${headerHeightPx}px)`).oya.pl4.pr3.$
+            }
           >
             <>
               {/* Sticky header section */}

--- a/src/components/RightSidebar.tsx
+++ b/src/components/RightSidebar.tsx
@@ -49,12 +49,7 @@ export function RightSidebar({ content, headerHeightPx }: RightSidebarProps) {
             animate={{ x: 0, opacity: 1 }}
             transition={{ delay: 0.2, ease: [0.51, 0.92, 0.24, 1], duration: 0.3 }}
             exit={{ transition: { ease: "linear", duration: 0.2 }, x: "100%" }}
-            css={
-              Css.w100
-                .mw(RIGHT_SIDEBAR_MIN_WIDTH)
-                .z0.mh(`calc(100vh - ${headerHeightPx}px)`)
-                .maxh(`calc(100vh - ${headerHeightPx}px)`).oya.pl4.pr3.$
-            }
+            css={Css.w100.mw(RIGHT_SIDEBAR_MIN_WIDTH).z0.h(`calc(100vh - ${headerHeightPx}px)`).oya.pl4.pr3.$}
           >
             <>
               {/* Sticky header section */}


### PR DESCRIPTION
# fix: make RightSidebar fill the remaining viewport height

## Description

- An open `RightSidebar` now stretches to the full remaining viewport (`100vh` minus the page header) instead of shrinking to its content.
- Short panes keep a full-height column so the close control, icon strip, and divider line stay aligned with the page instead of collapsing.

## Screenshots

### Previous
<img width="1624" height="995" alt="Screenshot 2026-08-25 at 9 37 55 AM" src="https://github.com/user-attachments/assets/02e2c9b4-3a0c-4bd3-ac6e-ed014a4b76a0" />
<img width="1624" height="995" alt="Screenshot 2026-08-25 at 9 38 04 AM" src="https://github.com/user-attachments/assets/e6f190e0-3e66-4004-a8eb-6c355ee95092" />



### Updated
<img width="1624" height="995" alt="Screenshot 2026-08-25 at 9 38 04 AM" src="https://github.com/user-attachments/assets/8c283415-b7c1-4fd8-adbc-e86fcdf9a2eb" />
<img width="1624" height="995" alt="Screenshot 2026-08-25 at 9 38 09 AM" src="https://github.com/user-attachments/assets/13eb4d25-1f0b-4255-ba20-ae5166a9a735" />


## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

Mental Checklist

- [ ] Add your squad to the reviewers list.
- [ ] Updated tests for this change.
- [x] Tested changes locally.
- [ ] Updated Documentation (if necessary).