### PR TITLE
chore: Bump @homebound/rtl-utils to 3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   "devDependencies": {
     "@homebound/eslint-config": "^5.0.0",
     "@homebound/rtl-react-router-utils": "2.1.0",
-    "@homebound/rtl-utils": "^2.71.0",
+    "@homebound/rtl-utils": "^3.0.2",
     "@homebound/truss": "2.29.5",
     "@homebound/tsconfig": "^1.2.0",
     "@semantic-release/exec": "^7.1.0",

--- a/src/components/AccordionList.test.tsx
+++ b/src/components/AccordionList.test.tsx
@@ -1,4 +1,4 @@
-import { click } from "@homebound/rtl-utils/build/lib";
+import { click } from "@homebound/rtl-utils";
 import { render } from "src/utils/rtl";
 import type { AccordionProps } from "./Accordion";
 import { AccordionList } from "./AccordionList";

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,7 +888,7 @@ __metadata:
     "@homebound/eslint-config": "npm:^5.0.0"
     "@homebound/form-state": "npm:^3.1.0"
     "@homebound/rtl-react-router-utils": "npm:2.1.0"
-    "@homebound/rtl-utils": "npm:^2.71.0"
+    "@homebound/rtl-utils": "npm:^3.0.2"
     "@homebound/truss": "npm:2.29.5"
     "@homebound/tsconfig": "npm:^1.2.0"
     "@internationalized/number": "npm:^3.6.8"
@@ -1027,13 +1027,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@homebound/rtl-utils@npm:^2.71.0":
-  version: 2.71.0
-  resolution: "@homebound/rtl-utils@npm:2.71.0"
+"@homebound/rtl-utils@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "@homebound/rtl-utils@npm:3.0.2"
   peerDependencies:
-    "@testing-library/react": ">=12 || >=13 || >=14"
-    react: ">=16 || >=17 || >=18"
-  checksum: 10/2617d6c729bf5242294607818621b15a5bd4ad343a0564a337fbd6415dc65f2b2b672450118493be0391ffe4a6b6d20324c00de18f56fee0daf1fd0253128159
+    "@apollo/client": ">=3"
+    "@homebound/better-apollo-mocked-provider": ">=1"
+    "@testing-library/react": ">=14"
+    history: ">=5"
+    react: ">=18"
+    react-dom: ">=18"
+    react-router: ">=6"
+    react-router-dom: ">=6"
+    use-query-params: ">=2"
+  peerDependenciesMeta:
+    "@apollo/client":
+      optional: true
+    "@homebound/better-apollo-mocked-provider":
+      optional: true
+    history:
+      optional: true
+    react-router:
+      optional: true
+    react-router-dom:
+      optional: true
+    use-query-params:
+      optional: true
+  checksum: 10/09b2a9a0f29bdbb0f4b3efa2bfd81636529fdf23e9a550f119d3a54f8990370bdb39db5403f6a7f0850c1efce0a245261d021293618289ad91bd30d16edb2d6c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

rtl-utils 3 is ESM-first with an exports map, so the one deep import of
`@homebound/rtl-utils/build/lib` moves to the package root.

---
Part of the dependency-update stack (14 PRs, land in order).
- ⬇️ Based on #1443
- ⬆️ Next: #1445

🤖 Generated with [Claude Code](https://claude.com/claude-code)
