### PR TITLE
chore: explain why matching proposals skip the strikethrough

### DIFF
--- a/src/inputs/hooks/useAiProposal.ts
+++ b/src/inputs/hooks/useAiProposal.ts
@@ -26,7 +26,7 @@ export type UseAiProposalResult<V> = {
  * re-entering the on-record value produces no change to `value` at all — there is nothing to observe.
  *
  * A proposal that matches what is already on record has no original worth striking through, so we
- * skip it. That is how creation flows arrive: the entity is created from the model's own values, so
+ * skip it. That is how creation flows arrive: the entity is created from the agent's own values, so
  * `value` already equals the proposal by the time the user reviews it.
  */
 export function useAiProposal<V>(

--- a/src/inputs/hooks/useAiProposal.ts
+++ b/src/inputs/hooks/useAiProposal.ts
@@ -26,7 +26,8 @@ export type UseAiProposalResult<V> = {
  * re-entering the on-record value produces no change to `value` at all — there is nothing to observe.
  *
  * A proposal that matches what is already on record has no original worth striking through, so we
- * skip it.
+ * skip it. That is how creation flows arrive: the entity is created from the model's own values, so
+ * `value` already equals the proposal by the time the user reviews it.
  */
 export function useAiProposal<V>(
   value: V | undefined,


### PR DESCRIPTION
## Description

Documents why `useAiProposal` skips the struck-through original when the proposal already matches the on-record value.

## Screenshots

N/A

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

Mental Checklist

- [ ] Add your squad to the reviewers list.
- [ ] Updated tests for this change.
- [ ] Tested changes locally.
- [x] Updated Documentation (if necessary).