### PR TITLE
feat: allow hiding original AI proposal values

### DIFF
--- a/src/inputs/AiProposals.stories.tsx
+++ b/src/inputs/AiProposals.stories.tsx
@@ -64,6 +64,17 @@ export function AllFields() {
         <AiTextField />
         <PlainTextField />
       </Section>
+
+      <Section title="All fields without showing the original value, i.e. optimistic entity creation">
+        <AiTextField showOriginalValue={false} />
+        <AiNumberField showOriginalValue={false} />
+        <AiSelectField showOriginalValue={false} />
+        <AiMultiSelectField showOriginalValue={false} />
+        <AiDateField showOriginalValue={false} />
+        <AiDateRangeField showOriginalValue={false} />
+        <AiAutocomplete showOriginalValue={false} />
+        <AiTextAreaField showOriginalValue={false} />
+      </Section>
     </div>
   );
 }
@@ -77,7 +88,15 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   );
 }
 
-function AiTextField({ original = "Old Cottage", readOnly }: { original?: string; readOnly?: boolean }) {
+function AiTextField({
+  original = "Old Cottage",
+  readOnly,
+  showOriginalValue,
+}: {
+  original?: string;
+  readOnly?: boolean;
+  showOriginalValue?: boolean;
+}) {
   const [value, setValue] = useState<string | undefined>(original);
   return (
     <TextField
@@ -85,6 +104,7 @@ function AiTextField({ original = "Old Cottage", readOnly }: { original?: string
       required
       value={value}
       proposedValue="Janes Cottage"
+      showOriginalValue={showOriginalValue}
       onChange={setValue}
       readOnly={readOnly}
     />
@@ -96,18 +116,35 @@ function PlainTextField() {
   return <TextField label="Lot" value={value} onChange={setValue} />;
 }
 
-function AiNumberField({ original = 20 }: { original?: number }) {
+function AiNumberField({ original = 20, showOriginalValue }: { original?: number; showOriginalValue?: boolean }) {
   const [value, setValue] = useState<number | undefined>(original);
-  return <NumberField label="Ceiling Height" value={value} proposedValue={25} onChange={setValue} />;
+  return (
+    <NumberField
+      label="Ceiling Height"
+      value={value}
+      proposedValue={25}
+      showOriginalValue={showOriginalValue}
+      onChange={setValue}
+    />
+  );
 }
 
-function AiSelectField({ original = "up", readOnly }: { original?: string; readOnly?: boolean }) {
+function AiSelectField({
+  original = "up",
+  readOnly,
+  showOriginalValue,
+}: {
+  original?: string;
+  readOnly?: boolean;
+  showOriginalValue?: boolean;
+}) {
   const [value, setValue] = useState<string | undefined>(original);
   return (
     <SelectField
       label="Primary Bedroom Location"
       value={value}
       proposedValue="down"
+      showOriginalValue={showOriginalValue}
       options={locations}
       onSelect={setValue}
       readOnly={readOnly}
@@ -115,38 +152,54 @@ function AiSelectField({ original = "up", readOnly }: { original?: string; readO
   );
 }
 
-function AiMultiSelectField() {
+function AiMultiSelectField({ showOriginalValue }: { showOriginalValue?: boolean }) {
   const [values, setValues] = useState<string[]>(["up"]);
   return (
     <MultiSelectField
       label="Bedroom Locations"
       values={values}
       proposedValues={["down", "sideways"]}
+      showOriginalValue={showOriginalValue}
       options={locations}
       onSelect={setValues}
     />
   );
 }
 
-function AiDateField() {
+function AiDateField({ showOriginalValue }: { showOriginalValue?: boolean }) {
   const [value, setValue] = useState<PlainDate | undefined>(jan2);
-  return <DateField label="Start Date" value={value} proposedValue={jan29} onChange={setValue} />;
-}
-
-function AiDateRangeField() {
-  const [value, setValue] = useState<DateRange | undefined>({ from: jan2, to: jan10 });
   return (
-    <DateRangeField label="Build Window" value={value} proposedValue={{ from: jan1, to: jan19 }} onChange={setValue} />
+    <DateField
+      label="Start Date"
+      value={value}
+      proposedValue={jan29}
+      showOriginalValue={showOriginalValue}
+      onChange={setValue}
+    />
   );
 }
 
-function AiAutocomplete() {
+function AiDateRangeField({ showOriginalValue }: { showOriginalValue?: boolean }) {
+  const [value, setValue] = useState<DateRange | undefined>({ from: jan2, to: jan10 });
+  return (
+    <DateRangeField
+      label="Build Window"
+      value={value}
+      proposedValue={{ from: jan1, to: jan19 }}
+      showOriginalValue={showOriginalValue}
+      onChange={setValue}
+    />
+  );
+}
+
+function AiAutocomplete({ showOriginalValue }: { showOriginalValue?: boolean }) {
   const [value, setValue] = useState<string | undefined>("Old Supplier");
   return (
     <Autocomplete<HasIdAndName>
       label="Supplier"
       value={value}
       proposedValue="Acme Lumber"
+      showOriginalValue={showOriginalValue}
       options={[{ id: "1", name: "Acme Lumber" }]}
       getOptionLabel={(o) => o.name}
       getOptionValue={(o) => o.id}
@@ -156,9 +209,15 @@ function AiAutocomplete() {
   );
 }
 
-function AiTextAreaField() {
+function AiTextAreaField({ showOriginalValue }: { showOriginalValue?: boolean }) {
   const [value, setValue] = useState<string | undefined>("Old note about the framing.");
   return (
-    <TextAreaField label="Notes" value={value} proposedValue="Framing inspection passed on 1/19." onChange={setValue} />
+    <TextAreaField
+      label="Notes"
+      value={value}
+      proposedValue="Framing inspection passed on 1/19."
+      showOriginalValue={showOriginalValue}
+      onChange={setValue}
+    />
   );
 }

--- a/src/inputs/Autocomplete.tsx
+++ b/src/inputs/Autocomplete.tsx
@@ -31,7 +31,10 @@ export type AutocompleteProps<T> = {
   /** A list of options that are disabled. Can be either the option itself or an object with the option and a reason why it is disabled */
   disabledOptions?: (Value | { value: Value; reason: string })[];
 } & Pick<PresentationFieldProps, "labelStyle"> &
-  Pick<TextFieldBaseProps<any>, "label" | "clearable" | "startAdornment" | "fullWidth" | "proposedValue">;
+  Pick<
+    TextFieldBaseProps<any>,
+    "label" | "clearable" | "startAdornment" | "fullWidth" | "proposedValue" | "showOriginalValue"
+  >;
 
 export function Autocomplete<T extends object>(props: AutocompleteProps<T>) {
   const {
@@ -42,6 +45,7 @@ export function Autocomplete<T extends object>(props: AutocompleteProps<T>) {
     onInputChange,
     value,
     proposedValue,
+    showOriginalValue,
     options,
     disabled,
     disabledOptions,
@@ -128,6 +132,7 @@ export function Autocomplete<T extends object>(props: AutocompleteProps<T>) {
         inputProps={inputProps}
         labelProps={labelProps}
         onChange={onInputChange}
+        showOriginalValue={showOriginalValue}
         {...proposalProps}
         clearable
         // Respect if caller to passes in `startAdornment={undefined}`

--- a/src/inputs/DateFields/DateFieldBase.tsx
+++ b/src/inputs/DateFields/DateFieldBase.tsx
@@ -53,8 +53,12 @@ type DateFieldCommonProps = Pick<
   useYearPicker?: boolean;
 };
 
-/** Value proposed by an AI model; puts the field in AI mode. */
-type ProposedValue<V> = { proposedValue?: V };
+type ProposedValue<V> = {
+  /** Value proposed by an AI model; puts the field in AI mode. */
+  proposedValue?: V;
+  /** Whether to render the on-record value struck through beside the AI proposal. */
+  showOriginalValue?: boolean;
+};
 
 export type DateFieldProps = DateFieldCommonProps &
   ProposedValue<PlainDate> & {
@@ -83,6 +87,7 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
     required,
     value,
     proposedValue,
+    showOriginalValue,
     onFocus,
     onBlur,
     // Pull `onChange` out of the props, but we're not directly using it. Do not want to keep it in `...others`
@@ -311,6 +316,7 @@ export function DateFieldBase(props: DateRangeFieldBaseProps | DateSingleFieldBa
         inputProps={{ ...inputProps, size: inputSize, onClick: state.open }}
         inputRef={inputRef}
         inputWrapRef={inputWrapRef}
+        showOriginalValue={showOriginalValue}
         {...proposalProps}
         onChange={(v) => {
           // hide the calendar if the user is manually entering the date

--- a/src/inputs/NumberField.tsx
+++ b/src/inputs/NumberField.tsx
@@ -19,6 +19,8 @@ export interface NumberFieldProps extends Pick<PresentationFieldProps, "labelSty
   value: number | undefined;
   /** Value proposed by an AI model; puts the field in AI mode. */
   proposedValue?: number;
+  /** Whether to render the on-record value struck through beside the AI proposal. */
+  showOriginalValue?: boolean;
   onChange: (value: number | undefined) => void;
   compact?: boolean;
   clearable?: boolean;
@@ -73,6 +75,7 @@ export function NumberField(props: NumberFieldProps) {
     helperText,
     value,
     proposedValue,
+    showOriginalValue,
     onChange,
     xss,
     displayDirection = false,
@@ -246,6 +249,7 @@ export function NumberField(props: NumberFieldProps) {
       errorMsg={errorMsg}
       helperText={helperText}
       tooltip={resolveTooltip(disabled, undefined, readOnly)}
+      showOriginalValue={showOriginalValue}
       {...proposalProps}
       {...otherProps}
     />

--- a/src/inputs/TextAreaField.tsx
+++ b/src/inputs/TextAreaField.tsx
@@ -23,6 +23,7 @@ export function TextAreaField<X extends Only<TextFieldXss, X>>(props: TextAreaFi
   const {
     value,
     proposedValue,
+    showOriginalValue,
     disabled = false,
     readOnly = false,
     onBlur,
@@ -76,6 +77,7 @@ export function TextAreaField<X extends Only<TextFieldXss, X>>(props: TextAreaFi
       inputWrapRef={inputWrapRef}
       textAreaMinHeight={preventNewLines ? 0 : undefined}
       tooltip={resolveTooltip(disabled, undefined, readOnly)}
+      showOriginalValue={showOriginalValue}
       {...proposalProps}
     />
   );

--- a/src/inputs/TextField.test.tsx
+++ b/src/inputs/TextField.test.tsx
@@ -129,6 +129,17 @@ describe("AI mode", () => {
     expect(r.query.name_originalValue).not.toBeInTheDocument();
   });
 
+  it("can omit the original while keeping the proposal styling", async () => {
+    // Given an AI proposal whose original value should not be shown
+    const r = await render(
+      <TestTextField value="Old Cottage" proposedValue="Janes Cottage" showOriginalValue={false} />,
+    );
+    // Then only the proposed value is shown in AI mode
+    expect(r.name).toHaveValue("Janes Cottage");
+    expect(r.name).toHaveAttribute("data-ai-mode", "true");
+    expect(r.query.name_originalValue).not.toBeInTheDocument();
+  });
+
   it("commits on edit and drops the AI treatment", async () => {
     const r = await render(<TestTextField value="Old Cottage" proposedValue="Janes Cottage" />);
     // When the user edits the field, which starts from the proposal

--- a/src/inputs/TextField.tsx
+++ b/src/inputs/TextField.tsx
@@ -38,6 +38,7 @@ export function TextField<X extends Only<TextFieldXss, X>>(props: TextFieldProps
     errorMsg,
     value,
     proposedValue,
+    showOriginalValue,
     onBlur,
     onFocus,
     api,
@@ -93,6 +94,7 @@ export function TextField<X extends Only<TextFieldXss, X>>(props: TextFieldProps
       inputRef={inputRef}
       tooltip={resolveTooltip(disabled, undefined, readOnly)}
       hideErrorMessage={hideErrorMessage}
+      showOriginalValue={showOriginalValue}
       {...proposalProps}
     />
   );

--- a/src/inputs/TextFieldBase.tsx
+++ b/src/inputs/TextFieldBase.tsx
@@ -51,6 +51,8 @@ export type TextFieldBaseProps<X> = {
   proposedValue?: string;
   /** The formatted value on record, rendered struck through beside the input. Independent of `proposedValue`. */
   originalValue?: string;
+  /** Whether to render `originalValue` beside the proposal. */
+  showOriginalValue?: boolean;
   /** Called on any edit the user makes, so the owning field can end AI mode. */
   onUserEdit?: VoidFunction;
   /** Called when the user leaves the field, so the owning field can retire the struck-through original. */
@@ -116,6 +118,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
     inputStylePalette,
     proposedValue,
     originalValue,
+    showOriginalValue = true,
     onUserEdit,
     onUserBlur,
   } = props;
@@ -137,7 +140,7 @@ export function TextFieldBase<X extends Only<TextFieldXss, X>>(props: TextFieldB
   // Takes precedence over the `inputStylePalette` / `borderless` / `borderOnHover` backgrounds below.
   const showProposal = proposedValue !== undefined;
   // Rendered as a sibling of the input rather than an overlay, so it survives focus.
-  const showOriginal = originalValue !== undefined && originalValue !== "";
+  const showOriginal = showOriginalValue && originalValue !== undefined && originalValue !== "";
 
   const [bgColor, hoverBgColor, disabledBgColor] = showProposal
     ? [Tokens.AiFieldBg, Palette.Purple100, Tokens.FieldBgDisabled]

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -25,6 +25,8 @@ export type ComboBoxBaseProps<O, V extends Value> = {
   values: V[] | undefined;
   /** Values proposed by an AI model; puts the field in AI mode. */
   proposedValues?: V[];
+  /** Whether to render the on-record value struck through beside the AI proposal. */
+  showOriginalValue?: boolean;
   onSelect: (values: V[], opts: O[]) => void;
   multiselect?: boolean;
   disabledOptions?: (V | { value: V; reason: string })[];
@@ -110,6 +112,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
     multiselect = false,
     values: propValues,
     proposedValues,
+    showOriginalValue,
     nothingSelectedText = "",
     disabledOptions,
     borderless,
@@ -433,6 +436,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
         borderless={borderless}
         tooltip={resolveTooltip(disabled, undefined, readOnly)}
         resetField={resetField}
+        showOriginalValue={showOriginalValue}
         {...proposalProps}
       />
       {state.isOpen && (

--- a/src/inputs/internal/ComboBoxInput.tsx
+++ b/src/inputs/internal/ComboBoxInput.tsx
@@ -48,7 +48,7 @@ type ComboBoxInputProps<O, V extends Value> = {
   /* Allows input to wrap to multiple lines */
   multiline?: boolean;
 } & PresentationFieldProps &
-  Pick<TextFieldBaseProps<any>, "proposedValue" | "originalValue" | "onUserEdit" | "onUserBlur">;
+  Pick<TextFieldBaseProps<any>, "proposedValue" | "originalValue" | "showOriginalValue" | "onUserEdit" | "onUserBlur">;
 
 export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V>) {
   const {

--- a/src/inputs/internal/MenuSearchField.tsx
+++ b/src/inputs/internal/MenuSearchField.tsx
@@ -10,7 +10,7 @@ import { TextFieldBase } from "../TextFieldBase";
 type TextFieldProps<X> = BeamTextFieldProps<X>;
 
 export function MenuSearchField<X extends Only<TextFieldXss, X>>(props: TextFieldProps<X>) {
-  const { value, proposedValue } = props;
+  const { value, proposedValue, showOriginalValue } = props;
   const { effectiveValue, proposalProps } = useAiProposal(value, proposedValue);
   const tid = useTestIds(props);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -22,6 +22,7 @@ export function MenuSearchField<X extends Only<TextFieldXss, X>>(props: TextFiel
       labelProps={labelProps}
       inputProps={inputProps}
       startAdornment={<Icon icon="search" />}
+      showOriginalValue={showOriginalValue}
       {...proposalProps}
       {...tid.search}
     />

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -39,6 +39,8 @@ export interface BeamTextFieldProps<X> extends BeamFocusableProps, PresentationF
   value: string | undefined;
   /** Value proposed by an AI model; puts the field in AI mode. */
   proposedValue?: string;
+  /** Whether to render the on-record value struck through beside the AI proposal. */
+  showOriginalValue?: boolean;
   /** Handler called when the interactive element state changes. */
   onChange: (value: string | undefined) => void;
   /** Called when the component loses focus, mostly for BoundTextField to use. */


### PR DESCRIPTION
## Description

- Add a `showOriginalValue` prop to AI-capable input fields, defaulting to `true`.

## Screenshots
<img width="679" height="763" alt="Screenshot 2026-09-09 at 12 50 19 PM" src="https://github.com/user-attachments/assets/f3d852fb-c57a-4ee8-b3be-792d13787505" />