### PR TITLE
feat: Standardize actions on Page Header for responsive support

### DIFF
--- a/src/components/Headers/HeaderActions.test.tsx
+++ b/src/components/Headers/HeaderActions.test.tsx
@@ -1,4 +1,5 @@
 import { HeaderActions } from "src/components/Headers/HeaderActions";
+import { setViewport } from "src/tests/viewport";
 import { click, render, withRouter } from "src/utils/rtl";
 
 describe("HeaderActions", () => {
@@ -44,5 +45,81 @@ describe("HeaderActions", () => {
     // Then the menu items are shown
     expect(r.verticalDots_export).toBeInTheDocument();
     expect(r.verticalDots_archive).toBeInTheDocument();
+  });
+
+  it("collapses two or more actions into a ButtonMenu at sm when collapseOnSm", async () => {
+    // Given collapseOnSm and a mobile viewport
+    setViewport("sm");
+    const r = await render(
+      <HeaderActions
+        collapseOnSm
+        actions={[
+          { label: "Upload", onClick: () => {} },
+          { kind: "icon", icon: "refresh", label: "Refresh", onClick: () => {} },
+        ]}
+      />,
+      withRouter(),
+    );
+    // Then the kebab is shown and the individual buttons are not
+    expect(r.verticalDots).toBeInTheDocument();
+    expect(r.query.upload).toBeNull();
+    expect(r.query.refresh).toBeNull();
+    // When opening the menu
+    click(r.verticalDots);
+    // Then both actions are menu items
+    expect(r.verticalDots_upload).toBeInTheDocument();
+    expect(r.verticalDots_refresh).toBeInTheDocument();
+  });
+
+  it("keeps a default action's icon when collapsed into the ButtonMenu", async () => {
+    // Given collapseOnSm, a mobile viewport, and a button action with an icon
+    setViewport("sm");
+    const r = await render(
+      <HeaderActions
+        collapseOnSm
+        actions={[
+          { label: "Upload", onClick: () => {} },
+          { variant: "secondary", icon: "refresh", label: "Refresh", onClick: () => {} },
+        ]}
+      />,
+      withRouter(),
+    );
+    // When opening the collapsed kebab
+    click(r.verticalDots);
+    // Then the menu item still shows that icon
+    expect(r.verticalDots_refresh.querySelector("[data-icon='refresh']")).toBeInTheDocument();
+  });
+
+  it("flattens kind:menu items into the collapsed ButtonMenu", async () => {
+    // Given collapseOnSm, a mobile viewport, and a nested menu action
+    setViewport("sm");
+    const r = await render(
+      <HeaderActions
+        collapseOnSm
+        actions={[
+          { label: "Upload", onClick: () => {} },
+          {
+            kind: "menu",
+            trigger: { icon: "verticalDots", variant: "outline" },
+            items: [{ label: "Archive", onClick: () => {} }],
+          },
+        ]}
+      />,
+      withRouter(),
+    );
+    // When opening the collapsed kebab
+    click(r.verticalDots);
+    // Then both the button action and the nested menu item are in that one menu
+    expect(r.verticalDots_upload).toBeInTheDocument();
+    expect(r.verticalDots_archive).toBeInTheDocument();
+  });
+
+  it("keeps a single action as a button at sm when collapseOnSm", async () => {
+    // Given collapseOnSm, one action, and a mobile viewport
+    setViewport("sm");
+    const r = await render(<HeaderActions collapseOnSm actions={[{ label: "Upload", onClick: () => {} }]} />);
+    // Then it stays a button, with no kebab
+    expect(r.upload).toBeInTheDocument();
+    expect(r.query.verticalDots).toBeNull();
   });
 });

--- a/src/components/Headers/HeaderActions.tsx
+++ b/src/components/Headers/HeaderActions.tsx
@@ -1,7 +1,9 @@
+import { PressEvent } from "@react-types/shared";
 import { Button, ButtonProps } from "src/components/Button";
-import { ButtonMenu, ButtonMenuProps } from "src/components/ButtonMenu";
+import { ButtonMenu, ButtonMenuProps, MenuItem } from "src/components/ButtonMenu";
 import { IconButton, IconButtonProps } from "src/components/IconButton";
 import { Css } from "src/Css";
+import { useBreakpoint } from "src/hooks/useBreakpoint";
 import { useTestIds } from "src/utils";
 
 /**
@@ -11,22 +13,34 @@ import { useTestIds } from "src/utils";
  * Tagged with `kind` (not `type`) because `ButtonProps` already has its own
  * unrelated `type?: "button" | "submit" | "reset"` HTML-attribute field.
  *
+ * Labels are `string` so actions can collapse into a `ButtonMenu` on mobile.
  * Icon actions always render with the `outline` `IconButton` variant, so `variant` is omitted here.
- * Menu actions always use a `verticalDots` trigger.
  */
 export type HeaderAction =
