### PR TITLE
chore: Bump trix to 2.

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-virtuoso": "^4.18.13",
     "temporal-polyfill": "^0.3.2",
     "tributejs": "^5.1.3",
-    "trix": "^1.3.5",
+    "trix": "^2.1.19",
     "use-debounce": "^10.1.1",
     "use-query-params": "^2.2.2"
   },

--- a/src/inputs/RichTextField.test.tsx
+++ b/src/inputs/RichTextField.test.tsx
@@ -1,4 +1,5 @@
 import { render } from "@homebound/rtl-utils";
+import { act } from "@testing-library/react";
 import { noop } from "src/utils";
 import { RichTextFieldImpl as RichTextField } from "./RichTextField";
 
@@ -12,5 +13,52 @@ describe("RichTextField", () => {
     const r = await render(<RichTextField value={""} onChange={noop} />);
     r.rerender(<RichTextField value="<div><!--block-->test</div>" onChange={noop} />);
     expect(r.getByText("test")).toBeInTheDocument();
+  });
+});
+
+describe("RichTextField controlled value", () => {
+  it("does not reload the editor when a stale echo of its own change renders", async () => {
+    // Given an editor whose parent stores the html it emits
+    const onChange = vi.fn();
+    const r = await render(<RichTextField value="" onChange={onChange} />);
+    const el = r.container.querySelector("trix-editor") as HTMLElement & {
+      editor: { loadHTML: (html: string) => void };
+    };
+    const loadHTML = vi.spyOn(el.editor, "loadHTML");
+    // And trix fires two change events for one keystroke before React commits, as trix 2 does
+    act(() => {
+      el.innerHTML = "<div><!--block-->Hello </div>";
+      el.dispatchEvent(new Event("trix-change"));
+      el.innerHTML = "<div><!--block-->Hello @fo</div>";
+      el.dispatchEvent(new Event("trix-change"));
+    });
+    expect(onChange).toHaveBeenCalledTimes(2);
+    // When the parent renders with the older of the two emitted values
+    r.rerender(<RichTextField value="<div><!--block-->Hello </div>" onChange={onChange} />);
+    // Then the editor keeps what the user typed
+    expect(loadHTML).not.toHaveBeenCalled();
+    expect(el.innerHTML).toBe("<div><!--block-->Hello @fo</div>");
+    // And when the parent catches up with the latest value, it is still not reloaded
+    r.rerender(<RichTextField value="<div><!--block-->Hello @fo</div>" onChange={onChange} />);
+    expect(loadHTML).not.toHaveBeenCalled();
+  });
+
+  it("reloads the editor when the parent supplies a genuinely new value", async () => {
+    // Given an editor that has emitted a change
+    const onChange = vi.fn();
+    const r = await render(<RichTextField value="" onChange={onChange} />);
+    const el = r.container.querySelector("trix-editor") as HTMLElement & {
+      editor: { loadHTML: (html: string) => void };
+    };
+    const loadHTML = vi.spyOn(el.editor, "loadHTML");
+    act(() => {
+      el.innerHTML = "<div><!--block-->typed</div>";
+      el.dispatchEvent(new Event("trix-change"));
+    });
+    // When the parent resets the value to html the editor never emitted
+    r.rerender(<RichTextField value="<div><!--block-->from server</div>" onChange={onChange} />);
+    // Then the editor is reloaded with it
+    expect(loadHTML).toHaveBeenCalledWith("<div><!--block-->from server</div>");
+    expect(r.getByText("from server")).toBeInTheDocument();
   });
 });

--- a/src/inputs/RichTextField.tsx
+++ b/src/inputs/RichTextField.tsx
@@ -8,7 +8,7 @@ import { maybeCall, noop } from "src/utils";
 import { withTestMock } from "src/utils/withTestMock";
 import Tribute from "tributejs";
 import "tributejs/dist/tribute.css";
-import "trix/dist/trix";
+import "trix";
 import "trix/dist/trix.css";
 import "./trix.css";
 
