### PR TITLE
feat: Add SelectedOptionPill and MultiSelectField withPillList.

### DIFF
--- a/src/forms/SelectedOptionPill.stories.tsx
+++ b/src/forms/SelectedOptionPill.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { Css } from "src/Css";
+import { SelectedOptionPill } from "src/forms/SelectedOptionPill";
+import { action } from "storybook/actions";
+
+export default {
+  component: SelectedOptionPill,
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/DchiwVkssXeYi2Er8sMU2k/H2-2026-Plans---Automated-Construction-Doc-Capture?node-id=1462-46208",
+    },
+  },
+} as Meta;
+
+export function Default() {
+  return (
+    <div css={Css.df.fdc.gap3.maxwPx(592).$}>
+      <SelectedOptionPill value={optionValue()} onRemove={action("onRemove")} />
+    </div>
+  );
+}
+
+export function WithHelperText() {
+  return (
+    <div css={Css.df.fdc.gap3.maxwPx(592).$}>
+      <SelectedOptionPill value={optionValue()} helperText={sourcesHelperText()} onRemove={action("onRemove")} />
+    </div>
+  );
+}
+
+export function AiMode() {
+  return (
+    <div css={Css.df.fdc.gap3.maxwPx(592).$}>
+      <SelectedOptionPill value={optionValue()} helperText={sourcesHelperText()} onRemove={action("onRemove")} aiMode />
+    </div>
+  );
+}
+
+function optionValue(): ReactNode {
+  return (
+    <span css={Css.sm.$}>
+      CEILBEAM01 <span css={Css.smSb.$}>Faux Ceiling Beams</span> Living Room 101
+    </span>
+  );
+}
+
+function sourcesHelperText(): ReactNode {
+  return (
+    <span css={Css.xs.$}>
+      Sources:{" "}
+      <a href="#page-3" css={Css.blue600.$}>
+        Page 3
+      </a>
+      ,{" "}
+      <a href="#page-76" css={Css.blue600.$}>
+        Page 76
+      </a>
+      ,{" "}
+      <a href="#page-50" css={Css.blue600.$}>
+        Page 50
+      </a>
+    </span>
+  );
+}

--- a/src/forms/SelectedOptionPill.stories.tsx
+++ b/src/forms/SelectedOptionPill.stories.tsx
@@ -38,6 +38,14 @@ export function AiMode() {
   );
 }
 