-  | ({ kind?: "default" } & ButtonProps)
-  | ({ kind: "icon" } & Omit<IconButtonProps, "variant">)
+  | ({ kind?: "default" } & Omit<ButtonProps, "label"> & { label: string })
+  | ({ kind: "icon" } & Omit<IconButtonProps, "variant" | "label"> & { label: string })
   | ({ kind: "menu" } & ButtonMenuProps);
 
 export type HeaderActionsProps = {
   actions: HeaderAction[];
+  /** Collapse two or more actions into a kebab `ButtonMenu` at `sm`. */
+  collapseOnSm?: boolean;
 };
 
-/** Internal renderer for `HeaderAction[]`. Not public — pass `actions` on `ContentHeader` or `GridTableLayout`. */
+/** Internal renderer for `HeaderAction[]`. Not public — pass `actions` on `ContentHeader`, `GridTableLayout`, or `PageHeader`. */
 export function HeaderActions(props: HeaderActionsProps) {
-  const { actions, ...otherProps } = props;
+  const { actions, collapseOnSm = false, ...otherProps } = props;
   const tid = useTestIds(otherProps, "headerActions");
+  const { sm } = useBreakpoint();
+  const collapse = collapseOnSm && sm && actions.length > 1;
+
+  if (collapse) {
+    return (
+      <div css={Css.df.aic.gap1.fs0.$} {...tid}>
+        <ButtonMenu trigger={{ icon: "verticalDots", variant: "outline" }} items={toMenuItems(actions)} />
+      </div>
+    );
+  }
 
   return (
     <div css={Css.df.aic.gap1.fs0.$} {...tid}>
@@ -49,5 +63,28 @@ export function HeaderActions(props: HeaderActionsProps) {
 function headerActionKey(action: HeaderAction, index: number): string {
   if (action.kind === "icon") return `${action.icon}-${index}`;
   if (action.kind === "menu") return `menu-${index}`;
-  return `${String(action.label)}-${index}`;
+  return `${action.label}-${index}`;
+}
+
+function toMenuItems(actions: HeaderAction[]): MenuItem[] {
+  return actions.flatMap((action): MenuItem[] => {
+    if (action.kind === "menu") return action.items;
+    const { label, onClick, disabled } = action;
+    // a non-string onClick could be a Promise for some buttons, but button menus don't support Promises, so we just need to trick it a little bit.
+    const itemOnClick: MenuItem["onClick"] =
+      typeof onClick === "string" ? onClick : () => void onClick({} as PressEvent);
+    if (action.kind === "icon") {
+      return [{ label, onClick: itemOnClick, disabled, icon: action.icon }];
+    }
+    return [
+      {
+        label,
+        onClick: itemOnClick,
+        disabled,
+        // Buttons can opt out of their default icon with `icon: null`, which menu items can't render.
+        ...(action.icon ? { icon: action.icon } : {}),
+        ...(action.variant === "danger" ? { destructive: true } : {}),
+      },
+    ];
+  });
 }

--- a/src/components/Headers/PageHeader.stories.tsx
+++ b/src/components/Headers/PageHeader.stories.tsx
@@ -5,7 +5,7 @@ import { Button } from "src/components/Button";
 import { PageHeader } from "src/components/Headers/PageHeader";
 import { TabContent } from "src/components/Tabs";
 import { testTabs } from "src/components/testData";
-import { withBeamDecorator, withRouter } from "src/utils/sb";
+import { newStory, viewportModes, withBeamDecorator, withRouter } from "src/utils/sb";
 import { action } from "storybook/actions";
 
 export default {
@@ -30,6 +30,20 @@ export function WithRightSlot() {
     />
   );
 }
+
+/** Two or more `actions` render as buttons on desktop and collapse into a kebab at `sm`. */
+export const WithActions = newStory(
+  () => (
+    <PageHeader
+      title="Test Title"
+      actions={[
+        { label: "Upload", variant: "primary", onClick: action("upload") },
+        { kind: "default", variant: "secondary", icon: "refresh", label: "Refresh", onClick: action("refresh") },
+      ]}
+    />
+  ),
+  { parameters: { chromatic: { modes: viewportModes("desktop", "mobile1") } } },
+);
 
 export function WithTabs() {
   const [selected, setSelected] = useState(testTabs[0].value);

--- a/src/components/Headers/PageHeader.test.tsx
+++ b/src/components/Headers/PageHeader.test.tsx
@@ -1,7 +1,9 @@
+import { Button } from "src/components/Button";
 import { PageHeader } from "src/components/Headers/PageHeader";
 import { Tab } from "src/components/Tabs";
+import { setViewport } from "src/tests/viewport";
 import { noop } from "src/utils";
-import { render, withRouter } from "src/utils/rtl";
+import { click, render, withRouter } from "src/utils/rtl";
 
 describe("PageHeader", () => {
   it("renders with tabs", async () => {
@@ -27,5 +29,70 @@ describe("PageHeader", () => {
     expect(r.header_tabs_tabA).toBeInTheDocument();
     expect(r.header_tabs_tabB).toBeInTheDocument();
     expect(r.header_tabs_tabC).toBeInTheDocument();
+  });
+
+  it("renders actions as buttons on desktop", async () => {
+    // Given a PageHeader with two actions
+    const r = await render(
+      <PageHeader
+        title="Documents"
+        actions={[
+          { label: "Upload", onClick: noop },
+          { kind: "icon", icon: "refresh", label: "Refresh", onClick: noop },
+        ]}
+      />,
+    );
+    // Then both render as buttons
+    expect(r.upload).toBeInTheDocument();
+    expect(r.refresh).toBeInTheDocument();
+  });
+
+  it("collapses two or more actions into a ButtonMenu at sm", async () => {
+    // Given a mobile viewport and two actions
+    setViewport("sm");
+    const r = await render(
+      <PageHeader
+        title="Documents"
+        actions={[
+          { label: "Upload", onClick: noop },
+          { kind: "icon", icon: "refresh", label: "Refresh", onClick: noop },
+        ]}
+      />,
+      withRouter(),
+    );
+    // Then the kebab is shown instead of the individual buttons
+    expect(r.verticalDots).toBeInTheDocument();
+    expect(r.query.upload).toBeNull();
+    click(r.verticalDots);
+    expect(r.verticalDots_upload).toBeInTheDocument();
+    expect(r.verticalDots_refresh).toBeInTheDocument();
+  });
+
+  it("keeps a single action as a button at sm", async () => {
+    // Given a mobile viewport and one action
+    setViewport("sm");
+    const r = await render(<PageHeader title="Documents" actions={[{ label: "Upload", onClick: noop }]} />);
+    // Then it stays a button
+    expect(r.upload).toBeInTheDocument();
+    expect(r.query.verticalDots).toBeNull();
+  });
+
+  it("still renders rightSlot at sm", async () => {
+    // Given a mobile viewport, actions, and a rightSlot
+    setViewport("sm");
+    const r = await render(
+      <PageHeader
+        title="Documents"
+        actions={[
+          { label: "Upload", onClick: noop },
+          { label: "Export", onClick: noop },
+        ]}
+        rightSlot={<Button label="Custom" onClick={noop} />}
+      />,
+      withRouter(),
+    );
+    // Then rightSlot is still shown next to the collapsed actions
+    expect(r.custom).toBeInTheDocument();
+    expect(r.verticalDots).toBeInTheDocument();
   });
 });

--- a/src/components/Headers/PageHeader.tsx
+++ b/src/components/Headers/PageHeader.tsx
@@ -1,21 +1,30 @@
 import { BaseHeader, BaseHeaderProps } from "src/components/Headers/BaseHeader";
+import { HeaderAction, HeaderActions } from "src/components/Headers/HeaderActions";
 import { RouteTabsProps, Tabs, TabsContentXss, TabsProps } from "src/components/Tabs";
 import { Only } from "src/Css";
 import { pageContentPaddingX } from "src/layouts/layoutSpacing";
 import { useTestIds } from "src/utils";
 
 export type PageHeaderProps<V extends string, X> = Omit<BaseHeaderProps, "bottomSlot"> & {
+  /** Rendered as buttons on desktop; two or more collapse into a `ButtonMenu` at `sm`. */
+  actions?: HeaderAction[];
   tabs?:
     | Omit<TabsProps<V, X>, "contentXss" | "omitFullBleedPadding" | "includeBottomBorder">
     | Omit<RouteTabsProps<V, X>, "contentXss" | "omitFullBleedPadding" | "includeBottomBorder">;
 };
 
 export function PageHeader<V extends string, X extends Only<TabsContentXss, X>>(props: PageHeaderProps<V, X>) {
-  const { tabs, ...otherProps } = props;
+  const { tabs, actions, rightSlot, ...otherProps } = props;
   const tid = useTestIds(otherProps, "header");
   return (
     <BaseHeader
       {...otherProps}
+      rightSlot={
+        <>
+          {rightSlot}
+          {actions && actions.length > 0 && <HeaderActions actions={actions} collapseOnSm />}
+        </>
+      }
       bottomSlot={
         tabs && (
           <div css={pageContentPaddingX}>


### PR DESCRIPTION
PageHeader's actions now transition from a inline buttons on desktop to an overflow menu on mobile