### PR TITLE
feat: rejected Tag type

### DIFF
--- a/src/components/Tag.stories.tsx
+++ b/src/components/Tag.stories.tsx
@@ -83,14 +83,14 @@ export function Secondary() {
   );
 }
 
-export function Rejected() {
+export function Strikethrough() {
   return (
     <div css={Css.df.fdc.aifs.gap1.$}>
-      <h3 css={Css.mb1.mdSb.$}>Rejected</h3>
+      <h3 css={Css.mb1.mdSb.$}>Strikethrough</h3>
       <p>Indicates a value that has been declined, i.e. a rejected AI suggestion.</p>
-      <Tag text="TRMCLG0004" type="rejected" variant="secondary" />
-      <Tag text="TRMCLG0004" type="rejected" variant="secondary" icon="xCircle" />
-      <Tag text="Rejected Label" type="rejected" />
+      <Tag text="TRMCLG0004" type="strikethrough" variant="secondary" />
+      <Tag text="TRMCLG0004" type="strikethrough" variant="secondary" icon="xCircle" />
+      <Tag text="Rejected Label" type="strikethrough" />
     </div>
   );
 }

--- a/src/components/Tag.stories.tsx
+++ b/src/components/Tag.stories.tsx
@@ -82,3 +82,15 @@ export function Secondary() {
     </div>
   );
 }
+
+export function Rejected() {
+  return (
+    <div css={Css.df.fdc.aifs.gap1.$}>
+      <h3 css={Css.mb1.mdSb.$}>Rejected</h3>
+      <p>Indicates a value that has been declined, i.e. a rejected AI suggestion.</p>
+      <Tag text="TRMCLG0004" type="rejected" variant="secondary" />
+      <Tag text="TRMCLG0004" type="rejected" variant="secondary" icon="xCircle" />
+      <Tag text="Rejected Label" type="rejected" />
+    </div>
+  );
+}

--- a/src/components/Tag.test.tsx
+++ b/src/components/Tag.test.tsx
@@ -54,6 +54,17 @@ describe("Tag", () => {
     });
   });
 
+  it("rejected type dims the tag and strikes through its text", async () => {
+    // Given a secondary rejected tag
+    const r = await render(<Tag text="TRMCLG0004" variant="secondary" type="rejected" data-testid="tag" />);
+
+    // Then it keeps the secondary outline, but is dimmed
+    expect(r.tag).toHaveStyle({ borderColor: Palette.Gray300, opacity: "0.5" });
+
+    // And its text is struck through
+    expect(r.getByText("TRMCLG0004")).toHaveStyle({ textDecoration: "line-through" });
+  });
+
   it("secondary variant does not uppercase text", async () => {
     // Given a secondary tag
     const r = await render(<Tag text="Secondary Label" variant="secondary" data-testid="tag" />);

--- a/src/components/Tag.test.tsx
+++ b/src/components/Tag.test.tsx
@@ -54,9 +54,9 @@ describe("Tag", () => {
     });
   });
 
