### PR TITLE
fix: Restore compatible changelog preset for publishing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "@types/react-dom": "^19.2.7",
     "array-move": "^4.0.0",
     "chromatic": "^18.7.2",
-    "conventional-changelog-conventionalcommits": "^10.4.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "husky": "^9.1.7",
     "jsdom": "29.0.0",
     "mobx": "^7.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -356,13 +356,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@conventional-changelog/template@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "@conventional-changelog/template@npm:1.4.0"
-  checksum: 10/dac527b0eb01ff4b2457b560f3fb61e24c8797cd5e7cafe4d4561454352714d8aec4d39092a15da068fc082878b1713a589cfd8471267f340f9a78c28057d74b
-  languageName: node
-  linkType: hard
-
 "@csstools/color-helpers@npm:^6.1.1":
   version: 6.1.1
   resolution: "@csstools/color-helpers@npm:6.1.1"
@@ -912,7 +905,7 @@ __metadata:
     array-move: "npm:^4.0.0"
     change-case: "npm:^5.4.4"
     chromatic: "npm:^18.7.2"
-    conventional-changelog-conventionalcommits: "npm:^10.4.0"
+    conventional-changelog-conventionalcommits: "npm:^9.3.1"
     date-fns: "npm:^4.4.0"
     dompurify: "npm:^3.4.15"
     fast-deep-equal: "npm:^3.1.3"
@@ -3874,12 +3867,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-conventionalcommits@npm:^10.4.0":
-  version: 10.4.0
-  resolution: "conventional-changelog-conventionalcommits@npm:10.4.0"
+"conventional-changelog-conventionalcommits@npm:^9.3.1":
+  version: 9.3.1
+  resolution: "conventional-changelog-conventionalcommits@npm:9.3.1"
   dependencies:
-    "@conventional-changelog/template": "npm:^1.4.0"
-  checksum: 10/e277c5e7226fc108478d5b67c6a581673b3443e022cfa3eea300e6ddf2683a93690048f9f07fb4e24b01ef174ab77c6cf04406b21afb70f9de5a7a61cb6acecf
+    compare-func: "npm:^2.0.0"
+  checksum: 10/6b924adcf31d36cbe1442f5c2d29dad345666bea9e805d8af6bfa28ab694e93abbdcb2462716b2a993f6eabf1d4bdc45209076249bd4825f5513ff061a99a4a2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Restore conventional-changelog-conventionalcommits to ^9.3.1 and regenerate yarn.lock.
- Preset v10 requires conventional-changelog-writer v9+, but the installed @semantic-release/release-notes-generator v14.1.1 uses writer v8, causing CI to fail during generateNotes.
- Keep the other dependency upgrades and release rules unchanged.

## Verification
- Reproduced the exact missing-helper error before the fix.
- Verified commit analysis and release-note generation for patch, minor, and breaking-change commits after the fix, without publishing.
- yarn install --immutable passes (existing unrelated peer-dependency warnings).
- yarn lint:ci passes.