### PR TITLE
feat: Upgrade to React 19 and its types.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "type-check": "yarn tsc"
   },
   "dependencies": {
-    "@homebound/form-state": "^2.28.0",
+    "@homebound/form-state": "^3.1.0",
     "@internationalized/number": "^3.6.8",
     "@popperjs/core": "^2.11.8",
     "@react-aria/interactions": "^3.28.1",
@@ -77,7 +77,7 @@
     "react-router-dom": "^6.30.6",
     "react-stately": "^3.50.0",
     "react-virtuoso": "^4.18.13",
-    "temporal-polyfill": "^0.3.2",
+    "temporal-polyfill": "^1.0.4",
     "tributejs": "^5.1.3",
     "trix": "^2.1.19",
     "use-debounce": "^10.1.1",

--- a/package.json
+++ b/package.json
@@ -110,9 +110,9 @@
     "@testing-library/react": "^16.3.3",
     "@tsconfig/recommended": "^1.0.13",
     "@types/node": "^22.20.1",
-    "@types/react": "^18.3.31",
+    "@types/react": "^19.2.18",
     "@types/react-beautiful-dnd": "^13.1.8",
-    "@types/react-dom": "^18.3.7",
+    "@types/react-dom": "^19.2.7",
     "array-move": "^4.0.0",
     "chromatic": "^18.7.2",
     "conventional-changelog-conventionalcommits": "^10.4.0",
@@ -124,8 +124,8 @@
     "oxlint-tsgolint": "^7.0.2001",
     "prettier": "^3.9.6",
     "prettier-plugin-organize-imports": "^4.3.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.2.8",
+    "react-dom": "^19.2.8",
     "semantic-release": "^25.0.9",
     "storybook": "^10.6.0",
     "tsup": "^8.5.1",
@@ -136,7 +136,6 @@
     "watch": "^1.0.2"
   },
   "resolutions": {
-    "@types/react": "18.0.28",
     "react-router": "6.30.6",
     "react-router-dom": "6.30.6",
     "@vitest/expect": "^5.0.0"

--- a/src/components/AppNav/AppNavGroup.tsx
+++ b/src/components/AppNav/AppNavGroup.tsx
@@ -77,7 +77,7 @@ function AppNavGroupDisclosure(props: AppNavGroupViewProps) {
         aria-hidden={!expanded}
         css={Css.oh.transitionHeight.h(contentHeight).$}
         {...tid.panel}
-        {...(!expanded ? { inert: "true" } : {})}
+        {...(!expanded ? { inert: true } : {})}
       >
         <div ref={setContentEl} css={Css.df.fdc.$}>
           <AppNavItems items={linkGroup.items} panelCollapsed={false} nested {...tid} />

--- a/src/components/Avatar/AvatarButton.tsx
+++ b/src/components/Avatar/AvatarButton.tsx
@@ -12,7 +12,7 @@ import { useTestIds } from "src/utils/useTestIds";
 
 export type AvatarButtonProps = {
   menuTriggerProps?: AriaButtonProps;
-  buttonRef?: RefObject<HTMLButtonElement>;
+  buttonRef?: RefObject<HTMLButtonElement | null>;
   /** Storybook-only visual state overrides for snapshotting pseudo-interactions. */
   __storyState?: {
     hovered?: boolean;

--- a/src/components/BeamContext.tsx
+++ b/src/components/BeamContext.tsx
@@ -66,7 +66,7 @@ export function BeamProvider({ children, documentTitleConfig, ...presentationPro
   // dependencies as well, i.e. things like GridTable rowStyles will memoize on openInDrawer.
   // So we use refs + a tick.
   const [, tick] = useReducer((prev) => prev + 1, 0);
-  const modalRef = useRef<ModalProps | undefined>();
+  const modalRef = useRef<ModalProps | undefined>(undefined);
   const modalHeaderDiv = useMemo(() => document.createElement("div"), []);
   const modalBannerDiv = useMemo(() => document.createElement("div"), []);
   const modalBodyDiv = useMemo(() => {

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -19,7 +19,7 @@ export type ButtonProps = {
   endAdornment?: ReactNode;
   /** HTML attributes to apply to the button element when it is being used to trigger a menu. */
   menuTriggerProps?: AriaButtonProps;
-  buttonRef?: RefObject<HTMLElement>;
+  buttonRef?: RefObject<HTMLElement | null>;
   /** Allow for setting "submit" | "button" | "reset" on button element */
   type?: ButtonHTMLAttributes<HTMLButtonElement>["type"];
   /** Denotes if this button is used to download a resource. Uses the anchor tag with the `download` attribute */

--- a/src/components/Carousel.stories.tsx
+++ b/src/components/Carousel.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta } from "@storybook/react-vite";
+import type { JSX } from "react";
 import { Carousel } from "src/components/Carousel";
 import { Chip } from "src/components/Chip";
 import { Css, Tokens } from "src/Css";

--- a/src/components/DnDGrid/DnDGrid.tsx
+++ b/src/components/DnDGrid/DnDGrid.tsx
@@ -26,10 +26,10 @@ export type DnDGridProps = {
 export function DnDGrid(props: DnDGridProps) {
   const { children, gridStyles, onReorder, activeItemStyles, lockAxis } = props;
   const gridEl = useRef<HTMLDivElement>(null);
-  const dragEl = useRef<HTMLElement>();
-  const cloneEl = useRef<HTMLElement>();
-  const initialOrder = useRef<string[]>();
-  const styleSnapshot = useRef<ElementStyleSnapshot>();
+  const dragEl = useRef<HTMLElement | undefined>(undefined);
+  const cloneEl = useRef<HTMLElement | undefined>(undefined);
+  const initialOrder = useRef<string[] | undefined>(undefined);
+  const styleSnapshot = useRef<ElementStyleSnapshot | undefined>(undefined);
   const reorderViaKeyboard = useRef(false);
   const transformFrom = useRef<{ x: number; y: number }>({ x: 0, y: 0 });
   const tid = useTestIds(props, "dndGrid");

--- a/src/components/DnDGrid/useDnDGridItem.tsx
+++ b/src/components/DnDGrid/useDnDGridItem.tsx
@@ -5,7 +5,7 @@ import { useDnDGridContext } from "src/components/DnDGrid/DnDGridContext";
 
 export type useDnDGridItemProps = {
   id: React.Key;
-  itemRef: React.RefObject<HTMLElement>;
+  itemRef: React.RefObject<HTMLElement | null>;
 };
 
 /** Provides props for a GridItem to be draggable */

--- a/src/components/Filters/BooleanFilter.tsx
+++ b/src/components/Filters/BooleanFilter.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from "react";
 import { BaseFilter } from "src/components/Filters/BaseFilter";
 import type { Filter, SelectedFilterLabelValue } from "src/components/Filters/types";
 import { SelectField } from "src/inputs/SelectField";

--- a/src/components/Filters/CheckboxFilter.tsx
+++ b/src/components/Filters/CheckboxFilter.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from "react";
 import { BaseFilter } from "src/components/Filters/BaseFilter";
 import type { Filter, SelectedFilterLabelValue } from "src/components/Filters/types";
 import { Checkbox } from "src/inputs";

--- a/src/components/Filters/MultiFilter.tsx
+++ b/src/components/Filters/MultiFilter.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from "react";
 import { BaseFilter } from "src/components/Filters/BaseFilter";
 import { resolveOptionSelectedFilterLabel } from "src/components/Filters/selectedFilterLabelUtils";
 import type { Filter, SelectedFilterLabelValue } from "src/components/Filters/types";

--- a/src/components/Filters/ToggleFilter.tsx
+++ b/src/components/Filters/ToggleFilter.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from "react";
 import { BaseFilter } from "src/components/Filters/BaseFilter";
 import type { Filter, SelectedFilterLabelValue } from "src/components/Filters/types";
 import { Switch } from "src/inputs/Switch";

--- a/src/components/Filters/TreeFilter.tsx
+++ b/src/components/Filters/TreeFilter.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from "react";
 import { BaseFilter } from "src/components/Filters/BaseFilter";
 import { resolveTreeSelectedFilterLabel } from "src/components/Filters/selectedFilterLabelUtils";
 import type { Filter, SelectedFilterLabelValue } from "src/components/Filters/types";

--- a/src/components/Filters/types.ts
+++ b/src/components/Filters/types.ts
@@ -1,3 +1,4 @@
+import type { JSX } from "react";
 import type { TestIds } from "src/utils/useTestIds";
 
 /**

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -21,7 +21,7 @@ export type IconButtonProps = {
   inc?: number;
   /** HTML attributes to apply to the button element when it is being used to trigger a menu. */
   menuTriggerProps?: AriaButtonProps;
-  buttonRef?: RefObject<HTMLButtonElement>;
+  buttonRef?: RefObject<HTMLButtonElement | null>;
   /** Whether to show a 16x16px version of the IconButton */
   compact?: boolean;
   /** Visual variant of the button. Defaults to "default". */

--- a/src/components/Layout/FormPageLayout.tsx
+++ b/src/components/Layout/FormPageLayout.tsx
@@ -149,7 +149,7 @@ function PageHeader<F>(props: FormPageLayoutProps<F>) {
 }
 
 type SectionWithRefs<F> = {
-  ref: RefObject<HTMLElement>;
+  ref: RefObject<HTMLElement | null>;
   section: FormSection<F>;
   sectionKey: string;
 };

--- a/src/components/Layout/FullBleed.tsx
+++ b/src/components/Layout/FullBleed.tsx
@@ -6,7 +6,11 @@ import { Css } from "src/Css";
 /** Provides a way to extend the full width of the ScrollableParent */
 export function FullBleed({ children, omitPadding = false }: { children: ReactElement; omitPadding?: boolean }) {
   const { paddingRight, paddingLeft } = useScrollableParent();
-  const { className, style, ...others } = children.props;
+  const { className, style, ...others } = children.props as {
+    className?: string;
+    style?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
 
   return paddingRight === "0px" && paddingLeft === "0px"
     ? children

--- a/src/components/Layout/GridTableLayout/GridTableLayout.tsx
+++ b/src/components/Layout/GridTableLayout/GridTableLayout.tsx
@@ -167,7 +167,7 @@ function GridTableLayoutComponent<
 
   // Imperative handle into GridTableLayoutActions' search box, so `clearFilters` can reset the search
   // input directly even when triggered from outside GridTableLayoutActions (e.g. the empty state below).
-  const searchApiRef = useRef<SearchBoxApi>();
+  const searchApiRef = useRef<SearchBoxApi | undefined>(undefined);
   const clearFilters = useCallback(() => {
     layoutState?.clearFilters();
     searchApiRef.current?.clear();

--- a/src/components/Layout/ScrollableContent.tsx
+++ b/src/components/Layout/ScrollableContent.tsx
@@ -1,4 +1,4 @@
-import { createContext, type ReactNode, type ReactPortal, useContext, useEffect } from "react";
+import { createContext, useContext, useEffect, type JSX, type ReactNode, type ReactPortal } from "react";
 import { createPortal } from "react-dom";
 import { useScrollableParent } from "src/components/Layout/ScrollableParent";
 import { Css, type Palette } from "src/Css";

--- a/src/components/Layout/ScrollableFooter.tsx
+++ b/src/components/Layout/ScrollableFooter.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, ReactPortal } from "react";
+import type { JSX, ReactNode, ReactPortal } from "react";
 import { createPortal } from "react-dom";
 import { useScrollableParent } from "src/components/Layout/ScrollableParent";
 

--- a/src/components/Layout/ScrollableParent.tsx
+++ b/src/components/Layout/ScrollableParent.tsx
@@ -1,13 +1,14 @@
 import {
   createContext,
-  type Dispatch,
-  type PropsWithChildren,
-  type SetStateAction,
   useContext,
   useEffect,
   useMemo,
   useRef,
   useState,
+  type Dispatch,
+  type JSX,
+  type PropsWithChildren,
+  type SetStateAction,
 } from "react";
 import { Css, maybeInc, type Properties } from "src/Css";
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,5 +1,6 @@
 import { useResizeObserver } from "@react-aria/utils";
 import {
+  type JSX,
   type MutableRefObject,
   type PropsWithChildren,
   type ReactNode,

--- a/src/components/Modal/OpenModal.tsx
+++ b/src/components/Modal/OpenModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, type JSX } from "react";
 import { Modal, type ModalProps } from "src/components/Modal/Modal";
 import { useModal } from "src/components/Modal/useModal";
 

--- a/src/components/Modal/useModal.tsx
+++ b/src/components/Modal/useModal.tsx
@@ -16,8 +16,8 @@ export interface UseModalHook {
 export function useModal(): UseModalHook {
   const { modalState, modalCanCloseChecks } = useBeamContext();
   const { inModal } = useModalContext();
-  const lastCanClose = useRef<CheckFn | undefined>();
-  const api = useRef<ModalApi>();
+  const lastCanClose = useRef<CheckFn | undefined>(undefined);
+  const api = useRef<ModalApi | undefined>(undefined);
   useEffect(() => {
     return () => {
       modalCanCloseChecks.current = modalCanCloseChecks.current.filter((c) => c !== lastCanClose.current);

--- a/src/components/NavLinks/NavLink.tsx
+++ b/src/components/NavLinks/NavLink.tsx
@@ -23,7 +23,7 @@ export type NavLinkProps = {
   openInNew?: boolean;
   /** HTML attributes to apply to the button element when it is being used to trigger a menu. */
   menuTriggerProps?: AriaButtonProps;
-  buttonRef?: RefObject<HTMLElement>;
+  buttonRef?: RefObject<HTMLElement | null>;
   /**
    * When true with an `icon`, shows icon only but keeps `label` for accessibility
    * (visually hidden text). Used by SideNav when the rail is collapsed.

--- a/src/components/SuperDrawer/SuperDrawer.stories.tsx
+++ b/src/components/SuperDrawer/SuperDrawer.stories.tsx
@@ -252,7 +252,7 @@ const Books: Book[] = [
 
 export function TableWithPrevNextAndCloseCheck() {
   const { openInDrawer, addCanCloseDrawerCheck } = useSuperDrawer();
-  const rowLookup = useRef<GridRowLookup<Row>>();
+  const rowLookup = useRef<GridRowLookup<Row> | undefined>(undefined);
   // Always prompts a confirmation message
   addCanCloseDrawerCheck(() => false);
   // Creates a setContent with prev/next handles to move up or down the table
@@ -298,7 +298,7 @@ export function TableWithPrevNextAndCloseCheck() {
  */
 export function TableWithPrevNext() {
   const { openInDrawer } = useSuperDrawer();
-  const rowLookup = useRef<GridRowLookup<Row>>();
+  const rowLookup = useRef<GridRowLookup<Row> | undefined>(undefined);
 
   // Creates a setContent with prev/next handles to move up or down the table
   function openRow(row: GridDataRow<Row>) {

--- a/src/components/SuperDrawer/components/SuperDrawerHeader.tsx
+++ b/src/components/SuperDrawer/components/SuperDrawerHeader.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { JSX, ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useBeamContext } from "src/components/BeamContext";
 import { ButtonGroup } from "src/components/ButtonGroup";

--- a/src/components/Table/GridTable.stories.tsx
+++ b/src/components/Table/GridTable.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta } from "@storybook/react-vite";
 import { observable } from "mobx";
-import { Fragment, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, type JSX, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   actionColumn,
   Button,
@@ -192,7 +192,7 @@ export function VirtualFiltering() {
     ],
     [],
   );
-  const rowLookup = useRef<GridRowLookup<Row> | undefined>();
+  const rowLookup = useRef<GridRowLookup<Row> | undefined>(undefined);
   const [filter, setFilter] = useState<string | undefined>();
   return (
     <div css={Css.df.fdc.vh100.$}>

--- a/src/components/Table/components/Row.tsx
+++ b/src/components/Table/components/Row.tsx
@@ -471,12 +471,12 @@ function RowImpl<R extends Kinded, S>(props: RowProps<R>): ReactElement {
             const cellElementWithHandle = React.cloneElement(
               cellElement as React.ReactElement,
               mergeProps(
-                (cellElement as React.ReactElement).props,
+                (cellElement as React.ReactElement<{ children?: React.ReactNode }>).props,
                 Css.props({ ...(!maybeSticky && Css.relative.$) }),
                 {
                   children: (
                     <>
-                      {(cellElement as React.ReactElement).props.children}
+                      {(cellElement as React.ReactElement<{ children?: React.ReactNode }>).props.children}
                       <ColumnResizeHandle
                         columnId={column.id}
                         columnIndex={columnIndex}

--- a/src/components/Table/components/TableCard.stories.tsx
+++ b/src/components/Table/components/TableCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from "@storybook/react-vite";
-import { type ReactNode, useState } from "react";
+import { useState, type JSX, type ReactNode } from "react";
 import { useLocation } from "react-router-dom";
 import { ProposedValue } from "src/components/ProposedValue";
 import { TableCardView } from "src/components/Table/components/TableCard";

--- a/src/components/Table/utils/utils.tsx
+++ b/src/components/Table/utils/utils.tsx
@@ -145,7 +145,7 @@ function isContentEmpty(content: ReactNode): boolean {
 }
 
 export type DragData<R extends Kinded> = {
-  rowRenderRef: React.RefObject<HTMLTableRowElement>;
+  rowRenderRef: React.RefObject<HTMLTableRowElement | null>;
   onDragStart?: (row: GridDataRow<R>, event: React.DragEvent<HTMLElement>) => void;
   onDragEnd?: (row: GridDataRow<R>, event: React.DragEvent<HTMLElement>) => void;
   onDrop?: (row: GridDataRow<R>, event: React.DragEvent<HTMLElement>) => void;

--- a/src/components/internal/CompoundField.tsx
+++ b/src/components/internal/CompoundField.tsx
@@ -1,4 +1,4 @@
-import { type FocusEvent, cloneElement, useState } from "react";
+import { cloneElement, useState, type FocusEvent, type JSX } from "react";
 import { Css, Tokens } from "src/Css";
 import type { TextFieldInternalProps } from "src/interfaces";
 

--- a/src/components/internal/DatePicker/Day.tsx
+++ b/src/components/internal/DatePicker/Day.tsx
@@ -1,5 +1,5 @@
-import { useRef } from "react";
-import { type DayProps, useDayRender } from "react-day-picker";
+import { useRef, type RefObject } from "react";
+import { useDayRender, type DayProps } from "react-day-picker";
 import { Css, Tokens } from "src/Css";
 import { useTestIds } from "src/utils";
 import "./day.css";
@@ -12,7 +12,7 @@ export function Day(props: DayProps) {
   const { isHidden, isButton, activeModifiers, buttonProps, divProps } = useDayRender(
     props.date,
     props.displayMonth,
-    buttonRef,
+    buttonRef as RefObject<HTMLButtonElement>,
   );
 
   if (isHidden) {

--- a/src/components/internal/MenuItem.tsx
+++ b/src/components/internal/MenuItem.tsx
@@ -1,5 +1,5 @@
 import type { Node } from "@react-types/shared";
-import { type KeyboardEvent, type MouseEvent, useRef } from "react";
+import { useRef, type JSX, type KeyboardEvent, type MouseEvent } from "react";
 import { useHover, useMenuItem } from "react-aria";
 import { Link, useNavigate } from "react-router-dom";
 import type { TreeState } from "react-stately";

--- a/src/forms/BoundChipSelectField.tsx
+++ b/src/forms/BoundChipSelectField.tsx
@@ -1,5 +1,6 @@
 import type { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
+import type { JSX } from "react";
 import type { Value } from "src/inputs";
 import { ChipSelectField, type ChipSelectFieldProps } from "src/inputs/ChipSelectField";
 import type { HasIdAndName, Optional } from "src/types";

--- a/src/forms/BoundMultiLineSelectField.tsx
+++ b/src/forms/BoundMultiLineSelectField.tsx
@@ -1,5 +1,6 @@
 import type { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
+import type { JSX } from "react";
 import { MultiLineSelectField, type MultiLineSelectFieldProps, type Value } from "src/inputs";
 import type { HasIdAndName, Optional } from "src/types";
 import { maybeCall } from "src/utils";

--- a/src/forms/BoundMultiSelectField.tsx
+++ b/src/forms/BoundMultiSelectField.tsx
@@ -1,5 +1,6 @@
 import type { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
+import type { JSX } from "react";
 import { MultiSelectField, type MultiSelectFieldProps, type Value } from "src/inputs";
 import type { HasIdAndName, Optional } from "src/types";
 import { maybeCall } from "src/utils";

--- a/src/forms/BoundSelectAndTextField.tsx
+++ b/src/forms/BoundSelectAndTextField.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from "react";
 import { CompoundField } from "src/components/internal/CompoundField";
 import type { Only } from "src/Css";
 import {

--- a/src/forms/BoundSelectField.tsx
+++ b/src/forms/BoundSelectField.tsx
@@ -1,5 +1,6 @@
 import type { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
+import type { JSX } from "react";
 import { SelectField, type SelectFieldProps, type Value } from "src/inputs";
 import type { HasIdIsh, HasNameIsh, Optional } from "src/types";
 import { maybeCall } from "src/utils";

--- a/src/forms/BoundTreeSelectField.tsx
+++ b/src/forms/BoundTreeSelectField.tsx
@@ -1,5 +1,6 @@
 import type { FieldState } from "@homebound/form-state";
 import { Observer } from "mobx-react";
+import type { JSX } from "react";
 import { TreeSelectField, type TreeSelectFieldProps, type Value } from "src/inputs";
 import type { TreeSelectResponse } from "src/inputs/TreeSelectField/utils";
 import type { HasIdAndName, Optional } from "src/types";

--- a/src/forms/FormLines.tsx
+++ b/src/forms/FormLines.tsx
@@ -1,4 +1,4 @@
-import { Children, cloneElement, type ReactNode } from "react";
+import { Children, cloneElement, type JSX, type ReactElement, type ReactNode } from "react";
 import { useModal } from "src/components";
 import { type PresentationFieldProps, PresentationProvider } from "src/components/PresentationContext";
 import { Css, Tokens } from "src/Css";
@@ -55,7 +55,7 @@ export function FormLines(props: FormLinesProps) {
       <div css={Css.df.fdc.gap(gap).pb(gap).w(sizes[width]).$}>
         {Children.map(children, (child) => {
           if (child && typeof child === "object" && "type" in child && (child.type as any).isFormHeading) {
-            const clone = cloneElement(child, { isFirst: firstFormHeading });
+            const clone = cloneElement(child as ReactElement<{ isFirst?: boolean }>, { isFirst: firstFormHeading });
             firstFormHeading = false;
             return clone;
           }

--- a/src/hooks/useGetRef.ts
+++ b/src/hooks/useGetRef.ts
@@ -4,7 +4,9 @@ import { type MutableRefObject, type RefObject, useRef } from "react";
  * Replaces code like `const ref = passedRef || useRef(null)` which was triggering rules-of-hooks violations. Used
  * to sometimes accept a caller's ref, or if they did not pass one, use an internal one anyway.
  */
-export const useGetRef = <T extends HTMLElement>(maybeRef: RefObject<T> | undefined): MutableRefObject<T | null> => {
-  const newRef = useRef(null);
+export const useGetRef = <T extends HTMLElement>(
+  maybeRef: RefObject<T | null> | undefined,
+): MutableRefObject<T | null> => {
+  const newRef = useRef<T | null>(null);
   return maybeRef || newRef;
 };

--- a/src/inputs/ChipSelectField.tsx
+++ b/src/inputs/ChipSelectField.tsx
@@ -1,5 +1,5 @@
 import { camelCase } from "change-case";
-import { type Key, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { type JSX, type Key, type ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { mergeProps, useButton, useFocus, useOverlayPosition, useSelect } from "react-aria";
 import { Item, Section, useListData, useSelectState } from "react-stately";
 import {

--- a/src/inputs/ChipTextField.tsx
+++ b/src/inputs/ChipTextField.tsx
@@ -1,4 +1,4 @@
-import { type KeyboardEvent, useEffect, useRef, useState } from "react";
+import { type FormEvent, type KeyboardEvent, useEffect, useRef, useState } from "react";
 import { useFocus } from "react-aria";
 import { chipBaseStyles } from "src/components";
 import { usePresentationContext } from "src/components/PresentationContext";
@@ -79,7 +79,7 @@ export function ChipTextField(props: ChipTextFieldProps) {
           (e.target as HTMLElement).blur();
         }
       }}
-      onInput={(e: KeyboardEvent<HTMLElement>) => {
+      onInput={(e: FormEvent<HTMLSpanElement>) => {
         const target = e.target as HTMLElement;
         if ("inputType" in e.nativeEvent && e.nativeEvent.inputType === "insertFromPaste") {
           // Clean up any formatting from pasted text

--- a/src/inputs/MultiLineSelectField.test.tsx
+++ b/src/inputs/MultiLineSelectField.test.tsx
@@ -1,5 +1,5 @@
 import { click, render } from "@homebound/rtl-utils";
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import { MultiLineSelectField, type MultiLineSelectFieldProps } from "src/inputs";
 import type { HasIdAndName, Optional } from "src/types";
 import { vi } from "vitest";

--- a/src/inputs/MultiLineSelectField.tsx
+++ b/src/inputs/MultiLineSelectField.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import { Button } from "src/components/Button";
 import { Label } from "src/components/Label";
 import { SelectField, type Value } from "src/inputs";

--- a/src/inputs/MultiSelectField.filterHeight.test.tsx
+++ b/src/inputs/MultiSelectField.filterHeight.test.tsx
@@ -1,6 +1,6 @@
 import { click, render } from "@homebound/rtl-utils";
 import { fireEvent } from "@testing-library/react";
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import { MultiSelectField } from "src/inputs";
 import type { HasIdAndName } from "src/types";
 import { describe, expect, it, vi } from "vitest";

--- a/src/inputs/MultiSelectField.stories.tsx
+++ b/src/inputs/MultiSelectField.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from "@storybook/react-vite";
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import type { IconKey } from "src/components";
 import { Icon } from "src/components";
 import { Css } from "src/Css";

--- a/src/inputs/MultiSelectField.test.tsx
+++ b/src/inputs/MultiSelectField.test.tsx
@@ -1,6 +1,6 @@
 import { click, render, type RenderResult } from "@homebound/rtl-utils";
 import { act, fireEvent } from "@testing-library/react";
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import { MultiSelectField, type MultiSelectFieldProps } from "src/inputs";
 import type { HasIdAndName, Optional } from "src/types";
 import { focus } from "src/utils/rtl";

--- a/src/inputs/MultiSelectField.tsx
+++ b/src/inputs/MultiSelectField.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { JSX, ReactNode } from "react";
 import type { Value } from "src/inputs";
 import { ComboBoxBase, type ComboBoxBaseProps } from "src/inputs/internal/ComboBoxBase";
 import type { HasIdAndName, Optional } from "src/types";

--- a/src/inputs/RichTextField.tsx
+++ b/src/inputs/RichTextField.tsx
@@ -57,7 +57,7 @@ export function RichTextFieldImpl(props: RichTextFieldProps) {
 
   // We get a reference to the Editor instance after trix-init fires
   const [editor, setEditor] = useState<Editor>();
-  const editorElement = useRef<HTMLElement>();
+  const editorElement = useRef<HTMLElement | undefined>(undefined);
 
   // Keep track of what we pass to onChange, so that we can make ourselves keep looking
   // like a controlled input, i.e. by only calling loadHTML if a new incoming `value` !== `currentHtml`,

--- a/src/inputs/SelectField.stories.tsx
+++ b/src/inputs/SelectField.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from "@storybook/react-vite";
-import { useState } from "react";
+import { type JSX, useState } from "react";
 import {
   ContrastScope,
   type GridColumn,

--- a/src/inputs/SelectField.test.tsx
+++ b/src/inputs/SelectField.test.tsx
@@ -1,6 +1,6 @@
 import { clickAndWait, typeAndWait } from "@homebound/rtl-utils";
 import { fireEvent } from "@testing-library/react";
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import { AuthorHeight } from "src/forms/formStateDomain";
 import { SelectField, type SelectFieldProps, type Value } from "src/inputs";
 import type { HasIdAndName, Optional } from "src/types";

--- a/src/inputs/SelectField.tsx
+++ b/src/inputs/SelectField.tsx
@@ -1,6 +1,6 @@
-import { useMemo } from "react";
+import { useMemo, type JSX } from "react";
 import type { Value } from "src/inputs";
-import { ComboBoxBase, type ComboBoxBaseProps, unsetOption } from "src/inputs/internal/ComboBoxBase";
+import { ComboBoxBase, unsetOption, type ComboBoxBaseProps } from "src/inputs/internal/ComboBoxBase";
 import type { HasIdIsh, HasNameIsh, Optional } from "src/types";
 import { defaultOptionLabel, defaultOptionValue } from "src/utils/options";
 

--- a/src/inputs/TextField.test.tsx
+++ b/src/inputs/TextField.test.tsx
@@ -158,7 +158,7 @@ describe("AI mode", () => {
 function TestTextField<X extends Only<TextFieldXss, X>>(props: Omit<TextFieldProps<X>, "onChange" | "label">) {
   const { value, ...otherProps } = props;
   const [internalValue, setValue] = useState(value);
-  const textFieldApi = useRef<TextFieldApi | undefined>();
+  const textFieldApi = useRef<TextFieldApi | undefined>(undefined);
   return (
     <>
       <TextField

--- a/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from "@storybook/react-vite";
-import { useState } from "react";
+import { useState, type JSX } from "react";
 import { Button, ContrastScope } from "src/components";
 import { Css } from "src/Css";
 import type { Value } from "src/inputs/index";

--- a/src/inputs/TreeSelectField/TreeSelectField.tsx
+++ b/src/inputs/TreeSelectField/TreeSelectField.tsx
@@ -1,6 +1,7 @@
 import type { Key as AriaKey } from "@react-types/shared";
 import React, {
   type Dispatch,
+  type JSX,
   type ReactNode,
   type SetStateAction,
   useCallback,

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -1,5 +1,5 @@
 import type { Key as AriaKey } from "@react-types/shared";
-import React, { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { type JSX, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useButton, useComboBox, useFilter, useOverlayPosition } from "react-aria";
 import { Item, useComboBoxState } from "react-stately";
 import { resolveTooltip } from "src/components";

--- a/src/inputs/internal/ListBox.tsx
+++ b/src/inputs/internal/ListBox.tsx
@@ -1,5 +1,5 @@
 import type { Key as AriaKey } from "@react-types/shared";
-import React, { type MutableRefObject, useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, type JSX, type MutableRefObject } from "react";
 import { useListBox } from "react-aria";
 import type { ListState } from "react-stately";
 import { Css, Tokens } from "src/Css";

--- a/src/inputs/internal/VirtualizedOptions.tsx
+++ b/src/inputs/internal/VirtualizedOptions.tsx
@@ -1,6 +1,6 @@
 import { getInteractionModality } from "@react-aria/interactions";
 import type { Node } from "@react-types/shared";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type JSX } from "react";
 import type { ListState } from "react-stately";
 import { Virtuoso, type VirtuosoHandle } from "react-virtuoso";
 import { LoadingDots } from "src/inputs/internal/LoadingDots";

--- a/src/layouts/DocumentScrollLayoutContext.tsx
+++ b/src/layouts/DocumentScrollLayoutContext.tsx
@@ -1,13 +1,14 @@
 import { useResizeObserver } from "@react-aria/utils";
 import {
   createContext,
-  type CSSProperties,
-  type ReactNode,
   useCallback,
   useContext,
   useLayoutEffect,
   useRef,
   useState,
+  type CSSProperties,
+  type JSX,
+  type ReactNode,
 } from "react";
 import type { BeamColor } from "src/colors";
 import { Css, Tokens } from "src/Css";

--- a/src/layouts/DocumentScrollToTopButton.tsx
+++ b/src/layouts/DocumentScrollToTopButton.tsx
@@ -35,7 +35,7 @@ export function DocumentScrollToTopButton({ viewportHeight }: DocumentScrollToTo
     <div
       {...tid.wrapper}
       aria-hidden={!visible}
-      {...(!visible ? { inert: "" } : {})}
+      {...(!visible ? { inert: true } : {})}
       css={{
         ...Css.fixed
           .bottom(getFloatingBottomOffset(scrollToTopOffsetPx))

--- a/src/utils/getInteractiveElement.tsx
+++ b/src/utils/getInteractiveElement.tsx
@@ -1,5 +1,5 @@
 import type { PressEvent } from "@react-types/shared";
-import type { HTMLAttributes, ReactNode } from "react";
+import type { HTMLAttributes, JSX, ReactNode } from "react";
 import { Link } from "react-router-dom";
 import type { Properties } from "src/Css";
 import { isAbsoluteUrl } from "src/utils/index";

--- a/src/utils/sb.tsx
+++ b/src/utils/sb.tsx
@@ -1,5 +1,5 @@
 import type { Decorator, StoryObj } from "@storybook/react-vite";
-import type { ReactNode } from "react";
+import type { JSX, ReactNode } from "react";
 import { BeamProvider } from "src/components";
 import { Css, type Properties } from "src/Css";
 import { documentScrollBodyMinHeight } from "src/layouts/layoutVars";

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,9 +906,9 @@ __metadata:
     "@testing-library/react": "npm:^16.3.3"
     "@tsconfig/recommended": "npm:^1.0.13"
     "@types/node": "npm:^22.20.1"
-    "@types/react": "npm:^18.3.31"
+    "@types/react": "npm:^19.2.18"
     "@types/react-beautiful-dnd": "npm:^13.1.8"
-    "@types/react-dom": "npm:^18.3.7"
+    "@types/react-dom": "npm:^19.2.7"
     array-move: "npm:^4.0.0"
     change-case: "npm:^5.4.4"
     chromatic: "npm:^18.7.2"
@@ -927,10 +927,10 @@ __metadata:
     oxlint-tsgolint: "npm:^7.0.2001"
     prettier: "npm:^3.9.6"
     prettier-plugin-organize-imports: "npm:^4.3.0"
-    react: "npm:^18.3.1"
+    react: "npm:^19.2.8"
     react-aria: "npm:^3.52.1"
     react-day-picker: "npm:8.10.2"
-    react-dom: "npm:^18.3.1"
+    react-dom: "npm:^19.2.8"
     react-popper: "npm:^2.3.0"
     react-router: "npm:^6.30.6"
     react-router-dom: "npm:^6.30.6"
@@ -3067,13 +3067,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:*":
-  version: 15.7.15
-  resolution: "@types/prop-types@npm:15.7.15"
-  checksum: 10/31aa2f59b28f24da6fb4f1d70807dae2aedfce090ec63eaf9ea01727a9533ef6eaf017de5bff99fbccad7d1c9e644f52c6c2ba30869465dd22b1a7221c29f356
-  languageName: node
-  linkType: hard
-
 "@types/react-beautiful-dnd@npm:^13.1.8":
   version: 13.1.8
   resolution: "@types/react-beautiful-dnd@npm:13.1.8"
@@ -3083,23 +3076,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:^18.3.7":
-  version: 18.3.7
-  resolution: "@types/react-dom@npm:18.3.7"
+"@types/react-dom@npm:^19.2.7":
+  version: 19.2.7
+  resolution: "@types/react-dom@npm:19.2.7"
   peerDependencies:
-    "@types/react": ^18.0.0
-  checksum: 10/317569219366d487a3103ba1e5e47154e95a002915fdcf73a44162c48fe49c3a57fcf7f57fc6979e70d447112681e6b13c6c3c1df289db8b544df4aab2d318f3
+    "@types/react": ^19.2.0
+  checksum: 10/84079ed3b5470b7fafe4478c9180c2b0f19f8c5aebe666091e1ee5bc15464acb248909553769bd338de5f508afe96fec353997aed0457bb0d3a1e6246bcafcb8
   languageName: node
   linkType: hard
 
-"@types/react@npm:18.0.28":
-  version: 18.0.28
-  resolution: "@types/react@npm:18.0.28"
+"@types/react@npm:*, @types/react@npm:^19.2.18":
+  version: 19.2.18
+  resolution: "@types/react@npm:19.2.18"
   dependencies:
-    "@types/prop-types": "npm:*"
-    "@types/scheduler": "npm:*"
-    csstype: "npm:^3.0.2"
-  checksum: 10/7a752e6c5e76139f258bc14827d2c574bb76d6e7eb1b240f24f79b269153cb88668c34ba7078d3de99ec1973b7022e1f788e71117bd52a287f382d24bb80be40
+    csstype: "npm:^3.2.2"
+  checksum: 10/c718ec5c5272ef5c1c77fcdd07f567c77197b593583539459b4bdaea89ca55ad7c814b7eb2151dccfa459b2c384b599a45e7e35550b789883d66b363d30c94d8
   languageName: node
   linkType: hard
 
@@ -3107,13 +3098,6 @@ __metadata:
   version: 1.20.6
   resolution: "@types/resolve@npm:1.20.6"
   checksum: 10/dc35f5517606b6687cd971c0281ac58bdee2c50c051b030f04647d3991688be2259c304ee97e5b5d4b9936072c36767eb5933b54611a407d6557972bb6fea4f6
-  languageName: node
-  linkType: hard
-
-"@types/scheduler@npm:*":
-  version: 0.26.0
-  resolution: "@types/scheduler@npm:0.26.0"
-  checksum: 10/295ede5e7f991c7c52f9ed8e58d3076526be9a560e59ae11bf1c1414f9755a17bd750f3bfed4657b118283d1eb082bb27dcbe2eadf335a982b0c3b6a562771c2
   languageName: node
   linkType: hard
 
@@ -3992,7 +3976,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"csstype@npm:^3.0.2, csstype@npm:^3.2.3":
+"csstype@npm:^3.0.2, csstype@npm:^3.2.2, csstype@npm:^3.2.3":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
   checksum: 10/ad41baf7e2ffac65ab544d79107bf7cd1a4bb9bab9ac3302f59ab4ba655d5e30942a8ae46e10ba160c6f4ecea464cc95b975ca2fefbdeeacd6ac63f12f99fe1f
@@ -5770,7 +5754,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.0.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -7398,15 +7382,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react-dom@npm:18.3.1"
+"react-dom@npm:^19.2.8":
+  version: 19.2.8
+  resolution: "react-dom@npm:19.2.8"
   dependencies:
-    loose-envify: "npm:^1.1.0"
-    scheduler: "npm:^0.23.2"
+    scheduler: "npm:^0.27.0"
   peerDependencies:
-    react: ^18.3.1
-  checksum: 10/3f4b73a3aa083091173b29812b10394dd06f4ac06aff410b74702cfb3aa29d7b0ced208aab92d5272919b612e5cda21aeb1d54191848cf6e46e9e354f3541f81
+    react: ^19.2.8
+  checksum: 10/fb45d500a8615a36d71a821213a3d4bfe32a70aa1d04ce17d8791dd10c4ef0281e7fdd46694e1112f0f2dcf58df89d12043a13228be9788458aa82f4885a9cdc
   languageName: node
   linkType: hard
 
@@ -7526,12 +7509,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react@npm:18.3.1"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10/261137d3f3993eaa2368a83110466fc0e558bc2c7f7ae7ca52d94f03aac945f45146bd85e5f481044db1758a1dbb57879e2fcdd33924e2dde1bdc550ce73f7bf
+"react@npm:^19.2.8":
+  version: 19.2.8
+  resolution: "react@npm:19.2.8"
+  checksum: 10/a3c697798035e295ca9e51591d3a8700824535cb8c070fac1f8abbe69717ceb99108cbc4ba7b31a606806f336b1eba705705f63b9d39ace198fe51e8990ac843
   languageName: node
   linkType: hard
 
@@ -7899,12 +7880,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.23.2":
-  version: 0.23.2
-  resolution: "scheduler@npm:0.23.2"
-  dependencies:
-    loose-envify: "npm:^1.1.0"
-  checksum: 10/e8d68b89d18d5b028223edf090092846868a765a591944760942b77ea1f69b17235f7e956696efbb62c8130ab90af7e0949bfb8eba7896335507317236966bc9
+"scheduler@npm:^0.27.0":
+  version: 0.27.0
+  resolution: "scheduler@npm:0.27.0"
+  checksum: 10/eab3c3a8373195173e59c147224fc30dabe6dd453f248f5e610e8458512a5a2ee3a06465dc400ebfe6d35c9f5b7f3bb6b2e41c88c86fd177c25a73e7286a1e06
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -886,7 +886,7 @@ __metadata:
   resolution: "@homebound/beam@workspace:."
   dependencies:
     "@homebound/eslint-config": "npm:^5.0.0"
-    "@homebound/form-state": "npm:^2.28.0"
+    "@homebound/form-state": "npm:^3.1.0"
     "@homebound/rtl-react-router-utils": "npm:2.1.0"
     "@homebound/rtl-utils": "npm:^2.71.0"
     "@homebound/truss": "npm:2.29.5"
@@ -938,7 +938,7 @@ __metadata:
     react-virtuoso: "npm:^4.18.13"
     semantic-release: "npm:^25.0.9"
     storybook: "npm:^10.6.0"
-    temporal-polyfill: "npm:^0.3.2"
+    temporal-polyfill: "npm:^1.0.4"
     tributejs: "npm:^5.1.3"
     trix: "npm:^2.1.19"
     tsup: "npm:^8.5.1"
@@ -995,17 +995,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@homebound/form-state@npm:^2.28.0":
-  version: 2.28.0
-  resolution: "@homebound/form-state@npm:2.28.0"
+"@homebound/form-state@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@homebound/form-state@npm:3.1.0"
   dependencies:
     "@types/object-hash": "npm:^3.0.6"
-    is-plain-object: "npm:^5.0.0"
+    is-plain-object: "npm:^5.1.0"
     object-hash: "npm:^3.0.0"
+    temporal-polyfill: "npm:^1.0.4"
   peerDependencies:
     mobx: ">=6"
     react: ">=16"
-  checksum: 10/181fccd80f2e869fb9bb65f34d5937eba1b201234efcffba6e63d901515c9776b744429f80b62b8f87a611811179921c2850865f0d1ab1d6bb703f51128bb878
+  checksum: 10/f769899092afca956a4c2525f635257ebc61c9d38aa31b52057467306ed8c6da559f4e54e1cdbad5bd2ed60e7feab01ae15cbec759ecb28c97dee6787b78c2be
   languageName: node
   linkType: hard
 
@@ -5185,10 +5186,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-object@npm:^5.0.0":
-  version: 5.0.0
-  resolution: "is-plain-object@npm:5.0.0"
-  checksum: 10/e32d27061eef62c0847d303125440a38660517e586f2f3db7c9d179ae5b6674ab0f469d519b2e25c147a1a3bc87156d0d5f4d8821e0ce4a9ee7fe1fcf11ce45c
+"is-plain-object@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "is-plain-object@npm:5.1.0"
+  checksum: 10/100adc3c2a7ef53968957346aecd1ee427053e1cfa5a12a0b6e49466dd86703d9f52440772f0aa296539691ac164deadfdff5c24c7cadb8635c6a00a9fcaf7ba
   languageName: node
   linkType: hard
 
@@ -8451,19 +8452,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"temporal-polyfill@npm:^0.3.2":
-  version: 0.3.2
-  resolution: "temporal-polyfill@npm:0.3.2"
+"temporal-polyfill@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "temporal-polyfill@npm:1.0.4"
   dependencies:
-    temporal-spec: "npm:0.3.1"
-  checksum: 10/3e4ced86e08e7893286b9471f28baacc7c1d29a854372405d81c490eaa3eaed860d2e1aa25094f110ff5edc5a9d932c7957a723004ac0a4f145e8045fa387fc0
+    temporal-spec: "npm:1.0.1"
+    temporal-utils: "npm:1.0.2"
+  checksum: 10/b88fe52d67e7c9abc1c043e7e686cdb507cbe07d1a9c6e0001cc308e1034901663feeeeba655be4d17bd8ed25ab95de064e523f1954461520191445b89fad933
   languageName: node
   linkType: hard
 
-"temporal-spec@npm:0.3.1":
-  version: 0.3.1
-  resolution: "temporal-spec@npm:0.3.1"
-  checksum: 10/69509d1a4162c834b76d1394a3a97cef57df9ec912b8aa549a989be8bd75f25a72c987fcc7747d566298b73d4264be9e48a8d0a91e60edcb71c7901aabfb00e7
+"temporal-spec@npm:1.0.1":
+  version: 1.0.1
+  resolution: "temporal-spec@npm:1.0.1"
+  checksum: 10/7623ba4c36cc4f7842aafb9289ee426650dcf5860a247d8f0ea48bfe8bee09ff7ed1dadabaa3892ecd81c9721b0103a8dae9409d6c343350d1fba7269a712ba6
+  languageName: node
+  linkType: hard
+
+"temporal-utils@npm:1.0.2":
+  version: 1.0.2
+  resolution: "temporal-utils@npm:1.0.2"
+  checksum: 10/ae7402c6bc9899364bf1b5b55a680654fd1728833b84b07ef94fb3a0719925960457ff2ea05ca4a089dc0529504a2d62f4579998aa1f80b82b6a3b56253ee940
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

React 19 is a dev dependency and type source only; the peer range stays
`react >=16` and no React 19-only runtime API is used. The @types/react
18.0.28 resolution pin is dropped, and the code adapts to the React 19 types:

- The global `JSX` namespace is gone, so files import `type JSX` from react.
- `useRef()` needs an initial value, so `useRef<T>()` becomes
  `useRef<T | undefined>(undefined)`.
- `useRef(null)` now yields `RefObject<T | null>`, so the `buttonRef`,
  `itemRef`, `rowRenderRef`, and `SectionWithRefs.ref` types accept null, and
  `useGetRef` does the same.
- `ReactElement.props` is `unknown`, so FullBleed, FormLines, and Row cast the
  child element to the props they read.
- `inert` is a boolean attribute rather than a string.

---
Part of the dependency-update stack (14 PRs, land in order).
- ⬇️ Based on #1441
- ⬆️ Next: #1443

🤖 Generated with [Claude Code](https://claude.com/claude-code)
