### PR TITLE
chore: Bump @homebound/form-state to 3.1 and temporal-polyfill to 1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "type-check": "yarn tsc"
   },
   "dependencies": {
-    "@homebound/form-state": "^2.28.0",
+    "@homebound/form-state": "^3.1.0",
     "@internationalized/number": "^3.6.8",
     "@popperjs/core": "^2.11.8",
     "@react-aria/interactions": "^3.28.1",
@@ -77,7 +77,7 @@
     "react-router-dom": "^6.30.6",
     "react-stately": "^3.50.0",
     "react-virtuoso": "^4.18.13",
-    "temporal-polyfill": "^0.3.2",
+    "temporal-polyfill": "^1.0.4",
     "tributejs": "^5.1.3",
     "trix": "^2.1.19",
     "use-debounce": "^10.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -886,7 +886,7 @@ __metadata:
   resolution: "@homebound/beam@workspace:."
   dependencies:
     "@homebound/eslint-config": "npm:^5.0.0"
-    "@homebound/form-state": "npm:^2.28.0"
+    "@homebound/form-state": "npm:^3.1.0"
     "@homebound/rtl-react-router-utils": "npm:2.1.0"
     "@homebound/rtl-utils": "npm:^2.71.0"
     "@homebound/truss": "npm:2.29.5"
@@ -938,7 +938,7 @@ __metadata:
     react-virtuoso: "npm:^4.18.13"
     semantic-release: "npm:^25.0.9"
     storybook: "npm:^10.6.0"
-    temporal-polyfill: "npm:^0.3.2"
+    temporal-polyfill: "npm:^1.0.4"
     tributejs: "npm:^5.1.3"
     trix: "npm:^2.1.19"
     tsup: "npm:^8.5.1"
@@ -995,17 +995,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@homebound/form-state@npm:^2.28.0":
-  version: 2.28.0
-  resolution: "@homebound/form-state@npm:2.28.0"
+"@homebound/form-state@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@homebound/form-state@npm:3.1.0"
   dependencies:
     "@types/object-hash": "npm:^3.0.6"
-    is-plain-object: "npm:^5.0.0"
+    is-plain-object: "npm:^5.1.0"
     object-hash: "npm:^3.0.0"
+    temporal-polyfill: "npm:^1.0.4"
   peerDependencies:
     mobx: ">=6"
     react: ">=16"
-  checksum: 10/181fccd80f2e869fb9bb65f34d5937eba1b201234efcffba6e63d901515c9776b744429f80b62b8f87a611811179921c2850865f0d1ab1d6bb703f51128bb878
+  checksum: 10/f769899092afca956a4c2525f635257ebc61c9d38aa31b52057467306ed8c6da559f4e54e1cdbad5bd2ed60e7feab01ae15cbec759ecb28c97dee6787b78c2be
   languageName: node
   linkType: hard
 
@@ -5185,10 +5186,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-object@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "is-plain-object@npm:5.0.0"
-  checksum: 10/e32d27061eef62c0847d303125440a38660517e586f2f3db7c9d179ae5b6674ab0f469d519b2e25c147a1a3bc87156d0d5f4d8821e0ce4a9ee7fe1fcf11ce45c
+"is-plain-object@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "is-plain-object@npm:5.1.0"
+  checksum: 10/100adc3c2a7ef53968957346aecd1ee427053e1cfa5a12a0b6e49466dd86703d9f52440772f0aa296539691ac164deadfdff5c24c7cadb8635c6a00a9fcaf7ba
   languageName: node
   linkType: hard
 
@@ -8451,19 +8452,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"temporal-polyfill@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "temporal-polyfill@npm:0.3.2"
+"temporal-polyfill@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "temporal-polyfill@npm:1.0.4"
   dependencies:
-    temporal-spec: "npm:0.3.1"
-  checksum: 10/3e4ced86e08e7893286b9471f28baacc7c1d29a854372405d81c490eaa3eaed860d2e1aa25094f110ff5edc5a9d932c7957a723004ac0a4f145e8045fa387fc0
+    temporal-spec: "npm:1.0.1"
+    temporal-utils: "npm:1.0.2"
+  checksum: 10/b88fe52d67e7c9abc1c043e7e686cdb507cbe07d1a9c6e0001cc308e1034901663feeeeba655be4d17bd8ed25ab95de064e523f1954461520191445b89fad933
   languageName: node
   linkType: hard
 
-"temporal-spec@npm:0.3.1":
-  version: 0.3.1
-  resolution: "temporal-spec@npm:0.3.1"
-  checksum: 10/69509d1a4162c834b76d1394a3a97cef57df9ec912b8aa549a989be8bd75f25a72c987fcc7747d566298b73d4264be9e48a8d0a91e60edcb71c7901aabfb00e7
+"temporal-spec@npm:1.0.1":
+  version: 1.0.1
+  resolution: "temporal-spec@npm:1.0.1"
+  checksum: 10/7623ba4c36cc4f7842aafb9289ee426650dcf5860a247d8f0ea48bfe8bee09ff7ed1dadabaa3892ecd81c9721b0103a8dae9409d6c343350d1fba7269a712ba6
+  languageName: node
+  linkType: hard
+
+"temporal-utils@npm:1.0.2":
+  version: 1.0.2
+  resolution: "temporal-utils@npm:1.0.2"
+  checksum: 10/ae7402c6bc9899364bf1b5b55a680654fd1728833b84b07ef94fb3a0719925960457ff2ea05ca4a089dc0529504a2d62f4579998aa1f80b82b6a3b56253ee940
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

form-state 3 is ESM-only and, from 3.1.0, depends on temporal-polyfill 1.x,
so Beam and form-state share a single temporal-polyfill copy.

---
Part of the dependency-update stack (14 PRs, land in order).
- ⬇️ Based on #1440
- ⬆️ Next: #1442

🤖 Generated with [Claude Code](https://claude.com/claude-code)
