### PR TITLE
fix: use `Tag` in Tabs aiMode instead of aiBadge;

### DIFF
--- a/src/components/Tabs.test.tsx
+++ b/src/components/Tabs.test.tsx
@@ -52,10 +52,20 @@ describe("TabsWithContent", () => {
   });
 
   describe("aiMode", () => {
-    it("badges the tab", async () => {
+    it("tags the tab", async () => {
       const r = await render(<TestAiTabs />, withRouter());
-      expect(r.tabs_tab2).toContainElement(r.aiBadge);
-      expect(r.query.tabs_tab1).not.toContainElement(r.query.aiBadge);
+      // Then only the ai tab is decorated
+      expect(r.tabs_tab2).toContainElement(r.tabs_tab2_aiTag);
+      expect(r.query.tabs_tab1_aiTag).toBeNull();
+    });
+
+    it("tags with the ai sparkle and no visible text", async () => {
+      const r = await render(<TestAiTabs />, withRouter());
+      // Then the tag is the purple, icon-only ai treatment
+      expect(r.tabs_tab2_aiTag).toHaveStyle({ backgroundColor: Palette.Purple200 });
+      expect(r.tabs_tab2_aiTag.querySelector("[data-icon='aiStar']")).toBeInTheDocument();
+      // And it adds no label of its own, since the tab name already says what the tab is
+      expect(r.tabs_tab2_aiTag.textContent).toBe("");
     });
 
     it("tints the label while the tab is unselected", async () => {
@@ -68,7 +78,7 @@ describe("TabsWithContent", () => {
       const r = await render(<TestAiTabs selected="tab2" />, withRouter());
       // Then it stays with the active treatment rather than going purple
       expect(r.tabs_tab2).not.toHaveStyle({ color: Palette.Purple700 });
-      expect(r.tabs_tab2).toContainElement(r.aiBadge);
+      expect(r.tabs_tab2).toContainElement(r.tabs_tab2_aiTag);
     });
   });
 

--- a/src/components/Tabs.test.tsx
+++ b/src/components/Tabs.test.tsx
@@ -59,13 +59,20 @@ describe("TabsWithContent", () => {
       expect(r.query.tabs_tab1_aiTag).toBeNull();
     });
 
-    it("tags with the ai sparkle and no visible text", async () => {
+    it("tags with the ai sparkle", async () => {
       const r = await render(<TestAiTabs />, withRouter());
       // Then the tag is the purple, icon-only ai treatment
       expect(r.tabs_tab2_aiTag).toHaveStyle({ backgroundColor: Palette.Purple200 });
       expect(r.tabs_tab2_aiTag.querySelector("[data-icon='aiStar']")).toBeInTheDocument();
-      // And it adds no label of its own, since the tab name already says what the tab is
-      expect(r.tabs_tab2_aiTag.textContent).toBe("");
+    });
+
+    it("labels the tag for screen readers only", async () => {
+      const r = await render(<TestAiTabs />, withRouter());
+      // Then the tag carries a label, since the sparkle alone says nothing to a screen reader
+      const label = r.getByText("Tab has AI proposals ready for review");
+      expect(r.tabs_tab2_aiTag).toContainElement(label);
+      // But it's not drawn, so the tab still reads as just its name plus the sparkle
+      expect(label).not.toBeVisible();
     });
 
     it("tints the label while the tab is unselected", async () => {

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -253,7 +253,15 @@ function TabImpl<V extends string>(props: TabImplProps<V>) {
   });
 
   const decoration = aiMode ? (
-    <Tag text="" preventTooltip icon="aiStar" type="ai" variant="primary" iconOnly {...tid.aiTag} />
+    <Tag
+      text="Tab has AI proposals ready for review"
+      preventTooltip
+      icon="aiStar"
+      type="ai"
+      variant="primary"
+      iconOnly
+      {...tid.aiTag}
+    />
   ) : icon ? (
     <Icon icon={icon} />
   ) : (

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -3,13 +3,12 @@ import { HTMLAttributes, KeyboardEvent, ReactNode, useEffect, useMemo, useRef, u
 import { mergeProps, useFocusRing, useHover } from "react-aria";
 import { matchPath } from "react-router";
 import { Link, useLocation } from "react-router-dom";
-import { FullBleed, IconKey, maybeTooltip, resolveTooltip } from "src/components";
+import { FullBleed, IconKey, maybeTooltip, resolveTooltip, Tag } from "src/components";
 import { Css, Margin, Only, Padding, Palette, Tokens, Xss } from "src/Css";
 import { BeamFocusableProps } from "src/interfaces";
 import { AnyObject } from "src/types";
 import { useTestIds } from "src/utils";
 import { defaultTestId } from "src/utils/defaultTestId";
-import { AiBadge } from "./AiBadge";
 import { Icon } from "./Icon";
 
 export type Tab<V extends string = string> = {
@@ -19,7 +18,7 @@ export type Tab<V extends string = string> = {
   icon?: IconKey;
   // Suffixes label with specified node. Expected to be used for cases where the decoration is not just an icon.
   endAdornment?: ReactNode;
-  /** Whether the tab's content is AI-driven, which adds AiBadge. Takes precedence over `icon` and `endAdornment`. */
+  /** Whether the tab's content is AI-driven, which adds an AI tag. Takes precedence over `icon` and `endAdornment`. */
   aiMode?: boolean;
   /** Whether the Tab is disabled. If a ReactNode, it's treated as a "disabled reason" that's shown in a tooltip. */
   disabled?: boolean | ReactNode;
@@ -226,6 +225,7 @@ function TabImpl<V extends string>(props: TabImplProps<V>) {
   const { baseStyles, activeStyles, focusRingStyles, hoverStyles, disabledStyles, activeHoverStyles, aiStyles } =
     useMemo(() => getTabStyles(), []);
   const uniqueValue = uniqueTabValue(tab);
+  const tid = useTestIds(others);
 
   const tabProps = {
     "aria-controls": `${uniqueValue}-tabPanel`,
@@ -252,7 +252,13 @@ function TabImpl<V extends string>(props: TabImplProps<V>) {
     ...(isRouteTab(tab) ? {} : { onClick: () => onClick(tab.value) }),
   });
 
-  const decoration = aiMode ? <AiBadge /> : icon ? <Icon icon={icon} /> : endAdornment;
+  const decoration = aiMode ? (
+    <Tag text="" preventTooltip icon="aiStar" type="ai" variant="primary" iconOnly {...tid.aiTag} />
+  ) : icon ? (
+    <Icon icon={icon} />
+  ) : (
+    endAdornment
+  );
 
   const tabLabel = (
     <>

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -9,6 +9,7 @@ export type TagType = "info" | "update" | "warning" | "error" | "success" | "neu
 export type TagVariant = "primary" | "secondary";
 
 type TagPropsBase<X> = {
+  /** Required even if using `iconOnly + preventTooltip`. In those cases an accessibility friendly message is expected */
   text: ReactNode;
   // Defaults to "neutral"
   type?: TagType;


### PR DESCRIPTION
Design requested that we use an ai mode Tag instead of the `aiBadge`. I haven't removed that component yet but it is going unused atm.
<img width="528" height="112" alt="Screenshot 2026-08-27 at 12 57 38 PM" src="https://github.com/user-attachments/assets/e205309f-60ef-4d8c-a604-f7ca60d140ee" />
