### PR TITLE
feat: Replace GridTableLayout actionMenu with HeaderAction[] actions

### DIFF
--- a/src/components/Headers/HeaderActions.tsx
+++ b/src/components/Headers/HeaderActions.tsx
@@ -26,13 +26,7 @@ export type HeaderActionsProps = {
   actions: HeaderAction[];
 };
 
-/**
- * Internal actions-row shared by header/section title rows.
- *
- * Used by `ContentHeader` today; expected to also back `PageHeader`, `WorkflowHeader`,
- * `FormSection`, and `FormSectionLayout`'s `actions` props. Not part of the public API —
- * consumers configure actions via each of those components' own `actions` prop instead.
- */
+/** Internal renderer for `HeaderAction[]`. Not public — pass `actions` on `ContentHeader` or `GridTableLayout`. */
 export function HeaderActions(props: HeaderActionsProps) {
   const { actions, ...otherProps } = props;
   const tid = useTestIds(otherProps, "headerActions");

--- a/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.stories.tsx
@@ -72,14 +72,18 @@ export function GridTableLayout() {
           rows: [simpleHeader, ...makeNestedRows(3)],
           sorting: { on: "client", initial: [columns[1].id!, "ASC"] },
         }}
-        actionMenu={{
-          tooltip: "I am the actionMenu",
-          items: [
-            { label: "First Action", onClick: noop },
-            { label: "Second Action", onClick: noop },
-            { label: "Third Action", onClick: noop },
-          ],
-        }}
+        actions={[
+          { label: "Add", onClick: noop },
+          {
+            kind: "menu",
+            tooltip: "I am the action menu",
+            items: [
+              { label: "First Action", onClick: noop },
+              { label: "Second Action", onClick: noop },
+              { label: "Third Action", onClick: noop },
+            ],
+          },
+        ]}
       />
     </TestProjectLayout>
   );

--- a/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.test.tsx
@@ -422,16 +422,14 @@ describe("GridTableLayout", () => {
     });
   });
 
