### PR TITLE
fix: Wrap GroupBy field so it won't extend more than necessary

### DIFF
--- a/src/components/Layout/GridTableLayout/FilterPanel.tsx
+++ b/src/components/Layout/GridTableLayout/FilterPanel.tsx
@@ -53,7 +53,11 @@ function FilterPanelOpen<F extends Record<string, unknown>, G extends Value = st
         ...(inDocumentScrollLayout ? pageContentPaddingX : undefined),
       }}
     >
-      {groupBy && <GroupByField {...groupBy} />}
+      {groupBy && (
+        <div>
+          <GroupByField {...groupBy} />
+        </div>
+      )}
       {filterControls}
       {activeFilterCount > 0 && (
         <Button label="Clear" variant="tertiary" onClick={() => maybeCall(onClear)} {...tid.clearBtn} />


### PR DESCRIPTION
### Before
<img width="936" height="144" alt="Screenshot 2026-08-25 at 3 43 52 PM" src="https://github.com/user-attachments/assets/84e7445d-5448-4577-9a15-dc34ebde5234" />

### After
<img width="597" height="170" alt="Screenshot 2026-08-25 at 3 44 07 PM" src="https://github.com/user-attachments/assets/92ff4ddf-fd46-4107-8e23-47b5abd7d949" />
