### PR TITLE
fix: Companion row reactivity

### DIFF
--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1526,6 +1526,46 @@ export function ActiveRow() {
   return <GridTable columns={columns} activeRowId="data_2" rowStyles={rowStyles} rows={rows} />;
 }
 
+/** Companions that add/remove/update via MobX without rebuilding `rows`. */
+export function CompanionRowsReactive() {
+  const pending = useMemo(() => observable({ show: true, message: "Review matches." }), []);
+  const rows = useMemo<GridDataRow<Row>[]>(
+    () => [
+      simpleHeader,
+      {
+        kind: "data",
+        id: "1",
+        data: { name: "Suggested option", value: 1 },
+        companion: () =>
+          pending.show
+            ? {
+                content: () => (
+                  <CompanionBanner
+                    tone="warning"
+                    message={pending.message}
+                    actions={<Button label="Dismiss" variant="text" onClick={() => (pending.show = false)} />}
+                  />
+                ),
+              }
+            : undefined,
+      },
+      { kind: "data", id: "2", data: { name: "Normal", value: 2 } },
+    ],
+    [pending],
+  );
+  const nameColumn: GridColumn<Row> = { header: "Name", data: ({ name }) => name, w: "200px" };
+  const valueColumn: GridColumn<Row> = { header: "Value", data: ({ value }) => value, w: "200px" };
+  return (
+    <div css={Css.df.fdc.gap2.$}>
+      <div css={Css.df.gap1.$}>
+        <Button label="Show companion" onClick={() => (pending.show = true)} />
+        <Button label="Change message" onClick={() => (pending.message = "Updated note.")} />
+      </div>
+      <GridTable columns={[nameColumn, valueColumn]} rows={rows} />
+    </div>
+  );
+}
+
 /** Mixed `aiMode` rows; Accept flips MobX so the functions re-evaluate without rebuilding `rows`. */
 export function AiModeRows() {
   const pending = useMemo(() => observable({ first: true, third: true }), []);

--- a/src/components/Table/GridTable.test.tsx
+++ b/src/components/Table/GridTable.test.tsx
@@ -1467,6 +1467,74 @@ describe("GridTable", () => {
       expect(row(r, 3).closest("tbody")).not.toBe(r.companion_1.closest("tbody"));
       expect(row(r, 1).closest("table")!.querySelectorAll("tbody")).toHaveLength(2);
     });
+
+    it("removes a companion when rerendered with the same data and companion undefined", async () => {
+      // Given a stable data object on a row with a trailing companion
+      const data = { name: "foo", value: 1 };
+      function Harness({ companion }: { companion?: GridDataRow<Row>["companion"] }) {
+        return (
+          <GridTable<Row>
+            columns={[nameColumn, valueColumn]}
+            rows={[
+              simpleHeader,
+              { kind: "data", id: "1", data, companion },
+              { kind: "data", id: "2", data: { name: "bar", value: 2 } },
+            ]}
+          />
+        );
+      }
+      const r = await render(<Harness companion={() => <span>Note</span>} />);
+      expect(r.companion_1).toBeInTheDocument();
+      expect(cell(r, 1, 0)).toHaveStyle({ boxShadow: "none" });
+      // When the same data is passed with no companion
+      await r.rerender(<Harness />);
+      // Then the companion is gone and the parent separator is restored
+      expect(r.query.companion_1).toBeNull();
+      expect(cell(r, 1, 0)).toHaveStyle({ boxShadow: insetSeparator });
+    });
+
+    it("reevaluates a function companion when its observables change", async () => {
+      // Given a companion that reads a MobX box
+      const pending = observable.box(true);
+      const rows: GridDataRow<Row>[] = [
+        simpleHeader,
+        {
+          kind: "data",
+          id: "1",
+          data: { name: "foo", value: 1 },
+          companion: () => (pending.get() ? <span>Note</span> : undefined),
+        },
+        { kind: "data", id: "2", data: { name: "bar", value: 2 } },
+      ];
+      const r = await render(<GridTable<Row> columns={[nameColumn, valueColumn]} rows={rows} />);
+      expect(r.companion_1).toBeInTheDocument();
+      expect(cell(r, 1, 0)).toHaveStyle({ boxShadow: "none" });
+      // When the observable flips without rebuilding rows
+      act(() => pending.set(false));
+      // Then the companion is gone and the parent separator is restored
+      expect(r.query.companion_1).toBeNull();
+      expect(cell(r, 1, 0)).toHaveStyle({ boxShadow: insetSeparator });
+    });
+
+    it("updates function companion content when its observables change", async () => {
+      // Given companion content that reads a MobX box
+      const message = observable.box("Hello");
+      const rows: GridDataRow<Row>[] = [
+        simpleHeader,
+        {
+          kind: "data",
+          id: "1",
+          data: { name: "foo", value: 1 },
+          companion: { content: () => <span>{message.get()}</span> },
+        },
+      ];
+      const r = await render(<GridTable<Row> columns={[nameColumn, valueColumn]} rows={rows} />);
+      expect(r.companion_1).toHaveTextContent("Hello");
+      // When the observable flips without rebuilding rows
+      act(() => message.set("Goodbye"));
+      // Then the companion text updates
+      expect(r.companion_1).toHaveTextContent("Goodbye");
+    });
   });
 
   describe("column sizes", () => {

--- a/src/components/Table/GridTable.tsx
+++ b/src/components/Table/GridTable.tsx
@@ -47,7 +47,7 @@ import { useDocumentScrollLayout } from "src/layouts/DocumentScrollLayoutContext
 import { stickyTableHeaderOffset } from "src/layouts/layoutVars";
 import { isPromise, useTestIds } from "src/utils";
 import { zIndices } from "src/utils/zIndices";
-import { CompanionRow, resolveCompanion } from "./components/CompanionRow";
+import { CompanionRow } from "./components/CompanionRow";
 import type { GridDataRow, GridRowKind } from "./components/Row";
 import { Row } from "./components/Row";
 import { RowGroup } from "./components/RowGroup";
@@ -563,7 +563,7 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
 
     const makeCompanionRow = (
       rs: RowState<R>,
-      resolved: NonNullable<ReturnType<typeof resolveCompanion>>,
+      resolved: NonNullable<RowState<R>["companion"]>,
       isFirstBodyRow: boolean,
       isLastBodyRow: boolean,
     ): ReactElement => {
@@ -593,7 +593,7 @@ export function GridTable<R extends Kinded, X extends Only<GridTableXss, X> = an
       isLastBodyRow: boolean,
       inHead: boolean,
     ): ReactElement => {
-      const resolved = resolveCompanion(rs.row.companion);
+      const resolved = rs.companion;
       const position = resolved?.position;
       const row = makeRow(
         rs,

--- a/src/components/Table/components/CompanionRow.tsx
+++ b/src/components/Table/components/CompanionRow.tsx
@@ -1,3 +1,4 @@
+import { observer } from "mobx-react";
 import { isValidElement, ReactNode } from "react";
 import { maybeApply } from "src/components/Table/GridTableApi";
 import type { GridStyle } from "src/components/Table/TableStyles";
@@ -24,7 +25,7 @@ type CompanionRowProps = {
 };
 
 /** Full-width row rendered beside a data row when `GridDataRow.companion` is set. */
-export function CompanionRow(props: CompanionRowProps) {
+function CompanionRowImpl(props: CompanionRowProps) {
   const {
     as,
     columnSizes,
@@ -93,6 +94,8 @@ export function CompanionRow(props: CompanionRowProps) {
   );
 }
 
+export const CompanionRow = observer(CompanionRowImpl);
+
 export type CompanionPosition = "leading" | "trailing";
 
 export type CompanionContent = MaybeFn<ReactNode>;
@@ -119,10 +122,14 @@ export function isCompanionConfig(companion: GridRowCompanion): companion is Com
 type ResolvedCompanion = { position: CompanionPosition; content: CompanionContent };
 
 /** Resolves companion placement and content; `undefined` when there is no companion. */
-export function resolveCompanion(companion: GridRowCompanion | null | undefined): ResolvedCompanion | undefined {
+export function resolveCompanion(
+  companion: MaybeFn<GridRowCompanion | null | undefined> | null | undefined,
+): ResolvedCompanion | undefined {
   if (companion == null) return undefined;
-  if (isCompanionConfig(companion)) {
-    return { position: companion.position ?? "trailing", content: companion.content };
+  const value = maybeApply(companion);
+  if (value == null) return undefined;
+  if (isCompanionConfig(value)) {
+    return { position: value.position ?? "trailing", content: value.content };
   }
-  return { position: "trailing", content: companion };
+  return { position: "trailing", content: value };
 }

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -582,10 +582,9 @@ export type GridDataRow<R extends Kinded> = {
   /** Paints the row with `Tokens.AiFieldBg`. Use `() => boolean` to read MobX without rebuilding `rows`. */
   aiMode?: MaybeFn<boolean>;
   /**
-   * Full-width content rendered with this row (no separator between them).
-   * Plain content / render fn defaults to `"trailing"`; use `{ position, content }` for `"leading"`.
+   * Full-width content with this row. Use `() => …` to read MobX without rebuilding `rows`; return `undefined` to hide.
    */
-  companion?: GridRowCompanion;
+  companion?: MaybeFn<GridRowCompanion | null | undefined>;
 } & IfAny<R, AnyObject, DiscriminateUnion<R, "kind", R["kind"]>>;
 
 // Used by TextFieldBase to set a border when the row is being hovered over

--- a/src/components/Table/utils/RowState.ts
+++ b/src/components/Table/utils/RowState.ts
@@ -1,5 +1,6 @@
 import { makeAutoObservable, observable, reaction } from "mobx";
 import { Kinded } from "src";
+import { resolveCompanion, type GridRowCompanion } from "src/components/Table/components/CompanionRow";
 import type { GridDataRow } from "src/components/Table/components/Row";
 import { GridRowApi, maybeApply } from "src/components/Table/GridTableApi";
 import type { MaybeFn } from "src/components/Table/types";
@@ -37,6 +38,7 @@ export class RowState<R extends Kinded> {
    */
   pinned = false;
   private _aiMode: MaybeFn<boolean> | undefined;
+  private _companion: MaybeFn<GridRowCompanion | null | undefined> | undefined;
   /** Whether we are dragged over. */
   isDraggedOver: DraggedOver = DraggedOver.None;
   /**
@@ -76,6 +78,7 @@ export class RowState<R extends Kinded> {
         _row: false,
         _data: observable.ref,
         _aiMode: observable.ref,
+        _companion: observable.ref,
         isCalculatingDirectMatch: false,
       } as any,
       { name: `RowState@${row.id}` },
@@ -108,11 +111,17 @@ export class RowState<R extends Kinded> {
     this._data = row.data;
     // Same boolean/fn identity across new row literals must not notify every row.
     if (this._aiMode !== row.aiMode) this._aiMode = row.aiMode;
+    if (this._companion !== row.companion) this._companion = row.companion;
   }
 
   /** True when `row.aiMode` is true or its function returns true. */
   get aiMode(): boolean {
     return !!maybeApply(this._aiMode);
+  }
+
+  /** Resolved companion for this row; `undefined` when hidden or unset. */
+  get companion() {
+    return resolveCompanion(this._companion);
   }
 
   /**


### PR DESCRIPTION
Companion rows now follow the same reactive path as aiMode. You can add, remove, or update them without rebuilding rows or changing data identity.

How it works

- `resolveCompanion` applies MaybeFn first and treats `null` / `undefined` as “no companion row”
- `RowState` stores `_companion` as `observable.ref` and exposes `get companion()`
- `makeRowGroup` reads `rs.companion`, so presence changes separators and last-row styling
- CompanionRow is an observer, so inner content: () => … can update in place

Usage
```
// React: new rows array, same data object
<GridTable rows={[simpleHeader, { kind: "data", id, data, companion: banner ?? undefined }]} />

// MobX: stable rows, fn re-evaluates
companion: () => (store.show ? <Banner /> : undefined)
```