-  describe("actionMenu", () => {
-    it("renders the action menu in table actions", async () => {
-      // Given a GridTableLayout with only an actionMenu configured
+  describe("actions", () => {
+    it("renders actions in table actions", async () => {
+      // Given a GridTableLayout with only actions configured
       const r = await render(
         <TestWrapper
           layoutStateProps={{}}
           hideEditColumns
-          actionMenu={{
-            items: [{ label: "First Action", onClick: noop }],
-          }}
+          actions={[{ kind: "menu", items: [{ label: "First Action", onClick: noop }] }]}
           tableProps={{
             columns: getColumns(),
             rows: [simpleHeader, ...getRows()],

--- a/src/components/Layout/GridTableLayout/GridTableLayout.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.tsx
@@ -3,6 +3,7 @@ import React, { RefObject, useCallback, useEffect, useLayoutEffect, useMemo, use
 import { ScrollableContent } from "src/components";
 import { Button } from "src/components/Button";
 import { getActiveFilterCount } from "src/components/Filters/utils";
+import { HeaderAction } from "src/components/Headers/HeaderActions";
 import { TableView } from "src/components/Table/components/ViewToggleButton";
 import { GridTable } from "src/components/Table/GridTable";
 import { GridTableApiImpl } from "src/components/Table/GridTableApi";
@@ -25,7 +26,7 @@ import {
   defaultDocumentScrollRightPaneWidth,
   DocumentScrollRightPaneLayout,
 } from "../RightPaneLayout/DocumentScrollRightPaneLayout";
-import { ActionButtonMenuProps, GridTableLayoutActions, SearchBoxApi } from "./GridTableLayoutActions";
+import { GridTableLayoutActions, SearchBoxApi } from "./GridTableLayoutActions";
 import { QueryTable, QueryTableProps } from "./QueryTable";
 import { usePersistedTableView } from "./usePersistedTableView";
 
@@ -49,8 +50,8 @@ export type GridTableLayoutProps<
   layoutState?: ReturnType<typeof useGridTableLayoutState<F>>;
   /** Title for the empty state when the table has no data rows. */
   emptyFallback?: string;
-  /** Renders a ButtonMenu with "verticalDots" icon as trigger */
-  actionMenu?: ActionButtonMenuProps;
+  /** Inline buttons, icon buttons, and an optional overflow menu (`kind: "menu"`). */
+  actions?: HeaderAction[];
   hideEditColumns?: boolean;
   totalCount?: number;
   /** When true, shows a view toggle button and renders the table with `as="card"` when in card view. */
@@ -98,7 +99,7 @@ function GridTableLayoutComponent<
   const {
     tableProps,
     layoutState,
-    actionMenu,
+    actions,
     hideEditColumns = false,
     withCardView,
     defaultView = "list",
@@ -133,7 +134,7 @@ function GridTableLayoutComponent<
     layoutState?.search ||
     hasHideableColumns ||
     withCardView ||
-    actionMenu
+    actions?.length
   );
   // Card render is driven by `view` alone so `defaultView="card"` works without `withCardView`
   // (which only controls whether the list/card toggle is shown).
@@ -186,7 +187,7 @@ function GridTableLayoutComponent<
       setView={setView}
       clearFilters={clearFilters}
       searchApi={searchApiRef}
-      actionMenu={actionMenu}
+      actions={actions}
     />
   );
 

--- a/src/components/Layout/GridTableLayout/GridTableLayoutActions.stories.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayoutActions.stories.tsx
@@ -112,18 +112,22 @@ export function WithCardView() {
   return <GridTableLayoutActions withCardView view={view} setView={setView} />;
 }
 
-export function WithActionMenu() {
+export function WithActions() {
   return (
     <GridTableLayoutActions
-      actionMenu={{
-        tooltip: "More actions",
-        defaultOpen: true,
-        items: [
-          { label: "Export", onClick: () => {} },
-          { label: "Import", onClick: () => {} },
-          { label: "Archive", onClick: () => {} },
-        ],
-      }}
+      actions={[
+        { label: "Add", onClick: () => {} },
+        {
+          kind: "menu",
+          tooltip: "More actions",
+          defaultOpen: true,
+          items: [
+            { label: "Export", onClick: () => {} },
+            { label: "Import", onClick: () => {} },
+            { label: "Archive", onClick: () => {} },
+          ],
+        },
+      ]}
     />
   );
 }
@@ -143,14 +147,18 @@ export function AllFeatures() {
       withCardView
       view={view}
       setView={setView}
-      actionMenu={{
-        tooltip: "More actions",
-        items: [
-          { label: "Export", onClick: () => {} },
-          { label: "Import", onClick: () => {} },
-          { label: "Archive", onClick: () => {} },
-        ],
-      }}
+      actions={[
+        { label: "Add", onClick: () => {} },
+        {
+          kind: "menu",
+          tooltip: "More actions",
+          items: [
+            { label: "Export", onClick: () => {} },
+            { label: "Import", onClick: () => {} },
+            { label: "Archive", onClick: () => {} },
+          ],
+        },
+      ]}
     />
   );
 }

--- a/src/components/Layout/GridTableLayout/GridTableLayoutActions.test.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayoutActions.test.tsx
@@ -171,20 +171,38 @@ describe("GridTableLayoutActions", () => {
   });
 });
 
-describe("actionMenu", () => {
-  it("renders the action menu when actionMenu is provided", async () => {
-    // Given actionMenu is provided
+describe("actions", () => {
+  it("renders inline buttons and a menu when actions are provided", async () => {
+    // Given actions with a button and a menu
     const r = await render(
-      <GridTableLayoutActions actionMenu={{ items: [{ label: "Action", onClick: noop }] }} />,
+      <GridTableLayoutActions
+        actions={[
+          { label: "Add", onClick: noop },
+          { kind: "menu", items: [{ label: "Action", onClick: noop }] },
+        ]}
+      />,
       withRouter(),
     );
-    // Then the vertical-dots menu trigger is shown
+    // Then the button and vertical-dots menu trigger are shown
+    expect(r.add).toBeInTheDocument();
     expect(r.verticalDots).toBeInTheDocument();
+    expect(r.query.verticalDots_action).toBeNull();
+    // When opening the menu
+    click(r.verticalDots);
+    // Then the menu item is shown
+    expect(r.verticalDots_action).toBeInTheDocument();
   });
 
-  it("does not render the action menu when actionMenu is not provided", async () => {
-    // Given no actionMenu
+  it("does not render the action menu when actions are not provided", async () => {
+    // Given no actions
     const r = await render(<GridTableLayoutActions />, withRouter());
+    // Then the vertical-dots menu trigger is not shown
+    expect(r.query.verticalDots).not.toBeInTheDocument();
+  });
+
+  it("does not render the action menu when actions is empty", async () => {
+    // Given an empty actions array
+    const r = await render(<GridTableLayoutActions actions={[]} />, withRouter());
     // Then the vertical-dots menu trigger is not shown
     expect(r.query.verticalDots).not.toBeInTheDocument();
   });

--- a/src/components/Layout/GridTableLayout/GridTableLayoutActions.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayoutActions.tsx
@@ -1,9 +1,9 @@
 import { memo, MutableRefObject, useMemo, useState } from "react";
 import { Button } from "src/components/Button";
-import { ButtonMenu, ButtonMenuProps } from "src/components/ButtonMenu";
 import { CountBadge } from "src/components/CountBadge";
 import { FilterDefs, FilterImpls, filterTestIdPrefix } from "src/components/Filters";
 import { getActiveFilterCount } from "src/components/Filters/utils";
+import { HeaderAction, HeaderActions } from "src/components/Headers/HeaderActions";
 import { Icon } from "src/components/Icon";
 import { IconButton } from "src/components/IconButton";
 import { EditColumnsButton } from "src/components/Table/components/EditColumnsButton";
@@ -30,9 +30,6 @@ export type SearchBoxApi = {
   clear: VoidFunction;
 };
 
-// Omit to force all action button menus to look the same
-export type ActionButtonMenuProps = Omit<ButtonMenuProps, "trigger">;
-
 type GridTableLayoutActionsProps<
   F extends Record<string, unknown>,
   G extends Value = string,
@@ -51,7 +48,7 @@ type GridTableLayoutActionsProps<
   setView?: (v: TableView) => void;
   clearFilters?: () => void;
   searchApi?: MutableRefObject<SearchBoxApi | undefined>;
-  actionMenu?: ActionButtonMenuProps;
+  actions?: HeaderAction[];
 };
 
 function GridTableLayoutActionsComponent<
@@ -73,7 +70,7 @@ function GridTableLayoutActionsComponent<
     setView,
     clearFilters,
     searchApi,
-    actionMenu,
+    actions,
   } = props;
   const testId = useTestIds(props, "gridTableLayoutActions");
   // Separate prefix so inline filter controls match FilterPanel's `filter_*` test ids.
@@ -194,13 +191,13 @@ function GridTableLayoutActionsComponent<
             />
           )}
         </div>
-        {(hasHideableColumns || withCardView || actionMenu) && (
+        {(hasHideableColumns || withCardView || !!actions?.length) && (
           <div css={Css.df.aic.gapPx(12).$}>
             {hasHideableColumns && view === "list" && columns && api && (
               <EditColumnsButton columns={columns} api={api} tooltip="Display columns" />
             )}
             {withCardView && view !== undefined && setView && <ViewToggleButton view={view} onChange={setView} />}
-            {actionMenu && <ButtonMenu {...actionMenu} trigger={{ icon: "verticalDots" }} />}
+            {!!actions?.length && <HeaderActions actions={actions} {...testId.actions} />}
           </div>
         )}
       </div>


### PR DESCRIPTION
Align the table toolbar with ContentHeader/FormSection so callers can pass inline buttons, icon buttons, and a verticalDots overflow menu in one actions array.