### PR TITLE
chore: Bump Truss to 2.29.6 for the test-time CSS injection fix.

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@homebound/eslint-config": "^5.0.0",
     "@homebound/rtl-react-router-utils": "2.1.0",
     "@homebound/rtl-utils": "^3.0.2",
-    "@homebound/truss": "2.29.5",
+    "@homebound/truss": "2.29.6",
     "@homebound/tsconfig": "^1.2.0",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/git": "^11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -889,7 +889,7 @@ __metadata:
     "@homebound/form-state": "npm:^3.1.0"
     "@homebound/rtl-react-router-utils": "npm:2.1.0"
     "@homebound/rtl-utils": "npm:^3.0.2"
-    "@homebound/truss": "npm:2.29.5"
+    "@homebound/truss": "npm:2.29.6"
     "@homebound/tsconfig": "npm:^1.2.0"
     "@internationalized/number": "npm:^3.6.8"
     "@popperjs/core": "npm:^2.11.8"
@@ -1057,9 +1057,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@homebound/truss@npm:2.29.5":
-  version: 2.29.5
-  resolution: "@homebound/truss@npm:2.29.5"
+"@homebound/truss@npm:2.29.6":
+  version: 2.29.6
+  resolution: "@homebound/truss@npm:2.29.6"
   dependencies:
     "@babel/generator": "npm:^7.29.1"
     "@babel/parser": "npm:^7.29.2"
@@ -1073,7 +1073,7 @@ __metadata:
     react: ">=18"
   bin:
     truss: cli.js
-  checksum: 10/83d9adc91469769f14c13d785b09ba3d45dbbbe61cfe1133d590c954147b8068b73233cdabb87de1ec0c076bcbcaa38e248cc7226ed3175281bdd5b947756c4e
+  checksum: 10/253179887cc215c19e3ce6fe19336c7453ca8fddf54cdc01523258aecbc3ee7dc4f5f566b925a9717bc4fd0ed0649c1009940b0b3748f5fef1a550eeac1d97ab
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Truss 2.29.5 appended every module's generated CSS to one `<style>` element, so jsdom re-parsed the whole accumulated sheet on each of the ~160 chunks a test file injects. 2.29.6 gives each chunk its own `<style>`.

Measured back to back on the same 24-core machine, Node 26.8.1:

| | Truss 2.29.5 | Truss 2.29.6 |
|---|---|---|
| Full suite (184 files, 1447 tests) | 115s | 65s |
| Import `src/components/Button` in one worker | 4.4s | 3.1s |
| vitest time in `import` | 72% | 54% |

---
Part of the dependency-update stack (16 PRs, land in order).
- ⬇️ Based on #1445
- ⬆️ Next: #1452

🤖 Generated with [Claude Code](https://claude.com/claude-code)