### PR TITLE
chore: Bump framer-motion to 13.

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "date-fns": "^4.4.0",
     "dompurify": "^3.4.15",
     "fast-deep-equal": "^3.1.3",
-    "framer-motion": "^9.1.7",
+    "framer-motion": "^13.2.0",
     "memoize-one": "^6.0.0",
     "mobx-utils": "^6.1.1",
     "react-aria": "^3.52.1",

--- a/src/components/Navbar/NavbarMobileMenu.tsx
+++ b/src/components/Navbar/NavbarMobileMenu.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from "framer-motion";
-import { useEffect, useState } from "react";
+import { type MouseEvent, useEffect, useState } from "react";
 import { FocusScope, usePreventScroll } from "react-aria";
 import { createPortal } from "react-dom";
 import { useLocation } from "react-router-dom";
@@ -122,7 +122,7 @@ function NavbarMobileDrawer({
           animate={{ x: 0 }}
           exit={{ x: "-100%" }}
           transition={{ ease: "linear", duration: 0.2 }}
-          onClick={(e) => e.stopPropagation()}
+          onClick={(e: MouseEvent) => e.stopPropagation()}
           {...tid.mobileMenuDrawer}
         >
           <div
@@ -166,7 +166,7 @@ function NavbarMobileDrawer({
                 transition={{ ease: "linear", duration: 0.2 }}
                 // String-route items render as `<a>` (react-router Link) and external URLs as `<a href>`;
                 // closing on any anchor click covers same-route taps that don't change the location.
-                onClickCapture={(e) => {
+                onClickCapture={(e: MouseEvent) => {
                   if ((e.target as Element).closest("a")) {
                     onClose();
                   }

--- a/src/components/SuperDrawer/SuperDrawer.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from "framer-motion";
-import { type ReactPortal, useEffect, useRef } from "react";
+import { type MouseEvent, type ReactPortal, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { AutoSaveStatusProvider, IconButton, type OpenInDrawerOpts, useSuperDrawer } from "src/components";
 import { useBeamContext } from "src/components/BeamContext";
@@ -96,7 +96,7 @@ export function SuperDrawer(): ReactPortal | null {
               transition={{ ease: "linear", duration: 0.2, delay: 0.2 }}
               exit={{ transition: { ease: "linear", duration: 0.2 }, x: width }}
               // Preventing clicks from triggering parent onClick
-              onClick={(e) => e.stopPropagation()}
+              onClick={(e: MouseEvent) => e.stopPropagation()}
             >
               <AutoSaveStatusProvider>
                 <header css={Css.p3.bb.bc(Tokens.SurfaceSeparator).df.aic.jcsb.gap3.$}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -477,22 +477,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emotion/is-prop-valid@npm:^0.8.2":
-  version: 0.8.8
-  resolution: "@emotion/is-prop-valid@npm:0.8.8"
-  dependencies:
-    "@emotion/memoize": "npm:0.7.4"
-  checksum: 10/e85bdeb9d9d23de422f271e0f5311a0142b15055bb7e610440dbf250f0cdfd049df88af72a49e2c6081954481f1cbeca9172e2116ff536b38229397dfbed8082
-  languageName: node
-  linkType: hard
-
-"@emotion/memoize@npm:0.7.4":
-  version: 0.7.4
-  resolution: "@emotion/memoize@npm:0.7.4"
-  checksum: 10/4e3920d4ec95995657a37beb43d3f4b7d89fed6caa2b173a4c04d10482d089d5c3ea50bbc96618d918b020f26ed6e9c4026bbd45433566576c1f7b056c3271dc
-  languageName: node
-  linkType: hard
-
 "@esbuild/aix-ppc64@npm:0.27.3":
   version: 0.27.3
   resolution: "@esbuild/aix-ppc64@npm:0.27.3"
@@ -932,7 +916,7 @@ __metadata:
     date-fns: "npm:^4.4.0"
     dompurify: "npm:^3.4.15"
     fast-deep-equal: "npm:^3.1.3"
-    framer-motion: "npm:^9.1.7"
+    framer-motion: "npm:^13.2.0"
     husky: "npm:^9.1.7"
     jsdom: "npm:29.0.0"
     memoize-one: "npm:^6.0.0"
@@ -4694,19 +4678,22 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:^9.1.7":
-  version: 9.1.7
-  resolution: "framer-motion@npm:9.1.7"
+"framer-motion@npm:^13.2.0":
+  version: 13.2.0
+  resolution: "framer-motion@npm:13.2.0"
   dependencies:
-    "@emotion/is-prop-valid": "npm:^0.8.2"
+    motion-dom: "npm:^13.2.0"
+    motion-utils: "npm:^13.0.0"
     tslib: "npm:^2.4.0"
   peerDependencies:
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  dependenciesMeta:
-    "@emotion/is-prop-valid":
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    react:
       optional: true
-  checksum: 10/7135c2d8acdd6b613efa17d2dc7f6c786f01958c84db04cb610d7349f9e114bd98b73073d3a7ed134434ae7d672706daa784ba6dee5cc8700407e84207b96589
+    react-dom:
+      optional: true
+  checksum: 10/57e04da36915ebfd08d1a17a2623fad9ce4bc6f1157e66f16c522f22677c26e5a52a61032cf9afc90e1a403997d5a4d7c03dc364c9f394ccbf8a4a1d489ee477
   languageName: node
   linkType: hard
 
@@ -6154,6 +6141,22 @@ __metadata:
   version: 6.16.1
   resolution: "mobx@npm:6.16.1"
   checksum: 10/01753230a35d2f8a376d4f0e5b0096848141a6c1567f09f4a5e6f7a983814e971141eccb58288e737a7b259618312e4c963523100ccc13f5505881ead7066c80
+  languageName: node
+  linkType: hard
+
+"motion-dom@npm:^13.2.0":
+  version: 13.2.0
+  resolution: "motion-dom@npm:13.2.0"
+  dependencies:
+    motion-utils: "npm:^13.0.0"
+  checksum: 10/b819cf3b920b9b1aaf8df90d3103f1baa7fc2de180551324f7fa82e58cc8e73f7dd20b6ed68044156dc42f9d4d6d88ea2dc288f9816d3567d2f7d141f0003f28
+  languageName: node
+  linkType: hard
+
+"motion-utils@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "motion-utils@npm:13.0.0"
+  checksum: 10/ee6296263ed6fd16a46eced143446e9335facdf72d1922ecdcfb945fb498d3723e9c94f3036fed4cc3cda7fca59de9b2971c11496fdfb8511cefb70eb2ec2da3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

None of the removed APIs (`exitBeforeEnter`, `AnimateSharedLayout`, motion
value `onChange`, the `@emotion/is-prop-valid` fallback) are used here. Two
`motion.div` click handlers now type their event parameter explicitly, since
the new types no longer infer it against the pinned @types/react 18.0.28.

---
Part of the dependency-update stack (14 PRs, land in order).
- ⬇️ Based on #1438
- ⬆️ Next: #1440

🤖 Generated with [Claude Code](https://claude.com/claude-code)