-  it("rejected type dims the tag and strikes through its text", async () => {
-    // Given a secondary rejected tag
-    const r = await render(<Tag text="TRMCLG0004" variant="secondary" type="rejected" data-testid="tag" />);
+  it("strikethrough type dims the tag and strikes through its text", async () => {
+    // Given a secondary strikethrough tag
+    const r = await render(<Tag text="TRMCLG0004" variant="secondary" type="strikethrough" data-testid="tag" />);
 
     // Then it keeps the secondary outline, but is dimmed
     expect(r.tag).toHaveStyle({ borderColor: Palette.Gray300, opacity: "0.5" });

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -5,13 +5,13 @@ import { Css, Margin, Only, Palette, Properties, Xss } from "src/Css";
 import { useTestIds } from "src/utils";
 
 export type TagXss = Margin | "backgroundColor" | "color";
-export type TagType = "info" | "update" | "warning" | "error" | "success" | "neutral" | "ai";
+export type TagType = "info" | "update" | "warning" | "error" | "success" | "neutral" | "ai" | "rejected";
 export type TagVariant = "primary" | "secondary";
 
 type TagPropsBase<X> = {
   /** Required even if using `iconOnly + preventTooltip`. In those cases an accessibility friendly message is expected */
   text: ReactNode;
-  // Defaults to "neutral"
+  // Defaults to "neutral". "rejected" additionally dims the tag and strikes through its text.
   type?: TagType;
   /** Defaults to "primary". Secondary is intended for use in TagGroup. */
   variant?: TagVariant;
@@ -28,6 +28,7 @@ export type TagProps<X> = TagPropsBase<X> & ({ iconOnly?: false; icon?: IconKey 
 export function Tag<X extends Only<Xss<TagXss>, X>>(props: TagProps<X>) {
   const { text, type, variant = "primary", xss, preventTooltip = false, iconOnly, icon, ...otherProps } = props;
   const isIconOnly = !!iconOnly && !!icon;
+  const isRejected = type === "rejected";
   const { background, iconColor, typography, padding } = getVariantStyles(variant, type);
   const tid = useTestIds(otherProps);
   const [showTooltip, setShowTooltip] = useState(false);
@@ -53,6 +54,7 @@ export function Tag<X extends Only<Xss<TagXss>, X>>(props: TagProps<X>) {
           ...typography,
           ...(isIconOnly ? Css.pxPx(2).$ : padding),
           ...background,
+          ...(isRejected ? Css.o50.$ : {}),
           ...xss,
         }}
       >
@@ -66,7 +68,7 @@ export function Tag<X extends Only<Xss<TagXss>, X>>(props: TagProps<X>) {
         {isIconOnly ? (
           <span css={Css.visuallyHidden.$}>{text}</span>
         ) : (
-          <span ref={ref} css={Css.lineClamp1.wbba.$}>
+          <span ref={ref} css={Css.lineClamp1.wbba.if(isRejected).tdlt.$}>
             {text}
           </span>
         )}

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -5,13 +5,13 @@ import { Css, Margin, Only, Palette, Properties, Xss } from "src/Css";
 import { useTestIds } from "src/utils";
 
 export type TagXss = Margin | "backgroundColor" | "color";
-export type TagType = "info" | "update" | "warning" | "error" | "success" | "neutral" | "ai" | "rejected";
+export type TagType = "info" | "update" | "warning" | "error" | "success" | "neutral" | "ai" | "strikethrough";
 export type TagVariant = "primary" | "secondary";
 
 type TagPropsBase<X> = {
   /** Required even if using `iconOnly + preventTooltip`. In those cases an accessibility friendly message is expected */
   text: ReactNode;
-  // Defaults to "neutral". "rejected" additionally dims the tag and strikes through its text.
+  // Defaults to "neutral".
   type?: TagType;
   /** Defaults to "primary". Secondary is intended for use in TagGroup. */
   variant?: TagVariant;
@@ -28,7 +28,7 @@ export type TagProps<X> = TagPropsBase<X> & ({ iconOnly?: false; icon?: IconKey 
 export function Tag<X extends Only<Xss<TagXss>, X>>(props: TagProps<X>) {
   const { text, type, variant = "primary", xss, preventTooltip = false, iconOnly, icon, ...otherProps } = props;
   const isIconOnly = !!iconOnly && !!icon;
-  const isRejected = type === "rejected";
+  const isStrikethrough = type === "strikethrough";
   const { background, iconColor, typography, padding } = getVariantStyles(variant, type);
   const tid = useTestIds(otherProps);
   const [showTooltip, setShowTooltip] = useState(false);
@@ -54,7 +54,7 @@ export function Tag<X extends Only<Xss<TagXss>, X>>(props: TagProps<X>) {
           ...typography,
           ...(isIconOnly ? Css.pxPx(2).$ : padding),
           ...background,
-          ...(isRejected ? Css.o50.$ : {}),
+          ...(isStrikethrough ? Css.o50.$ : {}),
           ...xss,
         }}
       >
@@ -68,7 +68,7 @@ export function Tag<X extends Only<Xss<TagXss>, X>>(props: TagProps<X>) {
         {isIconOnly ? (
           <span css={Css.visuallyHidden.$}>{text}</span>
         ) : (
-          <span ref={ref} css={Css.lineClamp1.wbba.if(isRejected).tdlt.$}>
+          <span ref={ref} css={Css.lineClamp1.wbba.if(isStrikethrough).tdlt.$}>
             {text}
           </span>
         )}


### PR DESCRIPTION
Add a new `rejected` tag type that will dim the tag and strikethrough the text.

Works with both `TagVariant`s