### PR TITLE
chore: Bump TypeScript to 6 and @types/node to 26.

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.3",
     "@tsconfig/recommended": "^1.0.13",
-    "@types/node": "^22.20.1",
+    "@types/node": "^26",
     "@types/react": "^19.2.18",
     "@types/react-beautiful-dnd": "^13.1.8",
     "@types/react-dom": "^19.2.7",
@@ -134,7 +134,7 @@
     "storybook": "^10.6.0",
     "tsup": "^8.5.1",
     "tsx": "^4.23.13",
-    "typescript": "5.9.3",
+    "typescript": "^6.0.0",
     "vite": "^8.2.2",
     "vitest": "^5.0.0",
     "watch": "^1.0.2"

--- a/src/css.d.ts
+++ b/src/css.d.ts
@@ -1,0 +1,11 @@
+// Beam imports CSS for its side effects, i.e. `import "./trix.css"`, and lets Vite and tsup turn those
+// imports into stylesheets at bundle time. TypeScript never has a module to resolve them to, because
+// no `.d.ts` describes a `.css` file.
+//
+// Up through TypeScript 5, that was fine: a side-effect import was not resolved or type-checked at all,
+// so an unresolvable one was silently accepted. TypeScript 6 turns on `noUncheckedSideEffectImports` by
+// default, which makes it resolve every import, and each CSS import then fails `yarn type-check` with
+// TS2882 "Cannot find module or type declarations for side-effect import". This ambient declaration
+// gives every `*.css` specifier a module to resolve to, so the imports type-check again without any
+// change to how they are bundled.
+declare module "*.css";

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -17,7 +17,7 @@ import { type InputStylePalette, usePresentationContext } from "src/components/P
 import { ProposedValue } from "src/components/ProposedValue";
 import { BorderHoverChild } from "src/components/Table/components/Row";
 // Side-effect import: injects CSS for the border-hover-on-row pattern
-import "src/components/Table/components/Row.css.ts";
+import "src/components/Table/components/Row.css";
 import { Css, increment, type Only, Palette, Tokens } from "src/Css";
 import { useLabelSuffix } from "src/forms/labelUtils";
 import { useGetRef } from "src/hooks/useGetRef";

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -5,7 +5,8 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: ["src/index.ts", "src/utils/rtlUtils.tsx"],
   format: ["esm", "cjs"],
-  dts: true,
+  // tsup still sets `baseUrl` for the dts build, which TypeScript 6 reports as a deprecation error
+  dts: { compilerOptions: { ignoreDeprecations: "6.0" } },
   clean: true,
   sourcemap: true,
   esbuildPlugins: [trussEsbuildPlugin({ mapping: "./src/Css.json" }) as Plugin],

--- a/yarn.lock
+++ b/yarn.lock
@@ -905,7 +905,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^7.0.1"
     "@testing-library/react": "npm:^16.3.3"
     "@tsconfig/recommended": "npm:^1.0.13"
-    "@types/node": "npm:^22.20.1"
+    "@types/node": "npm:^26"
     "@types/react": "npm:^19.2.18"
     "@types/react-beautiful-dnd": "npm:^13.1.8"
     "@types/react-dom": "npm:^19.2.7"
@@ -943,7 +943,7 @@ __metadata:
     trix: "npm:^2.1.19"
     tsup: "npm:^8.5.1"
     tsx: "npm:^4.23.13"
-    typescript: "npm:5.9.3"
+    typescript: "npm:^6.0.0"
     use-debounce: "npm:^10.1.1"
     use-query-params: "npm:^2.2.2"
     vite: "npm:^8.2.2"
@@ -3067,12 +3067,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^22.20.1":
-  version: 22.20.1
-  resolution: "@types/node@npm:22.20.1"
+"@types/node@npm:^26":
+  version: 26.5.0
+  resolution: "@types/node@npm:26.5.0"
   dependencies:
-    undici-types: "npm:~6.21.0"
-  checksum: 10/0949e49d0383569ebd1222a2f65a9adb9328a6a6dbed459a02cdb37c61147755386c004c4ffbe436de59f5859df1774b1dd6bf168f7aeee46884bb190e0c384f
+    undici-types: "npm:~8.9.0"
+  checksum: 10/db4b0ac5289abaf7fa6f280610853a3a9c88cd60ef686513fb773badf77bbf6089cafc9522bc99d0765f13b43cde3109b37a8183859a2adeec00ae07f0a4710d
   languageName: node
   linkType: hard
 
@@ -8821,23 +8821,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:^6.0.0":
+  version: 6.0.3
+  resolution: "typescript@npm:6.0.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
+  checksum: 10/0ef2357a4cffd916b52b683a021cdab0f81eea4e9aa35f2d254581c9a5106da02224e3392e1b0ed42b7a48f80c966e5f52b8e1a27941fa0523c1705a9c2e0330
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A^6.0.0#optional!builtin<compat/typescript>":
+  version: 6.0.3
+  resolution: "typescript@patch:typescript@npm%3A6.0.3#optional!builtin<compat/typescript>::version=6.0.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
+  checksum: 10/22b67a18dafedf9b1468b64ca20d9aa02ea61d449b65413d8aa6552aeb63f52ef369e86beb25b6b4c91a803d9726ee5c196f391a9b64201263263410a4223ee6
   languageName: node
   linkType: hard
 
@@ -8857,10 +8857,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.21.0":
-  version: 6.21.0
-  resolution: "undici-types@npm:6.21.0"
-  checksum: 10/ec8f41aa4359d50f9b59fa61fe3efce3477cc681908c8f84354d8567bb3701fafdddf36ef6bff307024d3feb42c837cf6f670314ba37fc8145e219560e473d14
+"undici-types@npm:~8.9.0":
+  version: 8.9.0
+  resolution: "undici-types@npm:8.9.0"
+  checksum: 10/8785591929de2b71d281c684e915c4a8c41becc225adbf42a3e89148f8b384724a21533494c30a1cbb85b4cbccd088d020788ff4f2d605013eb2863cd47a1639
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

TypeScript 6 checks side-effect imports, so src/css.d.ts gives the imported
CSS files an ambient module type, and the one import that spelled out a `.ts`
extension drops it. tsup still passes `baseUrl` to its dts build, which
TypeScript 6 reports as a deprecation error, so the tsup config silences that
deprecation. @types/node now matches the Node 26 runtime.

---
Part of the dependency-update stack (15 PRs, land in order).
- ⬇️ Based on #1444
- ⬆️ Next: #1447

🤖 Generated with [Claude Code](https://claude.com/claude-code)