### PR TITLE
fix: show card type=list tag above text

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -86,7 +86,7 @@ export function Card(props: CardProps) {
           />
         </div>
       )}
-      {/* Tag - list cards flow it below the text, otherwise it overlays the image */}
+      {/* Tag - list cards flow it above the text, otherwise it overlays the image */}
       {tag && !isList && (
         <div css={Css.absolute.left1.topPx(4).$}>
           <Tag type={tag.type} text={tag.text} {...tid.tag} />
@@ -94,6 +94,7 @@ export function Card(props: CardProps) {
       )}
       {/* Titles and detailContent */}
       <div css={Css.df.fdc.aifs.gap1.$}>
+        {tag && isList && <Tag type={tag.type} text={tag.text} {...tid.tag} />}
         <div>
           <div css={Css.xsSb.color(Tokens.OnSurfaceMuted).$} {...tid.subtitle}>
             {subtitle}
@@ -103,7 +104,6 @@ export function Card(props: CardProps) {
           </div>
         </div>
         <div {...tid.details}>{detailContent}</div>
-        {tag && isList && <Tag type={tag.type} text={tag.text} {...tid.tag} />}
       </div>
     </div>
   );


### PR DESCRIPTION
Follow up https://github.com/homebound-team/beam/pull/1397

Show the tag above the text instead on footer.
<img width="509" height="205" alt="Screenshot 2026-08-25 at 6 24 35 PM" src="https://github.com/user-attachments/assets/c7be6886-f498-4577-81a2-7aeb42e5c234" />