+export function Disabled() {
+  return (
+    <div css={Css.df.fdc.gap3.maxwPx(592).$}>
+      <SelectedOptionPill value={optionValue()} onRemove={action("onRemove")} disabled />
+    </div>
+  );
+}
+
 function optionValue(): ReactNode {
   return (
     <span css={Css.sm.$}>

--- a/src/forms/SelectedOptionPill.test.tsx
+++ b/src/forms/SelectedOptionPill.test.tsx
@@ -1,0 +1,48 @@
+import { Css, Palette } from "src/Css";
+import { SelectedOptionPill } from "src/forms/SelectedOptionPill";
+import { click, render } from "src/utils/rtl";
+import { vi } from "vitest";
+
+describe("SelectedOptionPill", () => {
+  it("renders value and helperText", async () => {
+    // Given a pill with value and helper text
+    // When rendered
+    const r = await render(
+      <SelectedOptionPill value="CEILBEAM01 Faux Ceiling Beams" helperText="Sources: Page 3" onRemove={() => {}} />,
+    );
+    // Then both are shown
+    expect(r.selectedOptionPill_value).toHaveTextContent("CEILBEAM01 Faux Ceiling Beams");
+    expect(r.selectedOptionPill_helperText).toHaveTextContent("Sources: Page 3");
+  });
+
+  it("omits the helperText slot when unset", async () => {
+    // Given a pill without helperText
+    // When rendered
+    const r = await render(<SelectedOptionPill value="Option" onRemove={() => {}} />);
+    // Then the caption is not in the document
+    expect(r.query.selectedOptionPill_helperText).toBeNull();
+  });
+
+  it("calls onRemove when the remove button is clicked", async () => {
+    // Given a pill with an onRemove handler
+    const onRemove = vi.fn();
+    const r = await render(<SelectedOptionPill value="Option" onRemove={onRemove} />);
+    // When the remove control is clicked
+    click(r.selectedOptionPill_remove);
+    // Then onRemove is called
+    expect(onRemove).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the AI background and purple capsule text when aiMode is true", async () => {
+    // Given a pill in aiMode
+    // When rendered
+    const r = await render(<SelectedOptionPill value="Option" onRemove={() => {}} aiMode />);
+    // Then the capsule has the AI wash and purple text
+    const capsule = r.selectedOptionPill_value.parentElement;
+    const backgroundImage = Css.aiBackground.$.backgroundImage ?? "";
+    expect(capsule).toHaveStyle({
+      backgroundImage,
+      color: Palette.Purple800,
+    });
+  });
+});

--- a/src/forms/SelectedOptionPill.test.tsx
+++ b/src/forms/SelectedOptionPill.test.tsx
@@ -33,6 +33,14 @@ describe("SelectedOptionPill", () => {
     expect(onRemove).toHaveBeenCalledTimes(1);
   });
 
+  it("omits the remove button when disabled", async () => {
+    // Given a disabled pill
+    // When rendered
+    const r = await render(<SelectedOptionPill value="Option" onRemove={() => {}} disabled />);
+    // Then the remove control is not in the document
+    expect(r.query.selectedOptionPill_remove).toBeNull();
+  });
+
   it("applies the AI background and purple capsule text when aiMode is true", async () => {
     // Given a pill in aiMode
     // When rendered

--- a/src/forms/SelectedOptionPill.tsx
+++ b/src/forms/SelectedOptionPill.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import { IconButton } from "src/components/IconButton";
+import { Css, Palette, Tokens } from "src/Css";
+import { useTestIds } from "src/utils/useTestIds";
+
+export type SelectedOptionPillProps = {
+  value: ReactNode;
+  helperText?: ReactNode;
+  onRemove: () => void;
+  aiMode?: boolean;
+};
+
+/** A selected-option capsule with a remove control. `aiMode` paints the capsule purple. */
+export function SelectedOptionPill(props: SelectedOptionPillProps) {
+  const { value, helperText, onRemove, aiMode = false } = props;
+  const tid = useTestIds(props, "selectedOptionPill");
+  return (
+    <div css={Css.df.fdc.gap1.w100.$} {...tid}>
+      <div
+        css={{
+          // Setting border-radius to 999px to make it a pill shape.
+          ...Css.df.aic.gap2.w100.plPx(20).pr2.py1.borderRadius("999px").ba.bcGray300.$,
+          ...(aiMode ? Css.aiBackground.color(Palette.Purple800).$ : Css.bgWhite.color(Tokens.OnSurface).$),
+        }}
+      >
+        <div css={Css.fg1.wbba.sm.$} {...tid.value}>
+          {value}
+        </div>
+        <IconButton icon="x" compact label="Remove" onClick={onRemove} {...tid.remove} />
+      </div>
+      {helperText && (
+        <div css={Css.plPx(20).xs.$} {...tid.helperText}>
+          {helperText}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/forms/SelectedOptionPill.tsx
+++ b/src/forms/SelectedOptionPill.tsx
@@ -8,11 +8,13 @@ export type SelectedOptionPillProps = {
   helperText?: ReactNode;
   onRemove: () => void;
   aiMode?: boolean;
+  /** Hides the remove control so the selection cannot be cleared. */
+  disabled?: boolean;
 };
 
 /** A selected-option capsule with a remove control. `aiMode` paints the capsule purple. */
 export function SelectedOptionPill(props: SelectedOptionPillProps) {
-  const { value, helperText, onRemove, aiMode = false } = props;
+  const { value, helperText, onRemove, aiMode = false, disabled = false } = props;
   const tid = useTestIds(props, "selectedOptionPill");
   return (
     <div css={Css.df.fdc.gap1.w100.$} {...tid}>
@@ -26,7 +28,7 @@ export function SelectedOptionPill(props: SelectedOptionPillProps) {
         <div css={Css.fg1.wbba.sm.$} {...tid.value}>
           {value}
         </div>
-        <IconButton icon="x" compact label="Remove" onClick={onRemove} {...tid.remove} />
+        {!disabled && <IconButton icon="x" compact label="Remove" onClick={onRemove} {...tid.remove} />}
       </div>
       {helperText && (
         <div css={Css.plPx(20).xs.$} {...tid.helperText}>

--- a/src/forms/SelectedOptionPillList.stories.tsx
+++ b/src/forms/SelectedOptionPillList.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta } from "@storybook/react-vite";
+import type { ReactNode } from "react";
+import { Css } from "src/Css";
+import { SelectedOptionPillList } from "src/forms/SelectedOptionPillList";
+import { action } from "storybook/actions";
+
+export default {
+  component: SelectedOptionPillList,
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/DchiwVkssXeYi2Er8sMU2k/H2-2026-Plans---Automated-Construction-Doc-Capture?node-id=1462-46208",
+    },
+  },
+} as Meta;
+
+export function Default() {
+  return (
+    <div css={Css.maxwPx(592).$}>
+      <SelectedOptionPillList options={createOptions()} />
+    </div>
+  );
+}
+
+function createOptions() {
+  return [
+    {
+      id: "keep",
+      value: optionValue("CEILBEAM01", "Faux Ceiling Beams", "Living Room 101"),
+      onRemove: action("onRemove keep"),
+    },
+    {
+      id: "ai-add",
+      value: optionValue("CAB001", "Upper Cabinets", "Kitchen"),
+      helperText: sourcesHelperText(),
+      onRemove: action("onRemove ai-add"),
+      aiMode: true,
+    },
+    {
+      id: "plain",
+      value: "A long option name that should wrap within the capsule instead of overflowing",
+      helperText: <span css={Css.xs.$}>Sources: Page 1</span>,
+      onRemove: action("onRemove plain"),
+    },
+  ];
+}
+
+function optionValue(id: string, name: string, location: string): ReactNode {
+  return (
+    <span css={Css.sm.$}>
+      {id} <span css={Css.smSb.$}>{name}</span> {location}
+    </span>
+  );
+}
+
+function sourcesHelperText(): ReactNode {
+  return (
+    <span css={Css.xs.$}>
+      Sources:{" "}
+      <a href="#page-3" css={Css.blue600.$}>
+        Page 3
+      </a>
+      ,{" "}
+      <a href="#page-76" css={Css.blue600.$}>
+        Page 76
+      </a>
+    </span>
+  );
+}

--- a/src/forms/SelectedOptionPillList.test.tsx
+++ b/src/forms/SelectedOptionPillList.test.tsx
@@ -1,0 +1,45 @@
+import { SelectedOptionPillList } from "src/forms/SelectedOptionPillList";
+import { click, render } from "src/utils/rtl";
+import { vi } from "vitest";
+
+describe("SelectedOptionPillList", () => {
+  it("renders a pill per option", async () => {
+    // Given two selected options
+    const options = [
+      { id: "a", value: "Option A", onRemove: () => {} },
+      { id: "b", value: "Option B", onRemove: () => {} },
+    ];
+    // When rendered
+    const r = await render(<SelectedOptionPillList options={options} />);
+    // Then each option's value is shown
+    expect(r.selectedOptionPillList_pill_value_0).toHaveTextContent("Option A");
+    expect(r.selectedOptionPillList_pill_value_1).toHaveTextContent("Option B");
+  });
+
+  it("calls the matching onRemove when a pill is removed", async () => {
+    // Given a list with per-option remove handlers
+    const onRemoveA = vi.fn();
+    const onRemoveB = vi.fn();
+    const r = await render(
+      <SelectedOptionPillList
+        options={[
+          { id: "a", value: "Option A", onRemove: onRemoveA },
+          { id: "b", value: "Option B", onRemove: onRemoveB },
+        ]}
+      />,
+    );
+    // When the second pill is removed
+    click(r.selectedOptionPillList_pill_remove_1);
+    // Then only that option's handler runs
+    expect(onRemoveB).toHaveBeenCalledTimes(1);
+    expect(onRemoveA).not.toHaveBeenCalled();
+  });
+
+  it("renders nothing when options is empty", async () => {
+    // Given no options
+    // When rendered
+    const r = await render(<SelectedOptionPillList options={[]} />);
+    // Then the list is absent
+    expect(r.query.selectedOptionPillList).toBeNull();
+  });
+});

--- a/src/forms/SelectedOptionPillList.tsx
+++ b/src/forms/SelectedOptionPillList.tsx
@@ -1,0 +1,21 @@
+import { Css } from "src/Css";
+import { SelectedOptionPill, type SelectedOptionPillProps } from "src/forms/SelectedOptionPill";
+import { useTestIds } from "src/utils/useTestIds";
+
+export type SelectedOptionPillListProps = {
+  options: Array<{ id: string } & SelectedOptionPillProps>;
+};
+
+/** A vertical stack of {@link SelectedOptionPill}s. Renders nothing when `options` is empty. */
+export function SelectedOptionPillList(props: SelectedOptionPillListProps) {
+  const { options } = props;
+  const tid = useTestIds(props, "selectedOptionPillList");
+  if (options.length === 0) return null;
+  return (
+    <div css={Css.df.fdc.gap2.w100.$} {...tid}>
+      {options.map(({ id, ...pill }) => (
+        <SelectedOptionPill key={id} {...pill} {...tid.pill} />
+      ))}
+    </div>
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -280,6 +280,8 @@ export * from "./forms/BoundToggleChipGroupField";
 export * from "./forms/BoundTreeSelectField";
 export * from "./forms/FormHeading";
 export * from "./forms/FormLines";
+export * from "./forms/SelectedOptionPill";
+export * from "./forms/SelectedOptionPillList";
 export * from "./forms/StaticField";
 export * from "./forms/SubmitButton";
 export { FormSection } from "./forms/FormSection/FormSection";

--- a/src/inputs/MultiSelectField.stories.tsx
+++ b/src/inputs/MultiSelectField.stories.tsx
@@ -199,6 +199,25 @@ export function MultiSelectFields() {
   );
 }
 
+export function WithPillList() {
+  return (
+    <div css={Css.df.fdc.gap2.maxwPx(480).$}>
+      <TestMultiSelectField
+        label="Favorite Icons"
+        values={[options[1].id, options[2].id, options[3].id]}
+        options={options}
+        withPillList
+        getOptionMenuLabel={(o) => (
+          <span css={Css.df.aic.gap1.$}>
+            {o.icon && <Icon icon={o.icon} />}
+            {o.name}
+          </span>
+        )}
+      />
+    </div>
+  );
+}
+
 export function Loading() {
   const loadTestOptions: TestOption[] = zeroTo(1000).map((i) => ({ id: String(i), name: `Project ${i}` }));
   const [loaded, setLoaded] = useState<TestOption[]>([]);

--- a/src/inputs/MultiSelectField.stories.tsx
+++ b/src/inputs/MultiSelectField.stories.tsx
@@ -214,6 +214,13 @@ export function WithPillList() {
           </span>
         )}
       />
+      <TestMultiSelectField
+        label="Disabled"
+        values={[options[1].id, options[2].id]}
+        options={options}
+        withPillList
+        disabled
+      />
     </div>
   );
 }

--- a/src/inputs/MultiSelectField.test.tsx
+++ b/src/inputs/MultiSelectField.test.tsx
@@ -220,6 +220,71 @@ describe("MultiSelectFieldTest", () => {
     expect(onSelect).toHaveBeenCalledWith([]);
   });
 
+  it("renders a pill list below the field when withPillList is true", async () => {
+    // Given a MultiSelectField with selected values and withPillList
+    const r = await render(<TestMultiSelectField values={["1", "3"]} options={options} withPillList />);
+    // Then selected options render as pills, not chips
+    expect(r.selectedOptionPillList_pill_value_0).toHaveTextContent("One");
+    expect(r.selectedOptionPillList_pill_value_1).toHaveTextContent("Three");
+    expect(r.queryAllByTestId("chip")).toHaveLength(0);
+    expect(r.query.selectedOptionsCount).toBeNull();
+    expect(r.age).toHaveValue("");
+  });
+
+  it("uses getOptionMenuLabel for pill content when provided", async () => {
+    // Given a MultiSelectField with withPillList and a custom menu label
+    const r = await render(
+      <TestMultiSelectField
+        values={["1"]}
+        options={options}
+        withPillList
+        getOptionMenuLabel={(o) => `Menu ${o.name}`}
+      />,
+    );
+    // Then the pill shows the menu label, not getOptionLabel
+    expect(r.selectedOptionPillList_pill_value).toHaveTextContent("Menu One");
+  });
+
+  it("does not put a single selection in the input when withPillList is true", async () => {
+    // Given a MultiSelectField with withPillList and one selected value
+    const r = await render(<TestMultiSelectField values={["1"]} options={options} withPillList />);
+    // Then the value is only in the pill, not the combobox
+    expect(r.selectedOptionPillList_pill_value).toHaveTextContent("One");
+    expect(r.age).toHaveValue("");
+  });
+
+  it("hides listbox chips when withPillList is true", async () => {
+    // Given a MultiSelectField with withPillList and a selected value
+    const r = await render(<TestMultiSelectField values={["1"]} options={options} withPillList />);
+    // When opening the menu
+    click(r.age);
+    // Then the listbox does not show ToggleChips
+    expect(r.getByRole("listbox")).toBeInTheDocument();
+    expect(r.queryAllByTestId("chip")).toHaveLength(0);
+  });
+
+  it("removes a value when a pill is removed", async () => {
+    // Given a MultiSelectField with withPillList and two selected values
+    const r = await render(<TestMultiSelectField values={["1", "2"]} options={options} withPillList />);
+    // When removing the first pill
+    click(r.selectedOptionPillList_pill_remove_0);
+    // Then onSelect is called without that value
+    expect(onSelect).toHaveBeenCalledWith(["2"]);
+  });
+
+  it("hides field and listbox chips when hideChips is true", async () => {
+    // Given a MultiSelectField that only hides chips
+    const r = await render(<TestMultiSelectField values={["1", "2"]} options={options} hideChips />);
+    // Then no field chips or count badge are shown
+    expect(r.queryAllByTestId("chip")).toHaveLength(0);
+    expect(r.query.selectedOptionPillList).toBeNull();
+    // When opening the menu
+    click(r.age);
+    // Then the listbox also has no chips
+    expect(r.getByRole("listbox")).toBeInTheDocument();
+    expect(r.queryAllByTestId("chip")).toHaveLength(0);
+  });
+
   it("preserves selections after tab-blur", async () => {
     const selectedRef: React.MutableRefObject<string[] | undefined> = { current: undefined };
     // Given a MultiSelectField with no selected values

--- a/src/inputs/MultiSelectField.test.tsx
+++ b/src/inputs/MultiSelectField.test.tsx
@@ -272,6 +272,16 @@ describe("MultiSelectFieldTest", () => {
     expect(onSelect).toHaveBeenCalledWith(["2"]);
   });
 
+  it("hides pill remove buttons when the field is disabled", async () => {
+    // Given a disabled MultiSelectField with withPillList
+    const r = await render(<TestMultiSelectField values={["1", "2"]} options={options} withPillList disabled />);
+    // Then selections still render as pills, but cannot be removed
+    expect(r.selectedOptionPillList_pill_value_0).toHaveTextContent("One");
+    expect(r.selectedOptionPillList_pill_value_1).toHaveTextContent("Two");
+    expect(r.query.selectedOptionPillList_pill_remove_0).toBeNull();
+    expect(r.query.selectedOptionPillList_pill_remove_1).toBeNull();
+  });
+
   it("hides field and listbox chips when hideChips is true", async () => {
     // Given a MultiSelectField that only hides chips
     const r = await render(<TestMultiSelectField values={["1", "2"]} options={options} hideChips />);

--- a/src/inputs/MultiSelectField.tsx
+++ b/src/inputs/MultiSelectField.tsx
@@ -39,9 +39,11 @@ export function MultiSelectField<O, V extends Value>(
     onSelect,
     options,
     autoSort = true,
+    disabled,
     ...otherProps
   } = props;
 
+  const isDisabled = !!disabled;
   const pillOptions = useMemo(() => {
     if (!withPillList) return [];
     const resolved = initializeOptions(options, getOptionValue, getOptionLabel, undefined, autoSort);
@@ -52,6 +54,7 @@ export function MultiSelectField<O, V extends Value>(
         return {
           id: String(value),
           value: getOptionMenuLabel?.(o) ?? getOptionLabel(o),
+          disabled: isDisabled,
           onRemove: () => {
             const nextValues = values.filter((v) => v !== value);
             const nextOpts = resolved.filter((opt) => nextValues.includes(getOptionValue(opt)));
@@ -61,7 +64,7 @@ export function MultiSelectField<O, V extends Value>(
       });
     // getOptionLabel / getOptionValue / getOptionMenuLabel / onSelect are typically lambdas
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [withPillList, options, values, autoSort]);
+  }, [withPillList, options, values, autoSort, isDisabled]);
 
   const field = (
     <ComboBoxBase
@@ -74,6 +77,7 @@ export function MultiSelectField<O, V extends Value>(
       onSelect={onSelect}
       options={options}
       autoSort={autoSort}
+      disabled={disabled}
       {...otherProps}
     />
   );

--- a/src/inputs/MultiSelectField.tsx
+++ b/src/inputs/MultiSelectField.tsx
@@ -1,15 +1,19 @@
-import type { JSX, ReactNode } from "react";
+import { useMemo, type JSX, type ReactNode } from "react";
+import { Css } from "src/Css";
+import { SelectedOptionPillList } from "src/forms/SelectedOptionPillList";
+import { ComboBoxBase, initializeOptions, type ComboBoxBaseProps } from "src/inputs/internal/ComboBoxBase";
 import type { Value } from "src/inputs/Value";
-import { ComboBoxBase, type ComboBoxBaseProps } from "src/inputs/internal/ComboBoxBase";
 import type { HasIdAndName, Optional } from "src/types";
 
 export type MultiSelectFieldProps<O, V extends Value> = {
-  /** Renders `opt` in the dropdown menu, defaults to the `getOptionLabel` prop. */
+  /** Renders `opt` in the dropdown menu and pill list, defaults to the `getOptionLabel` prop. */
   getOptionMenuLabel?: (opt: O) => string | ReactNode;
   getOptionValue: (opt: O) => V;
   getOptionLabel: (opt: O) => string;
   values: V[];
   onSelect: (values: V[], opts: O[]) => void;
+  /** Selected options render as a pill list below the field; in-field and listbox chips are hidden. */
+  withPillList?: boolean;
 } & Exclude<ComboBoxBaseProps<O, V>, "unsetLabel" | "addNew">;
 
 /**
@@ -28,7 +32,58 @@ export function MultiSelectField<O, V extends Value>(
   const {
     getOptionValue = (opt: O) => (opt as any).id, // if unset, assume O implements HasId
     getOptionLabel = (opt: O) => (opt as any).name, // if unset, assume O implements HasName
+    getOptionMenuLabel,
+    withPillList = false,
+    hideChips = false,
+    values,
+    onSelect,
+    options,
+    autoSort = true,
     ...otherProps
   } = props;
-  return <ComboBoxBase multiselect getOptionLabel={getOptionLabel} getOptionValue={getOptionValue} {...otherProps} />;
+
+  const pillOptions = useMemo(() => {
+    if (!withPillList) return [];
+    const resolved = initializeOptions(options, getOptionValue, getOptionLabel, undefined, autoSort);
+    return resolved
+      .filter((o) => values.includes(getOptionValue(o)))
+      .map((o) => {
+        const value = getOptionValue(o);
+        return {
+          id: String(value),
+          value: getOptionMenuLabel?.(o) ?? getOptionLabel(o),
+          onRemove: () => {
+            const nextValues = values.filter((v) => v !== value);
+            const nextOpts = resolved.filter((opt) => nextValues.includes(getOptionValue(opt)));
+            onSelect(nextValues, nextOpts);
+          },
+        };
+      });
+    // getOptionLabel / getOptionValue / getOptionMenuLabel / onSelect are typically lambdas
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [withPillList, options, values, autoSort]);
+
+  const field = (
+    <ComboBoxBase
+      multiselect
+      hideChips={withPillList || hideChips}
+      getOptionLabel={getOptionLabel}
+      getOptionValue={getOptionValue}
+      getOptionMenuLabel={getOptionMenuLabel}
+      values={values}
+      onSelect={onSelect}
+      options={options}
+      autoSort={autoSort}
+      {...otherProps}
+    />
+  );
+
+  if (!withPillList) return field;
+
+  return (
+    <div css={Css.df.fdc.gap2.w100.$}>
+      {field}
+      <SelectedOptionPillList options={pillOptions} />
+    </div>
+  );
 }

--- a/src/inputs/internal/ComboBoxBase.tsx
+++ b/src/inputs/internal/ComboBoxBase.tsx
@@ -88,6 +88,8 @@ export type ComboBoxBaseProps<O, V extends Value> = {
    * Set to false to maintain the original order of options.
    */
   autoSort?: boolean;
+  /** Hides selected-value chips in the closed field and in the open listbox. */
+  hideChips?: boolean;
 } & BeamFocusableProps &
   PresentationFieldProps;
 
@@ -122,6 +124,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
     onSearch,
     onAddNew,
     autoSort = true,
+    hideChips = false,
     ...otherProps
   } = props;
   const labelStyle = otherProps.labelStyle ?? fieldProps?.labelStyle ?? "above";
@@ -197,7 +200,14 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
   // Do a one-time initialize of fieldState
   const [fieldState, setFieldState] = useState<FieldState>(() => {
     return {
-      inputValue: getInputValue(selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly),
+      inputValue: getInputValue(
+        selectedOptions,
+        getOptionLabel,
+        multiselect,
+        nothingSelectedText,
+        isReadOnly,
+        hideChips,
+      ),
       searchValue: undefined,
       optionsLoading: false,
     };
@@ -359,10 +369,26 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
       setFieldState((prevState) => ({
         ...prevState,
         searchValue: "",
-        inputValue: getInputValue(selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly),
+        inputValue: getInputValue(
+          selectedOptions,
+          getOptionLabel,
+          multiselect,
+          nothingSelectedText,
+          isReadOnly,
+          hideChips,
+        ),
       }));
     }
-  }, [state.isOpen, selectedOptions, getOptionLabel, multiselect, nothingSelectedText, isReadOnly, debouncedSearch]);
+  }, [
+    state.isOpen,
+    selectedOptions,
+    getOptionLabel,
+    multiselect,
+    nothingSelectedText,
+    isReadOnly,
+    hideChips,
+    debouncedSearch,
+  ]);
 
   // Call on search callback when the user types in the input field
   useEffect(() => {
@@ -433,6 +459,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
         borderless={borderless}
         tooltip={resolveTooltip(disabled, undefined, readOnly)}
         resetField={resetField}
+        hideChips={hideChips}
         {...proposalProps}
       />
       {state.isOpen && (
@@ -456,6 +483,7 @@ export function ComboBoxBase<O, V extends Value>(props: ComboBoxBaseProps<O, V>)
             horizontalLayout={labelStyle === "left"}
             loading={fieldState.optionsLoading}
             disabledOptionsWithReasons={disabledOptionsWithReasons}
+            hideChips={hideChips}
           />
         </Popover>
       )}
@@ -489,7 +517,12 @@ function getInputValue<O>(
   multiselect: boolean,
   nothingSelectedText: string,
   readOnly?: boolean,
+  hideChips?: boolean,
 ) {
+  // Pill list (or hideChips) owns the selection UI — keep the input empty except placeholder-when-empty.
+  if (hideChips && multiselect) {
+    return selectedOptions.length === 0 ? nothingSelectedText : "";
+  }
   return selectedOptions.length === 1
     ? getOptionLabel(selectedOptions[0])
     : readOnly && selectedOptions.length > 0

--- a/src/inputs/internal/ComboBoxInput.tsx
+++ b/src/inputs/internal/ComboBoxInput.tsx
@@ -50,6 +50,8 @@ type ComboBoxInputProps<O, V extends Value> = {
   isTree?: boolean;
   /* Allows input to wrap to multiple lines */
   multiline?: boolean;
+  /** Hides selected-value chips and the selection count badge. */
+  hideChips?: boolean;
 } & PresentationFieldProps &
   Pick<TextFieldBaseProps<any>, "proposedValue" | "originalValue" | "onUserEdit" | "onUserBlur">;
 
@@ -75,6 +77,7 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
     inputRef,
     inputWrapRef,
     multiline = false,
+    hideChips = false,
     ...otherProps
   } = props;
 
@@ -87,7 +90,7 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
   const [isFocused, setIsFocused] = useState(false);
   const isMultiSelect = state.selectionManager.selectionMode === "multiple";
   // Show selections as chips when using multiselect when unfocused
-  const showChipSelection = isMultiSelect && state.selectionManager.selectedKeys.size > 0;
+  const showChipSelection = !hideChips && isMultiSelect && state.selectionManager.selectedKeys.size > 0;
   // For MultiSelect only show the `fieldDecoration` when input is not in focus.
   const showFieldDecoration =
     (!isMultiSelect || (isMultiSelect && !isFocused)) && fieldDecoration && selectedOptions.length === 1;
@@ -96,7 +99,7 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
 
   const chipLabels = isTree ? selectedOptionsLabels || [] : selectedOptions.map((o) => getOptionLabel(o));
   const selectedChipCount = chipLabels.length;
-  const showNumSelection = isMultiSelect && selectedChipCount > 1;
+  const showNumSelection = !hideChips && isMultiSelect && selectedChipCount > 1;
 
   useGrowingTextField({
     // This says: When using a multiselect, then only enable the growing textfield when we are focused on it.
@@ -239,7 +242,10 @@ export function ComboBoxInput<O, V extends Value>(props: ComboBoxInputProps<O, V
               ? Math.min(
                   String(
                     inputProps.value ||
-                      (isMultiSelect && selectedOptions.length === 1 && getOptionLabel(selectedOptions[0])) ||
+                      (!hideChips &&
+                        isMultiSelect &&
+                        selectedOptions.length === 1 &&
+                        getOptionLabel(selectedOptions[0])) ||
                       nothingSelectedText ||
                       "",
                   ).length || 1,

--- a/src/inputs/internal/ListBox.tsx
+++ b/src/inputs/internal/ListBox.tsx
@@ -21,6 +21,8 @@ type ListBoxProps<O, V extends AriaKey> = {
   loading?: boolean | (() => JSX.Element);
   disabledOptionsWithReasons?: Record<string, string | undefined>;
   isTree?: boolean;
+  /** Hides the selected-value ToggleChips above the options list. */
+  hideChips?: boolean;
 };
 
 /** A ListBox is an internal component used by SelectField and MultiSelectField to display the list of options */
@@ -36,6 +38,7 @@ export function ListBox<O, V extends AriaKey>(props: ListBoxProps<O, V>) {
     loading,
     disabledOptionsWithReasons = {},
     isTree,
+    hideChips = false,
   } = props;
   const { listBoxProps } = useListBox({ disallowEmptySelection: true, ...props }, state, listBoxRef);
   const positionMaxHeight = positionProps.style?.maxHeight;
@@ -108,7 +111,7 @@ export function ListBox<O, V extends AriaKey>(props: ListBoxProps<O, V>) {
       ref={listBoxRef}
       {...listBoxProps}
     >
-      {isMultiSelect && selectedOptions.length > 0 && (
+      {isMultiSelect && !hideChips && selectedOptions.length > 0 && (
         <ul
           css={Css.listReset.pt2.pl2.pb1.pr1.df.bb.bc(Tokens.SurfaceSeparator).add("flexWrap", "wrap").maxh("50%").oa.$}
           ref={selectedList}


### PR DESCRIPTION
Show selections as removable pills below the field instead of chips, so the combobox stays a picker and the list can carry helper text and AI styling.
## Within MultiSelectField via (with `withPillList: true`)
<img width="498" height="266" alt="Screenshot 2026-09-10 at 10 33 29 AM" src="https://github.com/user-attachments/assets/a898c642-a94a-400d-94b2-2b97818dd28a" />

## AI styles applied
<img width="602" height="69" alt="Screenshot 2026-09-10 at 10 33 53 AM" src="https://github.com/user-attachments/assets/5bee955c-f1ef-4864-b266-50e5ff7b9f70" />