@@ -63,6 +63,10 @@ export function RichTextFieldImpl(props: RichTextFieldProps) {
   // like a controlled input, i.e. by only calling loadHTML if a new incoming `value` !== `currentHtml`,
   // otherwise we'll constantly call loadHTML and reset the user's cursor location.
   const currentHtml = useRef<string | undefined>(undefined);
+  // Every html we've emitted via onChange since the last external load. trix can fire several
+  // `trix-change` events before React commits, so a render may still carry an older one of these.
+  // Those are echoes of the user's own edits, not new values, and must not trigger a reload.
+  const emittedHtml = useRef(new Set<string | undefined>());
 
   // Use a ref for onChange b/c so trixChange always has the latest
   const onChangeRef = useRef<RichTextFieldProps["onChange"]>(onChange);
@@ -90,6 +94,7 @@ export function RichTextFieldImpl(props: RichTextFieldProps) {
         }
 
         currentHtml.current = value;
+        emittedHtml.current.clear();
         editor.loadHTML(value || "");
         // Remove listener once we've initialized
         window.removeEventListener("trix-initialize", onEditorInit);
@@ -100,9 +105,11 @@ export function RichTextFieldImpl(props: RichTextFieldProps) {
           // If the user only types whitespace, treat that as undefined
           if ((textContent || "").trim() === "") {
             currentHtml.current = undefined;
+            emittedHtml.current.add(undefined);
             onChange && onChange(undefined, undefined, []);
           } else {
             currentHtml.current = innerHTML;
+            emittedHtml.current.add(innerHTML);
             const mentions = extractIdsFromMentions(mergeTags || [], textContent || "");
             onChange && onChange(innerHTML, textContent || undefined, mentions);
           }
@@ -130,8 +137,14 @@ export function RichTextFieldImpl(props: RichTextFieldProps) {
   }, [readOnly]);
 
   useEffect(() => {
-    // If our value prop changes (without the change coming from us), reload it
-    if (!readOnly && editor && value !== currentHtml.current) {
+    if (readOnly || !editor) return;
+    if (value === currentHtml.current) {
+      // The parent has caught up with our latest edit, so older echoes can no longer arrive
+      emittedHtml.current.clear();
+    } else if (!emittedHtml.current.has(value)) {
+      // The value changed without the change coming from us, so reload it
+      currentHtml.current = value;
+      emittedHtml.current.clear();
       editor.loadHTML(value || "");
     }
   }, [value, readOnly, editor]);

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -1,5 +1,6 @@
 import { configure } from "mobx";
 import { resetWindowScroll } from "src/tests/documentScroll";
+import "src/tests/elementInternals";
 import "src/tests/framerMotion";
 import "src/tests/matchers";
 import { resetViewport } from "src/tests/viewport";

--- a/src/tests/elementInternals.ts
+++ b/src/tests/elementInternals.ts
@@ -1,0 +1,18 @@
+// jsdom declares `ElementInternals` but implements none of the form-associated custom element
+// members. trix 2 sees the constructor, takes its ElementInternals code path, and then calls
+// `setFormValue`/`setValidity`, so fill in inert versions of what it uses.
+if (typeof ElementInternals !== "undefined") {
+  const proto = ElementInternals.prototype as any;
+  const noop = () => {};
+  for (const method of ["setFormValue", "setValidity"]) {
+    if (!(method in proto)) proto[method] = noop;
+  }
+  for (const method of ["checkValidity", "reportValidity"]) {
+    if (!(method in proto)) proto[method] = () => true;
+  }
+  for (const getter of ["form", "labels", "validationMessage", "willValidate", "validity"]) {
+    if (!(getter in proto)) Object.defineProperty(proto, getter, { get: () => undefined, configurable: true });
+  }
+}
+
+export {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -940,7 +940,7 @@ __metadata:
     storybook: "npm:^10.6.0"
     temporal-polyfill: "npm:^0.3.2"
     tributejs: "npm:^5.1.3"
-    trix: "npm:^1.3.5"
+    trix: "npm:^2.1.19"
     tsup: "npm:^8.5.1"
     tsx: "npm:^4.23.13"
     typescript: "npm:5.9.3"
@@ -4137,7 +4137,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dompurify@npm:^3.4.15":
+"dompurify@npm:^3.2.5, dompurify@npm:^3.4.15":
   version: 3.4.15
   resolution: "dompurify@npm:3.4.15"
   dependencies:
@@ -8667,10 +8667,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"trix@npm:^1.3.5":
-  version: 1.3.5
-  resolution: "trix@npm:1.3.5"
-  checksum: 10/d430d8da751fa4afeb8775a5051f5e8df6f3845dd93b545f66ab3c1ca8fd1fb7312e77b88ebf8570285b29aea83b9bd1910cb2fc9ace87828e4f371e32cc64b8
+"trix@npm:^2.1.19":
+  version: 2.1.19
+  resolution: "trix@npm:2.1.19"
+  dependencies:
+    dompurify: "npm:^3.2.5"
+  checksum: 10/a7f4b6e50b1d1714eb4d27ce520f958a6225a3bcd6b4a566320efc163e24701599bd0091a9e0b5b0e9302b8400fbf54d027a988f4419639a69f7ae530cd07f06
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

trix 2 no longer ships dist/trix.js, so RichTextField imports the package
entry point instead. It also drives form participation through
ElementInternals when the constructor exists, and jsdom declares the
constructor without its methods, so the test setup fills in inert versions of
the members trix calls.

trix 2 can fire several `trix-change` events before React commits, which
exposed a race in RichTextField's controlled-value handling: a render carrying
an older html we had already emitted looked like an external change and
triggered `loadHTML`, wiping the user's typing and the undo stack. The field
now remembers every html it has emitted since the last external load and
treats those as echoes, with regression tests for the stale echo and for a
genuinely new value.

---
Part of the dependency-update stack (14 PRs, land in order).
- ⬇️ Based on #1439
- ⬆️ Next: #1441

🤖 Generated with [Claude Code](https://claude.com/claude-code)
