### PR TITLE
feat: Support tooltips on primary workflow actions

### DIFF
--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -18,8 +18,8 @@ This document is the **canonical contract** for structural page layouts in Beam.
 | `NavbarLayout`            | `Navbar`                       | `navbar: NavbarProps`; body → **`children`**                                                                                                                                                                                                                                                                                                                                                                                                             |
 | `SideNavLayout`           | `SideNav`                      | `sideNav: SideNavProps`; content → **`children`**; `railWidthPx?`, `showCollapseToggle?`, `contrastRail?`                                                                                                                                                                                                                                                                                                                                                |
 | `PageHeaderLayout`        | `PageHeader`                   | `pageHeader: PageHeaderProps`; body → **`children`**                                                                                                                                                                                                                                                                                                                                                                                                     |
-| `StepperLayout`           | `WorkflowHeader` + steps       | `title`, `onCancel`, `completeLabel`, `onComplete`, `onSaveAndExit?`, `isDirty?` flattened onto `StepperLayoutProps`, `steps: StepperLayoutStep[]` (label/isValid/disabled/content — no `value`, it's derived from `label`) — active step's `content` is the body and need not be `FormSectionLayout`; `defaultStep?` picks the initial step; standalone, only ever under `EnvironmentBannerLayout` (see rule 3). `aiMode?` paints the body AI background and uses the `ai` Continue/Complete variant — pair with `FormSectionLayout` `aiMode` for the card + gradient title. |
-| `FocusedFormLayout`       | `WorkflowHeader` (no steps)    | Same flattened chrome as `StepperLayout`, plus `isValid`, `aiMode?` (page wash + `ai` CTA), and body → **`children`** (typically `FormSectionLayout`). Does **not** own JumpLinks — pass `withJumpLinks` on the body `FormSectionLayout`. Standalone, only ever under `EnvironmentBannerLayout` (see rule 3). |
+| `StepperLayout`           | `WorkflowHeader` + steps       | `title`, `onCancel`, `completeLabel`, `onComplete`, `onSaveAndExit?`, `isDirty?` flattened onto `StepperLayoutProps`, `steps: StepperLayoutStep[]` (label/`primaryDisabled?`/`disabled?`/content — no `value`, it's derived from `label`) — `primaryDisabled` gates Continue/Complete (`boolean \| ReactNode`, same as `Button.disabled`); `disabled` only locks the tab. Active step's `content` is the body and need not be `FormSectionLayout`; `defaultStep?` picks the initial step; standalone, only ever under `EnvironmentBannerLayout` (see rule 3). `aiMode?` paints the body AI background and uses the `ai` Continue/Complete variant — pair with `FormSectionLayout` `aiMode` for the card + gradient title. |
+| `FocusedFormLayout`       | `WorkflowHeader` (no steps)    | Same flattened chrome as `StepperLayout`, plus `primaryDisabled?` (gates Create/Save; a ReactNode is the tooltip), `aiMode?` (page wash + `ai` CTA), and body → **`children`** (typically `FormSectionLayout`). Does **not** own JumpLinks — pass `withJumpLinks` on the body `FormSectionLayout`. Standalone, only ever under `EnvironmentBannerLayout` (see rule 3). |
 | `CenteredLayout`          | centered body-width shell      | `size: "sm" \| "lg"`; body → **`children`**. **Not** a chrome peer (see rule 2). Horizontal padding 12px / 24px from `md`, publishes `--beam-layout-content-padding-x` for `layoutContainer` / sticky in-column chrome. `sm` = 720px content (768px shell max); `lg` = 1392px content (1440px shell max). `FormSectionLayout` wraps `CenteredLayout size="sm"` — do not wrap it again. |
 | `FormSectionLayout`       | form + optional JumpLinks      | `title`, `sections?`, `withJumpLinks?` (default false; rail needs 2+ includable sections, hidden on `sm`), `excludeJumpLink` on a section to omit it from the rail, `aiMode?` (`AiCard` + gradient title). Use as a `StepperLayout` step body or as `FocusedFormLayout` children. The rail does **not** shift the form: the content column mirrors the rail's 192px on its right, so the shell stays centered on the page exactly as it is without the rail (CSS-only `clamp`, no measuring). Below ~1152px there is no room for both, so the mirror shrinks and the form keeps its full width instead of narrowing. |
 
@@ -72,12 +72,13 @@ When the rail is collapsed, `SideNav` hides `top`, `items`, and `footer` (toggle
 
 Workflow pages skip `NavbarLayout`/`SideNavLayout` entirely. **`StepperLayout`** is the sequential
 experience: `steps` drives the header's tab strip, the active step's `content` is the body, and
-Continue/Complete is gated on that step's `isValid`. The layout owns step navigation (`defaultStep`
-only picks the start). **`FocusedFormLayout`** is the stepless workflow chrome: pass the body as
-**`children`** (typically `FormSectionLayout`). JumpLinks are owned by **`FormSectionLayout`**
-(`withJumpLinks`, section `excludeJumpLink`) — use the same body in a Stepper step or under
-FocusedForm. `aiMode` on the workflow paints a full-bleed wash; pair with `FormSectionLayout`
-`aiMode` for the card + gradient title.
+Continue/Complete is gated on that step's `primaryDisabled` (`boolean | ReactNode`, same as
+`Button.disabled`). Step `disabled` only locks the tab — it does not affect the CTA. The layout owns
+step navigation (`defaultStep` only picks the start). **`FocusedFormLayout`** is the stepless
+workflow chrome: pass the body as **`children`** (typically `FormSectionLayout`). JumpLinks are owned
+by **`FormSectionLayout`** (`withJumpLinks`, section `excludeJumpLink`) — use the same body in a
+Stepper step or under FocusedForm. `aiMode` on the workflow paints a full-bleed wash; pair with
+`FormSectionLayout` `aiMode` for the card + gradient title.
 
 ```tsx
 import {
@@ -111,7 +112,7 @@ import {
   onCancel={onCancel}
   completeLabel="Create"
   onComplete={onComplete}
-  isValid={formState.valid}
+  primaryDisabled={formState.valid ? false : "Fill all required fields to continue."}
   isDirty={() => formState.dirty}
 >
   <FormSectionLayout withJumpLinks title={formTitle} sections={sections} />
@@ -149,12 +150,12 @@ function CreateThingWorkflow() {
       steps={[
         {
           label: "Basics",
-          isValid: basicsForm.valid,
+          primaryDisabled: basicsForm.valid ? false : "Fill all required fields to continue.",
           content: <BasicsStep form={basicsForm} onLoad={setBasicsInput} />,
         },
         {
           label: "Details",
-          isValid: detailsForm.valid,
+          primaryDisabled: detailsForm.valid ? false : "Fill all required fields to continue.",
           disabled: !basicsForm.valid,
           content: <DetailsStep form={detailsForm} onLoad={setDetailsInput} />,
         },

--- a/src/components/StepperTabs/StepperTab.tsx
+++ b/src/components/StepperTabs/StepperTab.tsx
@@ -13,6 +13,7 @@ export type StepperTabProps = {
   /** Whether this step's content has been completed. */
   completed: boolean;
   onClick: (value: string) => void;
+  /** Tab isn't clickable. */
   disabled?: boolean;
   /** Collapses the tab down to its colored bottom border only, hiding the label — for the mobile view */
   collapsed?: boolean;

--- a/src/forms/StepperLayoutFormApp.tsx
+++ b/src/forms/StepperLayoutFormApp.tsx
@@ -37,18 +37,18 @@ function StepperLayoutForm({ formState, aiMode }: { formState: FormValue; aiMode
         const steps: StepperLayoutStep[] = [
           {
             label: "Author Details",
-            isValid: step1Valid,
+            primaryDisabled: step1Valid ? false : "Fill all required fields to continue.",
             content: <AuthorDetails formState={formState} aiMode={aiMode} />,
           },
           {
             label: "Books",
-            isValid: step2Valid,
+            primaryDisabled: step2Valid ? false : "Fill all required fields to continue.",
             disabled: !step1Valid,
             content: <BookList formState={formState} aiMode={aiMode} />,
           },
           {
             label: "Miscellaneous Author Information",
-            isValid: formState.birthday.valid,
+            primaryDisabled: formState.birthday.valid ? false : "Fill all required fields to continue.",
             disabled: !step2Valid,
             content: <MiscAuthorDetails formState={formState} showFormData={showFormData} aiMode={aiMode} />,
           },

--- a/src/forms/StepperLayoutMultiFormApp.tsx
+++ b/src/forms/StepperLayoutMultiFormApp.tsx
@@ -44,18 +44,18 @@ export function StepperLayoutMultiFormApp() {
         const steps: StepperLayoutStep[] = [
           {
             label: "Basics",
-            isValid: basicsForm.valid,
+            primaryDisabled: basicsForm.valid ? false : "Fill all required fields to continue.",
             content: <BasicsStep form={basicsForm} onLoad={loadBasics} loaded={!!basicsInput} />,
           },
           {
             label: "Contact",
-            isValid: contactForm.valid,
+            primaryDisabled: contactForm.valid ? false : "Fill all required fields to continue.",
             disabled: !basicsForm.valid,
             content: <ContactStep form={contactForm} onLoad={loadContact} loaded={!!contactInput} />,
           },
           {
             label: "Notes",
-            isValid: notesForm.valid,
+            primaryDisabled: notesForm.valid ? false : "Fill all required fields to continue.",
             disabled: !contactForm.valid,
             content: <NotesStep form={notesForm} onLoad={loadNotes} loaded={!!notesInput} />,
           },

--- a/src/layouts/Workflow/FocusedFormLayout.stories.tsx
+++ b/src/layouts/Workflow/FocusedFormLayout.stories.tsx
@@ -24,7 +24,6 @@ export function Default() {
         onCancel={action("cancel clicked")}
         completeLabel="Create"
         onComplete={action("complete clicked")}
-        isValid
       >
         <FormSectionLayout
           withJumpLinks
@@ -45,7 +44,6 @@ export function WithoutJumpLinks() {
         onCancel={action("cancel clicked")}
         completeLabel="Create"
         onComplete={action("complete clicked")}
-        isValid
       >
         <FormSectionLayout
           title="Link Design Package"
@@ -65,7 +63,6 @@ export function AiMode() {
         onCancel={action("cancel clicked")}
         completeLabel="Create"
         onComplete={action("complete clicked")}
-        isValid
         aiMode
       >
         <FormSectionLayout

--- a/src/layouts/Workflow/FocusedFormLayout.test.tsx
+++ b/src/layouts/Workflow/FocusedFormLayout.test.tsx
@@ -15,18 +15,46 @@ describe("FocusedFormLayout", () => {
     expect(r.focusedFormLayout_body).toBeInTheDocument();
   });
 
-  it("disables Create when isValid is false, and enables it once valid", async () => {
-    // Given an invalid focused form
-    const r = await render(<FocusedFormLayout {...baseProps({ isValid: false })} />, withRouter());
+  it("disables Create when primaryDisabled is true, and enables it once omitted", async () => {
+    // Given a focused form with primaryDisabled
+    const r = await render(<FocusedFormLayout {...baseProps({ primaryDisabled: true })} />, withRouter());
 
     // Then Create is disabled
     expect(r.create).toBeDisabled();
 
-    // When it becomes valid
-    r.rerender(<FocusedFormLayout {...baseProps({ isValid: true })} />);
+    // When primaryDisabled is omitted
+    r.rerender(<FocusedFormLayout {...baseProps()} />);
 
     // Then Create is enabled
     expect(r.create).not.toBeDisabled();
+  });
+
+  it("disables Create without a tooltip when primaryDisabled is true", async () => {
+    // Given a focused form with primaryDisabled true
+    const r = await render(<FocusedFormLayout {...baseProps({ primaryDisabled: true })} />, withRouter());
+
+    // Then Create is disabled and there is no tooltip
+    expect(r.create).toBeDisabled();
+    expect(r.query.tooltip).toBeNull();
+  });
+
+  it("shows a Beam tooltip on disabled Create when primaryDisabled is a reason", async () => {
+    // Given a focused form with a primaryDisabled reason
+    const r = await render(
+      <FocusedFormLayout {...baseProps({ primaryDisabled: "Fill all required fields to continue." })} />,
+      withRouter(),
+    );
+
+    // Then Create is disabled and wrapped in Beam's tooltip
+    expect(r.create).toBeDisabled();
+    expect(r.tooltip).toHaveAttribute("title", "Fill all required fields to continue.");
+
+    // When primaryDisabled is omitted
+    r.rerender(<FocusedFormLayout {...baseProps()} />);
+
+    // Then Create is enabled and the tooltip is gone
+    expect(r.create).not.toBeDisabled();
+    expect(r.query.tooltip).toBeNull();
   });
 
   it("renders Cancel and Create without Continue", async () => {
@@ -112,7 +140,6 @@ function baseProps(overrides: Partial<FocusedFormLayoutProps> = {}): FocusedForm
     onCancel: () => {},
     completeLabel: "Create",
     onComplete: () => {},
-    isValid: true,
     children: children ?? (
       <FormSectionLayout
         title="Link Design Package"

--- a/src/layouts/Workflow/FocusedFormLayout.tsx
+++ b/src/layouts/Workflow/FocusedFormLayout.tsx
@@ -6,8 +6,8 @@ import { WorkflowPageLayout } from "./WorkflowPageLayout";
 
 export type FocusedFormLayoutProps = Pick<BaseHeaderProps, "title" | "documentTitleSuffix" | "breadcrumbs"> &
   Pick<WorkflowActionsProps, "onCancel" | "completeLabel" | "onComplete" | "onSaveAndExit"> & {
-    /** Gates the Create/Save CTA. */
-    isValid: boolean;
+    /** Create/Save is disabled. A ReactNode is shown in Beam's tooltip. */
+    primaryDisabled?: WorkflowActionsProps["primaryDisabled"];
     /** Read on Cancel / leave — a callback so flipping dirty does not re-render. */
     isDirty?: () => boolean;
     /** Full-bleed AI wash on the body and the `ai` Create/Save variant. Pair with body `aiMode` (e.g. FormSectionLayout). */
@@ -22,8 +22,17 @@ export type FocusedFormLayoutProps = Pick<BaseHeaderProps, "title" | "documentTi
  * Contract: `docs/layouts.md`.
  */
 export function FocusedFormLayout(props: FocusedFormLayoutProps) {
-  const { onCancel, completeLabel, onComplete, onSaveAndExit, isValid, isDirty, aiMode, children, ...headerProps } =
-    props;
+  const {
+    onCancel,
+    completeLabel,
+    onComplete,
+    onSaveAndExit,
+    primaryDisabled,
+    isDirty,
+    aiMode,
+    children,
+    ...headerProps
+  } = props;
   const tid = useTestIds(props, "focusedFormLayout");
 
   return (
@@ -36,7 +45,7 @@ export function FocusedFormLayout(props: FocusedFormLayoutProps) {
       onSaveAndExit={onSaveAndExit}
       completeLabel={completeLabel}
       onComplete={onComplete}
-      primaryDisabled={!isValid}
+      primaryDisabled={primaryDisabled}
     >
       {children}
     </WorkflowPageLayout>

--- a/src/layouts/Workflow/StepperLayout.stories.tsx
+++ b/src/layouts/Workflow/StepperLayout.stories.tsx
@@ -50,7 +50,6 @@ export function WithContentHeaderAndTable() {
         steps={[
           {
             label: "Trade Partners",
-            isValid: true,
             content: (
               <div>
                 <ContentHeader
@@ -81,7 +80,6 @@ export function WithJumpLinks() {
         steps={[
           {
             label: "Details",
-            isValid: true,
             content: (
               <FormSectionLayout
                 withJumpLinks
@@ -105,7 +103,6 @@ export function WithJumpLinks() {
           },
           {
             label: "Review",
-            isValid: true,
             content: (
               <FormSectionLayout
                 title="Review"

--- a/src/layouts/Workflow/StepperLayout.test.tsx
+++ b/src/layouts/Workflow/StepperLayout.test.tsx
@@ -146,24 +146,27 @@ describe("StepperLayout", () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
-  it("disables Continue when the active step is invalid, and enables it once valid", async () => {
-    // Given a StepperLayout whose first (active) step is invalid
-    const r = await render(<StepperLayout {...baseProps({ steps: makeSteps({ oneIsValid: false }) })} />, withRouter());
+  it("disables Continue when the active step is primaryDisabled, and enables it once omitted", async () => {
+    // Given a StepperLayout whose first (active) step has primaryDisabled
+    const r = await render(
+      <StepperLayout {...baseProps({ steps: makeSteps({ onePrimaryDisabled: true }) })} />,
+      withRouter(),
+    );
 
     // Then Continue is disabled
     expect(r.continue).toBeDisabled();
 
-    // When the same step becomes valid
-    r.rerender(<StepperLayout {...baseProps({ steps: makeSteps({ oneIsValid: true }) })} />);
+    // When primaryDisabled is omitted
+    r.rerender(<StepperLayout {...baseProps({ steps: makeSteps() })} />);
 
     // Then Continue is enabled
     expect(r.continue).not.toBeDisabled();
   });
 
-  it("disables Save when the active (last) step is invalid, and enables it once valid", async () => {
-    // Given a StepperLayout on its last step, which is invalid
+  it("disables Save when the active (last) step is primaryDisabled, and enables it once omitted", async () => {
+    // Given a StepperLayout on its last step, which is primaryDisabled
     const r = await render(
-      <StepperLayout {...baseProps({ steps: makeSteps({ twoIsValid: false }), defaultStep: "stepTwo" })} />,
+      <StepperLayout {...baseProps({ steps: makeSteps({ twoPrimaryDisabled: true }), defaultStep: "stepTwo" })} />,
       withRouter(),
     );
 
@@ -171,7 +174,7 @@ describe("StepperLayout", () => {
     expect(r.save).toBeDisabled();
 
     // When the same step becomes valid
-    r.rerender(<StepperLayout {...baseProps({ steps: makeSteps({ twoIsValid: true }), defaultStep: "stepTwo" })} />);
+    r.rerender(<StepperLayout {...baseProps({ steps: makeSteps(), defaultStep: "stepTwo" })} />);
 
     // Then Save is enabled
     expect(r.save).not.toBeDisabled();
@@ -247,15 +250,70 @@ describe("StepperLayout", () => {
     expect(r.body).toBeInTheDocument();
     expect(r.query.stepTwoBody).not.toBeInTheDocument();
   });
+
+  it("disables Continue without a tooltip when primaryDisabled is true", async () => {
+    // Given a first step with primaryDisabled true
+    const r = await render(
+      <StepperLayout {...baseProps({ steps: makeSteps({ onePrimaryDisabled: true }) })} />,
+      withRouter(),
+    );
+
+    // Then Continue is disabled and there is no tooltip
+    expect(r.continue).toBeDisabled();
+    expect(r.query.tooltip).toBeNull();
+  });
+
+  it("shows a Beam tooltip on disabled Continue when primaryDisabled is a reason", async () => {
+    // Given a first step with a primaryDisabled reason
+    const r = await render(
+      <StepperLayout
+        {...baseProps({ steps: makeSteps({ onePrimaryDisabled: "Fill all required fields to continue." }) })}
+      />,
+      withRouter(),
+    );
+
+    // Then Continue is disabled and wrapped in Beam's tooltip
+    expect(r.continue).toBeDisabled();
+    expect(r.tooltip).toHaveAttribute("title", "Fill all required fields to continue.");
+
+    // When primaryDisabled is omitted
+    r.rerender(<StepperLayout {...baseProps({ steps: makeSteps() })} />);
+
+    // Then Continue is enabled and the tooltip is gone
+    expect(r.continue).not.toBeDisabled();
+    expect(r.query.tooltip).toBeNull();
+  });
+
+  it("shows a Beam tooltip on disabled Complete when primaryDisabled is a reason", async () => {
+    // Given a last step with a primaryDisabled reason
+    const r = await render(
+      <StepperLayout
+        {...baseProps({
+          steps: makeSteps({ twoPrimaryDisabled: "Fill all required fields to continue." }),
+          defaultStep: "stepTwo",
+        })}
+      />,
+      withRouter(),
+    );
+
+    // Then Save is disabled and wrapped in Beam's tooltip
+    expect(r.save).toBeDisabled();
+    expect(r.tooltip).toHaveAttribute("title", "Fill all required fields to continue.");
+  });
 });
 
-function makeSteps(overrides: { oneIsValid?: boolean; twoIsValid?: boolean } = {}): StepperLayoutStep[] {
-  const { oneIsValid = true, twoIsValid = true } = overrides;
+function makeSteps(
+  overrides: {
+    onePrimaryDisabled?: StepperLayoutStep["primaryDisabled"];
+    twoPrimaryDisabled?: StepperLayoutStep["primaryDisabled"];
+  } = {},
+): StepperLayoutStep[] {
+  const { onePrimaryDisabled, twoPrimaryDisabled } = overrides;
   return [
-    { label: "Step One", isValid: oneIsValid, content: <div data-testid="body">Body content</div> },
+    { label: "Step One", primaryDisabled: onePrimaryDisabled, content: <div data-testid="body">Body content</div> },
     {
       label: "Step Two",
-      isValid: twoIsValid,
+      primaryDisabled: twoPrimaryDisabled,
       content: <div data-testid="stepTwoBody">Step two content</div>,
     },
   ];

--- a/src/layouts/Workflow/StepperLayout.tsx
+++ b/src/layouts/Workflow/StepperLayout.tsx
@@ -7,15 +7,15 @@ import { WorkflowActionsProps } from "./WorkflowActions";
 import { WorkflowPageLayout } from "./WorkflowPageLayout";
 
 /**
- * A `StepperLayout` step: a `StepperTabsStep` (minus `value`, which is derived from `label`) plus
- * page content. Stepper chrome marks prior steps complete via current-step index; `isValid` only
- * gates the Continue/Complete CTA for the active step.
+ * A `StepperLayout` step: `StepperTabsStep` (minus `value`) plus page content.
  */
-export type StepperLayoutStep = Omit<StepperTabsStep, "value"> & {
+export type StepperLayoutStep = Omit<StepperTabsStep, "value" | "disabled"> & {
   /** Rendered as the page body while this is the active step. */
   content: ReactNode;
-  /** Gates Continue/Complete for the active step (form validity) */
-  isValid: boolean;
+  /** Tab isn't clickable. */
+  disabled?: boolean;
+  /** Continue/Complete is disabled. A ReactNode is shown in Beam's tooltip. */
+  primaryDisabled?: boolean | ReactNode;
 };
 
 export type StepperLayoutProps = Pick<BaseHeaderProps, "title" | "documentTitleSuffix" | "breadcrumbs"> &
@@ -64,7 +64,7 @@ export function StepperLayout(props: StepperLayoutProps) {
       onSaveAndExit={onSaveAndExit}
       completeLabel={completeLabel}
       onComplete={onComplete}
-      primaryDisabled={!activeStep?.isValid}
+      primaryDisabled={activeStep?.primaryDisabled}
       onContinue={async () => {
         const onContinue = activeStep?.onContinue;
         if (onContinue) {

--- a/src/layouts/Workflow/WorkflowActions.tsx
+++ b/src/layouts/Workflow/WorkflowActions.tsx
@@ -1,4 +1,5 @@
 import type { PressEvent } from "@react-types/shared";
+import { ReactNode } from "react";
 import { Button } from "src/components/Button";
 import { IconButton } from "src/components/IconButton";
 import { Css } from "src/Css";
@@ -13,8 +14,8 @@ export type WorkflowActionsProps = {
   completeLabel: "Create" | "Save";
   /** Called when the completion button is clicked. */
   onComplete: (e: PressEvent) => void | Promise<void>;
-  /** Disables whichever of Continue/Complete is currently shown, e.g. while the active step is invalid. */
-  primaryDisabled?: boolean;
+  /** Continue/Complete is disabled. A ReactNode is shown in Beam's tooltip. */
+  primaryDisabled?: boolean | ReactNode;
   /** When true, Continue/Complete use the `ai` button variant instead of `primary`. */
   aiMode?: boolean;
   isFirstStep?: boolean;


### PR DESCRIPTION
Changes 'isValid' prop to 'primaryDisabled' to better line up with Button.disabled prop, so it can easily pass through a "disabled reason" for the button. 'isValid' was thought to basically be 'formState.valid', but all it did was gate the Continue/Create buttons. The new name is more clear as to what the prop actually does vs just some information.